### PR TITLE
services(livekit) - Stop Sending EndFrame when Participant Disconnects

### DIFF
--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -556,10 +556,6 @@ class LiveKitTransport(BaseTransport):
     async def _on_participant_disconnected(self, participant_id: str):
         await self._call_event_handler("on_participant_disconnected", participant_id)
         await self._call_event_handler("on_participant_left", participant_id, "disconnected")
-        if self._input:
-            await self._input.process_frame(EndFrame(), FrameDirection.DOWNSTREAM)
-        if self._output:
-            await self._output.process_frame(EndFrame(), FrameDirection.DOWNSTREAM)
 
     async def _on_audio_track_subscribed(self, participant_id: str):
         await self._call_event_handler("on_audio_track_subscribed", participant_id)


### PR DESCRIPTION
**_How It Works Now:_**
A participant disconnecting triggers and EndFrame, invoking stop() on the input and output transports and causing the LiveKit room to disconnect.  

**_Proposal:_**
Match the daily implementation, and just trigger the callbacks in the LiveKitTransport.  Leave it up to the implementor to decide whether to send EndFrames when this happens.