### PR TITLE
Deepgram: disconnect and reconnect on language change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.43] - 2024-10-03
+
+### Fixed
+
+- Fixed an issue where changing a language with the Deepgram STT service
+  wouldn't apply the change. This was fixed by disconnecting and reconnecting
+  when the language changes
+
 ## [0.0.42] - 2024-10-02
 
 ### Added

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -408,6 +408,10 @@ class STTService(AIService):
         self.set_model_name(model)
 
     @abstractmethod
+    async def set_language(self, language: Language):
+        pass
+
+    @abstractmethod
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
         """Returns transcript as a string"""
         pass
@@ -419,7 +423,7 @@ class STTService(AIService):
                 logger.debug(f"Updating STT setting {key} to: [{value}]")
                 self._settings[key] = value
                 if key == "language":
-                    self._settings[key] = Language(value)
+                    await self.set_language(value)
             elif key == "model":
                 self.set_model_name(value)
             else:

--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -158,6 +158,12 @@ class DeepgramSTTService(STTService):
         await self._disconnect()
         await self._connect()
 
+    async def set_language(self, language: Language):
+        logger.debug(f"Switching STT language to: [{language}]")
+        self._settings["language"] = language
+        await self._disconnect()
+        await self._connect()
+
     async def start(self, frame: StartFrame):
         await super().start(frame)
         await self._connect()


### PR DESCRIPTION
This got lost in the settings update. Deepgram requires a disconnect/reconnect to change the language.