### PR TITLE
TTSService should only process LLMTextFrames

### DIFF
--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -20,12 +20,12 @@ from pipecat.frames.frames import (
     ErrorFrame,
     Frame,
     LLMFullResponseEndFrame,
+    LLMTextFrame,
     StartFrame,
     StartInterruptionFrame,
     STTMuteFrame,
     STTUpdateSettingsFrame,
     TextFrame,
-    TranscriptionFrame,
     TTSAudioRawFrame,
     TTSSpeakFrame,
     TTSStartedFrame,
@@ -291,8 +291,7 @@ class TTSService(AIService):
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
-
-        if isinstance(frame, TextFrame) and not isinstance(frame, TranscriptionFrame):
+        if isinstance(frame, LLMTextFrame):
             await self._process_text_frame(frame)
         elif isinstance(frame, StartInterruptionFrame):
             await self._handle_interruption(frame, direction)

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -19,13 +19,14 @@ from pipecat.frames.frames import (
     EndFrame,
     ErrorFrame,
     Frame,
+    InterimTranscriptionFrame,
     LLMFullResponseEndFrame,
-    LLMTextFrame,
     StartFrame,
     StartInterruptionFrame,
     STTMuteFrame,
     STTUpdateSettingsFrame,
     TextFrame,
+    TranscriptionFrame,
     TTSAudioRawFrame,
     TTSSpeakFrame,
     TTSStartedFrame,
@@ -291,7 +292,11 @@ class TTSService(AIService):
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
-        if isinstance(frame, LLMTextFrame):
+        if (
+            isinstance(frame, TextFrame)
+            and not isinstance(frame, InterimTranscriptionFrame)
+            and not isinstance(frame, TranscriptionFrame)
+        ):
             await self._process_text_frame(frame)
         elif isinstance(frame, StartInterruptionFrame):
             await self._handle_interruption(frame, direction)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In testing, I've seen that both `TranscriptionFrames` and `InterimTranscription` frames will result in the TTS service generating speech. Instead, we only want the `LLMTextFrame` to generate speech. Updating the `TTSService` to reflect this.