### PR TITLE
pipeline(parallel): wait for slowest endframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue that would cause `ParallelPipeline` to handle `EndFrame`
+  incorrectly causing the main pipeline to not terminate or terminate too early.
+
 - Fixed an audio stuttering issue in `FastPitchTTSService`.
 
 - Fixed a `BaseOutputTransport` issue that was causing non-audio frames being


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

If we are sending an EndFrame and a ParallelPipeline has multiple pipelines we want to wait before pushing the EndFrame downstream until the slowest pipeline is finished. Otherwise, we could be disconnecting from the transport too early.
