### PR TITLE
Fix error with new lines in f strings.

### DIFF
--- a/src/pipecat/processors/metrics/sentry.py
+++ b/src/pipecat/processors/metrics/sentry.py
@@ -29,8 +29,7 @@ class SentryMetrics(FrameProcessorMetrics):
                     description=f"TTFB for {self._processor_name()}",
                     start_timestamp=self._start_ttfb_time,
                 )
-                logger.debug(f"Sentry Span ID: {self._ttfb_metrics_span.span_id} Description: {
-                             self._ttfb_metrics_span.description} started.")
+                logger.debug(f"Sentry Span ID: {self._ttfb_metrics_span.span_id} Description: {self._ttfb_metrics_span.description} started.")
             self._should_report_ttfb = not report_only_initial_ttfb
 
     async def stop_ttfb_metrics(self):
@@ -46,8 +45,7 @@ class SentryMetrics(FrameProcessorMetrics):
                 description=f"Processing for {self._processor_name()}",
                 start_timestamp=self._start_processing_time,
             )
-            logger.debug(f"Sentry Span ID: {self._processing_metrics_span.span_id} Description: {
-                         self._processing_metrics_span.description} started.")
+            logger.debug(f"Sentry Span ID: {self._processing_metrics_span.span_id} Description: {self._processing_metrics_span.description} started.")
 
     async def stop_processing_metrics(self):
         stop_time = time.time()

--- a/src/pipecat/processors/metrics/sentry.py
+++ b/src/pipecat/processors/metrics/sentry.py
@@ -29,7 +29,8 @@ class SentryMetrics(FrameProcessorMetrics):
                     description=f"TTFB for {self._processor_name()}",
                     start_timestamp=self._start_ttfb_time,
                 )
-                logger.debug(f"Sentry Span ID: {self._ttfb_metrics_span.span_id} Description: {self._ttfb_metrics_span.description} started.")
+                logger.debug(f"""Sentry Span ID: {self._ttfb_metrics_span.span_id} Description: {
+                             self._ttfb_metrics_span.description} started.""")
             self._should_report_ttfb = not report_only_initial_ttfb
 
     async def stop_ttfb_metrics(self):
@@ -45,7 +46,8 @@ class SentryMetrics(FrameProcessorMetrics):
                 description=f"Processing for {self._processor_name()}",
                 start_timestamp=self._start_processing_time,
             )
-            logger.debug(f"Sentry Span ID: {self._processing_metrics_span.span_id} Description: {self._processing_metrics_span.description} started.")
+            logger.debug(f"""Sentry Span ID: {self._processing_metrics_span.span_id} Description: {
+                         self._processing_metrics_span.description} started.""")
 
     async def stop_processing_metrics(self):
         stop_time = time.time()


### PR DESCRIPTION
- Fixed the following error: Python version 3.10 does not allow new lines in expression parts of non-triple-quoted f-strings.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.