### PR TITLE
Fix Silero VAD import issue

### DIFF
--- a/src/pipecat/vad/silero.py
+++ b/src/pipecat/vad/silero.py
@@ -8,4 +8,5 @@ from loguru import logger
 
 logger.warning("DEPRECATED: Package `pipecat.vad` is deprecated, use `pipecat.audio.vad` instead.")
 
-from ..audio.vad.silero import SileroVAD, SileroVADAnalyzer
+from ..audio.vad.silero import SileroVADAnalyzer
+from ..processors.audio.vad.silero import SileroVAD


### PR DESCRIPTION
SileroVAD is at processors.audio.vad, not just audio.vad, so making that fix.