### PR TITLE
fix for Deepgram settings not merging properly

### DIFF
--- a/examples/foundational/13b-deepgram-transcription.py
+++ b/examples/foundational/13b-deepgram-transcription.py
@@ -14,7 +14,7 @@ from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineTask
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.services.deepgram import DeepgramSTTService
+from pipecat.services.deepgram import DeepgramSTTService, LiveOptions, Language
 from pipecat.transports.services.daily import DailyParams, DailyTransport
 
 from runner import configure
@@ -45,7 +45,10 @@ async def main():
             room_url, None, "Transcription bot", DailyParams(audio_in_enabled=True)
         )
 
-        stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+        stt = DeepgramSTTService(
+            api_key=os.getenv("DEEPGRAM_API_KEY"),
+            # live_options=LiveOptions(language=Language.FR),
+        )
 
         tl = TranscriptionLogger()
 

--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -139,7 +139,7 @@ class DeepgramSTTService(STTService):
         merged_options = default_options
         if live_options:
             merged_options = LiveOptions(**{**default_options.to_dict(), **live_options.to_dict()})
-        self._settings = merged_options
+        self._settings = merged_options.to_dict()
 
         self._client = DeepgramClient(
             api_key,


### PR DESCRIPTION
This code fixes the Deepgram service implementation so that this code works.

```
        stt = DeepgramSTTService(
            api_key=os.getenv("DEEPGRAM_API_KEY"),
            live_options=LiveOptions(language=Language.FR),
        )
```

Previously, this code resulted on transcription not working, because the Deepgram settings were overwritten with only the provided LiveOption values. Critical settings like `sample_rate` were overwritten as `None` rather than using appropriate default values for Pipecat.
