### PR TITLE
fixing [#868] bug where deepgram client fails due to langauge

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -138,6 +138,9 @@ class DeepgramSTTService(STTService):
         merged_options = default_options
         if live_options:
             merged_options = LiveOptions(**{**default_options.to_dict(), **live_options.to_dict()})
+
+        # deepgram connection requires language to be a string
+        merged_options.language = merged_options.language.value
         self._settings = merged_options.to_dict()
 
         self._client = DeepgramClient(


### PR DESCRIPTION
**Description:**
This PR fixes a bug in the `DeepgramSTTService` where the `language` parameter, defined as an enum, was causing a WebSocket connection failure during the pipeline initialization. The issue occurred because Deepgram's API expects the `language` parameter as a string, but an enum was being passed directly.

**Changes Made:**
- Ensured the `language` parameter is converted from an enum to its string value (`Language.EN.value`) before being passed to the API.
