### PR TITLE
 fix system frames parallel pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ async def on_audio_data(processor, audio, sample_rate, num_channels):
 
 ### Fixed
 
+- Fixed a `ParallelPipeline` issue that would cause system frames to be queued.
+
 - Fixed `FastAPIWebsocketTransport` so it can work with binary data (e.g. using
   the protobuf serializer).
 

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -200,7 +200,6 @@ class DailyTransportClient(EventHandler):
         self._other_participant_has_joined = False
 
         self._joined = False
-        self._joining = False
         self._leave_counter = 0
 
         self._executor = ThreadPoolExecutor(max_workers=5)
@@ -315,12 +314,11 @@ class DailyTransportClient(EventHandler):
 
     async def join(self):
         # Transport already joined, ignore.
-        if self._joined or self._joining:
+        if self._joined:
             # Increment leave counter if we already joined.
             self._leave_counter += 1
             return
 
-        self._joining = True
         logger.info(f"Joining {self._room_url}")
 
         # For performance reasons, never subscribe to video streams (unless a
@@ -353,7 +351,6 @@ class DailyTransportClient(EventHandler):
             error_msg = f"Time out joining {self._room_url}"
             logger.error(error_msg)
             await self._callbacks.on_error(error_msg)
-        self._joining = False
 
     async def _start_transcription(self):
         if not self._token:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

System frames need to be processed in the same task that they were generated. This makes them fast, immediate and frames that depend on this deterministic. This fixes an issue that was queuing system frames in ParallelPipeline making them run in a separate task.
