### PR TITLE
Add max_tokens and max_completion_tokens inputs for OpenAI

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -100,6 +100,8 @@ class BaseOpenAILLMService(LLMService):
         seed: Optional[int] = Field(default_factory=lambda: NOT_GIVEN, ge=0)
         temperature: Optional[float] = Field(default_factory=lambda: NOT_GIVEN, ge=0.0, le=2.0)
         top_p: Optional[float] = Field(default_factory=lambda: NOT_GIVEN, ge=0.0, le=1.0)
+        max_tokens: Optional[int] = Field(default_factory=lambda: NOT_GIVEN, ge=1)
+        max_completion_tokens: Optional[int] = Field(default_factory=lambda: NOT_GIVEN, ge=1)
         extra: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
     def __init__(
@@ -118,6 +120,8 @@ class BaseOpenAILLMService(LLMService):
             "seed": params.seed,
             "temperature": params.temperature,
             "top_p": params.top_p,
+            "max_tokens": params.max_tokens,
+            "max_completion_tokens": params.max_completion_tokens,
             "extra": params.extra if isinstance(params.extra, dict) else {},
         }
         self.set_model_name(model)
@@ -152,6 +156,8 @@ class BaseOpenAILLMService(LLMService):
             "seed": self._settings["seed"],
             "temperature": self._settings["temperature"],
             "top_p": self._settings["top_p"],
+            "max_tokens": self._settings["max_tokens"],
+            "max_completion_tokens": self._settings["max_completion_tokens"],
         }
 
         params.update(self._settings["extra"])


### PR DESCRIPTION
Adding support for:
- `max_tokens`, which is deprecated by OpenAI but is used by many other OpenAI spec LLM providers
- `max_completion_tokens`, which is used by OpenAI