### PR TITLE
transports(daily): subscribe to the desired video source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed Google Gemini message handling to properly convert appended messages to Gemini's required format
+- `DailyTransport.capture_participant_video` now allows capturing user's screen
+  share by simply passing `video_source="screenVideo"`.
+
+- Fixed Google Gemini message handling to properly convert appended messages to
+  Gemini's required format.
 
 ## [0.0.49] - 2024-11-17
 

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -499,9 +499,9 @@ class DailyTransportClient(EventHandler):
         video_source: str = "camera",
         color_format: str = "RGB",
     ):
-        # Only enable camera subscription on this participant
+        # Only enable the desired video source subscription on this participant.
         await self.update_subscriptions(
-            participant_settings={participant_id: {"media": {"camera": "subscribed"}}}
+            participant_settings={participant_id: {"media": {video_source: "subscribed"}}}
         )
 
         self._video_renderers[participant_id] = callback


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This will allow capturing `screenVideo` or `camera`. This supersedes https://github.com/pipecat-ai/pipecat/pull/726.