### PR TITLE
transports(daily): use a task to execute callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ async def on_audio_data(processor, audio, sample_rate, num_channels):
 
 ### Fixed
 
+- Fixed an issue in `DailyTransport` that would cause some internal callbacks to
+  not be executed.
+
 - Fixed an issue where other frames were being processed while a `CancelFrame`
   was being pushed down the pipeline.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This commit fixes an issue where we were not waiting for `asyncio.run_coroutine_threadsafe` to complete which can cause a series of undesired issues (e.g. not actually executing the coroutine).