### PR TITLE
AssemblyAI: don't disconnect on language change

### DIFF
--- a/src/pipecat/services/assemblyai.py
+++ b/src/pipecat/services/assemblyai.py
@@ -53,8 +53,6 @@ class AssemblyAISTTService(STTService):
     async def set_language(self, language: Language):
         logger.info(f"Switching STT language to: [{language}]")
         self._settings["language"] = language
-        await self._disconnect()
-        await self._connect()
 
     async def start(self, frame: StartFrame):
         await super().start(frame)


### PR DESCRIPTION
AssemblyAI streaming only supports English. Also, there's no requirement to disconnect/reconnect on settings changes.