### PR TITLE
Twilio serializer reading dtmf websocket messages

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -5,6 +5,7 @@
 #
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Literal, Mapping, Optional, Tuple
 
 from pipecat.audio.vad.vad_analyzer import VADParams
@@ -16,6 +17,23 @@ from pipecat.utils.utils import obj_count, obj_id
 
 if TYPE_CHECKING:
     from pipecat.observers.base_observer import BaseObserver
+
+
+class KeypadEntry(str, Enum):
+    """DTMF entries."""
+
+    ONE = "1"
+    TWO = "2"
+    THREE = "3"
+    FOUR = "4"
+    FIVE = "5"
+    SIX = "6"
+    SEVEN = "7"
+    EIGHT = "8"
+    NINE = "9"
+    ZERO = "0"
+    POUND = "#"
+    STAR = "*"
 
 
 def format_pts(pts: int | None):
@@ -613,6 +631,13 @@ class VisionImageRawFrame(InputImageRawFrame):
     def __str__(self):
         pts = format_pts(self.pts)
         return f"{self.name}(pts: {pts}, text: [{self.text}], size: {self.size}, format: {self.format})"
+
+
+@dataclass
+class InputDTMFFrame(Frame):
+    """A DTMF button input"""
+
+    button: KeypadEntry
 
 
 #

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -393,6 +393,13 @@ class TransportMessageFrame(DataFrame):
         return f"{self.name}(message: {self.message})"
 
 
+@dataclass
+class InputDTMFFrame(DataFrame):
+    """A DTMF button input"""
+
+    button: KeypadEntry
+
+
 #
 # System frames
 #
@@ -631,13 +638,6 @@ class VisionImageRawFrame(InputImageRawFrame):
     def __str__(self):
         pts = format_pts(self.pts)
         return f"{self.name}(pts: {pts}, text: [{self.text}], size: {self.size}, format: {self.format})"
-
-
-@dataclass
-class InputDTMFFrame(Frame):
-    """A DTMF button input"""
-
-    button: KeypadEntry
 
 
 #


### PR DESCRIPTION
Following the discord discussion on DTMF input, here is small feature PR that extends the Twilio serializer to read dtmf websocket messages sent by Twilio and generate InputDTMFFrame containing the corresponding value of KeypadEntry. I was not sure were to define KeypadEntry so I included it in frames.py for now.
<img width="870" alt="Screenshot 2025-01-16 at 17 47 01" src="https://github.com/user-attachments/assets/113b9efc-1e77-40e0-bc0f-a4c5b0b18c10" />
