### PR TITLE
done sent message to elevenlabs when closing connection

### DIFF
--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -357,7 +357,6 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
 
             if self._websocket:
                 logger.debug("Disconnecting from ElevenLabs")
-                await self._websocket.send(json.dumps({"text": ""}))
                 await self._websocket.close()
                 self._websocket = None
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fix: Prevent further errors when closing ElevenLabs WebSocket connection

We now ensure that no additional messages are sent to ElevenLabs after an error occurs in the WebSocket connection. Previously, sending messages to an already errored-out connection caused further errors and prevented the WebSocket from closing cleanly. This issue was observed multiple times, resulting in failures to reconnect to ElevenLabs. This fix improves error handling and ensures seamless reconnection.