### PR TITLE
Added a retry counter for the userIdleProcessor

### DIFF
--- a/examples/foundational/17-detect-user-idle.py
+++ b/examples/foundational/17-detect-user-idle.py
@@ -78,7 +78,8 @@ async def main():
                     {
                         "role": "system",
                         "content": "Ask the user if they are still there and try to prompt for some input, but be short.",
-                    })
+                    }
+                )
                 await user_idle.push_frame(LLMMessagesFrame(messages))
 
         user_idle = UserIdleProcessor(callback=user_idle_callback, retry_count=2, timeout=10.0)

--- a/examples/foundational/17-detect-user-idle.py
+++ b/examples/foundational/17-detect-user-idle.py
@@ -32,9 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        # (room_url, token) = await configure(session)
-        room_url = 'https://bdom.daily.co/support'
-        token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvIjp0cnVlLCJkIjoiOTdkYTBiMGMtNmIwMy00ZmMzLWJiNTgtNDJiMjdlODY0Y2ViIiwiaWF0IjoxNzMxOTg5Mjg0fQ.1G6Uo1RJxXbKZaRdhgeWKQKj-f2z2VC-1gFeztxIflY'
+        (room_url, token) = await configure(session)
 
         transport = DailyTransport(
             room_url,
@@ -74,6 +72,7 @@ async def main():
                     }
                 )
                 await user_idle.push_frame(LLMMessagesFrame(messages))
+
             else:
                 messages.append(
                     {

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -76,7 +76,6 @@ class UserIdleProcessor(FrameProcessor):
                 await asyncio.wait_for(self._idle_event.wait(), timeout=self._timeout)
             except asyncio.TimeoutError:
                 if not self._interrupted and self._retry_count >= 0:
-                    print(f"+++ User idle +++ ${self._retry_count}")
                     self._retry_count -= 1
                     await self._callback(self)
             except asyncio.CancelledError:

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -38,6 +38,7 @@ class UserIdleProcessor(FrameProcessor):
         self._timeout = timeout
         self._interrupted = False
         self._retry_count = retry_count
+        self._initial_retry_count = retry_count
         self._create_idle_task()
 
     async def _stop(self):
@@ -56,6 +57,7 @@ class UserIdleProcessor(FrameProcessor):
         # We shouldn't call the idle callback if the user or the bot are speaking
         if isinstance(frame, UserStartedSpeakingFrame):
             self._interrupted = True
+            self.retry_count = self._initial_retry_count
             self._idle_event.set()
         elif isinstance(frame, UserStoppedSpeakingFrame):
             self._interrupted = False


### PR DESCRIPTION
Adds a retry count to the UserIdleProcessor. This allows users to have conditional logic to retry multiple times when a user is idle, and then after a certain number of tries, end the call, for example. 