### PR TITLE
Empty text content bug fix for Gemini

### DIFF
--- a/examples/foundational/07p-interruptible-google-audio-in.py
+++ b/examples/foundational/07p-interruptible-google-audio-in.py
@@ -217,7 +217,11 @@ async def main():
             voice_id="79a125e8-cd45-4c13-8a67-188112f4dd22",  # British Lady
         )
 
-        llm = GoogleLLMService(model="gemini-1.5-flash-latest", api_key=os.getenv("GOOGLE_API_KEY"))
+        llm = GoogleLLMService(
+            model="gemini-1.5-flash-latest",
+            # model="gemini-exp-1114",
+            api_key=os.getenv("GOOGLE_API_KEY"),
+        )
 
         messages = [
             {

--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -64,7 +64,11 @@ async def main():
             voice_id="79a125e8-cd45-4c13-8a67-188112f4dd22",  # British Lady
         )
 
-        llm = GoogleLLMService(model="gemini-1.5-flash-latest", api_key=os.getenv("GOOGLE_API_KEY"))
+        llm = GoogleLLMService(
+            model="gemini-1.5-flash-latest",
+            # model="gemini-exp-1114",
+            api_key=os.getenv("GOOGLE_API_KEY"),
+        )
         llm.register_function("get_weather", get_weather)
         llm.register_function("get_image", get_image)
 
@@ -151,7 +155,6 @@ indicate you should use the get_image tool are:
                 allow_interruptions=True,
                 enable_metrics=True,
                 enable_usage_metrics=True,
-                report_only_initial_ttfb=True,
             ),
         )
 

--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -281,9 +281,10 @@ class GoogleAssistantContextAggregator(OpenAIAssistantContextAggregator):
                     )
                     run_llm = not bool(self._function_calls_in_progress)
             else:
-                self._context.add_message(
-                    glm.Content(role="model", parts=[glm.Part(text=aggregation)])
-                )
+                if aggregation.strip():
+                    self._context.add_message(
+                        glm.Content(role="model", parts=[glm.Part(text=aggregation)])
+                    )
 
             if self._pending_image_frame_message:
                 frame = self._pending_image_frame_message


### PR DESCRIPTION
When pushing function call context we need to make sure not to add text content items that are empty.

I'm not sure if this is a regression that snuck into Pipecat code, or whether this is new model behavior we haven't seen before. But either way, this is a small but important check. (If we push an empty text content message, all inference requests subsequently fail.)

Also started testing with `gemini-exp-1114`. Text, audio, image, and function calling inference all work with no changes to the `GoogleLLMService`.