### PR TITLE
Add python-dotenv to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pytest~=8.3.2
 ruff~=0.6.7
 setuptools~=72.2.0
 setuptools_scm~=8.1.0
+python-dotenv~=1.0.1


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I was testing a clean venv install of Pipecat and used dev-requirements.txt to set up my local env. I had to manually install python-dotenv. I'm adding it to dev-requirements.txt to avoid that manual step.