### PR TITLE
Update the Tavus example and comment about using the PERSONA_ID

### DIFF
--- a/examples/foundational/21-tavus-layer.py
+++ b/examples/foundational/21-tavus-layer.py
@@ -39,7 +39,6 @@ async def main():
         tavus = TavusVideoService(
             api_key=os.getenv("TAVUS_API_KEY"),
             replica_id=os.getenv("TAVUS_REPLICA_ID"),
-            persona_id=os.getenv("TAVUS_PERSONA_ID", "pipecat0"),
             session=session,
         )
 

--- a/src/pipecat/services/tavus.py
+++ b/src/pipecat/services/tavus.py
@@ -35,7 +35,7 @@ class TavusVideoService(AIService):
         *,
         api_key: str,
         replica_id: str,
-        persona_id: str = "pipecat0",
+        persona_id: str = "pipecat0",  # Use `pipecat0` so that your TTS voice is used in place of the Tavus persona
         session: aiohttp.ClientSession,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

We've received reports of the Tavus voice coming in in place of the TTS voice. The confusion was that people thought that a persona_id was required. It turns out that `pipecat0` should be used as the persona_id, which means a persona_id shouldn't be set by developers. This PR updates the example and adds a comment to clarify that. I'll also update the docs to clarify.