### PR TITLE
feat: toggle looping with soundfile mixer

### DIFF
--- a/examples/foundational/23-bot-background-sound.py
+++ b/examples/foundational/23-bot-background-sound.py
@@ -6,17 +6,13 @@
 
 import argparse
 import asyncio
+import aiohttp
 import os
 import sys
 
-import aiohttp
-from dotenv import load_dotenv
-from loguru import logger
-from runner import configure_with_args
-
 from pipecat.audio.mixers.soundfile_mixer import SoundfileMixer
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import LLMMessagesFrame, MixerEnableFrame, MixerUpdateSettingsFrame
+from pipecat.frames.frames import LLMMessagesFrame, MixerUpdateSettingsFrame, MixerEnableFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -24,6 +20,12 @@ from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.cartesia import CartesiaTTSService
 from pipecat.services.openai import OpenAILLMService
 from pipecat.transports.services.daily import DailyParams, DailyTransport
+
+from runner import configure_with_args
+
+from loguru import logger
+
+from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
@@ -38,11 +40,8 @@ async def main():
 
         (room_url, token, args) = await configure_with_args(session, parser)
 
-        script_dir = os.path.dirname(__file__)
-        ding_path = os.path.join(script_dir, "assets", "ding1.wav")
-
         soundfile_mixer = SoundfileMixer(
-            sound_files={"office": args.input, "ding": ding_path},
+            sound_files={"office": args.input},
             default_sound="office",
             volume=2.0,
         )
@@ -103,19 +102,11 @@ async def main():
             await transport.capture_participant_transcription(participant["id"])
             # Show how to use mixer control frames.
             await asyncio.sleep(10.0)
-            logger.info("10 Sending mixer control frames.")
             await task.queue_frame(MixerUpdateSettingsFrame({"volume": 0.5}))
             await asyncio.sleep(5.0)
-            logger.info("15 Sending mixer control frames.")
-            await task.queue_frame(
-                MixerUpdateSettingsFrame({"volume": 0.75, "sound": "ding", "loop": False})
-            )
-            # await task.queue_frame(MixerEnableFrame(False))
+            await task.queue_frame(MixerEnableFrame(False))
             await asyncio.sleep(5.0)
-            logger.info("20 Sending mixer control frames.")
             await task.queue_frame(MixerEnableFrame(True))
-            await task.queue_frame(MixerUpdateSettingsFrame({"sound": "ding"}))
-            await task.queue_frame(MixerUpdateSettingsFrame({"sound": "office", "loop": True}))
             await asyncio.sleep(5.0)
             # Kick off the conversation.
             messages.append({"role": "system", "content": "Please introduce yourself to the user."})

--- a/src/pipecat/audio/mixers/soundfile_mixer.py
+++ b/src/pipecat/audio/mixers/soundfile_mixer.py
@@ -113,8 +113,8 @@ class SoundfileMixer(BaseAudioMixer):
 
             # Convert from np to bytes again.
             self._sounds[sound_name] = np.frombuffer(audio, dtype=np.int16)
-        except Exception:
-            logger.error(f"Unable to open file {file_name}")
+        except Exception as e:
+            logger.error(f"Unable to open file {file_name}: {e}")
 
     def _mix_with_sound(self, audio: bytes):
         """Mixes raw audio frames with chunks of the same length from the sound


### PR DESCRIPTION
This allows a user to toggle looping audio when creating the mixer or dynamically with a control frame like this:
```
await task.queue_frame(MixerUpdateSettingsFrame({"sound": "ding", "loop": False}))
```

This allows users to trigger sound effects that aren't meant to be looped, e.g. a "ding" when a participant joins a call.


<div>
    <a href="https://www.loom.com/share/2c921603bb72490cb5db1cf447501f61">
      <p>Music and Sound Effects Demo 🎵 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/2c921603bb72490cb5db1cf447501f61">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2c921603bb72490cb5db1cf447501f61-ee4924fa98dad09f-full-play.gif">
    </a>
  </div>