### PR TITLE
Set Google TTS default language to en-US

### DIFF
--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -153,7 +153,7 @@ class GoogleTTSService(TTSService):
         rate: Optional[str] = None
         volume: Optional[str] = None
         emphasis: Optional[Literal["strong", "moderate", "reduced", "none"]] = None
-        language: Optional[str] = None
+        language: Optional[str] = "en-US"
         gender: Optional[Literal["male", "female", "neutral"]] = None
         google_style: Optional[Literal["apologetic", "calm", "empathetic", "firm", "lively"]] = None
 


### PR DESCRIPTION
Language is required; there is no default value.