### PR TITLE
Remove unnecessary prompt caching headers for Anthropic service

### DIFF
--- a/src/pipecat/services/anthropic.py
+++ b/src/pipecat/services/anthropic.py
@@ -154,8 +154,6 @@ class AnthropicLLMService(LLMService):
                 messages = context.get_messages_with_cache_control_markers()
 
             api_call = self._client.messages.create
-            if self._settings["enable_prompt_caching_beta"]:
-                api_call = self._client.beta.prompt_caching.messages.create
 
             await self.start_ttfb_metrics()
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This removes the extra headers that cause:

```
ERR pipecat.services.anthropic:_process_context:257 - AnthropicLLMService#0 exception: Error code: 400 - {'message': 'Cache configuration conflict: Cannot enable prompt caching in message body when it is explicitly disabled in request header'}
```

This header is no longer needed because prompt caching is out of beta, and does not require a header to use, and I believe it could be the cause of this issue.

I've left all other settings there for backwards compatibility, and should still work without this header.

TBH I'm not sure if it removes this error, but it's the only code involving headers I could find within the pipecat code