### PR TITLE
Update default Deepgram model

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -126,7 +126,7 @@ class DeepgramSTTService(STTService):
         default_options = LiveOptions(
             encoding="linear16",
             language=Language.EN,
-            model="nova-2-conversationalai",
+            model="nova-2-general",
             sample_rate=16000,
             channels=1,
             interim_results=True,


### PR DESCRIPTION
`nova-2-convresationalai` model is designed for IVR bot transcription (legacy naming)

```
conversationalai: Optimized for use cases in which a human is talking to an automated bot, such as IVR, a voice assistant, or an automated kiosk.
```

See: [Docs](https://developers.deepgram.com/docs/model#nova-2)

`nova-2-general` is the best default model for high quality voice (> 8Khz)

`nova-2-phonecall` is the best default model for phonecall audio (eg Mulaw 8Khz or Linear16)