### PR TITLE
[ENG-7781] Enable docker build without git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,4 @@ pythonpath = ["src"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+fallback_version = "0.0.0-dev"


### PR DESCRIPTION
Currently, pulling in Pipecat as a submodule fails unless git is installed and the chosen commit has been released.  This change will allow us to build internal applications 