### PR TITLE
adding "model" to all metrics frames if one exists

### DIFF
--- a/src/pipecat/services/anthropic.py
+++ b/src/pipecat/services/anthropic.py
@@ -252,8 +252,6 @@ class AnthropicLLMService(LLMService):
             cache_read_input_tokens: int):
         if prompt_tokens or completion_tokens or cache_creation_input_tokens or cache_read_input_tokens:
             tokens = {
-                "processor": self.name,
-                "model": self._model,
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "cache_creation_input_tokens": cache_creation_input_tokens,

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -92,7 +92,7 @@ class CartesiaTTSService(TTSService):
         self._cartesia_version = cartesia_version
         self._url = url
         self._voice_id = voice_id
-        self._model_id = model_id
+        self._model = model_id
         self._output_format = {
             "container": "raw",
             "encoding": encoding,
@@ -112,7 +112,7 @@ class CartesiaTTSService(TTSService):
 
     async def set_model(self, model: str):
         logger.debug(f"Switching TTS model to: [{model}]")
-        self._model_id = model
+        self._model = model
 
     async def set_voice(self, voice: str):
         logger.debug(f"Switching TTS voice to: [{voice}]")
@@ -253,7 +253,7 @@ class CartesiaTTSService(TTSService):
                 "transcript": text + " ",
                 "continue": True,
                 "context_id": self._context_id,
-                "model_id": self._model_id,
+                "model_id": self._model,
                 "voice": {
                     "mode": "id",
                     "id": self._voice_id

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -138,8 +138,6 @@ class BaseOpenAILLMService(LLMService):
         async for chunk in chunk_stream:
             if chunk.usage:
                 tokens = {
-                    "processor": self.name,
-                    "model": self._model,
                     "prompt_tokens": chunk.usage.prompt_tokens,
                     "completion_tokens": chunk.usage.completion_tokens,
                     "total_tokens": chunk.usage.total_tokens
@@ -182,8 +180,8 @@ class BaseOpenAILLMService(LLMService):
             if self.has_function(function_name):
                 await self._handle_function_call(context, tool_call_id, function_name, arguments)
             else:
-                raise OpenAIUnhandledFunctionException(
-                    f"The LLM tried to call a function named '{function_name}', but there isn't a callback registered for that function.")
+                raise OpenAIUnhandledFunctionException(f"The LLM tried to call a function named '{
+                    function_name}', but there isn't a callback registered for that function.")
 
     async def _handle_function_call(
             self,

--- a/src/pipecat/services/together.py
+++ b/src/pipecat/services/together.py
@@ -109,8 +109,6 @@ class TogetherLLMService(LLMService):
                 # logger.debug(f"Together LLM event: {chunk}")
                 if chunk.usage:
                     tokens = {
-                        "processor": self.name,
-                        "model": self._model,
                         "prompt_tokens": chunk.usage.prompt_tokens,
                         "completion_tokens": chunk.usage.completion_tokens,
                         "total_tokens": chunk.usage.total_tokens


### PR DESCRIPTION
this allows us to differentiate across models when handling metrics frames. should also make subclassing easier in general so that the model and processor are always included with various metrics so long as they exist.