### PR TITLE
Replace audioop for python 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Website = "https://pipecat.ai"
 [project.optional-dependencies]
 anthropic = [ "anthropic~=0.40.0" ]
 assemblyai = [ "assemblyai~=0.34.0" ]
+audio = [ "soundfile~=0.12.1" ]
 aws = [ "boto3~=1.35.27" ]
 azure = [ "azure-cognitiveservices-speech~=1.41.1", "openai~=1.57.2" ]
 canonical = [ "aiofiles~=24.1.0" ]

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -6,12 +6,23 @@
 
 import base64
 import json
+import sys
 
 from pydantic import BaseModel
 
-from pipecat.audio.utils import ulaw_to_pcm, pcm_to_ulaw
 from pipecat.frames.frames import AudioRawFrame, Frame, InputAudioRawFrame, StartInterruptionFrame
 from pipecat.serializers.base_serializer import FrameSerializer, FrameSerializerType
+
+if sys.version_info >= (3, 13):
+    try:
+        from pipecat.audio.utils import pcm_to_ulaw, ulaw_to_pcm
+    except ImportError:
+        raise ImportError(
+            "Audio processing support required for TwilioFrameSerializer. "
+            "Please install with: pip install pipecat-ai[audio]"
+        )
+else:
+    from pipecat.audio.utils import pcm_to_ulaw, ulaw_to_pcm
 
 
 class TwilioFrameSerializer(FrameSerializer):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`audioop` was removed in 3.13. This PR uses `soundfile` as a replacement.

Also, we keep using `audioop` for <3.13 and only require the new package for 3.13+.