### PR TITLE
Add explicit support for OpenAI organization and project based on …

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -116,6 +116,8 @@ class BaseOpenAILLMService(LLMService):
         model: str,
         api_key=None,
         base_url=None,
+        organization=None,
+        project=None,
         params: InputParams = InputParams(),
         **kwargs,
     ):
@@ -131,12 +133,14 @@ class BaseOpenAILLMService(LLMService):
             "extra": params.extra if isinstance(params.extra, dict) else {},
         }
         self.set_model_name(model)
-        self._client = self.create_client(api_key=api_key, base_url=base_url, **kwargs)
+        self._client = self.create_client(api_key=api_key, base_url=base_url, organization=organization, project=project, **kwargs)
 
-    def create_client(self, api_key=None, base_url=None, **kwargs):
+    def create_client(self, api_key=None, base_url=None, organization=None, project=None, **kwargs):
         return AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
+            organization=organization,
+            project=project,
             http_client=DefaultAsyncHttpxClient(
                 limits=httpx.Limits(
                     max_keepalive_connections=100, max_connections=1000, keepalive_expiry=None


### PR DESCRIPTION
Based on https://platform.openai.com/docs/api-reference/authentication

Note:
I learned during testing that if the OpenAI API key used doesn't match the Organization or Project ID, it will bill the API key's corresponding organization and project.

I personally think it is also fine to note merge this because a user can achieve the same effect by making API keys per Organization and Project.