### PR TITLE
transports: fix premature input transport closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ async def on_audio_data(processor, audio, sample_rate, num_channels):
 
 ### Fixed
 
+- Fixed a `DailyTransport` and `LiveKitTransport` issue where connections were
+  being closed in the input transport prematurely. This was causing frames
+  queued inside the pipeline being discarded.
+
 - Fixed an issue in `DailyTransport` that would cause some internal callbacks to
   not be executed.
 

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -200,8 +200,7 @@ class DailyTransportClient(EventHandler):
         self._other_participant_has_joined = False
 
         self._joined = False
-        self._joining = False
-        self._leaving = False
+        self._leave_counter = 0
 
         self._executor = ThreadPoolExecutor(max_workers=5)
 
@@ -263,7 +262,7 @@ class DailyTransportClient(EventHandler):
         self._callbacks = callbacks
 
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):
-        if not self._joined or self._leaving:
+        if not self._joined:
             return
 
         participant_id = None
@@ -315,12 +314,12 @@ class DailyTransportClient(EventHandler):
 
     async def join(self):
         # Transport already joined, ignore.
-        if self._joined or self._joining:
+        if self._joined:
+            # Increment leave counter if we already joined.
+            self._leave_counter += 1
             return
 
         logger.info(f"Joining {self._room_url}")
-
-        self._joining = True
 
         # For performance reasons, never subscribe to video streams (unless a
         # video renderer is registered).
@@ -335,7 +334,8 @@ class DailyTransportClient(EventHandler):
 
             if not error:
                 self._joined = True
-                self._joining = False
+                # Increment leave counter if we successfully joined.
+                self._leave_counter += 1
 
                 logger.info(f"Joined {self._room_url}")
 
@@ -423,12 +423,14 @@ class DailyTransportClient(EventHandler):
         return await asyncio.wait_for(future, timeout=10)
 
     async def leave(self):
+        # Decrement leave counter when leaving.
+        self._leave_counter -= 1
+
         # Transport not joined, ignore.
-        if not self._joined or self._leaving:
+        if not self._joined or self._leave_counter > 0:
             return
 
         self._joined = False
-        self._leaving = True
 
         logger.info(f"Leaving {self._room_url}")
 
@@ -438,7 +440,6 @@ class DailyTransportClient(EventHandler):
         try:
             error = await self._leave()
             if not error:
-                self._leaving = False
                 logger.info(f"Left {self._room_url}")
                 await self._callbacks.on_left()
             else:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixed a `DailyTransport` and `LiveKitTransport` issue where connections were being closed in the input transport prematurely. This was causing frames queued inside the pipeline being discarded.
