### PR TITLE
Support function pre-execute system prompt

### DIFF
--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -100,9 +100,17 @@ class OpenAILLMContext:
     def tools(self) -> List[ChatCompletionToolParam] | NotGiven:
         return self._tools
 
+    @tools.setter
+    def tools(self, value):
+        self._tools = value
+
     @property
     def tool_choice(self) -> ChatCompletionToolChoiceOptionParam | NotGiven:
         return self._tool_choice
+
+    @tool_choice.setter
+    def tool_choice(self, value):
+        self._tool_choice = value
 
     def add_message(self, message: ChatCompletionMessageParam):
         self._messages.append(message)

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -134,20 +134,31 @@ class LLMService(AIService):
         super().__init__(**kwargs)
         self._callbacks = {}
         self._start_callbacks = {}
+        self._pre_execute_prompts = {}
 
     # TODO-CB: callback function type
-    def register_function(self, function_name: str | None, callback, start_callback=None):
+    def register_function(
+        self, 
+        function_name: str | None, 
+        callback, 
+        start_callback=None, 
+        pre_execute_prompt: str | None = None
+    ):
         # Registering a function with the function_name set to None will run that callback
         # for all functions
         self._callbacks[function_name] = callback
         # QUESTION FOR CB: maybe this isn't needed anymore?
         if start_callback:
             self._start_callbacks[function_name] = start_callback
+        if pre_execute_prompt:
+            self._pre_execute_prompts[function_name] = pre_execute_prompt
 
     def unregister_function(self, function_name: str | None):
         del self._callbacks[function_name]
-        if self._start_callbacks[function_name]:
+        if function_name in self._start_callbacks:
             del self._start_callbacks[function_name]
+        if function_name in self._pre_execute_prompts:
+            del self._pre_execute_prompts[function_name]
 
     def has_function(self, function_name: str):
         if None in self._callbacks.keys():


### PR DESCRIPTION
This PR adds support for pre-execute prompts when registering functions. These prompts are sent to the LLM before executing a function call, allowing for additional context or instructions to be provided to the user before the function executes.

For instance, we can instruct the LLM to inform the user that "we're getting the information, please hold on" before executing RAG.