### PR TITLE
Fixing `enable_usage_metrics` setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `enable_usage_metrics` to control LLM/TTS usage metrics separately
+  from `enable_metrics`.
+
 ## [0.0.46] - 2024-10-19
 
 ### Added

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -156,7 +156,7 @@ class PipelineTask:
         start_frame = StartFrame(
             allow_interruptions=self._params.allow_interruptions,
             enable_metrics=self._params.enable_metrics,
-            enable_usage_metrics=self._params.enable_metrics,
+            enable_usage_metrics=self._params.enable_usage_metrics,
             report_only_initial_ttfb=self._params.report_only_initial_ttfb,
             clock=self._clock,
         )


### PR DESCRIPTION
While working on docs for Metrics (I'll link the PR shortly), I was trying to understand how the thing worked and came across this bug:

Expected:
| enable_metrics | enable_usage_metrics | Result |
|-|-|-|
| True | True | Usage metrics reported |
| True | False | Usage metrics not reported |
| False | True | Usage metrics reported |
| False | False | Usage metrics not reported |

Actual:
| enable_metrics | enable_usage_metrics | Result |
|-|-|-|
| True | True | Usage metrics reported |
| True | False | Usage metrics reported |
| False | [True/False] | Usage metrics not reported |

I noticed there was a pretty big metrics refactor somewhat recently, so I spent some time* trying to figure out if the setting was meant to be deprecated or not... I _think_ the intent is to allow users to configure these independently, so I left it at this small diff rather than rip it out everywhere. 

I tested this primarily with foundational examples 7/7a, with every config combination in the truth table above.

\* most of my time spent was actually banging my head against the wall having made code changes in the repo but not realizing I was using the released package rather than a local build 🤦🤦🤦 