### PR TITLE
handle multiple function calls in openai

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -183,7 +183,7 @@ class BaseOpenAILLMService(LLMService):
             tool_id_list.append(tool_call_id)
             for function_name,arguments,tool_id in zip(functions_list,arguments_list,tool_id_list):
                 if self.has_function(function_name):
-                    await self._handle_function_call(context, tool_call_id, function_name, arguments)
+                    await self._handle_function_call(context, tool_id, function_name, arguments)
                 else:
                     raise OpenAIUnhandledFunctionException(
                         f"The LLM tried to call a function named '{function_name}', but there isn't a callback registered for that function.")


### PR DESCRIPTION
openai can give multiple tool calls 
ex : "message": {
                "role": "assistant",
                "content": null,
                "tool_calls": [
                    {
                        "id": "call_cuC7cq3IoIqCN2IvwfGuNl8J",
                        "type": "function",
                        "function": {
                            "name": "add_numbers",
                            "arguments": "{\"a\": 1, \"b\": 2}"
                        }
                    },
                    {
                        "id": "call_SfbHakQINYSeK9a7VzQq50OW",
                        "type": "function",
                        "function": {
                            "name": "add_numbers",
                            "arguments": "{\"a\": 3, \"b\": 4}"
                        }
                    }
                ],
                "refusal": null
            },
            
  The current implementation assumes only single function call. In this case we get function name as add_numbersadd_numbers (here we have function name twice ).  This would fail when the openai is giving multiple tool calls.
  
  The fix I used is create a list of function names and call them. 