### PR TITLE
Register on error handler so that room error handler can be invoked from agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *~
 venv
 .venv
+.idea
 #*#
 
 # Distribution / packaging

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -819,6 +819,7 @@ class DailyTransport(BaseTransport):
         # these handlers.
         self._register_event_handler("on_joined")
         self._register_event_handler("on_left")
+        self._register_event_handler("on_error")
         self._register_event_handler("on_app_message")
         self._register_event_handler("on_call_state_updated")
         self._register_event_handler("on_dialin_ready")


### PR DESCRIPTION
Currently `on_error` handler can not be registered with transport.
It fails with error
```
Exception: Event handler on_error not registered
```
This is a small change which adds the `on_error` callback on transport unsing the existing `_register_event_handler` mechanism of BaseTransport.