### PR TITLE
fix(gemini): prevent non-audio modality processing

### DIFF
--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -288,6 +288,10 @@ class GeminiMultimodalLiveLLMService(LLMService):
         )
 
     async def _handle_transcribe_model_audio(self, audio, context):
+        # Early return if modalities are not set to audio.
+        if self._settings["modalities"] != GeminiMultimodalModalities.AUDIO:
+            return
+
         text = await self._transcribe_audio(audio, context)
         logger.debug(f"[Transcription:model] {text}")
         # We add user messages directly to the context. We don't do that for assistant messages,


### PR DESCRIPTION
Add an early return in the _handle_transcribe_model_audio method to prevent unnecessary processing when the modalities setting is not set to audio. This change ensures that audio transcription only occurs when appropriate.

Also this was causing a problem on text modality since we don't have audio on buffer! 