### PR TITLE
transports: streamline max_workers for ThreadPoolExecutors

### DIFF
--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -35,7 +35,9 @@ class BaseInputTransport(FrameProcessor):
 
         self._params = params
 
-        self._executor = ThreadPoolExecutor(max_workers=5)
+        # We read audio from a single queue one at a time and we then run VAD in
+        # a thread. Therefore, only one thread should be necessary.
+        self._executor = ThreadPoolExecutor(max_workers=1)
 
         # Task to process incoming audio (VAD) and push audio frames downstream
         # if passthrough is enabled.

--- a/src/pipecat/transports/local/audio.py
+++ b/src/pipecat/transports/local/audio.py
@@ -69,7 +69,9 @@ class LocalAudioOutputTransport(BaseOutputTransport):
     def __init__(self, py_audio: pyaudio.PyAudio, params: TransportParams):
         super().__init__(params)
 
-        self._executor = ThreadPoolExecutor(max_workers=5)
+        # We only write audio frames from a single task, so only one thread
+        # should be necessary.
+        self._executor = ThreadPoolExecutor(max_workers=1)
 
         self._out_stream = py_audio.open(
             format=py_audio.get_format_from_width(2),

--- a/src/pipecat/transports/local/tk.py
+++ b/src/pipecat/transports/local/tk.py
@@ -77,7 +77,9 @@ class TkOutputTransport(BaseOutputTransport):
     def __init__(self, tk_root: tk.Tk, py_audio: pyaudio.PyAudio, params: TransportParams):
         super().__init__(params)
 
-        self._executor = ThreadPoolExecutor(max_workers=5)
+        # We only write audio frames from a single task, so only one thread
+        # should be necessary.
+        self._executor = ThreadPoolExecutor(max_workers=1)
 
         self._out_stream = py_audio.open(
             format=py_audio.get_format_from_width(2),


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Explanation in comments. But basically, we don't need `max_workers` set to anything different than 1 since there's only a single task sending data to the thread, so only 1 thread needed.