### PR TITLE
Added: Additional DTMF frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It is now possible to specify the period of the `PipelineTask` heartbeat
   frames with `heartbeats_period_secs`.
 
+- Additional DTMF frames
+
 ### Fixed
 
 - Fixed a type error when using `voice_settings` in `ElevenLabsHttpTTSService`.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -394,10 +394,20 @@ class TransportMessageFrame(DataFrame):
 
 
 @dataclass
-class InputDTMFFrame(DataFrame):
-    """A DTMF button input"""
+class DTMFFrame(DataFrame):
+    """A DTMF button frame"""
 
     button: KeypadEntry
+
+
+@dataclass
+class InputDTMFFrame(DTMFFrame):
+    """A DTMF button input"""
+
+
+@dataclass
+class OuputDTMFFrame(DTMFFrame):
+    """A DTMF button output"""
 
 
 #


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Added a DTMF frame along with an output frame. Output frames could be useful if we wanted to send DTMF. An example for this would be building a chat bot tester where they may have to go through a DTMF auto attendant.