### PR TITLE
fixup type mismatches between rtvi data structures and together.py

### DIFF
--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -222,7 +222,7 @@ class RTVILLMFunctionCallResultData(BaseModel):
     function_name: str
     tool_call_id: str
     arguments: dict
-    result: dict
+    result: dict | str
 
 
 class RTVITranscriptionMessageData(BaseModel):

--- a/src/pipecat/services/together.py
+++ b/src/pipecat/services/together.py
@@ -173,7 +173,7 @@ class TogetherLLMService(LLMService):
             try:
                 arguments = json.loads(args_string)
                 await self.call_function(context=context,
-                                         tool_call_id=uuid.uuid4(),
+                                         tool_call_id=str(uuid.uuid4()),
                                          function_name=function_name,
                                          arguments=arguments)
                 return
@@ -301,7 +301,8 @@ class TogetherAssistantContextAggregator(LLMAssistantContextAggregator):
                 self._function_call_result = None
                 self._context.add_message({
                     "role": "tool",
-                    "content": frame.result
+                    # Together expects the content here to be a string, so stringify it
+                    "content": str(frame.result)
                 })
                 run_llm = True
             else:


### PR DESCRIPTION
Fix two issues that were preventing Together/Llama 3.1 function calling with RTVI:

1. `RTVILLMFunctionCallMessageData` expects `tool_call_id` to be a `str`, but together.py was passing a `UUID`.
2. `RTVILLMFunctionCallResultData` expected the `result` field to be a `dict`, but Together's library requires that message content for the `"tool"` role be a `str`.

For (2) I loosened the type of `RTVILLMFunctionCallResultData::result` to `dict | str`, and also forced the `"content"` into a `str` in together.py.

