### PR TITLE
fix: Send interruption to cartesia

### DIFF
--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -210,9 +210,10 @@ class CartesiaTTSService(WordTTSService):
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
         await self.stop_all_metrics()
-        cancel_msg = json.dumps({"context_id": self._context_id, "cancel": True})
-        await self._get_websocket().send(cancel_msg)
-        self._context_id = None
+        if not self._context_id:
+            cancel_msg = json.dumps({"context_id": self._context_id, "cancel": True})
+            await self._get_websocket().send(cancel_msg)
+            self._context_id = None
 
     async def flush_audio(self):
         if not self._context_id or not self._websocket:

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -210,6 +210,8 @@ class CartesiaTTSService(WordTTSService):
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
         await self.stop_all_metrics()
+        cancel_msg = json.dumps({"context_id": self._context_id, "cancel": True})
+        await self._get_websocket().send(cancel_msg)
         self._context_id = None
 
     async def flush_audio(self):


### PR DESCRIPTION
Currently, `cartesia.py` continues to receive messages even after an interruption has occurred. Although the following code:
```
async for message in self._get_websocket():
    msg = json.loads(message)
    if not msg or msg["context_id"] != self._context_id:
        continue
```
prevents `TTSAudioRawFrame` from being pushed, Cartesia's server still generates audio messages. [This PR introduces a cancellation message](https://docs.cartesia.ai/api-reference/tts/working-with-web-sockets/contexts#cancelling-requests) to stop outgoing requests. However, there are two limitations:
> 1. It will only halt requests that have not begun generating a response yet.
> 2. Any currently generating request will continue sending responses until completion.