### PR TITLE
transports(websockets): use frame serializers during interruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `WebsocketServerTransport` issue that would prevent interruptions with
+  `TwilioSerializer` from working.
+
 - `DailyTransport.capture_participant_video` now allows capturing user's screen
   share by simply passing `video_source="screenVideo"`.
 

--- a/src/pipecat/transports/network/fastapi_websocket.py
+++ b/src/pipecat/transports/network/fastapi_websocket.py
@@ -15,8 +15,6 @@ from pydantic.main import BaseModel
 
 from pipecat.frames.frames import (
     AudioRawFrame,
-    CancelFrame,
-    EndFrame,
     Frame,
     InputAudioRawFrame,
     StartFrame,

--- a/src/pipecat/transports/network/websocket_server.py
+++ b/src/pipecat/transports/network/websocket_server.py
@@ -148,6 +148,7 @@ class WebsocketServerOutputTransport(BaseOutputTransport):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, StartInterruptionFrame):
+            await self._write_frame(frame)
             self._next_send_time = 0
 
     async def write_raw_audio_frames(self, frames: bytes):
@@ -188,6 +189,11 @@ class WebsocketServerOutputTransport(BaseOutputTransport):
             self._next_send_time += self._send_interval
 
         self._websocket_audio_buffer = bytes()
+
+    async def _write_frame(self, frame: Frame):
+        payload = self._params.serializer.serialize(frame)
+        if payload and self._websocket:
+            await self._websocket.send(payload)
 
 
 class WebsocketServerTransport(BaseTransport):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This uses the frame serializer when interruptions happen which allows sending Twilio a `clear` message when using the `TwilioSerializer`. This already worked when using the FastAPI websocket transport but not this one.