### PR TITLE
Force ElevnLabsTTS websocket data flush for in-progress requests on StartInterruptionFrame

### DIFF
--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -276,6 +276,9 @@ class ElevenLabsTTSService(WordTTSService):
             await self.pause_processing_frames()
         elif isinstance(frame, BotStoppedSpeakingFrame):
             await self.resume_processing_frames()
+        elif isinstance(frame, StartInterruptionFrame):
+            await self._disconnect()
+            await self._connect()
 
     async def _connect(self):
         try:


### PR DESCRIPTION
This PR addresses an issue that occurs when long LLM responses are generated and an interruption frame (StartInterruptionFrame) is sent mid-way after a large number of text frames are sent to TTS websocket. In these cases, even though an interruption frame is triggered, the _receive_task_handler continues to receive and process the already-sent text frames synthesized responses and pushes them downstream to the aggregator then output transport. 

This issue is particularly noticeable when long responses (e.g., "10 ways to do something") are broken into multiple frames. To resolve this, a reconnect to the ElevenLabs WebSocket is triggered upon receiving a StartInterruptionFrame, ensuring that any in-progress requests are not processed by the _receive_task_handler, hence, preventing the downstream processing of stale responses. This change ensures that when interruption occurs (e.g. UserStartedSpeaking) the agent stops speaking immediately, which was the case in the REST-based ElevenLabsTTSService implementation.