### PR TITLE
Include deprecation warnings for LLMUserResponseAggregator and LLMAss…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,7 +458,7 @@ async def on_audio_data(processor, audio, sample_rate, num_channels):
 ### Deprecated
 
 - `LLMUserResponseAggregator` and `LLMAssistantResponseAggregator` are
-  mostly deprecated, use `OpenAILLMContext` instead.
+  deprecated. Use `OpenAILLMContext` instead.
 
 - The `vad` package is now deprecated and `audio.vad` should be used
   instead. The `avd` package will get removed in a future release.

--- a/examples/foundational/07p-interruptible-krisp.py
+++ b/examples/foundational/07p-interruptible-krisp.py
@@ -14,14 +14,10 @@ from loguru import logger
 from runner import configure
 
 from pipecat.audio.filters.krisp_filter import KrispFilter
-from pipecat.frames.frames import LLMMessagesFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
-from pipecat.processors.aggregators.llm_response import (
-    LLMAssistantResponseAggregator,
-    LLMUserResponseAggregator,
-)
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.deepgram import DeepgramSTTService, DeepgramTTSService
 from pipecat.services.openai import OpenAILLMService
 from pipecat.transports.services.daily import DailyParams, DailyTransport
@@ -63,18 +59,18 @@ async def main():
             },
         ]
 
-        tma_in = LLMUserResponseAggregator(messages)
-        tma_out = LLMAssistantResponseAggregator(messages)
+        context = OpenAILLMContext(messages)
+        context_aggregator = llm.create_context_aggregator(context)
 
         pipeline = Pipeline(
             [
                 transport.input(),  # Transport user input
                 stt,  # STT
-                tma_in,  # User responses
+                context_aggregator.user(),  # User responses
                 llm,  # LLM
                 tts,  # TTS
                 transport.output(),  # Transport bot output
-                tma_out,  # Assistant spoken responses
+                context_aggregator.assistant(),  # Assistant spoken responses
             ]
         )
 
@@ -84,7 +80,7 @@ async def main():
         async def on_first_participant_joined(transport, participant):
             # Kick off the conversation.
             messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-            await task.queue_frames([LLMMessagesFrame(messages)])
+            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
 

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import warnings
 from typing import List, Type
 
 from pipecat.frames.frames import (
@@ -26,6 +27,16 @@ from pipecat.processors.aggregators.openai_llm_context import (
     OpenAILLMContextFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+
+def _deprecation_warning(old_class: str):
+    warnings.warn(
+        f"{old_class} is deprecated and will be removed in a future version. "
+        f"Instead, create an OpenAILLMContext and use llm.create_context_aggregator(context) "
+        f"to get context-aware aggregators via .user() and .assistant() methods.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 class LLMResponseAggregator(FrameProcessor):
@@ -175,7 +186,10 @@ class LLMResponseAggregator(FrameProcessor):
 
 
 class LLMAssistantResponseAggregator(LLMResponseAggregator):
+    """DEPRECATED: Create an OpenAILLMContext and use llm.create_context_aggregator(context).assistant() instead."""
+
     def __init__(self, messages: List[dict] = []):
+        _deprecation_warning("LLMAssistantResponseAggregator")
         super().__init__(
             messages=messages,
             role="assistant",
@@ -187,7 +201,10 @@ class LLMAssistantResponseAggregator(LLMResponseAggregator):
 
 
 class LLMUserResponseAggregator(LLMResponseAggregator):
+    """DEPRECATED: Create an OpenAILLMContext and use llm.create_context_aggregator(context).user() instead."""
+
     def __init__(self, messages: List[dict] = []):
+        _deprecation_warning("LLMUserResponseAggregator")
         super().__init__(
             messages=messages,
             role="user",


### PR DESCRIPTION
…istantResponseAggregator

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The only remaining use of these classes are related to Langchain. We'll clean that up in a separate file.

Note: these classes have been deprecated since October. We need to be more clear about deprecation warnings so developers are aware of the changes.