### PR TITLE
Update PlayHT to use the latest Websocket connection endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `PlayHTTTSService` uses the new v4 websocket API, which also fixes an issue
+  where text inputted to the TTS didn't return audio.
+
 - The default model for `ElevenLabsTTSService` is now `eleven_flash_v2_5`.
 
 - `OpenAIRealtimeBetaLLMService` now takes a `model` parameter in the


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Updating to support the latest Websocket API from PlayHT: https://docs.play.ht/reference/playht-tts-websocket-api. This new endpoint also appears to solve the missing audio issue where sentences wouldn't be spoken.

Service changes impacting this PR:
1. Websocket URL:
```
When you make a POST request to /api/v4/websocket-auth, you get back a response like this:
jsonCopy{
  "websocket_urls": {
    "Play3.0-mini": "wss://ws.fal.run/playht-fal/playht-tts/ws?fal_jwt_token=<token1>",
    "PlayDialog": "wss://ws.fal.run/playht-fal/playht-tts-ldm/ws?fal_jwt_token=<token2>",
    "PlayDialogMultilingual": "wss://ws.fal.run/playht-fal/playht-tts-multilingual-ldm/ws?fal_jwt_token=<token3>"
  },
  "expires_at": "2024-12-11T22:17:37.429Z"
}
```

We need to get the wss URL from the response.

2. Also, they now include `start` and `end` messages:
```
For each request, receive, in order, a {"type":"start"} message, followed by audio output as binary messages, and a {"type":"end"} as indicator of end of request.
```