### PR TITLE
processors(filters): allow passing EndFrame

### DIFF
--- a/src/pipecat/processors/filters/frame_filter.py
+++ b/src/pipecat/processors/filters/frame_filter.py
@@ -6,7 +6,7 @@
 
 from typing import Tuple, Type
 
-from pipecat.frames.frames import ControlFrame, Frame, SystemFrame
+from pipecat.frames.frames import EndFrame, Frame, SystemFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 
@@ -23,7 +23,7 @@ class FrameFilter(FrameProcessor):
         if isinstance(frame, self._types):
             return True
 
-        return isinstance(frame, ControlFrame) or isinstance(frame, SystemFrame)
+        return isinstance(frame, (EndFrame, SystemFrame))
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)

--- a/src/pipecat/processors/filters/function_filter.py
+++ b/src/pipecat/processors/filters/function_filter.py
@@ -6,7 +6,7 @@
 
 from typing import Awaitable, Callable
 
-from pipecat.frames.frames import Frame, SystemFrame
+from pipecat.frames.frames import EndFrame, Frame, SystemFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 
@@ -24,9 +24,10 @@ class FunctionFilter(FrameProcessor):
     # Frame processor
     #
 
-    # Ignore system frames and frames that are not following the direction of this gate
+    # Ignore system frames, end frames and frames that are not following the
+    # direction of this gate
     def _should_passthrough_frame(self, frame, direction):
-        return isinstance(frame, SystemFrame) or direction != self._direction
+        return isinstance(frame, (SystemFrame, EndFrame)) or direction != self._direction
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)

--- a/src/pipecat/processors/filters/null_filter.py
+++ b/src/pipecat/processors/filters/null_filter.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-from pipecat.processors.frame_processor import FrameProcessor
+from pipecat.frames.frames import EndFrame, Frame, SystemFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 
 class NullFilter(FrameProcessor):
@@ -12,3 +13,13 @@ class NullFilter(FrameProcessor):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+    #
+    # Frame processor
+    #
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, (SystemFrame, EndFrame)):
+            await self.push_frame(frame, direction)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`EndFrame`s are a special control frames that should always be handled to let the pipelines finish properly.
