### PR TITLE
fix pyht format import

### DIFF
--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -37,8 +37,7 @@ from pipecat.transcriptions.language import Language
 
 try:
     from pyht.async_client import AsyncClient
-    from pyht.client import TTSOptions
-    from pyht.protos.api_pb2 import Format
+    from pyht.client import Format, TTSOptions
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Import of `format` from PyHT is incorrect and results in errors when using `PlayHTTTSHttpService`. This PR resolves the import correctly