### PR TITLE
Fix PlayHT TTFB metrics

### DIFF
--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -293,8 +293,6 @@ class PlayHTTTSService(TTSService):
         except Exception as e:
             logger.error(f"{self} error generating TTS: {e}")
             yield ErrorFrame(f"{self} error: {str(e)}")
-        finally:
-            await self.stop_all_metrics()
 
 
 class PlayHTHttpTTSService(TTSService):


### PR DESCRIPTION
We were calling `stop_all_metrics()` in a finally block, which was causing the metrics numbers to be very small. Removing that finally block isn't needed. Removing it resolves the TTFB metrics caluclation.