### PR TITLE
finalize on DeepgramSTTService on VAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `src/pipecat/services/gemini_multimodal_live/gemini.py` to support different
   modalities.
 
+- Changed `DeepgramSTTService` to send `finalize` event whenever VAD detects
+  `UserStoppedSpeakingFrame`. This helps in faster transcriptions and clearing
+  the `Deepgram` audio buffer.
+
 ### Fixed
 
 - Fixed an issue where websocket based TTS services could incorrectly terminate


### PR DESCRIPTION
### Description
This PR improves transcription speed and buffer management in `DeepgramSTTService` by triggering a `finalize` event when the Voice Activity Detection (VAD) identifies a `UserStoppedSpeakingFrame`. This ensures faster transcriptions and efficient clearing of the Deepgram audio buffer.

### Changes
- Added logic to send the `finalize` event upon detecting a `UserStoppedSpeakingFrame`.

### Reason for Change
The `finalize` event signals the end of an audio stream, enabling immediate processing of audio data. This reduces latency and optimizes real-time transcription performance, as recommended in the [Deepgram documentation](https://developers.deepgram.com/docs/finalize).