### PR TITLE
Fix ElevnLabsTTS websocket throttling issue

### DIFF
--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -387,6 +387,7 @@ class ElevenLabsTTSService(WordTTSService):
 
                 await self._send_text(text)
                 await self.start_tts_usage_metrics(text)
+                await asyncio.sleep(1)
             except Exception as e:
                 logger.error(f"{self} error sending message: {e}")
                 yield TTSStoppedFrame()


### PR DESCRIPTION
This PR addresses the issue where the ElevenLabs WebSocket encounters an error when messages are sent too quickly in succession, causing the websocket to abnormally close with error: ```sent 1009 (message too big); no close frame received```. To resolve this, a ```asyncio.sleep(1)``` delay can be introduced after sending text chunk to be synthesized. Ensuring the messages are sent with appropriate spacing, preventing the WebSocket from being overwhelmed and improving the stability of the connection when synthesizing long assistant responses.

This change does not affect the flow of the assistant, as the assistant naturally takes a few seconds to speak even the shortest sentence, hence, the introduced delay does not impact user experience.

I was able to reproduce the flow by asking the assistant to generate ```10 ways to ...```. It specifically happens when each point is put in separate chunk as follow:
```
Generating TTS: [1. example 1]
Generating TTS: [2. example 2]
...
```