### PR TITLE
fix: push input audio frame only via push_audio_frame()

### DIFF
--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -357,9 +357,6 @@ class LiveKitInputTransport(BaseInputTransport):
                         sample_rate=pipecat_audio_frame.sample_rate,
                         num_channels=pipecat_audio_frame.num_channels,
                     )
-                    await self.push_frame(
-                        pipecat_audio_frame
-                    )  # TODO: ensure audio frames are pushed with the default BaseInputTransport.push_audio_frame()
                     await self.push_audio_frame(input_audio_frame)
             except asyncio.CancelledError:
                 logger.info("Audio input task cancelled")


### PR DESCRIPTION
Resolves https://github.com/pipecat-ai/pipecat/issues/958.

In LiveKit transport, when handling audio input, push audio frames only with `push_audio_frame()` and remove the additional call to `push_frame()`.

I noticed it was handled this way in other transports:
- in `DailyInputTransport` (only one call to `push_audio_frame()`) 
- in `FastApiWebsocketInputTransport`(push audio frames with `push_audio_frame()`, others with `push_frame()`)
- etc.