### PR TITLE
Fix truncation timing of OpenAIRealtimeBetaLLMService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `29-livekit-audio-chat.py`, as a new foundational examples for
   `LiveKitTransportLayer`.
 
+### Fixed
+
+- Fixed an issue where `OpenAIRealtimeBetaLLMService` audio chunks were hitting
+  an error when truncating audio content.
+
 ## [0.0.52] - 2024-12-24
 
 ### Added

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -152,17 +152,38 @@ class OpenAIRealtimeBetaLLMService(LLMService):
     async def _handle_bot_stopped_speaking(self):
         self._current_audio_response = None
 
+    def _calculate_audio_duration_ms(
+        self, total_bytes: int, sample_rate: int = 24000, bytes_per_sample: int = 2
+    ) -> int:
+        """Calculate audio duration in milliseconds based on PCM audio parameters."""
+        samples = total_bytes / bytes_per_sample
+        duration_seconds = samples / sample_rate
+        return int(duration_seconds * 1000)
+
     async def _truncate_current_audio_response(self):
+        """Truncates the current audio response at the appropriate duration.
+
+        Calculates the actual duration of the audio content and truncates at the shorter of
+        either the wall clock time or the actual audio duration to prevent invalid truncation
+        requests.
+        """
         # if the bot is still speaking, truncate the last message
         if self._current_audio_response:
             current = self._current_audio_response
             self._current_audio_response = None
+
+            # Calculate actual audio duration instead of using wall clock time
+            audio_duration_ms = self._calculate_audio_duration_ms(current.total_size)
+
+            # Use the shorter of wall clock time or actual audio duration
             elapsed_ms = int(time.time() * 1000 - current.start_time_ms)
+            truncate_ms = min(elapsed_ms, audio_duration_ms)
+
             await self.send_client_event(
                 events.ConversationItemTruncateEvent(
                     item_id=current.item_id,
                     content_index=current.content_index,
-                    audio_end_ms=elapsed_ms,
+                    audio_end_ms=truncate_ms,
                 )
             )
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Previously, the code attempted to truncate audio responses based on wall clock time, which could exceed the actual audio duration and cause an error. Now, the code calculates actual audio duration from PCM parameters and uses the shorter of wall clock time or audio duration when truncating, preventing "invalid_request_error" responses from the API.
