### PR TITLE
Support using Pipecat turn detection instead of OpenAI Realtime API turn detection

### DIFF
--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -128,7 +128,7 @@ class OpenAIRealtimeBetaLLMService(LLMService):
     #
 
     async def _handle_interruption(self):
-        if self._session_properties.turn_detection is None:
+        if self._session_properties.turn_detection is False:
             await self.send_client_event(events.InputAudioBufferClearEvent())
             await self.send_client_event(events.ResponseCancelEvent())
         await self._truncate_current_audio_response()
@@ -138,11 +138,10 @@ class OpenAIRealtimeBetaLLMService(LLMService):
             await self.push_frame(TTSStoppedFrame())
 
     async def _handle_user_started_speaking(self, frame):
-        if self._session_properties.turn_detection is None:
-            await self._handle_interruption()
+        pass
 
     async def _handle_user_stopped_speaking(self, frame):
-        if self._session_properties.turn_detection is None:
+        if self._session_properties.turn_detection is False:
             await self.send_client_event(events.InputAudioBufferCommitEvent())
             await self.send_client_event(events.ResponseCreateEvent())
 

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -128,6 +128,8 @@ class OpenAIRealtimeBetaLLMService(LLMService):
     #
 
     async def _handle_interruption(self):
+        # None and False are different. Check for False. None means we're using OpenAI's
+        # built-in turn detection defaults.
         if self._session_properties.turn_detection is False:
             await self.send_client_event(events.InputAudioBufferClearEvent())
             await self.send_client_event(events.ResponseCancelEvent())
@@ -141,6 +143,8 @@ class OpenAIRealtimeBetaLLMService(LLMService):
         pass
 
     async def _handle_user_stopped_speaking(self, frame):
+        # None and False are different. Check for False. None means we're using OpenAI's
+        # built-in turn detection defaults.
         if self._session_properties.turn_detection is False:
             await self.send_client_event(events.InputAudioBufferCommitEvent())
             await self.send_client_event(events.ResponseCreateEvent())


### PR DESCRIPTION
This is mostly just for completeness, though it also could be useful for pipelines that want to switch on the fly between multiple LLM services.

To test, set `turn_detection` to `False` in the `openai_realtime_beta.SessionProperties`.

https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/19-openai-realtime-beta.py#L99