### PR TITLE
Adding hindi danda symbol as end of sentence marker

### DIFF
--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -14,7 +14,7 @@ ENDOFSENTENCE_PATTERN_STR = r"""
     (?<!Mrs)         # Negative lookbehind: not preceded by "Mrs"
     (?<!Prof)        # Negative lookbehind: not preceded by "Prof"
     [\.\?\!:;]|      # Match a period, question mark, exclamation point, colon, or semicolon
-    [。？！：；]       # the full-width version (mainly used in East Asian languages such as Chinese)
+    [。？！：；।]       # the full-width version (mainly used in East Asian languages such as Chinese, Hindi)
     $                # End of string
 """
 ENDOFSENTENCE_PATTERN = re.compile(ENDOFSENTENCE_PATTERN_STR, re.VERBOSE)

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -38,3 +38,14 @@ class TestUtilsString(unittest.IsolatedAsyncioTestCase):
         for i in chinese_sentences:
             assert match_endofsentence(i)
         assert not match_endofsentence("你好，")
+
+    async def test_endofsentence_hi(self):
+        hindi_sentences = [
+            "हैलो।",
+            "हैलो！",
+            "आप खाये हैं？",
+            "सुरक्षा पहले।",
+        ]
+        for i in hindi_sentences:
+            assert match_endofsentence(i)
+        assert not match_endofsentence("हैलो，")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Enhance sentence splitting for Hindi TTS by recognizing ‘Danda’ (Unicode: ।) as the end-of-sentence marker.
Note: ‘Danda’ is distinct from the pipe symbol (|) and is a unique Unicode character. This update ensures efficient processing and splitting of Hindi text during TTS.

#### Testing done

(venv) (base) vengadanathansrinivasan@vengadanathans-MacBook-Pro-2 pipecat-hi-fix % pytest tests/test_utils_string.py                                                
========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.12.4, pytest-8.3.4, pluggy-1.5.0 -- /Users/vengadanathansrinivasan/miniconda3/bin/python
cachedir: .pytest_cache
rootdir: /Users/vengadanathansrinivasan/workspace/arrowhead/pipecat-hi-fix
configfile: pyproject.toml
plugins: asyncio-0.25.2, anyio-4.4.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function
collected 3 items                                                                                                                                                      

tests/test_utils_string.py::TestUtilsString::test_endofsentence PASSED                                                                                           [ 33%]
tests/test_utils_string.py::TestUtilsString::test_endofsentence_hi PASSED                                                                                        [ 66%]
tests/test_utils_string.py::TestUtilsString::test_endofsentence_zh PASSED    