### PR TITLE
transports(base_output): wait for output tasks on EndFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ async def on_audio_data(processor, audio, sample_rate, num_channels):
 
 ### Fixed
 
+- Fixed a `BaseOutputTransport` issue that was causing audio to be discarded
+  after an `EndFrame` was received.
+
 - Fixed an issue in `WebsocketServerTransport` and `FastAPIWebsocketTransport`
   that would cause a busy loop when using audio mixer.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.