### PR TITLE
Add additional languages for Cartesia

### DIFF
--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -49,8 +49,16 @@ def language_to_cartesia_language(language: Language) -> str | None:
         Language.EN: "en",
         Language.ES: "es",
         Language.FR: "fr",
+        Language.HI: "hi",
+        Language.IT: "it",
         Language.JA: "ja",
+        Language.KO: "ko",
+        Language.NL: "nl",
+        Language.PL: "pl",
         Language.PT: "pt",
+        Language.RU: "ru",
+        Language.SV: "sv",
+        Language.TR: "tr",
         Language.ZH: "zh",
     }
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Aligning with what Cartesia supports: https://docs.cartesia.ai/api-reference/tts/tts#send.Generation%20Request.language.

It seems they've added timestamp support for additional languages, too.

I think they may have an issue with non-[Latin script](https://en.wikipedia.org/wiki/Latin_script) characters.