### PR TITLE
adding text chunker in 11labs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `examples/foundational/26d-gemini-multimodal-live-text.py` which is
   using Gemini as TEXT modality and using another TTS provider for TTS process.
 
+- Added `text_chunker` as utils and using it in `ElevenLabsTTSService` to
+  support chunked text as per their doc which recommends sending text word by
+  word, also Possible fix of #983. 
+
 ### Changed
 
 - Modified `OpenAIAssistantContextAggregator` to support controlled completions

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -29,6 +29,7 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.ai_services import WordTTSService
 from pipecat.services.websocket_service import WebsocketService
 from pipecat.transcriptions.language import Language
+from pipecat.utils.string import text_chunker
 
 # See .env.example for ElevenLabs configuration needed
 try:
@@ -407,7 +408,9 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
                     self._started = True
                     self._cumulative_time = 0
 
-                await self._send_text(text)
+                for text_chunk in text_chunker(text):
+                    # Ref: https://elevenlabs.io/docs/developer-guides/reducing-latency#3-use-the-input-streaming-websocket
+                    await self._send_text(text_chunk)
                 await self.start_tts_usage_metrics(text)
             except Exception as e:
                 logger.error(f"{self} error sending message: {e}")

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -5,6 +5,7 @@
 #
 
 import re
+import typing
 
 ENDOFSENTENCE_PATTERN_STR = r"""
     (?<![A-Z])       # Negative lookbehind: not preceded by an uppercase letter (e.g., "U.S.A.")
@@ -23,3 +24,21 @@ ENDOFSENTENCE_PATTERN = re.compile(ENDOFSENTENCE_PATTERN_STR, re.VERBOSE)
 def match_endofsentence(text: str) -> int:
     match = ENDOFSENTENCE_PATTERN.search(text.rstrip())
     return match.end() if match else 0
+
+
+def text_chunker(chunks: str) -> str:
+    """Used during input streaming to chunk text blocks and set last char to space"""
+    splitters = (".", ",", "?", "!", ";", ":", "—", "-", "(", ")", "[", "]", "}", " ")
+    buffer = ""
+    for text in chunks:
+        if buffer.endswith(splitters):
+            yield buffer if buffer.endswith(" ") else buffer + " "
+            buffer = text
+        elif text.startswith(splitters):
+            output = buffer + text[0]
+            yield output if output.endswith(" ") else output + " "
+            buffer = text[1:]
+        else:
+            buffer += text
+    if buffer != "":
+        yield buffer + " "


### PR DESCRIPTION
### Changelog
- **Added `text_chunker` utility**: 
  - Introduced a new utility to handle chunked text processing.
  - Integrated `text_chunker` into `ElevenLabsTTSService` to support sending text word by word, as recommended in the ElevenLabs documentation.
  - This change is a potential fix for issue #983.

### Motivation
The change is inspired by ElevenLabs' recommendation to use input streaming via WebSocket for text-to-speech applications. As per their documentation:
> "For applications where the text prompts can be streamed to the text-to-speech endpoints (such as LLM output), this allows for prompts to be fed to the endpoint while the speech is being generated. You can also configure the streaming chunk size when using the WebSocket, with smaller chunks generally rendering faster. As such, we recommend sending content word by word. Our model and tooling leverage context to ensure that sentence structure and more are persisted in the generated audio, even if we only receive a word at a time."

This implementation ensures faster rendering and better alignment with ElevenLabs' best practices, while also addressing potential issues like #983.