### PR TITLE
fix(services): handle TranscriptionFrame separately in TTSService

### DIFF
--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -25,12 +25,12 @@ from pipecat.frames.frames import (
     STTMuteFrame,
     STTUpdateSettingsFrame,
     TextFrame,
+    TranscriptionFrame,
     TTSAudioRawFrame,
     TTSSpeakFrame,
     TTSStartedFrame,
     TTSStoppedFrame,
     TTSUpdateSettingsFrame,
-    TranscriptionFrame,
     UserImageRequestFrame,
     VisionImageRawFrame,
 )

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -30,6 +30,7 @@ from pipecat.frames.frames import (
     TTSStartedFrame,
     TTSStoppedFrame,
     TTSUpdateSettingsFrame,
+    TranscriptionFrame,
     UserImageRequestFrame,
     VisionImageRawFrame,
 )
@@ -290,7 +291,7 @@ class TTSService(AIService):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, TextFrame):
+        if isinstance(frame, TextFrame) and not isinstance(frame, TranscriptionFrame):
             await self._process_text_frame(frame)
         elif isinstance(frame, StartInterruptionFrame):
             await self._handle_interruption(frame, direction)


### PR DESCRIPTION
Exclude TranscriptionFrame from text frame processing in TTSService by updating the type check condition. This resolves unintended processing behavior when handling different frame types.

Discussion: https://discord.com/channels/1239284677165056021/1326894066775887963