### PR TITLE
Generate ids with itertools.count

### DIFF
--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -3,32 +3,39 @@
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
+import collections
+import itertools
 
-from threading import Lock
-
-_COUNTS = {}
-_COUNTS_MUTEX = Lock()
-
-_ID = 0
-_ID_MUTEX = Lock()
+_COUNTS = collections.defaultdict(itertools.count)
+_ID = itertools.count()
 
 
 def obj_id() -> int:
-    global _ID, _ID_MUTEX
-    with _ID_MUTEX:
-        _ID += 1
-        return _ID
+    """
+    Generate a unique id for an object.
+
+    >>> obj_id()
+    0
+    >>> obj_id()
+    1
+    >>> obj_id()
+    2
+    """
+    return next(_ID)
 
 
 def obj_count(obj) -> int:
-    global _COUNTS, COUNTS_MUTEX
-    name = obj.__class__.__name__
-    with _COUNTS_MUTEX:
-        if name not in _COUNTS:
-            _COUNTS[name] = 0
-        else:
-            _COUNTS[name] += 1
-        return _COUNTS[name]
+    """Generate a unique id for an object.
+
+    >>> obj_count(object())
+    0
+    >>> obj_count(object())
+    1
+    >>> new_type = type('NewType', (object,), {})
+    >>> obj_count(new_type())
+    0
+    """
+    return next(_COUNTS[obj.__class__.__name__])
 
 
 def exp_smoothing(value: float, prev_value: float, factor: float) -> float:


### PR DESCRIPTION
Avoids the critical section with threading.Lock in favor of itertools.count.

`count` objects are threadsafe, and their critical section is implemented in C and provide better performance that Python level locking.

### Preliminary Benchmarks

This update also provides some speedup, I will make no claims on the factor as the benchmarks are not rigorous. 
Setup: Just ran these on my M2 macos with Python 3.12.5, better benching methodology can be done if requested.

**After**

```bash
$ python -m timeit -s "from pipecat.utils.utils import obj_count, obj_id" "obj_id()"
10000000 loops, best of 5: 31.7 nsec per loop
$ python -m timeit -s "from pipecat.utils.utils import obj_count, obj_id" "obj_count(object)"
5000000 loops, best of 5: 93.8 nsec per loop
```

**Before**

```bash
$ python -m timeit -s "from pipecat.utils.utils import obj_count, obj_id" "obj_id()"
2000000 loops, best of 5: 130 nsec per loop
$ python -m timeit -s "from pipecat.utils.utils import obj_count, obj_id" "obj_count(object)"
1000000 loops, best of 5: 226 nsec per loop
```