### PR TITLE
Support for Anthropic prompt caching beta

### DIFF
--- a/examples/foundational/19b-tools-video-anthropic.py
+++ b/examples/foundational/19b-tools-video-anthropic.py
@@ -77,7 +77,8 @@ async def main():
 
         llm = AnthropicLLMService(
             api_key=os.getenv("ANTHROPIC_API_KEY"),
-            model="claude-3-5-sonnet-20240620"
+            model="claude-3-5-sonnet-20240620",
+            enable_prompt_caching_beta=True
         )
         llm.register_function("get_weather", get_weather)
         llm.register_function("get_image", get_image)
@@ -136,10 +137,20 @@ indicate you should use the get_image tool are:
 If you need to use a tool, simply use the tool. Do not tell the user the tool you are using. Be brief and concise.
         """
 
-        messages = [{"role": "system",
-                     "content": system_prompt},
-                    {"role": "user",
-                     "content": "Start the conversation by introducing yourself."}]
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": system_prompt,
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": "Start the conversation by introducing yourself."
+            }]
 
         context = OpenAILLMContext(messages, tools)
         context_aggregator = llm.create_context_aggregator(context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Source = "https://github.com/pipecat-ai/pipecat"
 Website = "https://pipecat.ai"
 
 [project.optional-dependencies]
-anthropic = [ "anthropic~=0.28.1" ]
+anthropic = [ "anthropic~=0.34.0" ]
 azure = [ "azure-cognitiveservices-speech~=1.38.0" ]
 cartesia = [ "websockets~=12.0" ]
 daily = [ "daily-python~=0.10.1" ]


### PR DESCRIPTION
Implements prompt caching.

Missing: wiring up two new usage counts
  - cache_creation_input_tokens
  - cache_read_input_tokens

Anthropic docs are here: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching