### PR TITLE
bug fix: read run_llm from frame.properties for openai realtime service

### DIFF
--- a/src/pipecat/services/openai_realtime_beta/context.py
+++ b/src/pipecat/services/openai_realtime_beta/context.py
@@ -211,7 +211,9 @@ class OpenAIRealtimeAssistantContextAggregator(OpenAIAssistantContextAggregator)
                 await self._user_context_aggregator.push_frame(
                     RealtimeFunctionCallResultFrame(result_frame=frame)
                 )
-                run_llm = frame.run_llm
+
+                if frame.properties and frame.properties.run_llm is not None:
+                    run_llm = frame.properties.run_llm
 
             if run_llm:
                 await self._user_context_aggregator.push_context_frame()


### PR DESCRIPTION
Function calling with openai realtime service causes the bot to crash due to an error like this:

```
2025-01-21 17:01:44.375 | ERROR    | pipecat.services.openai_realtime_beta.context:_push_aggregation:223 - Error processing frame: 'FunctionCallResultFrame' object has no attribute 'run_llm'
```

In #970 we changed the way we read `run_llm` from each `frame` but apparently forgot to update the usage for openai realtime service. The change  was released in `v0.0.53` a few days ago.