### PR TITLE
Minor README update about Silero VAD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Pipecat makes use of WebRTC VAD by default when using a WebRTC transport layer. 
 pip install pipecat-ai[silero]
 ```
 
-The first time your run your bot with Silero, startup may take a while whilst it downloads and caches the model in the background. You can check the progress of this in the console.
-
 ## Hacking on the framework itself
 
 _Note that you may need to set up a virtual environment before following the instructions below. For instance, you might need to run the following from the root of the repo:_


### PR DESCRIPTION
We no longer download the model during first run - it's part of the repo.