### PR TITLE
Add transcript to Canonical Metrics Service

### DIFF
--- a/examples/canonical-metrics/bot.py
+++ b/examples/canonical-metrics/bot.py
@@ -97,7 +97,7 @@ async def main():
         call completion, CanonicalMetrics will send the audio buffer to Canonical for
         analysis. Visit https://voice.canonical.chat to learn more.
         """
-        audio_buffer_processor = AudioBufferProcessor()
+        audio_buffer_processor = AudioBufferProcessor(num_channels=2)
         canonical = CanonicalMetricsService(
             audio_buffer_processor=audio_buffer_processor,
             aiohttp_session=session,
@@ -105,6 +105,7 @@ async def main():
             call_id=str(uuid.uuid4()),
             assistant="pipecat-chatbot",
             assistant_speaks_first=True,
+            context=context,
         )
         pipeline = Pipeline(
             [

--- a/src/pipecat/services/canonical.py
+++ b/src/pipecat/services/canonical.py
@@ -15,10 +15,9 @@ import aiohttp
 from loguru import logger
 
 from pipecat.frames.frames import CancelFrame, EndFrame, Frame
-from pipecat.processors.audio import audio_buffer_processor
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.ai_services import AIService
 
 try:
     import aiofiles
@@ -69,6 +68,7 @@ class CanonicalMetricsService(AIService):
         api_url: str = "https://voiceapp.canonical.chat/api/v1",
         assistant_speaks_first: bool = True,
         output_dir: str = "recordings",
+        context: OpenAILLMContext | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -80,6 +80,7 @@ class CanonicalMetricsService(AIService):
         self._assistant = assistant
         self._assistant_speaks_first = assistant_speaks_first
         self._output_dir = output_dir
+        self._context = context
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
@@ -190,6 +191,9 @@ class CanonicalMetricsService(AIService):
             "callId": self._call_id,
             "assistant": {"id": self._assistant, "speaksFirst": self._assistant_speaks_first},
         }
+        if self._context is not None:
+            params["transcript"] = self._context.messages
+
         logger.debug(f"Completing upload for {params['filename']}")
         logger.debug(f"Slug: {params['slug']}")
         response = await self._aiohttp_session.post(


### PR DESCRIPTION
Updated the Canonical Metrics service to accept an `OpenAILLMContext` instance on the constructor. The metrics service uses this object to extract the messages to send them to Canonical along with the audio recording.

Updated the Canonical Metrics example to use stereo audio and pass in an instance of `OpenAILLMContext`. 