### PR TITLE
Further consolidate service update settings into a single ServiceUpdateSettingsFrame class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,8 @@ async def on_connected(processor):
 
 ### Changed
 
-- Updated individual update settings frame classes into a single UpdateSettingsFrame
-  class for STT, LLM, and TTS.
+- Updated individual update settings frame classes into a single
+  ServiceUpdateSettingsFrame class.
 
 - We now distinguish between input and output audio and image frames. We
   introduce `InputAudioRawFrame`, `OutputAudioRawFrame`, `InputImageRawFrame`

--- a/examples/foundational/07c-interruptible-deepgram.py
+++ b/examples/foundational/07c-interruptible-deepgram.py
@@ -50,7 +50,7 @@ async def main():
 
         stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
 
-        tts = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"), voice_id="aura-helios-en")
+        tts = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"), voice="aura-helios-en")
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 

--- a/examples/foundational/07c-interruptible-deepgram.py
+++ b/examples/foundational/07c-interruptible-deepgram.py
@@ -50,7 +50,7 @@ async def main():
 
         stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
 
-        tts = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"), voice="aura-helios-en")
+        tts = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"), voice_id="aura-helios-en")
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 

--- a/examples/foundational/07e-interruptible-playht.py
+++ b/examples/foundational/07e-interruptible-playht.py
@@ -4,10 +4,14 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import aiohttp
 import asyncio
 import os
 import sys
+
+import aiohttp
+from dotenv import load_dotenv
+from loguru import logger
+from runner import configure
 
 from pipecat.frames.frames import LLMMessagesFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -17,16 +21,10 @@ from pipecat.processors.aggregators.llm_response import (
     LLMAssistantResponseAggregator,
     LLMUserResponseAggregator,
 )
-from pipecat.services.playht import PlayHTTTSService
 from pipecat.services.openai import OpenAILLMService
+from pipecat.services.playht import PlayHTTTSService
 from pipecat.transports.services.daily import DailyParams, DailyTransport
 from pipecat.vad.silero import SileroVADAnalyzer
-
-from runner import configure
-
-from loguru import logger
-
-from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
@@ -54,7 +52,7 @@ async def main():
         tts = PlayHTTTSService(
             user_id=os.getenv("PLAYHT_USER_ID"),
             api_key=os.getenv("PLAYHT_API_KEY"),
-            voice_url="s3://voice-cloning-zero-shot/801a663f-efd0-4254-98d0-5c175514c3e8/jennifer/manifest.json",
+            voice_id="s3://voice-cloning-zero-shot/801a663f-efd0-4254-98d0-5c175514c3e8/jennifer/manifest.json",
         )
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")

--- a/examples/foundational/07e-interruptible-playht.py
+++ b/examples/foundational/07e-interruptible-playht.py
@@ -52,7 +52,7 @@ async def main():
         tts = PlayHTTTSService(
             user_id=os.getenv("PLAYHT_USER_ID"),
             api_key=os.getenv("PLAYHT_API_KEY"),
-            voice_id="s3://voice-cloning-zero-shot/801a663f-efd0-4254-98d0-5c175514c3e8/jennifer/manifest.json",
+            voice_url="s3://voice-cloning-zero-shot/801a663f-efd0-4254-98d0-5c175514c3e8/jennifer/manifest.json",
         )
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")

--- a/examples/foundational/07g-interruptible-openai-tts.py
+++ b/examples/foundational/07g-interruptible-openai-tts.py
@@ -4,10 +4,14 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import aiohttp
 import asyncio
 import os
 import sys
+
+import aiohttp
+from dotenv import load_dotenv
+from loguru import logger
+from runner import configure
 
 from pipecat.frames.frames import LLMMessagesFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -17,16 +21,9 @@ from pipecat.processors.aggregators.llm_response import (
     LLMAssistantResponseAggregator,
     LLMUserResponseAggregator,
 )
-from pipecat.services.openai import OpenAITTSService
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai import OpenAILLMService, OpenAITTSService
 from pipecat.transports.services.daily import DailyParams, DailyTransport
 from pipecat.vad.silero import SileroVADAnalyzer
-
-from runner import configure
-
-from loguru import logger
-
-from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
@@ -51,7 +48,7 @@ async def main():
             ),
         )
 
-        tts = OpenAITTSService(api_key=os.getenv("OPENAI_API_KEY"), voice="alloy")
+        tts = OpenAITTSService(api_key=os.getenv("OPENAI_API_KEY"), voice_id="alloy")
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 

--- a/examples/foundational/07g-interruptible-openai-tts.py
+++ b/examples/foundational/07g-interruptible-openai-tts.py
@@ -48,7 +48,7 @@ async def main():
             ),
         )
 
-        tts = OpenAITTSService(api_key=os.getenv("OPENAI_API_KEY"), voice_id="alloy")
+        tts = OpenAITTSService(api_key=os.getenv("OPENAI_API_KEY"), voice="alloy")
 
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 

--- a/examples/foundational/16-gpu-container-local-bot.py
+++ b/examples/foundational/16-gpu-container-local-bot.py
@@ -55,7 +55,7 @@ async def main():
         tts = DeepgramTTSService(
             aiohttp_session=session,
             api_key=os.getenv("DEEPGRAM_API_KEY"),
-            voice_id="aura-asteria-en",
+            voice="aura-asteria-en",
             base_url="http://0.0.0.0:8080/v1/speak",
         )
 

--- a/examples/foundational/16-gpu-container-local-bot.py
+++ b/examples/foundational/16-gpu-container-local-bot.py
@@ -5,9 +5,13 @@
 #
 
 import asyncio
-import aiohttp
 import os
 import sys
+
+import aiohttp
+from dotenv import load_dotenv
+from loguru import logger
+from runner import configure
 
 from pipecat.frames.frames import LLMMessagesFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -25,12 +29,6 @@ from pipecat.transports.services.daily import (
     DailyTransportMessageFrame,
 )
 from pipecat.vad.silero import SileroVADAnalyzer
-
-from runner import configure
-
-from loguru import logger
-
-from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
@@ -57,7 +55,7 @@ async def main():
         tts = DeepgramTTSService(
             aiohttp_session=session,
             api_key=os.getenv("DEEPGRAM_API_KEY"),
-            voice="aura-asteria-en",
+            voice_id="aura-asteria-en",
             base_url="http://0.0.0.0:8080/v1/speak",
         )
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -558,6 +558,8 @@ class TTSUpdateSettingsFrame(ControlFrame):
     style: Optional[str] = None
     style_degree: Optional[str] = None
     role: Optional[str] = None
+    gender: Optional[str] = None
+    google_style: Optional[str] = None
 
 
 @dataclass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -5,7 +5,7 @@
 #
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from pipecat.clocks.base_clock import BaseClock
 from pipecat.metrics.metrics import MetricsData
@@ -527,47 +527,11 @@ class UserImageRequestFrame(ControlFrame):
 
 
 @dataclass
-class LLMUpdateSettingsFrame(ControlFrame):
-    """A control frame containing a request to update LLM settings."""
+class ServiceUpdateSettingsFrame(ControlFrame):
+    """A control frame containing a request to update service settings."""
 
-    model: Optional[str] = None
-    temperature: Optional[float] = None
-    top_k: Optional[int] = None
-    top_p: Optional[float] = None
-    frequency_penalty: Optional[float] = None
-    presence_penalty: Optional[float] = None
-    max_tokens: Optional[int] = None
-    seed: Optional[int] = None
-    extra: dict = field(default_factory=dict)
-
-
-@dataclass
-class TTSUpdateSettingsFrame(ControlFrame):
-    """A control frame containing a request to update TTS settings."""
-
-    model: Optional[str] = None
-    voice: Optional[str] = None
-    language: Optional[Language] = None
-    speed: Optional[Union[str, float]] = None
-    emotion: Optional[List[str]] = None
-    engine: Optional[str] = None
-    pitch: Optional[str] = None
-    rate: Optional[str] = None
-    volume: Optional[str] = None
-    emphasis: Optional[str] = None
-    style: Optional[str] = None
-    style_degree: Optional[str] = None
-    role: Optional[str] = None
-    gender: Optional[str] = None
-    google_style: Optional[str] = None
-
-
-@dataclass
-class STTUpdateSettingsFrame(ControlFrame):
-    """A control frame containing a request to update STT settings."""
-
-    model: Optional[str] = None
-    language: Optional[Language] = None
+    service_type: str
+    settings: Dict[str, Any]
 
 
 @dataclass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -530,8 +530,22 @@ class UserImageRequestFrame(ControlFrame):
 class ServiceUpdateSettingsFrame(ControlFrame):
     """A control frame containing a request to update service settings."""
 
-    service_type: str
     settings: Dict[str, Any]
+
+
+@dataclass
+class LLMUpdateSettingsFrame(ServiceUpdateSettingsFrame):
+    pass
+
+
+@dataclass
+class TTSUpdateSettingsFrame(ServiceUpdateSettingsFrame):
+    pass
+
+
+@dataclass
+class STTUpdateSettingsFrame(ServiceUpdateSettingsFrame):
+    pass
 
 
 @dataclass

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -235,6 +235,14 @@ class TTSService(AIService):
     async def flush_audio(self):
         pass
 
+    @abstractmethod
+    async def set_gender(self, gender: str):
+        pass
+
+    @abstractmethod
+    async def set_google_style(self, google_style: str):
+        pass
+
     # Converts the text to audio.
     @abstractmethod
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:

--- a/src/pipecat/services/anthropic.py
+++ b/src/pipecat/services/anthropic.py
@@ -25,7 +25,7 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesFrame,
-    LLMUpdateSettingsFrame,
+    ServiceUpdateSettingsFrame,
     StartInterruptionFrame,
     TextFrame,
     UserImageRawFrame,
@@ -284,20 +284,16 @@ class AnthropicLLMService(LLMService):
                 cache_read_input_tokens=cache_read_input_tokens,
             )
 
-    async def _update_settings(self, frame: LLMUpdateSettingsFrame):
-        if frame.model is not None:
-            logger.debug(f"Switching LLM model to: [{frame.model}]")
-            self.set_model_name(frame.model)
-        if frame.max_tokens is not None:
-            await self.set_max_tokens(frame.max_tokens)
-        if frame.temperature is not None:
-            await self.set_temperature(frame.temperature)
-        if frame.top_k is not None:
-            await self.set_top_k(frame.top_k)
-        if frame.top_p is not None:
-            await self.set_top_p(frame.top_p)
-        if frame.extra:
-            await self.set_extra(frame.extra)
+    async def _update_settings(self, settings: Dict[str, Any]):
+        for key, value in settings.items():
+            setter = getattr(self, f"set_{key}", None)
+            if setter and callable(setter):
+                try:
+                    await setter(value)
+                except Exception as e:
+                    logger.warning(f"Error setting {key}: {e}")
+            else:
+                logger.warning(f"Unknown setting for Anthropic LLM service: {key}")
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
@@ -313,8 +309,8 @@ class AnthropicLLMService(LLMService):
             # UserImageRawFrames coming through the pipeline and add them
             # to the context.
             context = AnthropicLLMContext.from_image_frame(frame)
-        elif isinstance(frame, LLMUpdateSettingsFrame):
-            await self._update_settings(frame)
+        elif isinstance(frame, ServiceUpdateSettingsFrame) and frame.service_type == "llm":
+            await self._update_settings(frame.settings)
         elif isinstance(frame, LLMEnablePromptCachingFrame):
             logger.debug(f"Setting enable prompt caching to: [{frame.enable}]")
             self._enable_prompt_caching_beta = frame.enable

--- a/src/pipecat/services/aws.py
+++ b/src/pipecat/services/aws.py
@@ -6,6 +6,7 @@
 
 from typing import AsyncGenerator, Optional
 
+from loguru import logger
 from pydantic import BaseModel
 
 from pipecat.frames.frames import (
@@ -16,8 +17,6 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.services.ai_services import TTSService
-
-from loguru import logger
 
 try:
     import boto3
@@ -57,9 +56,16 @@ class AWSTTSService(TTSService):
             aws_secret_access_key=api_key,
             region_name=region,
         )
-        self._voice_id = voice_id
-        self._sample_rate = sample_rate
-        self._params = params
+        self._settings = {
+            "sample_rate": sample_rate,
+            "engine": params.engine,
+            "language": params.language,
+            "pitch": params.pitch,
+            "rate": params.rate,
+            "volume": params.volume,
+        }
+
+        self.set_voice(voice_id)
 
     def can_generate_metrics(self) -> bool:
         return True
@@ -67,18 +73,18 @@ class AWSTTSService(TTSService):
     def _construct_ssml(self, text: str) -> str:
         ssml = "<speak>"
 
-        if self._params.language:
-            ssml += f"<lang xml:lang='{self._params.language}'>"
+        if self._settings["language"]:
+            ssml += f"<lang xml:lang='{self._settings["language"]}'>"
 
         prosody_attrs = []
         # Prosody tags are only supported for standard and neural engines
-        if self._params.engine != "generative":
-            if self._params.rate:
-                prosody_attrs.append(f"rate='{self._params.rate}'")
-            if self._params.pitch:
-                prosody_attrs.append(f"pitch='{self._params.pitch}'")
-            if self._params.volume:
-                prosody_attrs.append(f"volume='{self._params.volume}'")
+        if self._settings["engine"] != "generative":
+            if self._settings["rate"]:
+                prosody_attrs.append(f"rate='{self._settings["rate"]}'")
+            if self._settings["pitch"]:
+                prosody_attrs.append(f"pitch='{self._settings["pitch"]}'")
+            if self._settings["volume"]:
+                prosody_attrs.append(f"volume='{self._settings["volume"]}'")
 
             if prosody_attrs:
                 ssml += f"<prosody {' '.join(prosody_attrs)}>"
@@ -90,40 +96,12 @@ class AWSTTSService(TTSService):
         if prosody_attrs:
             ssml += "</prosody>"
 
-        if self._params.language:
+        if self._settings["language"]:
             ssml += "</lang>"
 
         ssml += "</speak>"
 
         return ssml
-
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice_id = voice
-
-    async def set_engine(self, engine: str):
-        logger.debug(f"Switching TTS engine to: [{engine}]")
-        self._params.engine = engine
-
-    async def set_language(self, language: str):
-        logger.debug(f"Switching TTS language to: [{language}]")
-        self._params.language = language
-
-    async def set_pitch(self, pitch: str):
-        logger.debug(f"Switching TTS pitch to: [{pitch}]")
-        self._params.pitch = pitch
-
-    async def set_rate(self, rate: str):
-        logger.debug(f"Switching TTS rate to: [{rate}]")
-        self._params.rate = rate
-
-    async def set_volume(self, volume: str):
-        logger.debug(f"Switching TTS volume to: [{volume}]")
-        self._params.volume = volume
-
-    async def set_params(self, params: InputParams):
-        logger.debug(f"Switching TTS params to: [{params}]")
-        self._params = params
 
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"Generating TTS: [{text}]")
@@ -139,8 +117,8 @@ class AWSTTSService(TTSService):
                 "TextType": "ssml",
                 "OutputFormat": "pcm",
                 "VoiceId": self._voice_id,
-                "Engine": self._params.engine,
-                "SampleRate": str(self._sample_rate),
+                "Engine": self._settings["engine"],
+                "SampleRate": str(self._settings["sample_rate"]),
             }
 
             # Filter out None values
@@ -160,7 +138,7 @@ class AWSTTSService(TTSService):
                         chunk = audio_data[i : i + chunk_size]
                         if len(chunk) > 0:
                             await self.stop_ttfb_metrics()
-                            frame = TTSAudioRawFrame(chunk, self._sample_rate, 1)
+                            frame = TTSAudioRawFrame(chunk, self._settings["sample_rate"], 1)
                             yield frame
 
             await self.push_frame(TTSStoppedFrame())

--- a/src/pipecat/services/aws.py
+++ b/src/pipecat/services/aws.py
@@ -17,6 +17,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.services.ai_services import TTSService
+from pipecat.transcriptions.language import Language
 
 try:
     import boto3
@@ -29,10 +30,71 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
+def language_to_aws_language(language: Language) -> str | None:
+    match language:
+        case Language.CA:
+            return "ca-ES"
+        case Language.ZH:
+            return "cmn-CN"
+        case Language.DA:
+            return "da-DK"
+        case Language.NL:
+            return "nl-NL"
+        case Language.NL_BE:
+            return "nl-BE"
+        case Language.EN:
+            return "en-US"
+        case Language.EN_US:
+            return "en-US"
+        case Language.EN_AU:
+            return "en-AU"
+        case Language.EN_GB:
+            return "en-GB"
+        case Language.EN_NZ:
+            return "en-NZ"
+        case Language.EN_IN:
+            return "en-IN"
+        case Language.FI:
+            return "fi-FI"
+        case Language.FR:
+            return "fr-FR"
+        case Language.FR_CA:
+            return "fr-CA"
+        case Language.DE:
+            return "de-DE"
+        case Language.HI:
+            return "hi-IN"
+        case Language.IT:
+            return "it-IT"
+        case Language.JA:
+            return "ja-JP"
+        case Language.KO:
+            return "ko-KR"
+        case Language.NO:
+            return "nb-NO"
+        case Language.PL:
+            return "pl-PL"
+        case Language.PT:
+            return "pt-PT"
+        case Language.PT_BR:
+            return "pt-BR"
+        case Language.RO:
+            return "ro-RO"
+        case Language.RU:
+            return "ru-RU"
+        case Language.ES:
+            return "es-ES"
+        case Language.SV:
+            return "sv-SE"
+        case Language.TR:
+            return "tr-TR"
+    return None
+
+
 class AWSTTSService(TTSService):
     class InputParams(BaseModel):
         engine: Optional[str] = None
-        language: Optional[str] = None
+        language: Optional[Language] = Language.EN
         pitch: Optional[str] = None
         rate: Optional[str] = None
         volume: Optional[str] = None
@@ -59,7 +121,7 @@ class AWSTTSService(TTSService):
         self._settings = {
             "sample_rate": sample_rate,
             "engine": params.engine,
-            "language": params.language,
+            "language": language_to_aws_language(params.language) if params.language else "en-US",
             "pitch": params.pitch,
             "rate": params.rate,
             "volume": params.volume,

--- a/src/pipecat/services/azure.py
+++ b/src/pipecat/services/azure.py
@@ -178,7 +178,7 @@ class AzureTTSService(TTSService):
         *,
         api_key: str,
         region: str,
-        voice_id="en-US-SaraNeural",
+        voice="en-US-SaraNeural",
         sample_rate: int = 16000,
         params: InputParams = InputParams(),
         **kwargs,
@@ -200,7 +200,7 @@ class AzureTTSService(TTSService):
             "volume": params.volume,
         }
 
-        self.set_voice(voice_id)
+        self.set_voice(voice)
 
     def can_generate_metrics(self) -> bool:
         return True

--- a/src/pipecat/services/azure.py
+++ b/src/pipecat/services/azure.py
@@ -27,6 +27,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.services.ai_services import ImageGenService, STTService, TTSService
 from pipecat.services.openai import BaseOpenAILLMService
+from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
 
 # See .env.example for Azure configuration needed
@@ -70,10 +71,101 @@ class AzureLLMService(BaseOpenAILLMService):
         )
 
 
+def language_to_azure_language(language: Language) -> str | None:
+    match language:
+        case Language.BG:
+            return "bg-BG"
+        case Language.CA:
+            return "ca-ES"
+        case Language.ZH:
+            return "zh-CN"
+        case Language.ZH_TW:
+            return "zh-TW"
+        case Language.CS:
+            return "cs-CZ"
+        case Language.DA:
+            return "da-DK"
+        case Language.NL:
+            return "nl-NL"
+        case Language.EN:
+            return "en-US"
+        case Language.EN_US:
+            return "en-US"
+        case Language.EN_AU:
+            return "en-AU"
+        case Language.EN_GB:
+            return "en-GB"
+        case Language.EN_NZ:
+            return "en-NZ"
+        case Language.EN_IN:
+            return "en-IN"
+        case Language.ET:
+            return "et-EE"
+        case Language.FI:
+            return "fi-FI"
+        case Language.NL_BE:
+            return "nl-BE"
+        case Language.FR:
+            return "fr-FR"
+        case Language.FR_CA:
+            return "fr-CA"
+        case Language.DE:
+            return "de-DE"
+        case Language.DE_CH:
+            return "de-CH"
+        case Language.EL:
+            return "el-GR"
+        case Language.HI:
+            return "hi-IN"
+        case Language.HU:
+            return "hu-HU"
+        case Language.ID:
+            return "id-ID"
+        case Language.IT:
+            return "it-IT"
+        case Language.JA:
+            return "ja-JP"
+        case Language.KO:
+            return "ko-KR"
+        case Language.LV:
+            return "lv-LV"
+        case Language.LT:
+            return "lt-LT"
+        case Language.MS:
+            return "ms-MY"
+        case Language.NO:
+            return "nb-NO"
+        case Language.PL:
+            return "pl-PL"
+        case Language.PT:
+            return "pt-PT"
+        case Language.PT_BR:
+            return "pt-BR"
+        case Language.RO:
+            return "ro-RO"
+        case Language.RU:
+            return "ru-RU"
+        case Language.SK:
+            return "sk-SK"
+        case Language.ES:
+            return "es-ES"
+        case Language.SV:
+            return "sv-SE"
+        case Language.TH:
+            return "th-TH"
+        case Language.TR:
+            return "tr-TR"
+        case Language.UK:
+            return "uk-UA"
+        case Language.VI:
+            return "vi-VN"
+    return None
+
+
 class AzureTTSService(TTSService):
     class InputParams(BaseModel):
         emphasis: Optional[str] = None
-        language: Optional[str] = "en-US"
+        language: Optional[Language] = Language.EN
         pitch: Optional[str] = None
         rate: Optional[str] = "1.05"
         role: Optional[str] = None
@@ -99,7 +191,7 @@ class AzureTTSService(TTSService):
         self._settings = {
             "sample_rate": sample_rate,
             "emphasis": params.emphasis,
-            "language": params.language,
+            "language": language_to_azure_language(params.language) if params.language else "en-US",
             "pitch": params.pitch,
             "rate": params.rate,
             "role": params.role,

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -4,36 +4,35 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
+import base64
 import json
 import uuid
-import base64
-import asyncio
+from typing import AsyncGenerator, List, Optional, Union
 
-from typing import AsyncGenerator, Optional, Union, List
+from loguru import logger
 from pydantic.main import BaseModel
 
 from pipecat.frames.frames import (
     CancelFrame,
+    EndFrame,
     ErrorFrame,
     Frame,
-    StartInterruptionFrame,
+    LLMFullResponseEndFrame,
     StartFrame,
-    EndFrame,
+    StartInterruptionFrame,
     TTSAudioRawFrame,
     TTSStartedFrame,
     TTSStoppedFrame,
-    LLMFullResponseEndFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.ai_services import TTSService, WordTTSService
 from pipecat.transcriptions.language import Language
-from pipecat.services.ai_services import WordTTSService, TTSService
-
-from loguru import logger
 
 # See .env.example for Cartesia configuration needed
 try:
-    from cartesia import AsyncCartesia
     import websockets
+    from cartesia import AsyncCartesia
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
@@ -66,7 +65,7 @@ class CartesiaTTSService(WordTTSService):
         encoding: Optional[str] = "pcm_s16le"
         sample_rate: Optional[int] = 16000
         container: Optional[str] = "raw"
-        language: Optional[str] = "en"
+        language: Optional[Language] = Language.EN
         speed: Optional[Union[str, float]] = ""
         emotion: Optional[List[str]] = []
 
@@ -77,7 +76,7 @@ class CartesiaTTSService(WordTTSService):
         voice_id: str,
         cartesia_version: str = "2024-06-10",
         url: str = "wss://api.cartesia.ai/tts/websocket",
-        model_id: str = "sonic-english",
+        model: str = "sonic-english",
         params: InputParams = InputParams(),
         **kwargs,
     ):
@@ -101,17 +100,18 @@ class CartesiaTTSService(WordTTSService):
         self._api_key = api_key
         self._cartesia_version = cartesia_version
         self._url = url
-        self._voice_id = voice_id
-        self._model_id = model_id
-        self.set_model_name(model_id)
-        self._output_format = {
-            "container": params.container,
-            "encoding": params.encoding,
-            "sample_rate": params.sample_rate,
+        self._settings = {
+            "output_format": {
+                "container": params.container,
+                "encoding": params.encoding,
+                "sample_rate": params.sample_rate,
+            },
+            "language": language_to_cartesia_language(params.language) if params.language else None,
+            "speed": params.speed,
+            "emotion": params.emotion,
         }
-        self._language = params.language
-        self._speed = params.speed
-        self._emotion = params.emotion
+        self.set_model_name(model)
+        self.set_voice(voice_id)
 
         self._websocket = None
         self._context_id = None
@@ -125,42 +125,28 @@ class CartesiaTTSService(WordTTSService):
         await super().set_model(model)
         logger.debug(f"Switching TTS model to: [{model}]")
 
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice_id = voice
-
-    async def set_speed(self, speed: str):
-        logger.debug(f"Switching TTS speed to: [{speed}]")
-        self._speed = speed
-
-    async def set_emotion(self, emotion: list[str]):
-        logger.debug(f"Switching TTS emotion to: [{emotion}]")
-        self._emotion = emotion
-
-    async def set_language(self, language: Language):
-        logger.debug(f"Switching TTS language to: [{language}]")
-        self._language = language_to_cartesia_language(language)
-
     def _build_msg(
         self, text: str = "", continue_transcript: bool = True, add_timestamps: bool = True
     ):
-        voice_config = {"mode": "id", "id": self._voice_id}
+        voice_config = {}
+        voice_config["mode"] = "id"
+        voice_config["id"] = self._voice_id
 
-        if self._speed or self._emotion:
+        if self._settings["speed"] or self._settings["emotion"]:
             voice_config["__experimental_controls"] = {}
-            if self._speed:
-                voice_config["__experimental_controls"]["speed"] = self._speed
-            if self._emotion:
-                voice_config["__experimental_controls"]["emotion"] = self._emotion
+            if self._settings["speed"]:
+                voice_config["__experimental_controls"]["speed"] = self._settings["speed"]
+            if self._settings["emotion"]:
+                voice_config["__experimental_controls"]["emotion"] = self._settings["emotion"]
 
         msg = {
             "transcript": text,
             "continue": continue_transcript,
             "context_id": self._context_id,
-            "model_id": self._model_name,
+            "model_id": self.model_name,
             "voice": voice_config,
-            "output_format": self._output_format,
-            "language": self._language,
+            "output_format": self._settings["output_format"],
+            "language": self._settings["language"],
             "add_timestamps": add_timestamps,
         }
         return json.dumps(msg)
@@ -245,7 +231,7 @@ class CartesiaTTSService(WordTTSService):
                     self.start_word_timestamps()
                     frame = TTSAudioRawFrame(
                         audio=base64.b64decode(msg["data"]),
-                        sample_rate=self._output_format["sample_rate"],
+                        sample_rate=self._settings["output_format"]["sample_rate"],
                         num_channels=1,
                     )
                     await self.push_frame(frame)
@@ -303,7 +289,7 @@ class CartesiaHttpTTSService(TTSService):
         *,
         api_key: str,
         voice_id: str,
-        model_id: str = "sonic-english",
+        model: str = "sonic-english",
         base_url: str = "https://api.cartesia.ai",
         params: InputParams = InputParams(),
         **kwargs,
@@ -311,17 +297,18 @@ class CartesiaHttpTTSService(TTSService):
         super().__init__(**kwargs)
 
         self._api_key = api_key
-        self._voice_id = voice_id
-        self._model_id = model_id
-        self.set_model_name(model_id)
-        self._output_format = {
-            "container": params.container,
-            "encoding": params.encoding,
-            "sample_rate": params.sample_rate,
+        self._settings = {
+            "output_format": {
+                "container": params.container,
+                "encoding": params.encoding,
+                "sample_rate": params.sample_rate,
+            },
+            "language": params.language,
+            "speed": params.speed,
+            "emotion": params.emotion,
         }
-        self._language = params.language
-        self._speed = params.speed
-        self._emotion = params.emotion
+        self.set_voice(voice_id)
+        self.set_model_name(model)
 
         self._client = AsyncCartesia(api_key=api_key, base_url=base_url)
 
@@ -332,22 +319,6 @@ class CartesiaHttpTTSService(TTSService):
         logger.debug(f"Switching TTS model to: [{model}]")
         self._model_id = model
         await super().set_model(model)
-
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice_id = voice
-
-    async def set_speed(self, speed: str):
-        logger.debug(f"Switching TTS speed to: [{speed}]")
-        self._speed = speed
-
-    async def set_emotion(self, emotion: list[str]):
-        logger.debug(f"Switching TTS emotion to: [{emotion}]")
-        self._emotion = emotion
-
-    async def set_language(self, language: Language):
-        logger.debug(f"Switching TTS language to: [{language}]")
-        self._language = language_to_cartesia_language(language)
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
@@ -365,19 +336,19 @@ class CartesiaHttpTTSService(TTSService):
 
         try:
             voice_controls = None
-            if self._speed or self._emotion:
+            if self._settings["speed"] or self._settings["emotion"]:
                 voice_controls = {}
-                if self._speed:
-                    voice_controls["speed"] = self._speed
-                if self._emotion:
-                    voice_controls["emotion"] = self._emotion
+                if self._settings["speed"]:
+                    voice_controls["speed"] = self._settings["speed"]
+                if self._settings["emotion"]:
+                    voice_controls["emotion"] = self._settings["emotion"]
 
             output = await self._client.tts.sse(
                 model_id=self._model_id,
                 transcript=text,
                 voice_id=self._voice_id,
-                output_format=self._output_format,
-                language=self._language,
+                output_format=self._settings["output_format"],
+                language=self._settings["language"],
                 stream=False,
                 _experimental_voice_controls=voice_controls,
             )
@@ -386,7 +357,7 @@ class CartesiaHttpTTSService(TTSService):
 
             frame = TTSAudioRawFrame(
                 audio=output["audio"],
-                sample_rate=self._output_format["sample_rate"],
+                sample_rate=self._settings["output_format"]["sample_rate"],
                 num_channels=1,
             )
             yield frame

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -106,7 +106,7 @@ class CartesiaTTSService(WordTTSService):
                 "encoding": params.encoding,
                 "sample_rate": params.sample_rate,
             },
-            "language": language_to_cartesia_language(params.language) if params.language else None,
+            "language": language_to_cartesia_language(params.language) if params.language else "en",
             "speed": params.speed,
             "emotion": params.emotion,
         }
@@ -280,7 +280,7 @@ class CartesiaHttpTTSService(TTSService):
         encoding: Optional[str] = "pcm_s16le"
         sample_rate: Optional[int] = 16000
         container: Optional[str] = "raw"
-        language: Optional[str] = "en"
+        language: Optional[Language] = Language.EN
         speed: Optional[Union[str, float]] = ""
         emotion: Optional[List[str]] = []
 
@@ -303,7 +303,7 @@ class CartesiaHttpTTSService(TTSService):
                 "encoding": params.encoding,
                 "sample_rate": params.sample_rate,
             },
-            "language": params.language,
+            "language": language_to_cartesia_language(params.language) if params.language else None,
             "speed": params.speed,
             "emotion": params.emotion,
         }

--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -5,8 +5,9 @@
 #
 
 import asyncio
-
 from typing import AsyncGenerator
+
+from loguru import logger
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -23,8 +24,6 @@ from pipecat.frames.frames import (
 from pipecat.services.ai_services import STTService, TTSService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
-
-from loguru import logger
 
 # See .env.example for Deepgram configuration needed
 try:
@@ -50,32 +49,30 @@ class DeepgramTTSService(TTSService):
         self,
         *,
         api_key: str,
-        voice: str = "aura-helios-en",
+        voice_id: str = "aura-helios-en",
         sample_rate: int = 16000,
         encoding: str = "linear16",
         **kwargs,
     ):
         super().__init__(**kwargs)
 
-        self._voice = voice
-        self._sample_rate = sample_rate
-        self._encoding = encoding
+        self._settings = {
+            "sample_rate": sample_rate,
+            "encoding": encoding,
+        }
+        self.set_voice(voice_id)
         self._deepgram_client = DeepgramClient(api_key=api_key)
 
     def can_generate_metrics(self) -> bool:
         return True
 
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice = voice
-
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"Generating TTS: [{text}]")
 
         options = SpeakOptions(
-            model=self._voice,
-            encoding=self._encoding,
-            sample_rate=self._sample_rate,
+            model=self._voice_id,
+            encoding=self._settings["encoding"],
+            sample_rate=self._settings["sample_rate"],
             container="none",
         )
 
@@ -103,7 +100,9 @@ class DeepgramTTSService(TTSService):
                 chunk = audio_buffer.read(chunk_size)
                 if not chunk:
                     break
-                frame = TTSAudioRawFrame(audio=chunk, sample_rate=self._sample_rate, num_channels=1)
+                frame = TTSAudioRawFrame(
+                    audio=chunk, sample_rate=self._settings["sample_rate"], num_channels=1
+                )
                 yield frame
 
             await self.push_frame(TTSStoppedFrame())
@@ -135,7 +134,7 @@ class DeepgramSTTService(STTService):
     ):
         super().__init__(**kwargs)
 
-        self._live_options = live_options
+        self._settings = vars(live_options)
 
         self._client = DeepgramClient(
             api_key, config=DeepgramClientOptions(url=url, options={"keepalive": "true"})
@@ -147,7 +146,7 @@ class DeepgramSTTService(STTService):
 
     @property
     def vad_enabled(self):
-        return self._live_options.vad_events
+        return self._settings["vad_events"]
 
     def can_generate_metrics(self) -> bool:
         return self.vad_enabled
@@ -155,13 +154,7 @@ class DeepgramSTTService(STTService):
     async def set_model(self, model: str):
         await super().set_model(model)
         logger.debug(f"Switching STT model to: [{model}]")
-        self._live_options.model = model
-        await self._disconnect()
-        await self._connect()
-
-    async def set_language(self, language: Language):
-        logger.debug(f"Switching STT language to: [{language}]")
-        self._live_options.language = language
+        self._settings["model"] = model
         await self._disconnect()
         await self._connect()
 
@@ -182,7 +175,7 @@ class DeepgramSTTService(STTService):
         yield None
 
     async def _connect(self):
-        if await self._connection.start(self._live_options):
+        if await self._connection.start(self._settings):
             logger.debug(f"{self}: Connected to Deepgram")
         else:
             logger.error(f"{self}: Unable to connect to Deepgram")

--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -49,7 +49,7 @@ class DeepgramTTSService(TTSService):
         self,
         *,
         api_key: str,
-        voice_id: str = "aura-helios-en",
+        voice: str = "aura-helios-en",
         sample_rate: int = 16000,
         encoding: str = "linear16",
         **kwargs,
@@ -60,7 +60,7 @@ class DeepgramTTSService(TTSService):
             "sample_rate": sample_rate,
             "encoding": encoding,
         }
-        self.set_voice(voice_id)
+        self.set_voice(voice)
         self._deepgram_client = DeepgramClient(api_key=api_key)
 
     def can_generate_metrics(self) -> bool:

--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -120,7 +120,7 @@ class DeepgramSTTService(STTService):
         url: str = "",
         live_options: LiveOptions = LiveOptions(
             encoding="linear16",
-            language="en-US",
+            language=Language.EN,
             model="nova-2-conversationalai",
             sample_rate=16000,
             channels=1,

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -50,6 +50,76 @@ def sample_rate_from_output_format(output_format: str) -> int:
     return 16000
 
 
+def language_to_elevenlabs_language(language: Language) -> str | None:
+    match language:
+        case Language.BG:
+            return "bg"
+        case Language.ZH:
+            return "zh"
+        case Language.CS:
+            return "cs"
+        case Language.DA:
+            return "da"
+        case Language.NL:
+            return "nl"
+        case (
+            Language.EN
+            | Language.EN_US
+            | Language.EN_AU
+            | Language.EN_GB
+            | Language.EN_NZ
+            | Language.EN_IN
+        ):
+            return "en"
+        case Language.FI:
+            return "fi"
+        case Language.FR | Language.FR_CA:
+            return "fr"
+        case Language.DE | Language.DE_CH:
+            return "de"
+        case Language.EL:
+            return "el"
+        case Language.HI:
+            return "hi"
+        case Language.HU:
+            return "hu"
+        case Language.ID:
+            return "id"
+        case Language.IT:
+            return "it"
+        case Language.JA:
+            return "ja"
+        case Language.KO:
+            return "ko"
+        case Language.MS:
+            return "ms"
+        case Language.NO:
+            return "no"
+        case Language.PL:
+            return "pl"
+        case Language.PT:
+            return "pt-PT"
+        case Language.PT_BR:
+            return "pt-BR"
+        case Language.RO:
+            return "ro"
+        case Language.RU:
+            return "ru"
+        case Language.SK:
+            return "sk"
+        case Language.ES:
+            return "es"
+        case Language.SV:
+            return "sv"
+        case Language.TR:
+            return "tr"
+        case Language.UK:
+            return "uk"
+        case Language.VI:
+            return "vi"
+    return None
+
+
 def calculate_word_times(
     alignment_info: Mapping[str, Any], cumulative_time: float
 ) -> List[Tuple[str, float]]:
@@ -128,7 +198,9 @@ class ElevenLabsTTSService(WordTTSService):
         self._url = url
         self._settings = {
             "sample_rate": sample_rate_from_output_format(params.output_format),
-            "language": params.language,
+            "language": language_to_elevenlabs_language(params.language)
+            if params.language
+            else "en",
             "output_format": params.output_format,
             "optimize_streaming_latency": params.optimize_streaming_latency,
             "stability": params.stability,

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -20,6 +20,7 @@ from pipecat.frames.frames import (
     TranscriptionFrame,
 )
 from pipecat.services.ai_services import STTService
+from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
 
 # See .env.example for Gladia configuration needed
@@ -33,10 +34,88 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
+def language_to_gladia_language(language: Language) -> str | None:
+    match language:
+        case Language.BG:
+            return "bg"
+        case Language.CA:
+            return "ca"
+        case Language.ZH:
+            return "zh"
+        case Language.CS:
+            return "cs"
+        case Language.DA:
+            return "da"
+        case Language.NL:
+            return "nl"
+        case (
+            Language.EN
+            | Language.EN_US
+            | Language.EN_AU
+            | Language.EN_GB
+            | Language.EN_NZ
+            | Language.EN_IN
+        ):
+            return "en"
+        case Language.ET:
+            return "et"
+        case Language.FI:
+            return "fi"
+        case Language.FR | Language.FR_CA:
+            return "fr"
+        case Language.DE | Language.DE_CH:
+            return "de"
+        case Language.EL:
+            return "el"
+        case Language.HI:
+            return "hi"
+        case Language.HU:
+            return "hu"
+        case Language.ID:
+            return "id"
+        case Language.IT:
+            return "it"
+        case Language.JA:
+            return "ja"
+        case Language.KO:
+            return "ko"
+        case Language.LV:
+            return "lv"
+        case Language.LT:
+            return "lt"
+        case Language.MS:
+            return "ms"
+        case Language.NO:
+            return "no"
+        case Language.PL:
+            return "pl"
+        case Language.PT | Language.PT_BR:
+            return "pt"
+        case Language.RO:
+            return "ro"
+        case Language.RU:
+            return "ru"
+        case Language.SK:
+            return "sk"
+        case Language.ES:
+            return "es"
+        case Language.SV:
+            return "sv"
+        case Language.TH:
+            return "th"
+        case Language.TR:
+            return "tr"
+        case Language.UK:
+            return "uk"
+        case Language.VI:
+            return "vi"
+    return None
+
+
 class GladiaSTTService(STTService):
     class InputParams(BaseModel):
         sample_rate: Optional[int] = 16000
-        language: Optional[str] = "english"
+        language: Optional[Language] = Language.EN
         transcription_hint: Optional[str] = None
         endpointing: Optional[int] = 200
         prosody: Optional[bool] = None
@@ -56,7 +135,7 @@ class GladiaSTTService(STTService):
         self._url = url
         self._settings = {
             "sample_rate": params.sample_rate,
-            "language": params.language,
+            "language": language_to_gladia_language(params.language) if params.language else "en",
             "transcription_hint": params.transcription_hint,
             "endpointing": params.endpointing,
             "prosody": params.prosody,

--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -272,7 +272,7 @@ class GoogleTTSService(TTSService):
         logger.debug(f"Switch TTS gender to [{gender}]")
         self._params.gender = gender
 
-    async def google_style(
+    async def set_google_style(
         self, google_style: Literal["apologetic", "calm", "empathetic", "firm", "lively"]
     ) -> None:
         logger.debug(f"Switching TTS google style to: [{google_style}]")

--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -30,6 +30,7 @@ from pipecat.processors.aggregators.openai_llm_context import (
 )
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.ai_services import LLMService, TTSService
+from pipecat.transcriptions.language import Language
 
 try:
     import google.ai.generativelanguage as glm
@@ -145,13 +146,100 @@ class GoogleLLMService(LLMService):
             await self._process_context(context)
 
 
+def language_to_google_language(language: Language) -> str | None:
+    match language:
+        case Language.BG:
+            return "bg-BG"
+        case Language.CA:
+            return "ca-ES"
+        case Language.ZH:
+            return "cmn-CN"
+        case Language.ZH_TW:
+            return "cmn-TW"
+        case Language.CS:
+            return "cs-CZ"
+        case Language.DA:
+            return "da-DK"
+        case Language.NL:
+            return "nl-NL"
+        case Language.EN:
+            return "en-US"
+        case Language.EN_US:
+            return "en-US"
+        case Language.EN_AU:
+            return "en-AU"
+        case Language.EN_GB:
+            return "en-GB"
+        case Language.EN_IN:
+            return "en-IN"
+        case Language.ET:
+            return "et-EE"
+        case Language.FI:
+            return "fi-FI"
+        case Language.NL_BE:
+            return "nl-BE"
+        case Language.FR:
+            return "fr-FR"
+        case Language.FR_CA:
+            return "fr-CA"
+        case Language.DE:
+            return "de-DE"
+        case Language.EL:
+            return "el-GR"
+        case Language.HI:
+            return "hi-IN"
+        case Language.HU:
+            return "hu-HU"
+        case Language.ID:
+            return "id-ID"
+        case Language.IT:
+            return "it-IT"
+        case Language.JA:
+            return "ja-JP"
+        case Language.KO:
+            return "ko-KR"
+        case Language.LV:
+            return "lv-LV"
+        case Language.LT:
+            return "lt-LT"
+        case Language.MS:
+            return "ms-MY"
+        case Language.NO:
+            return "nb-NO"
+        case Language.PL:
+            return "pl-PL"
+        case Language.PT:
+            return "pt-PT"
+        case Language.PT_BR:
+            return "pt-BR"
+        case Language.RO:
+            return "ro-RO"
+        case Language.RU:
+            return "ru-RU"
+        case Language.SK:
+            return "sk-SK"
+        case Language.ES:
+            return "es-ES"
+        case Language.SV:
+            return "sv-SE"
+        case Language.TH:
+            return "th-TH"
+        case Language.TR:
+            return "tr-TR"
+        case Language.UK:
+            return "uk-UA"
+        case Language.VI:
+            return "vi-VN"
+    return None
+
+
 class GoogleTTSService(TTSService):
     class InputParams(BaseModel):
         pitch: Optional[str] = None
         rate: Optional[str] = None
         volume: Optional[str] = None
         emphasis: Optional[Literal["strong", "moderate", "reduced", "none"]] = None
-        language: Optional[str] = "en-US"
+        language: Optional[Language] = Language.EN
         gender: Optional[Literal["male", "female", "neutral"]] = None
         google_style: Optional[Literal["apologetic", "calm", "empathetic", "firm", "lively"]] = None
 
@@ -173,7 +261,9 @@ class GoogleTTSService(TTSService):
             "rate": params.rate,
             "volume": params.volume,
             "emphasis": params.emphasis,
-            "language": params.language,
+            "language": language_to_google_language(params.language)
+            if params.language
+            else "en-US",
             "gender": params.gender,
             "google_style": params.google_style,
         }

--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import json
-from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
+from typing import AsyncGenerator, List, Literal, Optional
 
 from loguru import logger
 from pydantic import BaseModel
@@ -17,7 +17,7 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesFrame,
-    ServiceUpdateSettingsFrame,
+    LLMUpdateSettingsFrame,
     TextFrame,
     TTSAudioRawFrame,
     TTSStartedFrame,
@@ -63,21 +63,6 @@ class GoogleLLMService(LLMService):
     def _create_client(self, model: str):
         self.set_model_name(model)
         self._client = gai.GenerativeModel(model)
-
-    async def set_model(self, model: str):
-        logger.debug(f"Switching LLM model to: [{model}]")
-        self._create_client(model)
-
-    async def _update_settings(self, settings: Dict[str, Any]):
-        for key, value in settings.items():
-            setter = getattr(self, f"set_{key}", None)
-            if setter and callable(setter):
-                try:
-                    await setter(value)
-                except Exception as e:
-                    logger.warning(f"Error setting {key}: {e}")
-            else:
-                logger.warning(f"Unknown setting for Google LLM service: {key}")
 
     def _get_messages_from_openai_context(self, context: OpenAILLMContext) -> List[glm.Content]:
         openai_messages = context.get_messages()
@@ -151,7 +136,7 @@ class GoogleLLMService(LLMService):
             context = OpenAILLMContext.from_messages(frame.messages)
         elif isinstance(frame, VisionImageRawFrame):
             context = OpenAILLMContext.from_image_frame(frame)
-        elif isinstance(frame, ServiceUpdateSettingsFrame) and frame.service_type == "llm":
+        elif isinstance(frame, LLMUpdateSettingsFrame):
             await self._update_settings(frame.settings)
         else:
             await self.push_frame(frame, direction)
@@ -182,8 +167,17 @@ class GoogleTTSService(TTSService):
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
 
-        self._voice_id: str = voice_id
-        self._params = params
+        self._settings = {
+            "sample_rate": sample_rate,
+            "pitch": params.pitch,
+            "rate": params.rate,
+            "volume": params.volume,
+            "emphasis": params.emphasis,
+            "language": params.language,
+            "gender": params.gender,
+            "google_style": params.google_style,
+        }
+        self.set_voice(voice_id)
         self._client: texttospeech_v1.TextToSpeechAsyncClient = self._create_client(
             credentials, credentials_path
         )
@@ -216,84 +210,44 @@ class GoogleTTSService(TTSService):
 
         # Voice tag
         voice_attrs = [f"name='{self._voice_id}'"]
-        if self._params.language:
-            voice_attrs.append(f"language='{self._params.language}'")
-        if self._params.gender:
-            voice_attrs.append(f"gender='{self._params.gender}'")
+        if self._settings["language"]:
+            voice_attrs.append(f"language='{self._settings['language']}'")
+        if self._settings["gender"]:
+            voice_attrs.append(f"gender='{self._settings['gender']}'")
         ssml += f"<voice {' '.join(voice_attrs)}>"
 
         # Prosody tag
         prosody_attrs = []
-        if self._params.pitch:
-            prosody_attrs.append(f"pitch='{self._params.pitch}'")
-        if self._params.rate:
-            prosody_attrs.append(f"rate='{self._params.rate}'")
-        if self._params.volume:
-            prosody_attrs.append(f"volume='{self._params.volume}'")
+        if self._settings["pitch"]:
+            prosody_attrs.append(f"pitch='{self._settings['pitch']}'")
+        if self._settings["rate"]:
+            prosody_attrs.append(f"rate='{self._settings['rate']}'")
+        if self._settings["volume"]:
+            prosody_attrs.append(f"volume='{self._settings['volume']}'")
 
         if prosody_attrs:
             ssml += f"<prosody {' '.join(prosody_attrs)}>"
 
         # Emphasis tag
-        if self._params.emphasis:
-            ssml += f"<emphasis level='{self._params.emphasis}'>"
+        if self._settings["emphasis"]:
+            ssml += f"<emphasis level='{self._settings['emphasis']}'>"
 
         # Google style tag
-        if self._params.google_style:
-            ssml += f"<google:style name='{self._params.google_style}'>"
+        if self._settings["google_style"]:
+            ssml += f"<google:style name='{self._settings['google_style']}'>"
 
         ssml += text
 
         # Close tags
-        if self._params.google_style:
+        if self._settings["google_style"]:
             ssml += "</google:style>"
-        if self._params.emphasis:
+        if self._settings["emphasis"]:
             ssml += "</emphasis>"
         if prosody_attrs:
             ssml += "</prosody>"
         ssml += "</voice></speak>"
 
         return ssml
-
-    async def set_voice(self, voice: str) -> None:
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice_id = voice
-
-    async def set_language(self, language: str) -> None:
-        logger.debug(f"Switching TTS language to: [{language}]")
-        self._params.language = language
-
-    async def set_pitch(self, pitch: str) -> None:
-        logger.debug(f"Switching TTS pitch to: [{pitch}]")
-        self._params.pitch = pitch
-
-    async def set_rate(self, rate: str) -> None:
-        logger.debug(f"Switching TTS rate to: [{rate}]")
-        self._params.rate = rate
-
-    async def set_volume(self, volume: str) -> None:
-        logger.debug(f"Switching TTS volume to: [{volume}]")
-        self._params.volume = volume
-
-    async def set_emphasis(
-        self, emphasis: Literal["strong", "moderate", "reduced", "none"]
-    ) -> None:
-        logger.debug(f"Switching TTS emphasis to: [{emphasis}]")
-        self._params.emphasis = emphasis
-
-    async def set_gender(self, gender: Literal["male", "female", "neutral"]) -> None:
-        logger.debug(f"Switch TTS gender to [{gender}]")
-        self._params.gender = gender
-
-    async def set_google_style(
-        self, google_style: Literal["apologetic", "calm", "empathetic", "firm", "lively"]
-    ) -> None:
-        logger.debug(f"Switching TTS google style to: [{google_style}]")
-        self._params.google_style = google_style
-
-    async def set_params(self, params: InputParams) -> None:
-        logger.debug(f"Switching TTS params to: [{params}]")
-        self._params = params
 
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"Generating TTS: [{text}]")
@@ -304,11 +258,11 @@ class GoogleTTSService(TTSService):
             ssml = self._construct_ssml(text)
             synthesis_input = texttospeech_v1.SynthesisInput(ssml=ssml)
             voice = texttospeech_v1.VoiceSelectionParams(
-                language_code=self._params.language, name=self._voice_id
+                language_code=self._settings["language"], name=self._voice_id
             )
             audio_config = texttospeech_v1.AudioConfig(
                 audio_encoding=texttospeech_v1.AudioEncoding.LINEAR16,
-                sample_rate_hertz=self.sample_rate,
+                sample_rate_hertz=self._settings["sample_rate"],
             )
 
             request = texttospeech_v1.SynthesizeSpeechRequest(
@@ -331,7 +285,7 @@ class GoogleTTSService(TTSService):
                 if not chunk:
                     break
                 await self.stop_ttfb_metrics()
-                frame = TTSAudioRawFrame(chunk, self.sample_rate, 1)
+                frame = TTSAudioRawFrame(chunk, self._settings["sample_rate"], 1)
                 yield frame
                 await asyncio.sleep(0)  # Allow other tasks to run
 

--- a/src/pipecat/services/lmnt.py
+++ b/src/pipecat/services/lmnt.py
@@ -22,6 +22,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.ai_services import TTSService
+from pipecat.transcriptions.language import Language
 
 # See .env.example for LMNT configuration needed
 try:
@@ -34,6 +35,32 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
+def language_to_lmnt_language(language: Language) -> str | None:
+    match language:
+        case Language.DE:
+            return "de"
+        case (
+            Language.EN
+            | Language.EN_US
+            | Language.EN_AU
+            | Language.EN_GB
+            | Language.EN_NZ
+            | Language.EN_IN
+        ):
+            return "en"
+        case Language.ES:
+            return "es"
+        case Language.FR | Language.FR_CA:
+            return "fr"
+        case Language.PT | Language.PT_BR:
+            return "pt"
+        case Language.ZH | Language.ZH_TW:
+            return "zh"
+        case Language.KO:
+            return "ko"
+    return None
+
+
 class LmntTTSService(TTSService):
     def __init__(
         self,
@@ -41,7 +68,7 @@ class LmntTTSService(TTSService):
         api_key: str,
         voice_id: str,
         sample_rate: int = 24000,
-        language: str = "en",
+        language: Language = Language.EN,
         **kwargs,
     ):
         # Let TTSService produce TTSStoppedFrames after a short delay of
@@ -55,7 +82,7 @@ class LmntTTSService(TTSService):
                 "encoding": "pcm_s16le",
                 "sample_rate": sample_rate,
             },
-            "language": language,
+            "language": language_to_lmnt_language(language) if language else "en",
         }
 
         self.set_voice(voice_id)

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -24,7 +24,7 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesFrame,
-    ServiceUpdateSettingsFrame,
+    LLMUpdateSettingsFrame,
     StartInterruptionFrame,
     TextFrame,
     TTSAudioRawFrame,
@@ -111,14 +111,16 @@ class BaseOpenAILLMService(LLMService):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self._settings = {
+            "frequency_penalty": params.frequency_penalty,
+            "presence_penalty": params.presence_penalty,
+            "seed": params.seed,
+            "temperature": params.temperature,
+            "top_p": params.top_p,
+            "extra": params.extra if isinstance(params.extra, dict) else {},
+        }
         self.set_model_name(model)
         self._client = self.create_client(api_key=api_key, base_url=base_url, **kwargs)
-        self._frequency_penalty = params.frequency_penalty
-        self._presence_penalty = params.presence_penalty
-        self._seed = params.seed
-        self._temperature = params.temperature
-        self._top_p = params.top_p
-        self._extra = params.extra if isinstance(params.extra, dict) else {}
 
     def create_client(self, api_key=None, base_url=None, **kwargs):
         return AsyncOpenAI(
@@ -134,30 +136,6 @@ class BaseOpenAILLMService(LLMService):
     def can_generate_metrics(self) -> bool:
         return True
 
-    async def set_frequency_penalty(self, frequency_penalty: float):
-        logger.debug(f"Switching LLM frequency_penalty to: [{frequency_penalty}]")
-        self._frequency_penalty = frequency_penalty
-
-    async def set_presence_penalty(self, presence_penalty: float):
-        logger.debug(f"Switching LLM presence_penalty to: [{presence_penalty}]")
-        self._presence_penalty = presence_penalty
-
-    async def set_seed(self, seed: int):
-        logger.debug(f"Switching LLM seed to: [{seed}]")
-        self._seed = seed
-
-    async def set_temperature(self, temperature: float):
-        logger.debug(f"Switching LLM temperature to: [{temperature}]")
-        self._temperature = temperature
-
-    async def set_top_p(self, top_p: float):
-        logger.debug(f"Switching LLM top_p to: [{top_p}]")
-        self._top_p = top_p
-
-    async def set_extra(self, extra: Dict[str, Any]):
-        logger.debug(f"Switching LLM extra to: [{extra}]")
-        self._extra = extra
-
     async def get_chat_completions(
         self, context: OpenAILLMContext, messages: List[ChatCompletionMessageParam]
     ) -> AsyncStream[ChatCompletionChunk]:
@@ -168,14 +146,14 @@ class BaseOpenAILLMService(LLMService):
             "tools": context.tools,
             "tool_choice": context.tool_choice,
             "stream_options": {"include_usage": True},
-            "frequency_penalty": self._frequency_penalty,
-            "presence_penalty": self._presence_penalty,
-            "seed": self._seed,
-            "temperature": self._temperature,
-            "top_p": self._top_p,
+            "frequency_penalty": self._settings["frequency_penalty"],
+            "presence_penalty": self._settings["presence_penalty"],
+            "seed": self._settings["seed"],
+            "temperature": self._settings["temperature"],
+            "top_p": self._settings["top_p"],
         }
 
-        params.update(self._extra)
+        params.update(self._settings["extra"])
 
         chunks = await self._client.chat.completions.create(**params)
         return chunks
@@ -295,17 +273,6 @@ class BaseOpenAILLMService(LLMService):
                         f"The LLM tried to call a function named '{function_name}', but there isn't a callback registered for that function."
                     )
 
-    async def _update_settings(self, settings: Dict[str, Any]):
-        for key, value in settings.items():
-            setter = getattr(self, f"set_{key}", None)
-            if setter and callable(setter):
-                try:
-                    await setter(value)
-                except Exception as e:
-                    logger.warning(f"Error setting {key}: {e}")
-            else:
-                logger.warning(f"Unknown setting for OpenAI LLM service: {key}")
-
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
 
@@ -316,7 +283,7 @@ class BaseOpenAILLMService(LLMService):
             context = OpenAILLMContext.from_messages(frame.messages)
         elif isinstance(frame, VisionImageRawFrame):
             context = OpenAILLMContext.from_image_frame(frame)
-        elif isinstance(frame, ServiceUpdateSettingsFrame) and frame.service_type == "llm":
+        elif isinstance(frame, LLMUpdateSettingsFrame):
             await self._update_settings(frame.settings)
         else:
             await self.push_frame(frame, direction)
@@ -414,29 +381,27 @@ class OpenAITTSService(TTSService):
         self,
         *,
         api_key: str | None = None,
-        voice: str = "alloy",
+        voice_id: str = "alloy",
         model: Literal["tts-1", "tts-1-hd"] = "tts-1",
         sample_rate: int = 24000,
         **kwargs,
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
 
-        self._voice: ValidVoice = VALID_VOICES.get(voice, "alloy")
+        self._settings = {
+            "sample_rate": sample_rate,
+        }
         self.set_model_name(model)
-        self._sample_rate = sample_rate
+        self.set_voice(voice_id)
 
         self._client = AsyncOpenAI(api_key=api_key)
 
     def can_generate_metrics(self) -> bool:
         return True
 
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._voice = VALID_VOICES.get(voice, self._voice)
-
     async def set_model(self, model: str):
         logger.debug(f"Switching TTS model to: [{model}]")
-        self._model = model
+        self.set_model_name(model)
 
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"Generating TTS: [{text}]")
@@ -446,7 +411,7 @@ class OpenAITTSService(TTSService):
             async with self._client.audio.speech.with_streaming_response.create(
                 input=text,
                 model=self.model_name,
-                voice=self._voice,
+                voice=VALID_VOICES[self._voice_id],
                 response_format="pcm",
             ) as r:
                 if r.status_code != 200:
@@ -465,7 +430,7 @@ class OpenAITTSService(TTSService):
                 async for chunk in r.iter_bytes(8192):
                     if len(chunk) > 0:
                         await self.stop_ttfb_metrics()
-                        frame = TTSAudioRawFrame(chunk, self.sample_rate, 1)
+                        frame = TTSAudioRawFrame(chunk, self._settings["sample_rate"], 1)
                         yield frame
                 await self.push_frame(TTSStoppedFrame())
         except BadRequestError as e:

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -381,7 +381,7 @@ class OpenAITTSService(TTSService):
         self,
         *,
         api_key: str | None = None,
-        voice_id: str = "alloy",
+        voice: str = "alloy",
         model: Literal["tts-1", "tts-1-hd"] = "tts-1",
         sample_rate: int = 24000,
         **kwargs,
@@ -392,7 +392,7 @@ class OpenAITTSService(TTSService):
             "sample_rate": sample_rate,
         }
         self.set_model_name(model)
-        self.set_voice(voice_id)
+        self.set_voice(voice)
 
         self._client = AsyncOpenAI(api_key=api_key)
 

--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -6,17 +6,21 @@
 
 import io
 import struct
-
 from typing import AsyncGenerator
-
-from pipecat.frames.frames import Frame, TTSAudioRawFrame, TTSStartedFrame, TTSStoppedFrame
-from pipecat.services.ai_services import TTSService
 
 from loguru import logger
 
+from pipecat.frames.frames import (
+    Frame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.services.ai_services import TTSService
+
 try:
-    from pyht.client import TTSOptions
     from pyht.async_client import AsyncClient
+    from pyht.client import TTSOptions
     from pyht.protos.api_pb2 import Format
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
@@ -28,7 +32,7 @@ except ModuleNotFoundError as e:
 
 class PlayHTTTSService(TTSService):
     def __init__(
-        self, *, api_key: str, user_id: str, voice_url: str, sample_rate: int = 16000, **kwargs
+        self, *, api_key: str, user_id: str, voice_id: str, sample_rate: int = 16000, **kwargs
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
 
@@ -39,16 +43,22 @@ class PlayHTTTSService(TTSService):
             user_id=self._user_id,
             api_key=self._speech_key,
         )
+        self._settings = {
+            "sample_rate": sample_rate,
+            "quality": "higher",
+            "format": Format.FORMAT_WAV,
+            "voice_engine": "PlayHT2.0-turbo",
+        }
+        self.set_voice(voice_id)
         self._options = TTSOptions(
-            voice=voice_url, sample_rate=sample_rate, quality="higher", format=Format.FORMAT_WAV
+            voice=self._voice_id,
+            sample_rate=self._settings["sample_rate"],
+            quality=self._settings["quality"],
+            format=self._settings["format"],
         )
 
     def can_generate_metrics(self) -> bool:
         return True
-
-    async def set_voice(self, voice: str):
-        logger.debug(f"Switching TTS voice to: [{voice}]")
-        self._options.voice = voice
 
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"Generating TTS: [{text}]")
@@ -60,7 +70,7 @@ class PlayHTTTSService(TTSService):
             await self.start_ttfb_metrics()
 
             playht_gen = self._client.tts(
-                text, voice_engine="PlayHT2.0-turbo", options=self._options
+                text, voice_engine=self._settings["voice_engine"], options=self._options
             )
 
             await self.start_tts_usage_metrics(text)
@@ -83,7 +93,7 @@ class PlayHTTTSService(TTSService):
                 else:
                     if len(chunk):
                         await self.stop_ttfb_metrics()
-                        frame = TTSAudioRawFrame(chunk, 16000, 1)
+                        frame = TTSAudioRawFrame(chunk, self._settings["sample_rate"], 1)
                         yield frame
             await self.push_frame(TTSStoppedFrame())
         except Exception as e:

--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -32,7 +32,7 @@ except ModuleNotFoundError as e:
 
 class PlayHTTTSService(TTSService):
     def __init__(
-        self, *, api_key: str, user_id: str, voice_id: str, sample_rate: int = 16000, **kwargs
+        self, *, api_key: str, user_id: str, voice_url: str, sample_rate: int = 16000, **kwargs
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
 
@@ -49,7 +49,7 @@ class PlayHTTTSService(TTSService):
             "format": Format.FORMAT_WAV,
             "voice_engine": "PlayHT2.0-turbo",
         }
-        self.set_voice(voice_id)
+        self.set_voice(voice_url)
         self._options = TTSOptions(
             voice=self._voice_id,
             sample_rate=self._settings["sample_rate"],

--- a/src/pipecat/services/together.py
+++ b/src/pipecat/services/together.py
@@ -50,13 +50,15 @@ class TogetherLLMService(OpenAILLMService):
     ):
         super().__init__(api_key=api_key, base_url=base_url, model=model, params=params, **kwargs)
         self.set_model_name(model)
-        self._max_tokens = params.max_tokens
-        self._frequency_penalty = params.frequency_penalty
-        self._presence_penalty = params.presence_penalty
-        self._temperature = params.temperature
-        self._top_k = params.top_k
-        self._top_p = params.top_p
-        self._extra = params.extra if isinstance(params.extra, dict) else {}
+        self._settings = {
+            "max_tokens": params.max_tokens,
+            "frequency_penalty": params.frequency_penalty,
+            "presence_penalty": params.presence_penalty,
+            "seed": params.seed,
+            "temperature": params.temperature,
+            "top_p": params.top_p,
+            "extra": params.extra if isinstance(params.extra, dict) else {},
+        }
 
     def can_generate_metrics(self) -> bool:
         return True
@@ -72,42 +74,3 @@ class TogetherLLMService(OpenAILLMService):
                 )
             ),
         )
-
-    async def set_frequency_penalty(self, frequency_penalty: float):
-        logger.debug(f"Switching LLM frequency_penalty to: [{frequency_penalty}]")
-        self._frequency_penalty = frequency_penalty
-
-    async def set_max_tokens(self, max_tokens: int):
-        logger.debug(f"Switching LLM max_tokens to: [{max_tokens}]")
-        self._max_tokens = max_tokens
-
-    async def set_presence_penalty(self, presence_penalty: float):
-        logger.debug(f"Switching LLM presence_penalty to: [{presence_penalty}]")
-        self._presence_penalty = presence_penalty
-
-    async def set_temperature(self, temperature: float):
-        logger.debug(f"Switching LLM temperature to: [{temperature}]")
-        self._temperature = temperature
-
-    async def set_top_k(self, top_k: float):
-        logger.debug(f"Switching LLM top_k to: [{top_k}]")
-        self._top_k = top_k
-
-    async def set_top_p(self, top_p: float):
-        logger.debug(f"Switching LLM top_p to: [{top_p}]")
-        self._top_p = top_p
-
-    async def set_extra(self, extra: Dict[str, Any]):
-        logger.debug(f"Switching LLM extra to: [{extra}]")
-        self._extra = extra
-
-    async def _update_settings(self, settings: Dict[str, Any]):
-        for key, value in settings.items():
-            setter = getattr(self, f"set_{key}", None)
-            if setter and callable(setter):
-                try:
-                    await setter(value)
-                except Exception as e:
-                    logger.warning(f"Error setting {key}: {e}")
-            else:
-                logger.warning(f"Unknown setting for Together LLM service: {key}")

--- a/src/pipecat/services/xtts.py
+++ b/src/pipecat/services/xtts.py
@@ -19,6 +19,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.services.ai_services import TTSService
+from pipecat.transcriptions.language import Language
 
 try:
     import resampy
@@ -36,12 +37,56 @@ except ModuleNotFoundError as e:
 # https://github.com/coqui-ai/xtts-streaming-server
 
 
+def language_to_xtts_language(language: Language) -> str | None:
+    match language:
+        case Language.CS:
+            return "cs"
+        case Language.DE:
+            return "de"
+        case (
+            Language.EN
+            | Language.EN_US
+            | Language.EN_AU
+            | Language.EN_GB
+            | Language.EN_NZ
+            | Language.EN_IN
+        ):
+            return "en"
+        case Language.ES:
+            return "es"
+        case Language.FR:
+            return "fr"
+        case Language.HI:
+            return "hi"
+        case Language.HU:
+            return "hu"
+        case Language.IT:
+            return "it"
+        case Language.JA:
+            return "ja"
+        case Language.KO:
+            return "ko"
+        case Language.NL:
+            return "nl"
+        case Language.PL:
+            return "pl"
+        case Language.PT | Language.PT_BR:
+            return "pt"
+        case Language.RU:
+            return "ru"
+        case Language.TR:
+            return "tr"
+        case Language.ZH:
+            return "zh-cn"
+    return None
+
+
 class XTTSService(TTSService):
     def __init__(
         self,
         *,
         voice_id: str,
-        language: str,
+        language: Language,
         base_url: str,
         aiohttp_session: aiohttp.ClientSession,
         **kwargs,
@@ -49,7 +94,7 @@ class XTTSService(TTSService):
         super().__init__(**kwargs)
 
         self._settings = {
-            "language": language,
+            "language": language_to_xtts_language(language) if language else "en",
             "base_url": base_url,
         }
         self.set_voice(voice_id)


### PR DESCRIPTION
Hijacked this PR to make the change to simplify the service update settings. There's not a base class for service updates called `ServiceUpdateSettingsFrame`. There are subclasses for different service types: `LLMUpdateSettingsFrame`, `TTSUpdateSettingsFrame`, `STTUpdateSettingsFrame`.

When these frames are processed, there's an `_update_settings` handler in ai_services.py that is responsible for facilitating the update. For most values, this is a key lookup. There is special case handling for `model` and `voice` needed to ensure keys are mapped correctly.

For each service that has InputParams, those params are part of a `_settings` object which is updated by the `_update_settings` handlers.

This change simplifies maintaining settings updates for services. Going forward, the keys are to:
- Unify naming for similar settings across services. In this PR, `voice_id` and `model` are used uniformly for services. Previously, the same change was made for `language`.
- Settings no longer need setter functions. The single `_update_settings` method will do the trick unless special handling is required. You can see an example of that for Cartesia's `speed` and `emotion` params.

Lastly, in this PR, I'm also applying the Language type across all services. Includes must be from the Language enum. Language strings are translated to the correct format for each service before applying them.