### PR TITLE
Facilitate manual presence management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 env/
 __pycache__/
 *~
+venv
 #*#
 
 # Distribution / packaging


### PR DESCRIPTION
This proposed PR allows for more flexibility in session shutdown within the transport service. Instead of leaving the call as soon as the bot is the last one in the room, the caller is able to specify their own minimum value for other participants. This also allows the caller to decide themselves when the bot should leave.

This has a specific use case in the AI assistant, where by design we don't kick the bot from the session right away as soon as it is the lone participant. We wait 60 seconds, giving room for someone to rejoin if they left by mistake, before destroying the session. 