### PR TITLE
Cleanup constructor args in examples

### DIFF
--- a/src/samples/foundational/01-say-one-thing.py
+++ b/src/samples/foundational/01-say-one-thing.py
@@ -23,8 +23,8 @@ async def main(room_url):
             None,
             "Say One Thing",
             meeting_duration_minutes,
+            mic_enabled=True
         )
-        transport._mic_enabled = True
         tts = ElevenLabsTTSService(aiohttp_session=session, api_key=os.getenv("ELEVENLABS_API_KEY"), voice_id=os.getenv("ELEVENLABS_VOICE_ID"))
 
         # Register an event handler so we can play the audio when the participant joins.

--- a/src/samples/foundational/02-llm-say-one-thing.py
+++ b/src/samples/foundational/02-llm-say-one-thing.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import os
 
@@ -20,8 +19,8 @@ async def main(room_url):
             None,
             "Say One Thing From an LLM",
             duration_minutes=meeting_duration_minutes,
+            mic_enabled=True
         )
-        transport._mic_enabled = True
 
         tts = ElevenLabsTTSService(aiohttp_session=session, api_key=os.getenv("ELEVENLABS_API_KEY"), voice_id=os.getenv("ELEVENLABS_VOICE_ID"))
         # tts = AzureTTSService(api_key=os.getenv("AZURE_SPEECH_API_KEY"), region=os.getenv("AZURE_SPEECH_REGION"))

--- a/src/samples/foundational/03-still-frame.py
+++ b/src/samples/foundational/03-still-frame.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import aiohttp
 import os
@@ -23,11 +22,11 @@ async def main(room_url):
             None,
             "Show a still frame image",
             duration_minutes=meeting_duration_minutes,
+            mic_enabled=False,
+            camera_enabled=True,
+            camera_width=1024,
+            camera_height=1024
         )
-        transport._mic_enabled = False
-        transport._camera_enabled = True
-        transport._camera_width = 1024
-        transport._camera_height = 1024
 
         imagegen = FalImageGenService(image_size="1024x1024", aiohttp_session=session, key_id=os.getenv("FAL_KEY_ID"), key_secret=os.getenv("FAL_KEY_SECRET"))
         # imagegen = OpenAIImageGenService(aiohttp_session=session, api_key=os.getenv("OPENAI_DALLE_API_KEY"), image_size="1024x1024")

--- a/src/samples/foundational/04-utterance-and-speech.py
+++ b/src/samples/foundational/04-utterance-and-speech.py
@@ -1,7 +1,5 @@
-import argparse
 import asyncio
 import os
-import re
 
 import aiohttp
 
@@ -19,10 +17,10 @@ async def main(room_url: str):
             None,
             "Static And Dynamic Speech",
             duration_minutes=1,
+            mic_enabled=True,
+            mic_sample_rate=16000,
+            camera_enabled=False
         )
-        transport._mic_enabled = True
-        transport._mic_sample_rate = 16000
-        transport._camera_enabled = False
 
         llm = AzureLLMService(api_key=os.getenv("AZURE_CHATGPT_API_KEY"), endpoint=os.getenv("AZURE_CHATGPT_ENDPOINT"), model=os.getenv("AZURE_CHATGPT_MODEL"))
         azure_tts = AzureTTSService(api_key=os.getenv("AZURE_SPEECH_API_KEY"), region=os.getenv("AZURE_SPEECH_REGION"))

--- a/src/samples/foundational/05-sync-speech-and-image.py
+++ b/src/samples/foundational/05-sync-speech-and-image.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import aiohttp
 import os
@@ -20,12 +19,12 @@ async def main(room_url):
             None,
             "Month Narration Bot",
             duration_minutes=meeting_duration_minutes,
+            mic_enabled=True,
+            camera_enabled=True,
+            mic_sample_rate=16000,
+            camera_width=1024,
+            camera_height=1024
         )
-        transport._mic_enabled = True
-        transport._camera_enabled = True
-        transport._mic_sample_rate = 16000
-        transport._camera_width = 1024
-        transport._camera_height = 1024
 
         llm = AzureLLMService(api_key=os.getenv("AZURE_CHATGPT_API_KEY"), endpoint=os.getenv("AZURE_CHATGPT_ENDPOINT"), model=os.getenv("AZURE_CHATGPT_MODEL"))
         tts = ElevenLabsTTSService(aiohttp_session=session, api_key=os.getenv("ELEVENLABS_API_KEY"), voice_id="ErXwobaYiN019PkySvjV")

--- a/src/samples/foundational/06-listen-and-respond.py
+++ b/src/samples/foundational/06-listen-and-respond.py
@@ -7,10 +7,6 @@ from dailyai.queue_aggregators import LLMAssistantContextAggregator, LLMContextA
 from samples.foundational.support.runner import configure
 
 async def main(room_url: str, token):
-    global transport
-    global llm
-    global tts
-
     transport = DailyTransportService(
         room_url,
         token,

--- a/src/samples/foundational/08-bots-arguing.py
+++ b/src/samples/foundational/08-bots-arguing.py
@@ -12,21 +12,17 @@ from samples.foundational.support.runner import configure
 
 async def main(room_url:str):
     async with aiohttp.ClientSession() as session:
-        global transport
-        global llm
-        global tts
-
         transport = DailyTransportService(
             room_url,
             None,
             "Respond bot",
-            duration_minutes=10
+            duration_minutes=10,
+            mic_enabled=True,
+            mic_sample_rate=16000,
+            camera_enabled=True,
+            camera_width=1024,
+            camera_height=1024
         )
-        transport._mic_enabled = True
-        transport._mic_sample_rate = 16000
-        transport._camera_enabled = True
-        transport._camera_width = 1024
-        transport._camera_height = 1024
 
         llm = AzureLLMService(api_key=os.getenv("AZURE_CHATGPT_API_KEY"), endpoint=os.getenv("AZURE_CHATGPT_ENDPOINT"), model=os.getenv("AZURE_CHATGPT_MODEL"))
         tts1 = AzureTTSService(api_key=os.getenv("AZURE_SPEECH_API_KEY"), region=os.getenv("AZURE_SPEECH_REGION"))

--- a/src/samples/foundational/10-wake-word.py
+++ b/src/samples/foundational/10-wake-word.py
@@ -105,16 +105,17 @@ class ImageSyncAggregator(AIService):
 
 async def main(room_url: str, token):
     async with aiohttp.ClientSession() as session:
-        global transport
-        global llm
-        global tts
-
         transport = DailyTransportService(
             room_url,
             token,
             "Santa Cat",
             duration_minutes=3,
-            start_transcription=True
+            start_transcription=True,
+            mic_enabled=True,
+            mic_sample_rate=16000,
+            camera_enabled=True,
+            camera_width=720,
+            camera_height=1280
         )
         transport._mic_enabled = True
         transport._mic_sample_rate = 16000

--- a/src/samples/foundational/11-sound-effects.py
+++ b/src/samples/foundational/11-sound-effects.py
@@ -65,20 +65,15 @@ class InboundSoundEffectWrapper(AIService):
 
 async def main(room_url: str, token):
     async with aiohttp.ClientSession() as session:
-
-        global transport
-        global llm
-        global tts
-
         transport = DailyTransportService(
             room_url,
             token,
             "Respond bot",
             duration_minutes=5,
+            mic_enabled=True,
+            mic_sample_rate=16000,
+            camera_enabled=False
         )
-        transport._mic_enabled = True
-        transport._mic_sample_rate = 16000
-        transport._camera_enabled = False
 
         llm = AzureLLMService(api_key=os.getenv("AZURE_CHATGPT_API_KEY"), endpoint=os.getenv("AZURE_CHATGPT_ENDPOINT"), model=os.getenv("AZURE_CHATGPT_MODEL"))
         tts = ElevenLabsTTSService(aiohttp_session=session, api_key=os.getenv("ELEVENLABS_API_KEY"), voice_id="ErXwobaYiN019PkySvjV")

--- a/src/samples/foundational/13-whisper-transcription.py
+++ b/src/samples/foundational/13-whisper-transcription.py
@@ -6,18 +6,16 @@ from dailyai.services.whisper_ai_services import WhisperSTTService
 from samples.foundational.support.runner import configure
 
 async def main(room_url: str):
-    global transport
-    global stt
-
     transport = DailyTransportService(
         room_url,
         None,
         "Transcription bot",
-        start_transcription=True
+        start_transcription=True,
+        mic_enabled=False,
+        camera_enabled=False,
+        speaker_enabled=True
     )
-    transport._mic_enabled = False
-    transport._camera_enabled = False
-    transport._speaker_enabled = True
+
     stt = WhisperSTTService()
     transcription_output_queue = asyncio.Queue()
 


### PR DESCRIPTION
Pass configuration parameters as constructor arguments rather than setting properties on object in examples. Also removed some unused modules and unused `global` declarations.