### PR TITLE
[ISSUE] doctest fix WIP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/src/pipecat/processors/aggregators/user_response.py
+++ b/src/pipecat/processors/aggregators/user_response.py
@@ -27,15 +27,18 @@ class ResponseAggregator(FrameProcessor):
         UserStoppedSpeakingFrame() -> TextFrame("Hello world.")
 
     Doctest: FIXME to work with asyncio
+    >>> import asyncio
+
     >>> async def print_frames(aggregator, frame):
-    ...     async for frame in aggregator.process_frame(frame):
+    ...     async for frame in aggregator.process_frame(frame, FrameDirection.DOWNSTREAM):
     ...         if isinstance(frame, TextFrame):
     ...             print(frame.text)
 
+    >>> loop = asyncio.new_event_loop()
     >>> aggregator = ResponseAggregator(start_frame = UserStartedSpeakingFrame,
     ...                                 end_frame=UserStoppedSpeakingFrame,
     ...                                 accumulator_frame=TranscriptionFrame,
-    ...                                 pass_through=False)
+    ...                                 loop=loop)
     >>> asyncio.run(print_frames(aggregator, UserStartedSpeakingFrame()))
     >>> asyncio.run(print_frames(aggregator, TranscriptionFrame("Hello,", 1, 1)))
     >>> asyncio.run(print_frames(aggregator, TranscriptionFrame("world.",  1, 2)))
@@ -51,8 +54,9 @@ class ResponseAggregator(FrameProcessor):
         end_frame,
         accumulator_frame: TextFrame,
         interim_accumulator_frame: TextFrame | None = None,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(**kwargs)
 
         self._start_frame = start_frame
         self._end_frame = end_frame


### PR DESCRIPTION
#### Attempting to fix the pytests - starting with doctests...

run with
`pytest --doctest-modules -v src/pipecat/processors/aggregators/user_response.py`

this (now) produces the error:
```
>>> asyncio.run(print_frames(aggregator, UserStartedSpeakingFrame()))
UNEXPECTED EXCEPTION: TypeError("'async for' requires an object with __aiter__ method, got coroutine")
```
I tried an `await` in the offending line `async for frame in aggregator.process_frame(frame, FrameDirection.DOWNSTREAM):` but the tests still don’t pass because they never print anything.

anyone know how to update `def print_frames` to fix this (and alllll the other tests that also use it)?
