### PR TITLE
chore: Enable build without git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,4 @@ pythonpath = ["src"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+fallback_version = "0.0.0-dev"


### PR DESCRIPTION
This will allow the module build to succeed outside of a git repository.