### PR TITLE
Fix: Update scipy dependency to ~1.13.1 to resolve ModuleNotFoundErro…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "protobuf~=4.25.4",
     "pydantic~=2.8.2",
     "pyloudnorm~=0.1.1",
-    "scipy~=1.14.1",
+    "scipy~=1.13.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
…r. 
scipi 1.14.1 does not exist on pypi, but v 1.13.1 does. I am assuming this is a typo.