### PR TITLE
Fix uncaught exception when accessing 'tool_calls' in NoneType delta in response handling

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -223,6 +223,9 @@ class BaseOpenAILLMService(LLMService):
 
             await self.stop_ttfb_metrics()
 
+            if not chunk.choices[0].delta:
+                continue
+
             if chunk.choices[0].delta.tool_calls:
                 # We're streaming the LLM response to enable the fastest response times.
                 # For text, we just yield each chunk as we receive it and count on consumers


### PR DESCRIPTION
In the response handling code, `chunk.choices[0].delta` can be `None` for the last chunk in certain responses. Currently, the code attempts to access `chunk.choices[0].delta.tool_calls` directly without checking if `delta` is `None`. This results in an uncaught exception when `chunk.choices[0].delta` is `None`, causing an error:

> `'NoneType' object has no attribute 'tool_calls'`

This the solution to the issue raise by me #669 