### PR TITLE
Use Google Gemini message format when adding message to the LLM context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated STT and TTS services with language options that match the supported
   languages for each service.
 
+### Fixed
+
+- Fixed Google Gemini message handling to properly convert appended messages to Gemini's required format
+
 ## [0.0.49] - 2024-11-17
 
 ### Added

--- a/src/pipecat/services/google.py
+++ b/src/pipecat/services/google.py
@@ -332,6 +332,22 @@ class GoogleLLMContext(OpenAILLMContext):
         self._messages[:] = messages
         self._restructure_from_openai_messages()
 
+    def add_messages(self, messages: List):
+        # Convert each message individually
+        converted_messages = []
+        for msg in messages:
+            if isinstance(msg, glm.Content):
+                # Already in Gemini format
+                converted_messages.append(msg)
+            else:
+                # Convert from standard format to Gemini format
+                converted = self.from_standard_message(msg)
+                if converted is not None:
+                    converted_messages.append(converted)
+
+        # Add the converted messages to our existing messages
+        self._messages.extend(converted_messages)
+
     def get_messages_for_logging(self):
         msgs = []
         for message in self.messages:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

For Gemini, we're already using `_restructure_from_openai_messages` for initial messages and setting the context (`LLMMessagesUpdateFrame`). This PR also restructures the message when adding to the context (`LLMMessagesAppendFrame`).