### PR TITLE
Support function calling for Grok

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -533,6 +533,7 @@ class OpenAIAssistantContextAggregator(LLMAssistantContextAggregator):
                     self._context.add_message(
                         {
                             "role": "assistant",
+                            "content": "",  # content field required for Grok function calling
                             "tool_calls": [
                                 {
                                     "id": frame.tool_call_id,


### PR DESCRIPTION
Grok is looking for `content: string` in the message for function calling. Without it, there's a fatal error. This PR adds a content param with an empty string. I've tested OpenAI, Together, Grok and all work well with this change.