### PR TITLE
Update deepgram.py

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -148,7 +148,7 @@ class DeepgramSTTService(STTService):
                 options={"keepalive": "true"},  # verbose=logging.DEBUG
             ),
         )
-        self._connection: AsyncListenWebSocketClient = self._client.listen.asyncwebsocket.v("1")
+        self._connection: AsyncListenWebSocketClient = self._client.listen.live.v("1")
         self._connection.on(LiveTranscriptionEvents.Transcript, self._on_message)
         if self.vad_enabled:
             self._connection.on(LiveTranscriptionEvents.SpeechStarted, self._on_speech_started)


### PR DESCRIPTION
checkout this from deepgram official docs
from deepgram import DeepgramClient, DeepgramClientOptions, LiveTranscriptionEvents, LiveOptions

API_KEY = "DEEPGRAM_API_KEY"

def main():
    try:
        config = DeepgramClientOptions(
            options={"keepalive": "true"} # Comment this out to see the effect of not using keepalive
        )
        
        deepgram = DeepgramClient(API_KEY, config)

        dg_connection = deepgram.listen.live.v("1")

        def on_message(self, result, **kwargs):
            sentence = result.channel.alternatives[0].transcript
            if len(sentence) == 0:
                return
            print(f"speaker: {sentence}")

        def on_metadata(self, result, **kwargs):
            print(f"\n\n{result}\n\n")

        def on_error(self, error, **kwargs):
            print(f"\n\n{error}\n\n")

        dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
        dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
        dg_connection.on(LiveTranscriptionEvents.Error, on_error)

        options = LiveOptions(
            model="nova-2", 
            language="en-US", 
            smart_format=True,
        )
        
        dg_connection.start(options)

    except Exception as e:
        print(f"Could not open socket: {e}")

if __name__ == "__main__":
    main()
here they use  dg_connection = deepgram.listen.live.v("1") but we use self._client.listen.asyncwebsocket.v("1") my deepgram connections are losing after some time Cant this be the reason?

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.