### PR TITLE
adding more daily room params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `29-livekit-audio-chat.py`, as a new foundational examples for
   `LiveKitTransportLayer`.
+- Added `enable_prejoin_ui`, `max_participants` and `start_video_off` params
+  to `DailyRoomProperties`.
 
 ### Fixed
 

--- a/src/pipecat/transports/services/helpers/daily_rest.py
+++ b/src/pipecat/transports/services/helpers/daily_rest.py
@@ -39,20 +39,25 @@ class DailyRoomProperties(BaseModel, extra="allow"):
     Attributes:
         exp: Optional Unix epoch timestamp for room expiration (e.g., time.time() + 300 for 5 minutes)
         enable_chat: Whether chat is enabled in the room
+        enable_prejoin_ui: Whether the pre-join UI is enabled
         enable_emoji_reactions: Whether emoji reactions are enabled
         eject_at_room_exp: Whether to remove participants when room expires
         enable_dialout: Whether SIP dial-out is enabled
         sip: SIP configuration parameters
         sip_uri: SIP URI information returned by Daily
+        start_video_off: Whether video is off by default
     """
 
     exp: Optional[float] = None
     enable_chat: bool = False
+    enable_prejoin_ui: bool = True
     enable_emoji_reactions: bool = False
     eject_at_room_exp: bool = True
     enable_dialout: Optional[bool] = None
+    max_participants: Optional[int] = None
     sip: Optional[DailyRoomSipParams] = None
     sip_uri: Optional[dict] = None
+    start_video_off: bool = False
 
     @property
     def sip_endpoint(self) -> str:

--- a/src/pipecat/transports/services/helpers/daily_rest.py
+++ b/src/pipecat/transports/services/helpers/daily_rest.py
@@ -43,9 +43,12 @@ class DailyRoomProperties(BaseModel, extra="allow"):
         enable_emoji_reactions: Whether emoji reactions are enabled
         eject_at_room_exp: Whether to remove participants when room expires
         enable_dialout: Whether SIP dial-out is enabled
+        max_participants: Maximum number of participants allowed in the room
         sip: SIP configuration parameters
         sip_uri: SIP URI information returned by Daily
         start_video_off: Whether video is off by default
+
+    Reference: https://docs.daily.co/reference/rest-api/rooms/create-room#properties
     """
 
     exp: Optional[float] = None


### PR DESCRIPTION
### **Description of Changes**
This PR introduces the following updates to the `DailyRoomProperties` model:

1. **New Parameters Added**:
   - `enable_prejoin_ui`: Enables or disables the pre-join UI for the room.
   - `max_participants`: Specifies the maximum number of participants allowed in the room.
   - `start_video_off`: Configures whether video is off by default when participants join.

2. **Default Values Updated**:
   - `enable_prejoin_ui` is set to `True` by default.
   - `start_video_off` is set to `False` by default.

3. **Documentation**:
   - Updated the docstring to reflect the new parameters and their functionalities.

These changes provide enhanced configuration options for room properties, improving the flexibility of room management and participant behavior settings.

---

### **Reason for Changes**
These updates are intended to:
- Improve usability by allowing pre-join UI customization (`enable_prejoin_ui`).
- Introduce control over participant limits (`max_participants`).
- Provide better video behavior settings (`start_video_off`).

---
