### PR TITLE
transports(fastapi): don't try to close socket

### DIFF
--- a/src/pipecat/transports/network/fastapi_websocket.py
+++ b/src/pipecat/transports/network/fastapi_websocket.py
@@ -70,16 +70,6 @@ class FastAPIWebsocketInputTransport(BaseInputTransport):
         await self._callbacks.on_client_connected(self._websocket)
         self._receive_task = self.get_event_loop().create_task(self._receive_messages())
 
-    async def stop(self, frame: EndFrame):
-        await super().stop(frame)
-        if self._websocket.client_state != WebSocketState.DISCONNECTED:
-            await self._websocket.close()
-
-    async def cancel(self, frame: CancelFrame):
-        await super().cancel(frame)
-        if self._websocket.client_state != WebSocketState.DISCONNECTED:
-            await self._websocket.close()
-
     async def _receive_messages(self):
         async for message in self._websocket.iter_text():
             frame = self._params.serializer.deserialize(message)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The websocket is passed from outside (in the transport constructor) so we should not be trying to close it. FastAPI does actually close it later. We didn't see any issue because these functions were not implemented properly. The value to check was `application_state` instead of `client_state`. But in any case, Pipecat should not be responsible for closing things passed from outside.
