### PR TITLE
Implement LMNT full-duplex TTS generation

### DIFF
--- a/examples/foundational/06b-streamed-listen-and-respond.py
+++ b/examples/foundational/06b-streamed-listen-and-respond.py
@@ -1,0 +1,88 @@
+import asyncio
+import aiohttp
+import logging
+import os
+from dailyai.pipeline.frames import LLMMessagesQueueFrame
+from dailyai.pipeline.pipeline import Pipeline
+
+from dailyai.services.daily_transport_service import DailyTransportService
+from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
+from dailyai.services.open_ai_services import OpenAILLMService
+from dailyai.services.ai_services import FrameLogger
+from dailyai.pipeline.aggregators import (
+    LLMAssistantContextAggregator,
+    LLMUserContextAggregator,
+)
+from runner import configure
+
+from dotenv import load_dotenv
+load_dotenv()
+
+logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
+logger = logging.getLogger("dailyai")
+logger.setLevel(logging.DEBUG)
+
+
+async def main(room_url: str, token):
+    async with aiohttp.ClientSession() as session:
+        transport = DailyTransportService(
+            room_url,
+            token,
+            "Respond bot",
+            duration_minutes=5,
+            start_transcription=True,
+            mic_enabled=True,
+            mic_sample_rate=16000,
+            camera_enabled=False,
+            vad_enabled=True,
+        )
+
+        tts = ElevenLabsTTSService(
+            aiohttp_session=session,
+            api_key=os.getenv("ELEVENLABS_API_KEY"),
+            voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
+        )
+
+        llm = OpenAILLMService(
+            api_key=os.getenv("OPENAI_API_KEY"),
+            model="gpt-4-turbo-preview")
+        fl = FrameLogger("Inner")
+        fl2 = FrameLogger("Outer")
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. Your output will be converted to audio. Respond to what the user said in a creative and helpful way.",
+            },
+        ]
+
+        tma_in = LLMUserContextAggregator(
+            messages, transport._my_participant_id)
+        tma_out = LLMAssistantContextAggregator(
+            messages, transport._my_participant_id
+        )
+        pipeline = Pipeline(
+            processors=[
+                fl,
+                tma_in,
+                llm,
+                fl2,
+                tts,
+                tma_out,
+            ],
+        )
+
+        @transport.event_handler("on_first_other_participant_joined")
+        async def on_first_other_participant_joined(transport):
+            # Kick off the conversation.
+            messages.append(
+                {"role": "system", "content": "Please introduce yourself to the user."})
+            await pipeline.queue_frames([LLMMessagesQueueFrame(messages)])
+
+        transport.transcription_settings["extra"]["endpointing"] = True
+        transport.transcription_settings["extra"]["punctuate"] = True
+        await transport.run(pipeline)
+
+
+if __name__ == "__main__":
+    (url, token) = configure()
+    asyncio.run(main(url, token))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "fal",
     "faster_whisper",
     "google-cloud-texttospeech",
+    "lmnt",
     "numpy",
     "openai",
     "Pillow",

--- a/src/dailyai/pipeline/pipeline.py
+++ b/src/dailyai/pipeline/pipeline.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import AsyncGenerator, AsyncIterable, Iterable, List
 from dailyai.pipeline.frame_processor import FrameProcessor
 
-from dailyai.pipeline.frames import EndPipeFrame, EndFrame, Frame
+from dailyai.pipeline.frames import EndPipeFrame, EndFrame, Frame, ControlFrame
 
 
 class Pipeline:
@@ -108,3 +108,20 @@ class Pipeline:
                     yield final_frame
         else:
             yield initial_frame
+
+
+class CustomPipeline(Pipeline):
+    """Used for services that don't neatly map to the frame processor model
+    of standard pipelines. For example, LMNT's full-duplex TTS streaming."""
+    # TODO-CB: Maybe this is a BasePipeline?
+
+    def __init__(self,
+                 source: asyncio.Queue | None = None,
+                 sink: asyncio.Queue[Frame] | None = None):
+        super().__init__(processors=[], source=source, sink=sink)
+
+    def run_pipeline(self):
+        """Right now, we'll override this in a subclass and
+        access the source and sink queues directly, but I
+        might need to clean that up later."""
+        pass

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -409,6 +409,7 @@ class BaseTransportService:
             try:
                 frames_or_frame: Frame | list[Frame] = self._threadsafe_send_queue.get(
                 )
+                print(f"!!! frames_or_frame is {frames_or_frame}")
                 if (
                     isinstance(frames_or_frame, AudioFrame)
                     and len(frames_or_frame.data) > largest_write_size

--- a/src/dailyai/services/lmnt_ai_services.py
+++ b/src/dailyai/services/lmnt_ai_services.py
@@ -1,0 +1,91 @@
+import asyncio
+from asyncio import QueueEmpty
+
+from typing import AsyncGenerator
+from lmnt.api import Speech
+
+from dailyai.services.ai_services import AIService, TTSService
+from dailyai.pipeline.frames import (
+    Frame,
+    TextFrame,
+    AudioFrame,
+    LLMResponseEndFrame
+)
+from dailyai.pipeline.pipeline import CustomPipeline
+
+
+# Since LMNT offers "full duplex" streaming, we have to implement a different
+# kind of process_frame function, so we don't subclass TTSService. But this
+# class can be used in place of any other TTS service
+class LmntStreamingTTSPipeline(CustomPipeline):
+
+    def __init__(
+        self,
+        *,
+        api_key,
+        voice_id="lily",
+        source,
+        sink
+    ):
+        super().__init__(source=source, sink=sink)
+
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._connection = None
+        # self._run_thread = asyncio.to_thread(self.run_connection)
+
+    async def run_pipeline(self):
+        print(f"@@@ !!! starting run_connection, hopefully in a thread")
+        async with Speech() as speech:
+            connection = await speech.synthesize_streaming(self._voice_id, format="raw", sample_rate=16000)
+            print(f"@@@ connection created")
+            t1 = asyncio.create_task(self.in_task(connection))
+            t2 = asyncio.create_task(self.out_task(connection))
+            await asyncio.gather(t1, t2)
+            print(f"@@@ !!! run_connection is past the asyncio.gather")
+            connection.finish()
+            print(f"@@@ !!! run_connection is past finish()")
+
+        print(f"@@@ !!! run_ connection is past the async with block, and is presumably done")
+
+    async def in_task(self, connection):
+        while True:
+            frame = await self.source.get()
+            print(f"@@@ GOT FRAME IN IN TASK: {frame}")
+            if isinstance(frame, LLMResponseEndFrame):
+                print(f"@@@ got an LLM response end; flushing, er, finishing")
+                await connection.flush()
+                print(f"@@@ PAST FLUSH")
+            elif isinstance(frame, TextFrame):
+                # Then it must be a TextFrame
+                await connection.append_text(frame.text)
+            else:
+                await self.sink.put(frame)
+
+    async def out_task(self, connection):
+        async for message in connection:
+            print(f"### OUT_TASK GOT A MESSAGE")
+            frame = AudioFrame(message['audio'])
+            print(f"@@@ out_task got some audio data! {frame}")
+            await self.sink.put(frame)
+        print(f"@@@ out_task seems to be done with the async for")
+
+
+class LmntTTSService(TTSService):
+
+    def __init__(
+        self,
+        *,
+        api_key,
+        voice_id="lily"
+    ):
+        super().__init__()
+
+        self._api_key = api_key
+        self._voice_id = voice_id
+
+    async def run_tts(self, sentence) -> AsyncGenerator[bytes, None]:
+        async with Speech() as speech:
+            print(f"@@@ Sentence is {sentence}, voice is {self._voice_id}")
+            synthesis = await speech.synthesize('Hello, world.', 'lily')
+            yield AudioFrame[synthesis['audio']]


### PR DESCRIPTION
[LMNT](https://lmnt.com) has an interesting approach to 'full-duplex' TTS:

```python
async def main():
  async with Speech() as speech:
    connection = await speech.synthesize_streaming('lily')
    t1 = asyncio.create_task(reader_task(connection))
    t2 = asyncio.create_task(writer_task(connection))
    asyncio.gather([t1, t2])
    connection.close()
```

This doesn't really work with our `FrameProcessor` architecture, but it does actually work pretty well with the idea of a custom pipeline. I've started building that out in `examples/foundational/02a-async-llm-say-one-thing.py`. 

I'm currently stuck because I think there's a bug in their implementation. After I get the first chunk of audio back, the websocket connection to LMNT seems to close. I've tried logging just about everywhere I can think of, and I can't find an explanation. I'm going to try and get in touch with the LMNT team to troubleshoot.

(I found out about LMNT through [Andy Korman](https://www.linkedin.com/in/andykorman/), who I met at our Voice + AI Summit.)