### PR TITLE
Small fixes to the Daily REST API helper

### DIFF
--- a/src/pipecat/transports/services/helpers/daily_rest.py
+++ b/src/pipecat/transports/services/helpers/daily_rest.py
@@ -296,7 +296,9 @@ class DailyRESTHelper:
             room_url: Daily room URL
             expiry_time: Token validity duration in seconds (default: 1 hour)
             owner: Whether token has owner privileges
-            params: Parameters for creating a Daily meeting token
+            params: Optional additional token properties. Note that room_name,
+                exp, and is_owner will be set based on the other function
+                parameters regardless of values in params.
 
         Returns:
             str: Meeting token
@@ -309,7 +311,7 @@ class DailyRESTHelper:
                 "No Daily room specified. You must specify a Daily room in order a token to be generated."
             )
 
-        expiration: float = time.time() + expiry_time
+        expiration: int = int(time.time() + expiry_time)
 
         room_name = self.get_name_from_url(room_url)
 
@@ -327,7 +329,7 @@ class DailyRESTHelper:
             )
         else:
             params.properties.room_name = room_name
-            params.properties.exp = int(expiration)
+            params.properties.exp = expiration
             params.properties.is_owner = owner
 
         json = params.model_dump(exclude_none=True)

--- a/src/pipecat/transports/services/helpers/daily_rest.py
+++ b/src/pipecat/transports/services/helpers/daily_rest.py
@@ -319,13 +319,9 @@ class DailyRESTHelper:
 
         if params is None:
             params = DailyMeetingTokenParams(
-                **{
-                    "properties": {
-                        "room_name": room_name,
-                        "is_owner": owner,
-                        "exp": int(expiration),
-                    }
-                }
+                properties=DailyMeetingTokenProperties(
+                    room_name=room_name, is_owner=owner, exp=expiration
+                )
             )
         else:
             params.properties.room_name = room_name


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Two small things related to the Daily REST API helper:
- Fix type validation error by converting timestamp to integer before Pydantic validation
- Improve token parameter construction by using proper Pydantic model constructors instead of dict unpacking

This is clean up from a PR that was merged earlier today.