### PR TITLE
improve task creation and cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- In order to create tasks in Pipecat it is now recommended to use
-  `utils.asyncio.create_task()`. It takes care of uncaught exceptions, task
+- In order to create tasks in Pipecat frame processors it is now recommended to
+  use `FrameProcessor.create_task()` (which uses the new
+  `utils.asyncio.create_task()`). It takes care of uncaught exceptions, task
   cancellation handling and task management. To cancel or wait for a task there
-  is `utils.asyncio.cancel_task()` and `utils.asyncio.wait_for_task()`. All of
+  is `FrameProcessor.cancel_task()` and `FrameProcessor.wait_for_task()`. All of
   Pipecat processors have been updated accordingly. Also, when a pipeline runner
   finishes, a warning about dangling tasks might appear, which indicates if any
   of the created tasks was never cancelled or awaited for (using these new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- In order to create tasks in Pipecat it is now recommended to use
+  `utils.asyncio.create_task()`. It takes care of uncaught exceptions, task
+  cancellation handling and task management. To cancel or wait for a task there
+  is `utils.asyncio.cancel_task()` and `utils.asyncio.wait_for_task()`. All of
+  Pipecat processors have been updated accordingly. Also, when a pipeline runner
+  finishes, a warning about dangling tasks might appear, which indicates if any
+  of the created tasks was never cancelled or awaited for (using these new
+  functions).
+
 - It is now possible to specify the period of the `PipelineTask` heartbeat
   frames with `heartbeats_period_secs`.
 
@@ -40,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TranscriptProcessor`.
 
 ### Fixed
+
+- Fixed an `GeminiMultimodalLiveLLMService` issue that was preventing the user
+  to push initial LLM assistant messages (using `LLMMessagesAppendFrame`).
+
+- Added missing `FrameProcessor.cleanup()` calls to `Pipeline`,
+  `ParallelPipeline` and `UserIdleProcessor`.
 
 - Fixed a type error when using `voice_settings` in `ElevenLabsHttpTTSService`.
 

--- a/examples/foundational/14-function-calling.py
+++ b/examples/foundational/14-function-calling.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -31,7 +31,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14c-function-calling-together.py
+++ b/examples/foundational/14c-function-calling-together.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14f-function-calling-groq.py
+++ b/examples/foundational/14f-function-calling-groq.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14g-function-calling-grok.py
+++ b/examples/foundational/14g-function-calling-grok.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14h-function-calling-azure.py
+++ b/examples/foundational/14h-function-calling-azure.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14i-function-calling-fireworks.py
+++ b/examples/foundational/14i-function-calling-fireworks.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14j-function-calling-nim.py
+++ b/examples/foundational/14j-function-calling-nim.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 
@@ -93,7 +93,7 @@ async def main():
         messages = [
             {
                 "role": "system",
-                "content": """You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. 
+                "content": """You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way.
 
 You have one functions available:
 

--- a/examples/foundational/14l-function-calling-deepseek.py
+++ b/examples/foundational/14l-function-calling-deepseek.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 
@@ -93,7 +93,7 @@ async def main():
         messages = [
             {
                 "role": "system",
-                "content": """You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. 
+                "content": """You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way.
 
 You have one functions available:
 

--- a/examples/foundational/14m-function-calling-openrouter.py
+++ b/examples/foundational/14m-function-calling-openrouter.py
@@ -15,7 +15,7 @@ from openai.types.chat import ChatCompletionToolParam
 from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -32,7 +32,7 @@ logger.add(sys.stderr, level="DEBUG")
 
 async def start_fetch_weather(function_name, llm, context):
     """Push a frame to the LLM; this is handy when the LLM response might take a while."""
-    await llm.push_frame(TextFrame("Let me check on that."))
+    await llm.push_frame(TTSSpeakFrame("Let me check on that."))
     logger.debug(f"Starting fetch_weather_from_api with function_name: {function_name}")
 
 

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -169,8 +169,7 @@ class OutputGate(FrameProcessor):
         self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
 
     async def _stop(self):
-        self._gate_task.cancel()
-        await self._gate_task
+        await self.cancel_task(self._gate_task)
 
     async def _gate_task_handler(self):
         while True:

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -101,12 +101,12 @@ HIGH PRIORITY SIGNALS:
 
 Examples:
 # Complete Wh-question
-[{"role": "assistant", "content": "I can help you learn."}, 
+[{"role": "assistant", "content": "I can help you learn."},
  {"role": "user", "content": "What's the fastest way to learn Spanish"}]
 Output: YES
 
 # Complete Yes/No question despite STT error
-[{"role": "assistant", "content": "I know about planets."}, 
+[{"role": "assistant", "content": "I know about planets."},
  {"role": "user", "content": "Is is Jupiter the biggest planet"}]
 Output: YES
 
@@ -118,12 +118,12 @@ Output: YES
 
 Examples:
 # Direct instruction
-[{"role": "assistant", "content": "I can explain many topics."}, 
+[{"role": "assistant", "content": "I can explain many topics."},
  {"role": "user", "content": "Tell me about black holes"}]
 Output: YES
 
 # Action demand
-[{"role": "assistant", "content": "I can help with math."}, 
+[{"role": "assistant", "content": "I can help with math."},
  {"role": "user", "content": "Solve this equation x plus 5 equals 12"}]
 Output: YES
 
@@ -134,12 +134,12 @@ Output: YES
 
 Examples:
 # Specific answer
-[{"role": "assistant", "content": "What's your favorite color?"}, 
+[{"role": "assistant", "content": "What's your favorite color?"},
  {"role": "user", "content": "I really like blue"}]
 Output: YES
 
 # Option selection
-[{"role": "assistant", "content": "Would you prefer morning or evening?"}, 
+[{"role": "assistant", "content": "Would you prefer morning or evening?"},
  {"role": "user", "content": "Morning"}]
 Output: YES
 
@@ -153,17 +153,17 @@ MEDIUM PRIORITY SIGNALS:
 
 Examples:
 # Self-correction reaching completion
-[{"role": "assistant", "content": "What would you like to know?"}, 
+[{"role": "assistant", "content": "What would you like to know?"},
  {"role": "user", "content": "Tell me about... no wait, explain how rainbows form"}]
 Output: YES
 
 # Topic change with complete thought
-[{"role": "assistant", "content": "The weather is nice today."}, 
+[{"role": "assistant", "content": "The weather is nice today."},
  {"role": "user", "content": "Actually can you tell me who invented the telephone"}]
 Output: YES
 
 # Mid-sentence completion
-[{"role": "assistant", "content": "Hello I'm ready."}, 
+[{"role": "assistant", "content": "Hello I'm ready."},
  {"role": "user", "content": "What's the capital of? France"}]
 Output: YES
 
@@ -175,12 +175,12 @@ Output: YES
 
 Examples:
 # Acknowledgment
-[{"role": "assistant", "content": "Should we talk about history?"}, 
+[{"role": "assistant", "content": "Should we talk about history?"},
  {"role": "user", "content": "Sure"}]
 Output: YES
 
 # Disagreement with completion
-[{"role": "assistant", "content": "Is that what you meant?"}, 
+[{"role": "assistant", "content": "Is that what you meant?"},
  {"role": "user", "content": "No not really"}]
 Output: YES
 
@@ -194,12 +194,12 @@ LOW PRIORITY SIGNALS:
 
 Examples:
 # Word repetition but complete
-[{"role": "assistant", "content": "I can help with that."}, 
+[{"role": "assistant", "content": "I can help with that."},
  {"role": "user", "content": "What what is the time right now"}]
 Output: YES
 
 # Missing punctuation but complete
-[{"role": "assistant", "content": "I can explain that."}, 
+[{"role": "assistant", "content": "I can explain that."},
  {"role": "user", "content": "Please tell me how computers work"}]
 Output: YES
 
@@ -211,12 +211,12 @@ Output: YES
 
 Examples:
 # Filler words but complete
-[{"role": "assistant", "content": "What would you like to know?"}, 
+[{"role": "assistant", "content": "What would you like to know?"},
  {"role": "user", "content": "Um uh how do airplanes fly"}]
 Output: YES
 
 # Thinking pause but incomplete
-[{"role": "assistant", "content": "I can explain anything."}, 
+[{"role": "assistant", "content": "I can explain anything."},
  {"role": "user", "content": "Well um I want to know about the"}]
 Output: NO
 
@@ -241,17 +241,17 @@ DECISION RULES:
 
 Examples:
 # Incomplete despite corrections
-[{"role": "assistant", "content": "What would you like to know about?"}, 
+[{"role": "assistant", "content": "What would you like to know about?"},
  {"role": "user", "content": "Can you tell me about"}]
 Output: NO
 
 # Complete despite multiple artifacts
-[{"role": "assistant", "content": "I can help you learn."}, 
+[{"role": "assistant", "content": "I can help you learn."},
  {"role": "user", "content": "How do you I mean what's the best way to learn programming"}]
 Output: YES
 
 # Trailing off incomplete
-[{"role": "assistant", "content": "I can explain anything."}, 
+[{"role": "assistant", "content": "I can explain anything."},
  {"role": "user", "content": "I was wondering if you could tell me why"}]
 Output: NO
 """
@@ -374,8 +374,7 @@ class OutputGate(FrameProcessor):
         self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
 
     async def _stop(self):
-        self._gate_task.cancel()
-        await self._gate_task
+        await cancel_task(self._gate_task)
 
     async def _gate_task_handler(self):
         while True:

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -374,7 +374,7 @@ class OutputGate(FrameProcessor):
         self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
 
     async def _stop(self):
-        await cancel_task(self._gate_task)
+        await self.cancel_task(self._gate_task)
 
     async def _gate_task_handler(self):
         while True:

--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -15,6 +15,7 @@ from runner import configure
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.frames.frames import LLMMessagesAppendFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -70,6 +71,21 @@ async def main():
                 enable_usage_metrics=True,
             ),
         )
+
+        @transport.event_handler("on_first_participant_joined")
+        async def on_first_participant_joined(transport, participant):
+            await task.queue_frames(
+                [
+                    LLMMessagesAppendFrame(
+                        messages=[
+                            {
+                                "role": "assistant",
+                                "content": "Greet the user.",
+                            }
+                        ]
+                    )
+                ]
+            )
 
         runner = PipelineRunner()
 

--- a/src/pipecat/audio/vad/silero.py
+++ b/src/pipecat/audio/vad/silero.py
@@ -159,5 +159,5 @@ class SileroVADAnalyzer(VADAnalyzer):
             return new_confidence
         except Exception as e:
             # This comes from an empty audio array
-            logger.exception(f"Error analyzing audio with Silero VAD: {e}")
+            logger.error(f"Error analyzing audio with Silero VAD: {e}")
             return 0

--- a/src/pipecat/pipeline/base_task.py
+++ b/src/pipecat/pipeline/base_task.py
@@ -11,6 +11,18 @@ from pipecat.frames.frames import Frame
 
 
 class BaseTask(ABC):
+    @property
+    @abstractmethod
+    def id(self) -> int:
+        """Returns the unique indetifier for this task."""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Returns the name of this task."""
+        pass
+
     @abstractmethod
     def has_finished(self) -> bool:
         """Indicates whether the tasks has finished. That is, all processors

--- a/src/pipecat/pipeline/pipeline.py
+++ b/src/pipecat/pipeline/pipeline.py
@@ -71,6 +71,7 @@ class Pipeline(BasePipeline):
     #
 
     async def cleanup(self):
+        await super().cleanup()
         await self._cleanup_processors()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):

--- a/src/pipecat/pipeline/runner.py
+++ b/src/pipecat/pipeline/runner.py
@@ -10,7 +10,7 @@ import signal
 from loguru import logger
 
 from pipecat.pipeline.task import PipelineTask
-from pipecat.utils.utils import obj_count, obj_id
+from pipecat.utils.utils import current_tasks, obj_count, obj_id
 
 
 class PipelineRunner:
@@ -33,6 +33,7 @@ class PipelineRunner:
         # everything gets cleaned up nicely.
         if self._sig_task:
             await self._sig_task
+        self._print_dangling_tasks()
         logger.debug(f"Runner {self} finished running {task}")
 
     async def stop_when_done(self):
@@ -55,6 +56,11 @@ class PipelineRunner:
     async def _sig_cancel(self):
         logger.warning(f"Interruption detected. Canceling runner {self}")
         await self.cancel()
+
+    def _print_dangling_tasks(self):
+        tasks = [t.get_name() for t in current_tasks()]
+        if tasks:
+            logger.warning(f"Dangling tasks detected: {tasks}")
 
     def __str__(self):
         return self.name

--- a/src/pipecat/pipeline/runner.py
+++ b/src/pipecat/pipeline/runner.py
@@ -10,7 +10,8 @@ import signal
 from loguru import logger
 
 from pipecat.pipeline.task import PipelineTask
-from pipecat.utils.utils import current_tasks, obj_count, obj_id
+from pipecat.utils.asyncio import current_tasks
+from pipecat.utils.utils import obj_count, obj_id
 
 
 class PipelineRunner:

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -30,7 +30,7 @@ from pipecat.pipeline.base_pipeline import BasePipeline
 from pipecat.pipeline.base_task import BaseTask
 from pipecat.pipeline.task_observer import TaskObserver
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id
+from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id, wait_for_task
 
 HEARTBEAT_SECONDS = 1.0
 HEARTBEAT_MONITOR_SECONDS = HEARTBEAT_SECONDS * 5
@@ -165,7 +165,7 @@ class PipelineTask(BaseTask):
         """
         try:
             push_task = self._create_tasks()
-            await asyncio.gather(push_task)
+            await wait_for_task(push_task)
         except asyncio.CancelledError:
             # We are awaiting on the push task and it might be cancelled
             # (e.g. Ctrl-C). This means we will get a CancelledError here as

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -125,10 +125,12 @@ class PipelineTask(BaseTask):
 
     @property
     def id(self) -> int:
+        """Returns the unique indetifier for this task."""
         return self._id
 
     @property
     def name(self) -> str:
+        """Returns the name of this task."""
         return self._name
 
     def has_finished(self) -> bool:

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -94,8 +94,8 @@ class PipelineTask(BaseTask):
         params: PipelineParams = PipelineParams(),
         clock: BaseClock = SystemClock(),
     ):
-        self.id: int = obj_id()
-        self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
+        self._id: int = obj_id()
+        self._name: str = f"{self.__class__.__name__}#{obj_count(self)}"
 
         self._pipeline = pipeline
         self._clock = clock
@@ -122,6 +122,14 @@ class PipelineTask(BaseTask):
         pipeline.link(self._sink)
 
         self._observer = TaskObserver(params.observers)
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def has_finished(self) -> bool:
         """Indicates whether the tasks has finished. That is, all processors

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -30,7 +30,8 @@ from pipecat.pipeline.base_pipeline import BasePipeline
 from pipecat.pipeline.base_task import BaseTask
 from pipecat.pipeline.task_observer import TaskObserver
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id, wait_for_task
+from pipecat.utils.asyncio import cancel_task, create_task, wait_for_task
+from pipecat.utils.utils import obj_count, obj_id
 
 HEARTBEAT_SECONDS = 1.0
 HEARTBEAT_MONITOR_SECONDS = HEARTBEAT_SECONDS * 5

--- a/src/pipecat/pipeline/task_observer.py
+++ b/src/pipecat/pipeline/task_observer.py
@@ -12,7 +12,7 @@ from attr import dataclass
 from pipecat.frames.frames import Frame
 from pipecat.observers.base_observer import BaseObserver
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.utils.utils import cancel_task, create_task, obj_count
+from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id
 
 
 @dataclass
@@ -55,8 +55,17 @@ class TaskObserver(BaseObserver):
     """
 
     def __init__(self, observers: List[BaseObserver] = []):
-        self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
+        self._id: int = obj_id()
+        self._name: str = f"{self.__class__.__name__}#{obj_count(self)}"
         self._proxies: List[Proxy] = self._create_proxies(observers)
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     async def stop(self):
         """Stops all proxy observer tasks."""

--- a/src/pipecat/pipeline/task_observer.py
+++ b/src/pipecat/pipeline/task_observer.py
@@ -12,7 +12,8 @@ from attr import dataclass
 from pipecat.frames.frames import Frame
 from pipecat.observers.base_observer import BaseObserver
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id
+from pipecat.utils.asyncio import cancel_task, create_task
+from pipecat.utils.utils import obj_count, obj_id
 
 
 @dataclass

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -41,8 +41,8 @@ class FrameProcessor:
         loop: asyncio.AbstractEventLoop | None = None,
         **kwargs,
     ):
-        self.id: int = obj_id()
-        self.name = name or f"{self.__class__.__name__}#{obj_count(self)}"
+        self._id: int = obj_id()
+        self._name = name or f"{self.__class__.__name__}#{obj_count(self)}"
         self._parent: "FrameProcessor" | None = None
         self._prev: "FrameProcessor" | None = None
         self._next: "FrameProcessor" | None = None
@@ -82,6 +82,14 @@ class FrameProcessor:
         # task. This avoid problems like audio overlapping. System frames are
         # the exception to this rule. This create this task.
         self.__create_push_task()
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     @property
     def interruptions_allowed(self):

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -24,7 +24,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.metrics.metrics import LLMTokenUsage, MetricsData
 from pipecat.processors.metrics.frame_processor_metrics import FrameProcessorMetrics
-from pipecat.utils.asyncio import cancel_task, create_task
+from pipecat.utils.asyncio import cancel_task, create_task, wait_for_task
 from pipecat.utils.utils import obj_count, obj_id
 
 
@@ -156,6 +156,9 @@ class FrameProcessor:
 
     async def cancel_task(self, task: asyncio.Task, timeout: Optional[float] = None):
         await cancel_task(task, timeout)
+
+    async def wait_for_task(self, task: asyncio.Task, timeout: Optional[float] = None):
+        await wait_for_task(task, timeout)
 
     async def cleanup(self):
         await self.__cancel_input_task()

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -6,15 +6,15 @@
 
 import asyncio
 import inspect
+import sys
 from enum import Enum
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Coroutine, Optional
 
 from loguru import logger
 
 from pipecat.clocks.base_clock import BaseClock
 from pipecat.frames.frames import (
     CancelFrame,
-    EndFrame,
     ErrorFrame,
     Frame,
     StartFrame,
@@ -24,7 +24,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.metrics.metrics import LLMTokenUsage, MetricsData
 from pipecat.processors.metrics.frame_processor_metrics import FrameProcessorMetrics
-from pipecat.utils.utils import obj_count, obj_id
+from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id
 
 
 class FrameDirection(Enum):
@@ -141,6 +141,13 @@ class FrameProcessor:
         await self.stop_ttfb_metrics()
         await self.stop_processing_metrics()
 
+    def create_task(self, coroutine: Coroutine) -> asyncio.Task:
+        name = f"{self}::{coroutine.cr_code.co_name}"
+        return create_task(self.get_event_loop(), coroutine, name)
+
+    async def cancel_task(self, task: asyncio.Task, timeout: Optional[float] = None):
+        await cancel_task(task, timeout)
+
     async def cleanup(self):
         await self.__cancel_input_task()
         await self.__cancel_push_task()
@@ -188,7 +195,6 @@ class FrameProcessor:
     async def resume_processing_frames(self):
         logger.trace(f"{self}: resuming frame processing")
         self.__input_event.set()
-        self.__should_block_frames = False
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         if isinstance(frame, StartFrame):
@@ -283,61 +289,44 @@ class FrameProcessor:
     def __create_input_task(self):
         self.__should_block_frames = False
         self.__input_queue = asyncio.Queue()
-        self.__input_frame_task = self.get_event_loop().create_task(
-            self.__input_frame_task_handler()
-        )
         self.__input_event = asyncio.Event()
+        self.__input_frame_task = self.create_task(self.__input_frame_task_handler())
 
     async def __cancel_input_task(self):
-        self.__input_frame_task.cancel()
-        await self.__input_frame_task
+        await self.cancel_task(self.__input_frame_task)
 
     async def __input_frame_task_handler(self):
         while True:
-            try:
-                if self.__should_block_frames:
-                    logger.trace(f"{self}: frame processing paused")
-                    await self.__input_event.wait()
-                    self.__input_event.clear()
-                    logger.trace(f"{self}: frame processing resumed")
+            if self.__should_block_frames:
+                logger.trace(f"{self}: frame processing paused")
+                await self.__input_event.wait()
+                self.__input_event.clear()
+                self.__should_block_frames = False
+                logger.trace(f"{self}: frame processing resumed")
 
-                (frame, direction, callback) = await self.__input_queue.get()
+            (frame, direction, callback) = await self.__input_queue.get()
 
-                # Process the frame.
-                await self.process_frame(frame, direction)
+            # Process the frame.
+            await self.process_frame(frame, direction)
 
-                # If this frame has an associated callback, call it now.
-                if callback:
-                    await callback(self, frame, direction)
+            # If this frame has an associated callback, call it now.
+            if callback:
+                await callback(self, frame, direction)
 
-                self.__input_queue.task_done()
-            except asyncio.CancelledError:
-                logger.trace(f"{self}: cancelled input task")
-                break
-            except Exception as e:
-                logger.exception(f"{self}: Uncaught exception {e}")
-                await self.push_error(ErrorFrame(str(e)))
+            self.__input_queue.task_done()
 
     def __create_push_task(self):
         self.__push_queue = asyncio.Queue()
-        self.__push_frame_task = self.get_event_loop().create_task(self.__push_frame_task_handler())
+        self.__push_frame_task = self.create_task(self.__push_frame_task_handler())
 
     async def __cancel_push_task(self):
-        self.__push_frame_task.cancel()
-        await self.__push_frame_task
+        await self.cancel_task(self.__push_frame_task)
 
     async def __push_frame_task_handler(self):
         while True:
-            try:
-                (frame, direction) = await self.__push_queue.get()
-                await self.__internal_push_frame(frame, direction)
-                self.__push_queue.task_done()
-            except asyncio.CancelledError:
-                logger.trace(f"{self}: cancelled push task")
-                break
-            except Exception as e:
-                logger.exception(f"{self}: Uncaught exception {e}")
-                await self.push_error(ErrorFrame(str(e)))
+            (frame, direction) = await self.__push_queue.get()
+            await self.__internal_push_frame(frame, direction)
+            self.__push_queue.task_done()
 
     async def _call_event_handler(self, event_name: str, *args, **kwargs):
         try:

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -24,7 +24,8 @@ from pipecat.frames.frames import (
 )
 from pipecat.metrics.metrics import LLMTokenUsage, MetricsData
 from pipecat.processors.metrics.frame_processor_metrics import FrameProcessorMetrics
-from pipecat.utils.utils import cancel_task, create_task, obj_count, obj_id
+from pipecat.utils.asyncio import cancel_task, create_task
+from pipecat.utils.utils import obj_count, obj_id
 
 
 class FrameDirection(Enum):

--- a/src/pipecat/processors/idle_frame_processor.py
+++ b/src/pipecat/processors/idle_frame_processor.py
@@ -49,12 +49,11 @@ class IdleFrameProcessor(FrameProcessor):
                     self._idle_event.set()
 
     async def cleanup(self):
-        self._idle_task.cancel()
-        await self._idle_task
+        await self.cancel_task(self._idle_task)
 
     def _create_idle_task(self):
         self._idle_event = asyncio.Event()
-        self._idle_task = self.get_event_loop().create_task(self._idle_task_handler())
+        self._idle_task = self.create_task(self._idle_task_handler())
 
     async def _idle_task_handler(self):
         while True:
@@ -62,7 +61,5 @@ class IdleFrameProcessor(FrameProcessor):
                 await asyncio.wait_for(self._idle_event.wait(), timeout=self._timeout)
             except asyncio.TimeoutError:
                 await self._callback(self)
-            except asyncio.CancelledError:
-                break
             finally:
                 self._idle_event.clear()

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -103,7 +103,7 @@ class UserIdleProcessor(FrameProcessor):
     def _create_idle_task(self) -> None:
         """Creates the idle task if it hasn't been created yet."""
         if self._idle_task is None:
-            self._idle_task = self.get_event_loop().create_task(self._idle_task_handler())
+            self._idle_task = self.create_task(self._idle_task_handler())
 
     @property
     def retry_count(self) -> int:
@@ -113,11 +113,7 @@ class UserIdleProcessor(FrameProcessor):
     async def _stop(self) -> None:
         """Stops and cleans up the idle monitoring task."""
         if self._idle_task is not None:
-            self._idle_task.cancel()
-            try:
-                await self._idle_task
-            except asyncio.CancelledError:
-                pass  # Expected when task is cancelled
+            await self.cancel_task(self._idle_task)
             self._idle_task = None
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
@@ -178,7 +174,5 @@ class UserIdleProcessor(FrameProcessor):
                     if not should_continue:
                         await self._stop()
                         break
-            except asyncio.CancelledError:
-                break
             finally:
                 self._idle_event.clear()

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -156,6 +156,7 @@ class UserIdleProcessor(FrameProcessor):
 
     async def cleanup(self) -> None:
         """Cleans up resources when processor is shutting down."""
+        await super().cleanup()
         if self._idle_task:  # Only stop if task exists
             await self._stop()
 

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -253,20 +253,18 @@ class TTSService(AIService):
     async def start(self, frame: StartFrame):
         await super().start(frame)
         if self._push_stop_frames:
-            self._stop_frame_task = self.get_event_loop().create_task(self._stop_frame_handler())
+            self._stop_frame_task = self.create_task(self._stop_frame_handler())
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
         if self._stop_frame_task:
-            self._stop_frame_task.cancel()
-            await self._stop_frame_task
+            await self.cancel_task(self._stop_frame_task)
             self._stop_frame_task = None
 
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)
         if self._stop_frame_task:
-            self._stop_frame_task.cancel()
-            await self._stop_frame_task
+            await self.cancel_task(self._stop_frame_task)
             self._stop_frame_task = None
 
     async def _update_settings(self, settings: Dict[str, Any]):
@@ -364,23 +362,20 @@ class TTSService(AIService):
             await self.push_frame(TTSTextFrame(text))
 
     async def _stop_frame_handler(self):
-        try:
-            has_started = False
-            while True:
-                try:
-                    frame = await asyncio.wait_for(
-                        self._stop_frame_queue.get(), self._stop_frame_timeout_s
-                    )
-                    if isinstance(frame, TTSStartedFrame):
-                        has_started = True
-                    elif isinstance(frame, (TTSStoppedFrame, StartInterruptionFrame)):
-                        has_started = False
-                except asyncio.TimeoutError:
-                    if has_started:
-                        await self.push_frame(TTSStoppedFrame())
-                        has_started = False
-        except asyncio.CancelledError:
-            pass
+        has_started = False
+        while True:
+            try:
+                frame = await asyncio.wait_for(
+                    self._stop_frame_queue.get(), self._stop_frame_timeout_s
+                )
+                if isinstance(frame, TTSStartedFrame):
+                    has_started = True
+                elif isinstance(frame, (TTSStoppedFrame, StartInterruptionFrame)):
+                    has_started = False
+            except asyncio.TimeoutError:
+                if has_started:
+                    await self.push_frame(TTSStoppedFrame())
+                    has_started = False
 
 
 class WordTTSService(TTSService):
@@ -388,7 +383,7 @@ class WordTTSService(TTSService):
         super().__init__(**kwargs)
         self._initial_word_timestamp = -1
         self._words_queue = asyncio.Queue()
-        self._words_task = self.get_event_loop().create_task(self._words_task_handler())
+        self._words_task = self.create_task(self._words_task_handler())
 
     def start_word_timestamps(self):
         if self._initial_word_timestamp == -1:
@@ -421,35 +416,29 @@ class WordTTSService(TTSService):
 
     async def _stop_words_task(self):
         if self._words_task:
-            self._words_task.cancel()
-            await self._words_task
+            await self.cancel_task(self._words_task)
             self._words_task = None
 
     async def _words_task_handler(self):
         last_pts = 0
         while True:
-            try:
-                (word, timestamp) = await self._words_queue.get()
-                if word == "Reset" and timestamp == 0:
-                    self.reset_word_timestamps()
-                    frame = None
-                elif word == "LLMFullResponseEndFrame" and timestamp == 0:
-                    frame = LLMFullResponseEndFrame()
-                    frame.pts = last_pts
-                elif word == "TTSStoppedFrame" and timestamp == 0:
-                    frame = TTSStoppedFrame()
-                    frame.pts = last_pts
-                else:
-                    frame = TTSTextFrame(word)
-                    frame.pts = self._initial_word_timestamp + timestamp
-                if frame:
-                    last_pts = frame.pts
-                    await self.push_frame(frame)
-                self._words_queue.task_done()
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.exception(f"{self} exception: {e}")
+            (word, timestamp) = await self._words_queue.get()
+            if word == "Reset" and timestamp == 0:
+                self.reset_word_timestamps()
+                frame = None
+            elif word == "LLMFullResponseEndFrame" and timestamp == 0:
+                frame = LLMFullResponseEndFrame()
+                frame.pts = last_pts
+            elif word == "TTSStoppedFrame" and timestamp == 0:
+                frame = TTSStoppedFrame()
+                frame.pts = last_pts
+            else:
+                frame = TTSTextFrame(word)
+                frame.pts = self._initial_word_timestamp + timestamp
+            if frame:
+                last_pts = frame.pts
+                await self.push_frame(frame)
+            self._words_queue.task_done()
 
 
 class STTService(AIService):

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -8,7 +8,7 @@ import asyncio
 import io
 import wave
 from abc import abstractmethod
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional, Tuple
 
 from loguru import logger
 
@@ -69,7 +69,7 @@ class AIService(FrameProcessor):
     async def cancel(self, frame: CancelFrame):
         pass
 
-    async def _update_settings(self, settings: Dict[str, Any]):
+    async def _update_settings(self, settings: Mapping[str, Any]):
         from pipecat.services.openai_realtime_beta.events import (
             SessionProperties,
         )
@@ -267,7 +267,7 @@ class TTSService(AIService):
             await self.cancel_task(self._stop_frame_task)
             self._stop_frame_task = None
 
-    async def _update_settings(self, settings: Dict[str, Any]):
+    async def _update_settings(self, settings: Mapping[str, Any]):
         for key, value in settings.items():
             if key in self._settings:
                 logger.info(f"Updating TTS setting {key} to: [{value}]")
@@ -468,7 +468,7 @@ class STTService(AIService):
         """Returns transcript as a string"""
         pass
 
-    async def _update_settings(self, settings: Dict[str, Any]):
+    async def _update_settings(self, settings: Mapping[str, Any]):
         logger.info(f"Updating STT settings: {self._settings}")
         for key, value in settings.items():
             if key in self._settings:

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -187,16 +187,13 @@ class CartesiaTTSService(WordTTSService, WebsocketService):
     async def _connect(self):
         await self._connect_websocket()
 
-        self._receive_task = self.get_event_loop().create_task(
-            self._receive_task_handler(self.push_error)
-        )
+        self._receive_task = self.create_task(self._receive_task_handler(self.push_error))
 
     async def _disconnect(self):
         await self._disconnect_websocket()
 
         if self._receive_task:
-            self._receive_task.cancel()
-            await self._receive_task
+            await self.cancel_task(self._receive_task)
             self._receive_task = None
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/fish.py
+++ b/src/pipecat/services/fish.py
@@ -104,15 +104,12 @@ class FishAudioTTSService(TTSService, WebsocketService):
 
     async def _connect(self):
         await self._connect_websocket()
-        self._receive_task = self.get_event_loop().create_task(
-            self._receive_task_handler(self.push_error)
-        )
+        self._receive_task = self.create_task(self._receive_task_handler(self.push_error))
 
     async def _disconnect(self):
         await self._disconnect_websocket()
         if self._receive_task:
-            self._receive_task.cancel()
-            await self._receive_task
+            await self.cancel_task(self._receive_task)
             self._receive_task = None
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -51,7 +51,6 @@ from pipecat.services.openai import (
     OpenAIUserContextAggregator,
 )
 from pipecat.utils.time import time_now_iso8601
-from pipecat.utils.utils import wait_for_task
 
 from . import events
 from .audio_transcriber import AudioTranscriber

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -51,6 +51,7 @@ from pipecat.services.openai import (
     OpenAIUserContextAggregator,
 )
 from pipecat.utils.time import time_now_iso8601
+from pipecat.utils.utils import wait_for_task
 
 from . import events
 from .audio_transcriber import AudioTranscriber
@@ -182,9 +183,13 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
         self._audio_input_paused = start_audio_paused
         self._video_input_paused = start_video_paused
+        self._context = None
         self._websocket = None
         self._receive_task = None
-        self._context = None
+        self._transcribe_audio_task = None
+        self._transcribe_model_audio_task = None
+        self._transcribe_audio_queue = asyncio.Queue()
+        self._transcribe_model_audio_queue = asyncio.Queue()
 
         self._disconnecting = False
         self._api_session_ready = False
@@ -275,7 +280,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
             )
             await self.send_client_event(evt)
         if self._transcribe_user_audio and self._context:
-            self.create_task(self._handle_transcribe_user_audio(audio, self._context))
+            await self._transcribe_audio_queue.put(audio)
 
     async def _handle_transcribe_user_audio(self, audio, context):
         text = await self._transcribe_audio(audio, context)
@@ -392,6 +397,10 @@ class GeminiMultimodalLiveLLMService(LLMService):
             logger.info(f"Connecting to {uri}")
             self._websocket = await websockets.connect(uri=uri)
             self._receive_task = self.create_task(self._receive_task_handler())
+            self._transcribe_audio_task = self.create_task(self._transcribe_audio_handler())
+            self._transcribe_model_audio_task = self.create_task(
+                self._transcribe_model_audio_handler()
+            )
             config = events.Config.model_validate(
                 {
                     "setup": {
@@ -443,6 +452,12 @@ class GeminiMultimodalLiveLLMService(LLMService):
             if self._receive_task:
                 await self.cancel_task(self._receive_task, timeout=1.0)
                 self._receive_task = None
+            if self._transcribe_audio_task:
+                await self.cancel_task(self._transcribe_audio_task)
+                self._transcribe_audio_task = None
+            if self._transcribe_model_audio_task:
+                await self.cancel_task(self._transcribe_model_audio_task)
+                self._transcribe_model_audio_task = None
             self._disconnecting = False
         except Exception as e:
             logger.error(f"{self} error disconnecting: {e}")
@@ -469,33 +484,35 @@ class GeminiMultimodalLiveLLMService(LLMService):
     #
 
     async def _receive_task_handler(self):
-        try:
-            async for message in self._websocket:
-                evt = events.parse_server_event(message)
-                # logger.debug(f"Received event: {message[:500]}")
-                # logger.debug(f"Received event: {evt}")
+        async for message in self._websocket:
+            evt = events.parse_server_event(message)
+            # logger.debug(f"Received event: {message[:500]}")
+            # logger.debug(f"Received event: {evt}")
 
-                if evt.setupComplete:
-                    await self._handle_evt_setup_complete(evt)
-                elif evt.serverContent and evt.serverContent.modelTurn:
-                    await self._handle_evt_model_turn(evt)
-                elif evt.serverContent and evt.serverContent.turnComplete:
-                    await self._handle_evt_turn_complete(evt)
-                elif evt.toolCall:
-                    await self._handle_evt_tool_call(evt)
+            if evt.setupComplete:
+                await self._handle_evt_setup_complete(evt)
+            elif evt.serverContent and evt.serverContent.modelTurn:
+                await self._handle_evt_model_turn(evt)
+            elif evt.serverContent and evt.serverContent.turnComplete:
+                await self._handle_evt_turn_complete(evt)
+            elif evt.toolCall:
+                await self._handle_evt_tool_call(evt)
+            elif False:  # !!! todo: error events?
+                await self._handle_evt_error(evt)
+                # errors are fatal, so exit the receive loop
+                return
+            else:
+                pass
 
-                elif False:  # !!! todo: error events?
-                    await self._handle_evt_error(evt)
-                    # errors are fatal, so exit the receive loop
-                    return
+    async def _transcribe_audio_handler(self):
+        while True:
+            audio = await self._transcribe_audio_queue.get()
+            await self._handle_transcribe_user_audio(audio, self._context)
 
-                else:
-                    pass
-        except asyncio.CancelledError:
-            logger.debug("websocket receive task cancelled")
-            raise
-        except Exception as e:
-            logger.error(f"{self} exception: {e}")
+    async def _transcribe_model_audio_handler(self):
+        while True:
+            audio = await self._transcribe_model_audio_queue.get()
+            await self._handle_transcribe_model_audio(audio, self._context)
 
     #
     #
@@ -676,7 +693,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         self._bot_text_buffer = ""
 
         if audio and self._transcribe_model_audio and self._context:
-            self.create_task(self._handle_transcribe_model_audio(audio, self._context))
+            await self._transcribe_model_audio.put(audio)
         elif text:
             await self.push_frame(LLMFullResponseEndFrame())
 

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -692,7 +692,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         self._bot_text_buffer = ""
 
         if audio and self._transcribe_model_audio and self._context:
-            await self._transcribe_model_audio.put(audio)
+            await self._transcribe_model_audio_queue.put(audio)
         elif text:
             await self.push_frame(LLMFullResponseEndFrame())
 

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -180,7 +180,7 @@ class GladiaSTTService(STTService):
         await super().start(frame)
         response = await self._setup_gladia()
         self._websocket = await websockets.connect(response["url"])
-        self._receive_task = self.get_event_loop().create_task(self._receive_task_handler())
+        self._receive_task = self.create_task(self._receive_task_handler())
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)

--- a/src/pipecat/services/lmnt.py
+++ b/src/pipecat/services/lmnt.py
@@ -113,16 +113,13 @@ class LmntTTSService(TTSService, WebsocketService):
     async def _connect(self):
         await self._connect_websocket()
 
-        self._receive_task = self.get_event_loop().create_task(
-            self._receive_task_handler(self.push_error)
-        )
+        self._receive_task = self.create_task(self._receive_task_handler(self.push_error))
 
     async def _disconnect(self):
         await self._disconnect_websocket()
 
         if self._receive_task:
-            self._receive_task.cancel()
-            await self._receive_task
+            await self.cancel_task(self._receive_task)
             self._receive_task = None
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -277,7 +277,7 @@ class OpenAIRealtimeBetaLLMService(LLMService):
                     "OpenAI-Beta": "realtime=v1",
                 },
             )
-            self._receive_task = self.get_event_loop().create_task(self._receive_task_handler())
+            self._receive_task = self.create_task(self._receive_task_handler())
         except Exception as e:
             logger.error(f"{self} initialization error: {e}")
             self._websocket = None
@@ -291,11 +291,7 @@ class OpenAIRealtimeBetaLLMService(LLMService):
                 await self._websocket.close()
                 self._websocket = None
             if self._receive_task:
-                self._receive_task.cancel()
-                try:
-                    await asyncio.wait_for(self._receive_task, timeout=1.0)
-                except asyncio.TimeoutError:
-                    logger.warning("Timed out waiting for receive task to finish")
+                await self.cancel_task(self._receive_task, timeout=1.0)
                 self._receive_task = None
             self._disconnecting = False
         except Exception as e:
@@ -332,40 +328,32 @@ class OpenAIRealtimeBetaLLMService(LLMService):
     #
 
     async def _receive_task_handler(self):
-        try:
-            async for message in self._websocket:
-                evt = events.parse_server_event(message)
-                if evt.type == "session.created":
-                    await self._handle_evt_session_created(evt)
-                elif evt.type == "session.updated":
-                    await self._handle_evt_session_updated(evt)
-                elif evt.type == "response.audio.delta":
-                    await self._handle_evt_audio_delta(evt)
-                elif evt.type == "response.audio.done":
-                    await self._handle_evt_audio_done(evt)
-                elif evt.type == "conversation.item.created":
-                    await self._handle_evt_conversation_item_created(evt)
-                elif evt.type == "conversation.item.input_audio_transcription.completed":
-                    await self.handle_evt_input_audio_transcription_completed(evt)
-                elif evt.type == "response.done":
-                    await self._handle_evt_response_done(evt)
-                elif evt.type == "input_audio_buffer.speech_started":
-                    await self._handle_evt_speech_started(evt)
-                elif evt.type == "input_audio_buffer.speech_stopped":
-                    await self._handle_evt_speech_stopped(evt)
-                elif evt.type == "response.audio_transcript.delta":
-                    await self._handle_evt_audio_transcript_delta(evt)
-                elif evt.type == "error":
-                    await self._handle_evt_error(evt)
-                    # errors are fatal, so exit the receive loop
-                    return
-
-                else:
-                    pass
-        except asyncio.CancelledError:
-            logger.debug("websocket receive task cancelled")
-        except Exception as e:
-            logger.error(f"{self} exception: {e}")
+        async for message in self._websocket:
+            evt = events.parse_server_event(message)
+            if evt.type == "session.created":
+                await self._handle_evt_session_created(evt)
+            elif evt.type == "session.updated":
+                await self._handle_evt_session_updated(evt)
+            elif evt.type == "response.audio.delta":
+                await self._handle_evt_audio_delta(evt)
+            elif evt.type == "response.audio.done":
+                await self._handle_evt_audio_done(evt)
+            elif evt.type == "conversation.item.created":
+                await self._handle_evt_conversation_item_created(evt)
+            elif evt.type == "conversation.item.input_audio_transcription.completed":
+                await self.handle_evt_input_audio_transcription_completed(evt)
+            elif evt.type == "response.done":
+                await self._handle_evt_response_done(evt)
+            elif evt.type == "input_audio_buffer.speech_started":
+                await self._handle_evt_speech_started(evt)
+            elif evt.type == "input_audio_buffer.speech_stopped":
+                await self._handle_evt_speech_stopped(evt)
+            elif evt.type == "response.audio_transcript.delta":
+                await self._handle_evt_audio_transcript_delta(evt)
+            elif evt.type == "error":
+                await self._handle_evt_error(evt)
+                # errors are fatal, so exit the receive loop
+                return
 
     async def _handle_evt_session_created(self, evt):
         # session.created is received right after connecting. Send a message

--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -165,16 +165,13 @@ class PlayHTTTSService(TTSService, WebsocketService):
     async def _connect(self):
         await self._connect_websocket()
 
-        self._receive_task = self.get_event_loop().create_task(
-            self._receive_task_handler(self.push_error)
-        )
+        self._receive_task = self.create_task(self._receive_task_handler(self.push_error))
 
     async def _disconnect(self):
         await self._disconnect_websocket()
 
         if self._receive_task:
-            self._receive_task.cancel()
-            await self._receive_task
+            await self.cancel_task(self._receive_task)
             self._receive_task = None
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/tavus.py
+++ b/src/pipecat/services/tavus.py
@@ -75,6 +75,14 @@ class TavusVideoService(AIService):
         logger.debug(f"TavusVideoService persona grabbed {response_json}")
         return response_json["persona_name"]
 
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._end_conversation()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._end_conversation()
+
     async def _end_conversation(self) -> None:
         url = f"https://tavusapi.com/v2/conversations/{self._conversation_id}/end"
         headers = {"Content-Type": "application/json", "x-api-key": self._api_key}
@@ -105,8 +113,6 @@ class TavusVideoService(AIService):
             await self.stop_processing_metrics()
         elif isinstance(frame, StartInterruptionFrame):
             await self._send_interrupt_message()
-        elif isinstance(frame, (EndFrame, CancelFrame)):
-            await self._end_conversation()
         else:
             await self.push_frame(frame, direction)
 

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -85,10 +85,6 @@ class WebsocketService(ABC):
                 await self._receive_messages()
                 logger.debug(f"{self} connection established successfully")
                 retry_count = 0  # Reset counter on successful message receive
-
-            except asyncio.CancelledError:
-                break
-
             except Exception as e:
                 retry_count += 1
                 if retry_count >= MAX_RETRIES:

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -35,8 +35,8 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.transports.base_transport import TransportParams
+from pipecat.utils.asyncio import wait_for_task
 from pipecat.utils.time import nanoseconds_to_seconds
-from pipecat.utils.utils import wait_for_task
 
 
 class BaseOutputTransport(FrameProcessor):

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -217,22 +217,19 @@ class BaseOutputTransport(FrameProcessor):
     #
 
     def _create_sink_tasks(self):
-        loop = self.get_event_loop()
         self._sink_queue = asyncio.Queue()
-        self._sink_task = loop.create_task(self._sink_task_handler())
         self._sink_clock_queue = asyncio.PriorityQueue()
-        self._sink_clock_task = loop.create_task(self._sink_clock_task_handler())
+        self._sink_task = self.create_task(self._sink_task_handler())
+        self._sink_clock_task = self.create_task(self._sink_clock_task_handler())
 
     async def _cancel_sink_tasks(self):
         # Stop sink tasks.
         if self._sink_task:
-            self._sink_task.cancel()
-            await self._sink_task
+            await self.cancel_task(self._sink_task)
             self._sink_task = None
         # Stop sink clock tasks.
         if self._sink_clock_task:
-            self._sink_clock_task.cancel()
-            await self._sink_clock_task
+            await self.cancel_task(self._sink_clock_task)
             self._sink_clock_task = None
 
     async def _sink_frame_handler(self, frame: Frame):
@@ -269,7 +266,7 @@ class BaseOutputTransport(FrameProcessor):
 
                 self._sink_clock_queue.task_done()
             except asyncio.CancelledError:
-                break
+                raise
             except Exception as e:
                 logger.exception(f"{self} error processing sink clock queue: {e}")
 
@@ -317,49 +314,42 @@ class BaseOutputTransport(FrameProcessor):
             return without_mixer(vad_stop_secs)
 
     async def _sink_task_handler(self):
-        try:
-            async for frame in self._next_frame():
-                # Notify the bot started speaking upstream if necessary and that
-                # it's actually speaking.
-                if isinstance(frame, TTSAudioRawFrame):
-                    await self._bot_started_speaking()
-                    await self.push_frame(BotSpeakingFrame())
-                    await self.push_frame(BotSpeakingFrame(), FrameDirection.UPSTREAM)
+        async for frame in self._next_frame():
+            # Notify the bot started speaking upstream if necessary and that
+            # it's actually speaking.
+            if isinstance(frame, TTSAudioRawFrame):
+                await self._bot_started_speaking()
+                await self.push_frame(BotSpeakingFrame())
+                await self.push_frame(BotSpeakingFrame(), FrameDirection.UPSTREAM)
 
-                # No need to push EndFrame, it's pushed from process_frame().
-                if isinstance(frame, EndFrame):
-                    break
+            # No need to push EndFrame, it's pushed from process_frame().
+            if isinstance(frame, EndFrame):
+                break
 
-                # Handle frame.
-                await self._sink_frame_handler(frame)
+            # Handle frame.
+            await self._sink_frame_handler(frame)
 
-                # Also, push frame downstream in case anyone else needs it.
-                await self.push_frame(frame)
+            # Also, push frame downstream in case anyone else needs it.
+            await self.push_frame(frame)
 
-                # Send audio.
-                if isinstance(frame, OutputAudioRawFrame):
-                    await self.write_raw_audio_frames(frame.audio)
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            logger.exception(f"{self} error writing to microphone: {e}")
+            # Send audio.
+            if isinstance(frame, OutputAudioRawFrame):
+                await self.write_raw_audio_frames(frame.audio)
 
     #
     # Camera task
     #
 
     def _create_camera_task(self):
-        loop = self.get_event_loop()
         # Create camera output queue and task if needed.
         if self._params.camera_out_enabled:
             self._camera_out_queue = asyncio.Queue()
-            self._camera_out_task = loop.create_task(self._camera_out_task_handler())
+            self._camera_out_task = self.create_task(self._camera_out_task_handler())
 
     async def _cancel_camera_task(self):
         # Stop camera output task.
         if self._camera_out_task and self._params.camera_out_enabled:
-            self._camera_out_task.cancel()
-            await self._camera_out_task
+            await self.cancel_task(self._camera_out_task)
             self._camera_out_task = None
 
     async def _draw_image(self, frame: OutputImageRawFrame):
@@ -387,19 +377,14 @@ class BaseOutputTransport(FrameProcessor):
         self._camera_out_frame_duration = 1 / self._params.camera_out_framerate
         self._camera_out_frame_reset = self._camera_out_frame_duration * 5
         while True:
-            try:
-                if self._params.camera_out_is_live:
-                    await self._camera_out_is_live_handler()
-                elif self._camera_images:
-                    image = next(self._camera_images)
-                    await self._draw_image(image)
-                    await asyncio.sleep(self._camera_out_frame_duration)
-                else:
-                    await asyncio.sleep(self._camera_out_frame_duration)
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.exception(f"{self} error writing to camera: {e}")
+            if self._params.camera_out_is_live:
+                await self._camera_out_is_live_handler()
+            elif self._camera_images:
+                image = next(self._camera_images)
+                await self._draw_image(image)
+                await asyncio.sleep(self._camera_out_frame_duration)
+            else:
+                await asyncio.sleep(self._camera_out_frame_duration)
 
     async def _camera_out_is_live_handler(self):
         image = await self._camera_out_queue.get()

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -36,6 +36,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.transports.base_transport import TransportParams
 from pipecat.utils.time import nanoseconds_to_seconds
+from pipecat.utils.utils import wait_for_task
 
 
 class BaseOutputTransport(FrameProcessor):
@@ -87,9 +88,9 @@ class BaseOutputTransport(FrameProcessor):
         # for these tasks before cancelling the camera and audio tasks below
         # because they might be still rendering.
         if self._sink_task:
-            await self._sink_task
+            await wait_for_task(self._sink_task)
         if self._sink_clock_task:
-            await self._sink_clock_task
+            await wait_for_task(self._sink_clock_task)
 
         # We can now cancel the camera task.
         await self._cancel_camera_task()

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -16,6 +16,7 @@ from pipecat.audio.filters.base_audio_filter import BaseAudioFilter
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer
 from pipecat.processors.frame_processor import FrameProcessor
+from pipecat.utils.utils import obj_count, obj_id
 
 
 class TransportParams(BaseModel):
@@ -46,10 +47,14 @@ class TransportParams(BaseModel):
 class BaseTransport(ABC):
     def __init__(
         self,
-        input_name: str | None = None,
-        output_name: str | None = None,
-        loop: asyncio.AbstractEventLoop | None = None,
+        *,
+        name: Optional[str] = None,
+        input_name: Optional[str] = None,
+        output_name: Optional[str] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
+        self.id: int = obj_id()
+        self.name = name or f"{self.__class__.__name__}#{obj_count(self)}"
         self._input_name = input_name
         self._output_name = output_name
         self._loop = loop or asyncio.get_running_loop()
@@ -89,3 +94,6 @@ class BaseTransport(ABC):
                     handler(self, *args, **kwargs)
         except Exception as e:
             logger.exception(f"Exception in event handler {event_name}: {e}")
+
+    def __str__(self):
+        return self.name

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -53,12 +53,20 @@ class BaseTransport(ABC):
         output_name: Optional[str] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
-        self.id: int = obj_id()
-        self.name = name or f"{self.__class__.__name__}#{obj_count(self)}"
+        self._id: int = obj_id()
+        self._name = name or f"{self.__class__.__name__}#{obj_count(self)}"
         self._input_name = input_name
         self._output_name = output_name
         self._loop = loop or asyncio.get_running_loop()
         self._event_handlers: dict = {}
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     @abstractmethod
     def input(self) -> FrameProcessor:

--- a/src/pipecat/transports/local/audio.py
+++ b/src/pipecat/transports/local/audio.py
@@ -98,6 +98,7 @@ class LocalAudioOutputTransport(BaseOutputTransport):
 
 class LocalAudioTransport(BaseTransport):
     def __init__(self, params: TransportParams):
+        super().__init__()
         self._params = params
         self._pyaudio = pyaudio.PyAudio()
 

--- a/src/pipecat/transports/local/tk.py
+++ b/src/pipecat/transports/local/tk.py
@@ -127,6 +127,7 @@ class TkOutputTransport(BaseOutputTransport):
 
 class TkLocalTransport(BaseTransport):
     def __init__(self, tk_root: tk.Tk, params: TransportParams):
+        super().__init__()
         self._tk_root = tk_root
         self._params = params
         self._pyaudio = pyaudio.PyAudio()

--- a/src/pipecat/transports/network/fastapi_websocket.py
+++ b/src/pipecat/transports/network/fastapi_websocket.py
@@ -68,11 +68,9 @@ class FastAPIWebsocketInputTransport(BaseInputTransport):
     async def start(self, frame: StartFrame):
         await super().start(frame)
         if self._params.session_timeout:
-            self._monitor_websocket_task = self.get_event_loop().create_task(
-                self._monitor_websocket()
-            )
+            self._monitor_websocket_task = self.create_task(self._monitor_websocket())
         await self._callbacks.on_client_connected(self._websocket)
-        self._receive_task = self.get_event_loop().create_task(self._receive_messages())
+        self._receive_task = self.create_task(self._receive_messages())
 
     def _iter_data(self) -> typing.AsyncIterator[bytes | str]:
         if self._params.serializer.type == FrameSerializerType.BINARY:
@@ -96,11 +94,8 @@ class FastAPIWebsocketInputTransport(BaseInputTransport):
 
     async def _monitor_websocket(self):
         """Wait for self._params.session_timeout seconds, if the websocket is still open, trigger timeout event."""
-        try:
-            await asyncio.sleep(self._params.session_timeout)
-            await self._callbacks.on_session_timeout(self._websocket)
-        except asyncio.CancelledError:
-            logger.info(f"Monitoring task cancelled for: {self._websocket}")
+        await asyncio.sleep(self._params.session_timeout)
+        await self._callbacks.on_session_timeout(self._websocket)
 
 
 class FastAPIWebsocketOutputTransport(BaseOutputTransport):

--- a/src/pipecat/transports/network/websocket_server.py
+++ b/src/pipecat/transports/network/websocket_server.py
@@ -71,7 +71,7 @@ class WebsocketServerInputTransport(BaseInputTransport):
 
     async def start(self, frame: StartFrame):
         await super().start(frame)
-        self._server_task = self.get_event_loop().create_task(self._server_task_handler())
+        self._server_task = self.create_task(self._server_task_handler())
 
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
@@ -131,6 +131,7 @@ class WebsocketServerInputTransport(BaseInputTransport):
                 await self._callbacks.on_session_timeout(websocket)
         except asyncio.CancelledError:
             logger.info(f"Monitoring task cancelled for: {websocket.remote_address}")
+            raise
 
 
 class WebsocketServerOutputTransport(BaseOutputTransport):

--- a/src/pipecat/transports/network/websocket_server.py
+++ b/src/pipecat/transports/network/websocket_server.py
@@ -76,12 +76,11 @@ class WebsocketServerInputTransport(BaseInputTransport):
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
         self._stop_server_event.set()
-        await self._server_task
+        await self.wait_for_task(self._server_task)
 
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)
-        self._stop_server_event.set()
-        await self._server_task
+        await self.cancel_task(self._server_task)
 
     async def _server_task_handler(self):
         logger.info(f"Starting websocket server on {self._host}:{self._port}")

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -476,7 +476,9 @@ class DailyTransportClient(EventHandler):
         return await asyncio.wait_for(future, timeout=10)
 
     async def cleanup(self):
-        await cancel_task(self._callback_task)
+        if self._callback_task:
+            await cancel_task(self._callback_task)
+            self._callback_task = None
         # Make sure we don't block the event loop in case `client.release()`
         # takes extra time.
         await self._loop.run_in_executor(self._executor, self._cleanup)

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -181,6 +181,7 @@ class DailyTransportClient(EventHandler):
         params: DailyParams,
         callbacks: DailyCallbacks,
         loop: asyncio.AbstractEventLoop,
+        transport_name: str,
     ):
         super().__init__()
 
@@ -194,6 +195,7 @@ class DailyTransportClient(EventHandler):
         self._params: DailyParams = params
         self._callbacks = callbacks
         self._loop = loop
+        self._transport_name = transport_name
 
         self._participant_id: str = ""
         self._video_renderers = {}
@@ -220,7 +222,9 @@ class DailyTransportClient(EventHandler):
         # are holding the GIL).
         self._callback_queue = asyncio.Queue()
         self._callback_task = create_task(
-            self._loop, self._callback_task_handler(), "DailyTransportClient::callback_task"
+            self._loop,
+            self._callback_task_handler(),
+            f"{self._transport_name}::DailyTransportClient::callback_task",
         )
 
         self._camera: VirtualCameraDevice | None = None
@@ -907,7 +911,7 @@ class DailyTransport(BaseTransport):
         self._params = params
 
         self._client = DailyTransportClient(
-            room_url, token, bot_name, params, callbacks, self._loop
+            room_url, token, bot_name, params, callbacks, self._loop, self.name
         )
         self._input: DailyInputTransport | None = None
         self._output: DailyOutputTransport | None = None

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -46,7 +46,7 @@ from pipecat.transcriptions.language import Language
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.utils.utils import cancel_task, create_task
+from pipecat.utils.asyncio import cancel_task, create_task
 
 try:
     from daily import CallClient, Daily, EventHandler

--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -28,7 +28,7 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.utils.utils import create_task
+from pipecat.utils.asyncio import create_task
 
 try:
     from livekit import rtc

--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -73,6 +73,7 @@ class LiveKitTransportClient:
         params: LiveKitParams,
         callbacks: LiveKitCallbacks,
         loop: asyncio.AbstractEventLoop,
+        transport_name: str,
     ):
         self._url = url
         self._token = token
@@ -80,6 +81,7 @@ class LiveKitTransportClient:
         self._params = params
         self._callbacks = callbacks
         self._loop = loop
+        self._transport_name = transport_name
         self._room = rtc.Room(loop=loop)
         self._participant_id: str = ""
         self._connected = False
@@ -219,14 +221,14 @@ class LiveKitTransportClient:
         create_task(
             self._loop,
             self._async_on_participant_connected(participant),
-            "LiveKitTransportClient::_async_on_participant_connected",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_participant_connected",
         )
 
     def _on_participant_disconnected_wrapper(self, participant: rtc.RemoteParticipant):
         create_task(
             self._loop,
             self._async_on_participant_disconnected(participant),
-            "LiveKitTransportClient::_async_on_participant_disconnected",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_participant_disconnected",
         )
 
     def _on_track_subscribed_wrapper(
@@ -238,7 +240,7 @@ class LiveKitTransportClient:
         create_task(
             self._loop,
             self._async_on_track_subscribed(track, publication, participant),
-            "LiveKitTransportClient::_async_on_track_subscribed",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_track_subscribed",
         )
 
     def _on_track_unsubscribed_wrapper(
@@ -250,26 +252,28 @@ class LiveKitTransportClient:
         create_task(
             self._loop,
             self._async_on_track_unsubscribed(track, publication, participant),
-            "LiveKitTransportClient::_async_on_track_unsubscribed",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_track_unsubscribed",
         )
 
     def _on_data_received_wrapper(self, data: rtc.DataPacket):
         create_task(
             self._loop,
             self._async_on_data_received(data),
-            "LiveKitTransportClient::_async_on_data_received",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_data_received",
         )
 
     def _on_connected_wrapper(self):
         create_task(
-            self._loop, self._async_on_connected(), "LiveKitTransportClient::_async_on_connected"
+            self._loop,
+            self._async_on_connected(),
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_connected",
         )
 
     def _on_disconnected_wrapper(self):
         create_task(
             self._loop,
             self._async_on_disconnected(),
-            "LiveKitTransportClient::_async_on_disconnected",
+            f"{self._transport_name}::LiveKitTransportClient::_async_on_disconnected",
         )
 
     # Async methods for event handling
@@ -299,7 +303,7 @@ class LiveKitTransportClient:
             create_task(
                 self._loop,
                 self._process_audio_stream(audio_stream, participant.sid),
-                "LiveKitTransportClient::_process_audio_stream",
+                f"{self._transport_name}::LiveKitTransportClient::_process_audio_stream",
             )
 
     async def _async_on_track_unsubscribed(
@@ -474,7 +478,7 @@ class LiveKitTransport(BaseTransport):
         self._params = params
 
         self._client = LiveKitTransportClient(
-            url, token, room_name, self._params, callbacks, self._loop
+            url, token, room_name, self._params, callbacks, self._loop, self.name
         )
         self._input: LiveKitInputTransport | None = None
         self._output: LiveKitOutputTransport | None = None

--- a/src/pipecat/utils/asyncio.py
+++ b/src/pipecat/utils/asyncio.py
@@ -1,0 +1,114 @@
+#
+# Copyright (c) 2024–2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import asyncio
+from typing import Coroutine, Optional, Set
+
+from loguru import logger
+
+_TASKS: Set[asyncio.Task] = set()
+
+
+def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str) -> asyncio.Task:
+    """
+    Creates and schedules a new asyncio Task that runs the given coroutine.
+
+    The task is added to a global set of created tasks.
+
+    Args:
+        loop (asyncio.AbstractEventLoop): The event loop to use for creating the task.
+        coroutine (Coroutine): The coroutine to be executed within the task.
+        name (str): The name to assign to the task for identification.
+
+    Returns:
+        asyncio.Task: The created task object.
+    """
+
+    async def run_coroutine():
+        try:
+            await coroutine
+        except asyncio.CancelledError:
+            logger.trace(f"{name}: task cancelled")
+            # Re-raise the exception to ensure the task is cancelled.
+            raise
+        except Exception as e:
+            logger.exception(f"{name}: unexpected exception: {e}")
+
+    task = loop.create_task(run_coroutine())
+    task.set_name(name)
+    _TASKS.add(task)
+    logger.trace(f"{name}: task created")
+    return task
+
+
+async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
+    """Wait for an asyncio.Task to complete with optional timeout handling.
+
+    This function awaits the specified asyncio.Task and handles scenarios for
+    timeouts, cancellations, and other exceptions. It also ensures that the task
+    is removed from the set of registered tasks upon completion or failure.
+
+    Args:
+        task (asyncio.Task): The asyncio Task to wait for.
+        timeout (Optional[float], optional): The maximum number of seconds
+            to wait for the task to complete. If None, waits indefinitely.
+            Defaults to None.
+    """
+    name = task.get_name()
+    try:
+        if timeout:
+            await asyncio.wait_for(task, timeout=timeout)
+        else:
+            await task
+    except asyncio.TimeoutError:
+        logger.warning(f"{name}: timed out waiting for task to finish")
+    except asyncio.CancelledError:
+        logger.trace(f"{name}: unexpected task cancellation (maybe Ctrl-C?)")
+    except Exception as e:
+        logger.exception(f"{name}: unexpected exception while stopping task: {e}")
+    finally:
+        try:
+            _TASKS.remove(task)
+        except KeyError as e:
+            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
+
+
+async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
+    """Cancels the given asyncio Task and awaits its completion with an
+    optional timeout.
+
+    This function removes the task from the set of registered tasks upon
+    completion or failure.
+
+    Args:
+        task (asyncio.Task): The task to be cancelled.
+        timeout (Optional[float]): The optional timeout in seconds to wait for the task to cancel.
+
+    """
+    name = task.get_name()
+    task.cancel()
+    try:
+        if timeout:
+            await asyncio.wait_for(task, timeout=timeout)
+        else:
+            await task
+    except asyncio.TimeoutError:
+        logger.warning(f"{name}: timed out waiting for task to cancel")
+    except asyncio.CancelledError:
+        # Here are sure the task is cancelled properly.
+        pass
+    except Exception as e:
+        logger.exception(f"{name}: unexpected exception while cancelling task: {e}")
+    finally:
+        try:
+            _TASKS.remove(task)
+        except KeyError as e:
+            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
+
+
+def current_tasks() -> Set[asyncio.Task]:
+    """Returns the list of currently created/registered tasks."""
+    return _TASKS

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -44,6 +44,20 @@ def obj_count(obj) -> int:
 
 
 def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str) -> asyncio.Task:
+    """
+    Creates and schedules a new asyncio Task that runs the given coroutine.
+
+    The task is added to a global set of created tasks.
+
+    Args:
+        loop (asyncio.AbstractEventLoop): The event loop to use for creating the task.
+        coroutine (Coroutine): The coroutine to be executed within the task.
+        name (str): The name to assign to the task for identification.
+
+    Returns:
+        asyncio.Task: The created task object.
+    """
+
     async def run_coroutine():
         try:
             await coroutine
@@ -62,6 +76,18 @@ def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str
 
 
 async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
+    """Wait for an asyncio.Task to complete with optional timeout handling.
+
+    This function awaits the specified asyncio.Task and handles scenarios for
+    timeouts, cancellations, and other exceptions. It also ensures that the task
+    is removed from the set of registered tasks upon completion or failure.
+
+    Args:
+        task (asyncio.Task): The asyncio Task to wait for.
+        timeout (Optional[float], optional): The maximum number of seconds
+            to wait for the task to complete. If None, waits indefinitely.
+            Defaults to None.
+    """
     name = task.get_name()
     try:
         if timeout:
@@ -82,6 +108,17 @@ async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
 
 
 async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
+    """Cancels the given asyncio Task and awaits its completion with an
+    optional timeout.
+
+    This function removes the task from the set of registered tasks upon
+    completion or failure.
+
+    Args:
+        task (asyncio.Task): The task to be cancelled.
+        timeout (Optional[float]): The optional timeout in seconds to wait for the task to cancel.
+
+    """
     name = task.get_name()
     task.cancel()
     try:
@@ -104,4 +141,5 @@ async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
 
 
 def current_tasks() -> Set[asyncio.Task]:
+    """Returns the list of currently created/registered tasks."""
     return _TASKS

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -4,16 +4,11 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import asyncio
 import collections
 import itertools
-from typing import Coroutine, Optional, Set
-
-from loguru import logger
 
 _COUNTS = collections.defaultdict(itertools.count)
 _ID = itertools.count()
-_TASKS: Set[asyncio.Task] = set()
 
 
 def obj_id() -> int:
@@ -41,105 +36,3 @@ def obj_count(obj) -> int:
     0
     """
     return next(_COUNTS[obj.__class__.__name__])
-
-
-def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str) -> asyncio.Task:
-    """
-    Creates and schedules a new asyncio Task that runs the given coroutine.
-
-    The task is added to a global set of created tasks.
-
-    Args:
-        loop (asyncio.AbstractEventLoop): The event loop to use for creating the task.
-        coroutine (Coroutine): The coroutine to be executed within the task.
-        name (str): The name to assign to the task for identification.
-
-    Returns:
-        asyncio.Task: The created task object.
-    """
-
-    async def run_coroutine():
-        try:
-            await coroutine
-        except asyncio.CancelledError:
-            logger.trace(f"{name}: task cancelled")
-            # Re-raise the exception to ensure the task is cancelled.
-            raise
-        except Exception as e:
-            logger.exception(f"{name}: unexpected exception: {e}")
-
-    task = loop.create_task(run_coroutine())
-    task.set_name(name)
-    _TASKS.add(task)
-    logger.trace(f"{name}: task created")
-    return task
-
-
-async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
-    """Wait for an asyncio.Task to complete with optional timeout handling.
-
-    This function awaits the specified asyncio.Task and handles scenarios for
-    timeouts, cancellations, and other exceptions. It also ensures that the task
-    is removed from the set of registered tasks upon completion or failure.
-
-    Args:
-        task (asyncio.Task): The asyncio Task to wait for.
-        timeout (Optional[float], optional): The maximum number of seconds
-            to wait for the task to complete. If None, waits indefinitely.
-            Defaults to None.
-    """
-    name = task.get_name()
-    try:
-        if timeout:
-            await asyncio.wait_for(task, timeout=timeout)
-        else:
-            await task
-    except asyncio.TimeoutError:
-        logger.warning(f"{name}: timed out waiting for task to finish")
-    except asyncio.CancelledError:
-        logger.trace(f"{name}: unexpected task cancellation (maybe Ctrl-C?)")
-    except Exception as e:
-        logger.exception(f"{name}: unexpected exception while stopping task: {e}")
-    finally:
-        try:
-            _TASKS.remove(task)
-        except KeyError as e:
-            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
-
-
-async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
-    """Cancels the given asyncio Task and awaits its completion with an
-    optional timeout.
-
-    This function removes the task from the set of registered tasks upon
-    completion or failure.
-
-    Args:
-        task (asyncio.Task): The task to be cancelled.
-        timeout (Optional[float]): The optional timeout in seconds to wait for the task to cancel.
-
-    """
-    name = task.get_name()
-    task.cancel()
-    try:
-        if timeout:
-            await asyncio.wait_for(task, timeout=timeout)
-        else:
-            await task
-    except asyncio.TimeoutError:
-        logger.warning(f"{name}: timed out waiting for task to cancel")
-    except asyncio.CancelledError:
-        # Here are sure the task is cancelled properly.
-        pass
-    except Exception as e:
-        logger.exception(f"{name}: unexpected exception while cancelling task: {e}")
-    finally:
-        try:
-            _TASKS.remove(task)
-        except KeyError as e:
-            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
-
-
-def current_tasks() -> Set[asyncio.Task]:
-    """Returns the list of currently created/registered tasks."""
-    return _TASKS

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -97,14 +97,14 @@ async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
     except asyncio.TimeoutError:
         logger.warning(f"{name}: timed out waiting for task to finish")
     except asyncio.CancelledError:
-        logger.error(f"{name}: unexpected task cancellation")
+        logger.trace(f"{name}: unexpected task cancellation (maybe Ctrl-C?)")
     except Exception as e:
         logger.exception(f"{name}: unexpected exception while stopping task: {e}")
     finally:
         try:
             _TASKS.remove(task)
         except KeyError as e:
-            logger.error(f"{name}: error removing task (already removed?): {e}")
+            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
 
 
 async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
@@ -137,7 +137,7 @@ async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
         try:
             _TASKS.remove(task)
         except KeyError as e:
-            logger.error(f"{name}: error removing task (already removed?): {e}")
+            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
 
 
 def current_tasks() -> Set[asyncio.Task]:

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -3,8 +3,13 @@
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
+
+import asyncio
 import collections
 import itertools
+from typing import Coroutine, Optional
+
+from loguru import logger
 
 _COUNTS = collections.defaultdict(itertools.count)
 _ID = itertools.count()
@@ -35,3 +40,37 @@ def obj_count(obj) -> int:
     0
     """
     return next(_COUNTS[obj.__class__.__name__])
+
+
+def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str) -> asyncio.Task:
+    async def run_coroutine():
+        try:
+            await coroutine
+        except asyncio.CancelledError:
+            logger.trace(f"{name}: cancelling task")
+            # Re-raise the exception to ensure the task is cancelled.
+            raise
+        except Exception as e:
+            logger.exception(f"{name}: unexpected exception: {e}")
+
+    task = loop.create_task(run_coroutine())
+    task.set_name(name)
+    logger.trace(f"{name}: task created")
+    return task
+
+
+async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
+    name = task.get_name()
+    task.cancel()
+    try:
+        if timeout:
+            await asyncio.wait_for(task, timeout=timeout)
+        else:
+            await task
+    except asyncio.TimeoutError:
+        logger.warning(f"{name}: timed out waiting for task to finish")
+    except asyncio.CancelledError:
+        # Here are sure the task is cancelled properly.
+        logger.trace(f"{name}: task cancelled")
+    except Exception as e:
+        logger.exception(f"{name}: unexpected exception while cancelling task: {e}")

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -74,7 +74,10 @@ async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
     except asyncio.CancelledError:
         # Here are sure the task is cancelled properly.
         logger.trace(f"{name}: task cancelled")
-        _TASKS.remove(task)
+        try:
+            _TASKS.remove(task)
+        except KeyError as e:
+            logger.error(f"{name}: error removing task (already removed?): {e}")
     except Exception as e:
         logger.exception(f"{name}: unexpected exception while cancelling task: {e}")
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -32,8 +32,7 @@ from pipecat.processors.frameworks.langchain import LangchainProcessor
 class TestLangchain(unittest.IsolatedAsyncioTestCase):
     class MockProcessor(FrameProcessor):
         def __init__(self, name):
-            super().__init__()
-            self.name = name
+            super().__init__(name=name)
             self.token: list[str] = []
             # Start collecting tokens when we see the start frame
             self.start_collecting = False


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

If a `FrameProcessor` needs to create a task it should use `FrameProcessor.create_task()` and `FrameProcessor.cancel_task()`. This gives Pipecat more control over all the tasks that are created in Pipecat.

Both functions internally use the utils module: `utils.create_task()` and `utils.cancel_task()` which should also be used outside of FrameProcessors. That is, unless strictly necessary, we should avoid using `asyncio.create_task()`.