### PR TITLE
Changed Polly authentication params to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `29-livekit-audio-chat.py`, as a new foundational examples for
   `LiveKitTransportLayer`.
 
+### Changed
+
+- api_key, aws_access_key_id and region are no longer required parameters for the PollyTTSService (AWSTTSService)
+
 ### Fixed
 
 - Fixed an issue where `OpenAIRealtimeBetaLLMService` audio chunks were hitting

--- a/src/pipecat/services/aws.py
+++ b/src/pipecat/services/aws.py
@@ -119,9 +119,9 @@ class PollyTTSService(TTSService):
     def __init__(
         self,
         *,
-        api_key: str,
-        aws_access_key_id: str,
-        region: str,
+        api_key: Optional[str] = None,
+        aws_access_key_id: Optional[str] = None,
+        region: Optional[str] = None,
         voice_id: str = "Joanna",
         sample_rate: int = 24000,
         params: InputParams = InputParams(),


### PR DESCRIPTION
Changed the Polly authentication params to be optional rather than required. Boto3 has a bunch of different methods of obtaining auth. Locally, it picks up my auth from AWS CLI and in production an IAM role is used. Obviously you can still use access keys, but this stops lint and IDE errors.