### PR TITLE
fix for pathological cases where we don't get timestamps from Cartesia

### DIFF
--- a/examples/foundational/19c-tools-togetherai.py
+++ b/examples/foundational/19c-tools-togetherai.py
@@ -117,8 +117,8 @@ Reminder:
             context_aggregator.user(),       # User speech to text
             llm,                             # LLM
             tts,                             # TTS
-            transport.output(),              # Transport bot output
             context_aggregator.assistant(),  # Assistant spoken responses and tool context
+            transport.output(),              # Transport bot output
         ])
 
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True, enable_metrics=True))


### PR DESCRIPTION
We occasionally don't get timestamps at all from Cartesia.

This is currently reproducible with the tts input "2 + 2 = 4"

I added in a fix for that, plus some comments about the code more generally.

The comments were motivate by:
  1. Looking at, but failing to fix, the issue that Cartesia processing time metric is broken
  2. Thinking about how to fix, but then not tackling, LLM context aggregation support for Cartesia models that don't do timestamps