### PR TITLE
Fix error with readme example - SyntaxError: positional argument follows keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ async def main():
     transport = DailyTransport(
       room_url=...,
       token=...,
-      "Bot Name",
-      DailyParams(audio_out_enabled=True))
+      bot_name="Bot Name",
+      params=DailyParams(audio_out_enabled=True))
 
     # Use Eleven Labs for Text-to-Speech
     tts = ElevenLabsTTSService(


### PR DESCRIPTION
Fix for the error in the README.md example 

Running the code as is gives a `SyntaxError: positional argument follows keyword argument` due to `bot_name` and `params` keywords not being provided in the DailyTransport object instantiation call 

Thanks!