### PR TITLE
Format and Support Unicode for LLM Message Debug Logs

### DIFF
--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -115,7 +115,7 @@ class OpenAILLMContext:
         return self._messages
 
     def get_messages_json(self) -> str:
-        return json.dumps(self._messages, cls=CustomEncoder)
+        return json.dumps(self._messages, cls=CustomEncoder, ensure_ascii=False, indent=2)
 
     def get_messages_for_logging(self) -> str:
         msgs = []


### PR DESCRIPTION
# Overview

I am currently debugging workflows in Arabic. When I try to view LLM context it is difficult because:

* the unicode characters do not render properly
* the json is not prettified.


## Comparisons

<img width="903" alt="Screenshot 2024-10-01 at 1 37 59 PM" src="https://github.com/user-attachments/assets/1141b688-5de0-446c-a7c7-5740efd4b26b">


<img width="888" alt="Screenshot 2024-10-01 at 1 36 12 PM" src="https://github.com/user-attachments/assets/5e98cc90-fd27-4f37-b0ee-f73125aa71b9">


## Alternative Approachs

* We could pass in a custom formatter, but I figure because this is just debug logs for a relatively simple approach this would be sufficient.


## Notes

There are other places in the codebase where we could do this but I wanted to start small as I am very very new to the codebase and contributing and want to get a lay of the land before I go any further.
