### PR TITLE
Remove @abstractmethod from set_model and set_model in TTSService class

### DIFF
--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -232,11 +232,9 @@ class TTSService(AIService):
     def sample_rate(self) -> int:
         return self._sample_rate
 
-    @abstractmethod
     async def set_model(self, model: str):
         self.set_model_name(model)
 
-    @abstractmethod
     def set_voice(self, voice: str):
         self._voice_id = voice
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

These were marked as `@abstractmethod`, but none of the subclasses implemented the methods. This causes an IDE error, which I'm resolving.