### PR TITLE
Cartesia error handling

### DIFF
--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -15,6 +15,7 @@ from typing import AsyncGenerator
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.frames.frames import (
     CancelFrame,
+    ErrorFrame,
     Frame,
     AudioRawFrame,
     StartInterruptionFrame,
@@ -173,6 +174,12 @@ class CartesiaTTSService(TTSService):
                         num_channels=1
                     )
                     await self.push_frame(frame)
+                elif msg["type"] == "error":
+                    logger.error(f"Cartesia error: {msg}")
+                    await self.stop_all_metrics()
+                    await self.push_frame(ErrorFrame(f'Cartesia error: {msg["error"]}'))
+                else:
+                    logger.error(f"Cartesia error, unknown message type: {msg}")
         except asyncio.CancelledError:
             pass
         except Exception as e:


### PR DESCRIPTION
Two things that should have been done in the initial Cartesia TTS implementation:
  * Handle WebSocket `type: error` messages by logging the complete message and pushing an `ErrorFrame` down the pipeline.
  * Log an error if we get a WebSocket message of unknown type, so we'll catch any more things like this earlier in development.