### PR TITLE
fixing IdleFrameProcessor and UserIdleProcessor init logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where setting the voice and model for `RimeHttpTTSService`
   wasn't working.
 
+- Fixed an issue where `IdleFrameProcessor` and `UserIdleProcessor` were getting
+  initialized before the start of the pipeline.
+
 ## [0.0.52] - 2024-12-24
 
 ### Added

--- a/src/pipecat/processors/idle_frame_processor.py
+++ b/src/pipecat/processors/idle_frame_processor.py
@@ -7,7 +7,7 @@
 import asyncio
 from typing import Awaitable, Callable, List
 
-from pipecat.frames.frames import Frame
+from pipecat.frames.frames import Frame, StartFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 
@@ -31,10 +31,11 @@ class IdleFrameProcessor(FrameProcessor):
         self._timeout = timeout
         self._types = types
 
-        self._create_idle_task()
-
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
+
+        if isinstance(frame, StartFrame):
+            self._create_idle_task()
 
         await self.push_frame(frame, direction)
 

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -14,6 +14,7 @@ from pipecat.frames.frames import (
     Frame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    StartFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
@@ -36,7 +37,6 @@ class UserIdleProcessor(FrameProcessor):
         self._callback = callback
         self._timeout = timeout
         self._interrupted = False
-        self._create_idle_task()
 
     async def _stop(self):
         self._idle_task.cancel()
@@ -46,7 +46,9 @@ class UserIdleProcessor(FrameProcessor):
         await super().process_frame(frame, direction)
 
         # Check for end frames before processing
-        if isinstance(frame, (EndFrame, CancelFrame)):
+        if isinstance(frame, StartFrame):
+            self._create_idle_task()
+        elif isinstance(frame, (EndFrame, CancelFrame)):
             await self._stop()
 
         await self.push_frame(frame, direction)

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -12,9 +12,9 @@ from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
     Frame,
+    StartFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
-    StartFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 


### PR DESCRIPTION
Fixed an issue where `IdleFrameProcessor` and `UserIdleProcessor` were getting initialized before the start of the pipeline, causing pre-mature events before time