### PR TITLE
Remove eleven_multilinguagal_v2 from language code list

### DIFF
--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -44,10 +44,11 @@ except ModuleNotFoundError as e:
 
 ElevenLabsOutputFormat = Literal["pcm_16000", "pcm_22050", "pcm_24000", "pcm_44100"]
 
+# Models that support language codes
+# eleven_multilingual_v2 doesn't support language codes, so it's excluded
 ELEVENLABS_MULTILINGUAL_MODELS = {
-    "eleven_turbo_v2_5",
-    "eleven_multilingual_v2",
     "eleven_flash_v2_5",
+    "eleven_turbo_v2_5",
 }
 
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The docs aren't clear on this, but `eleven_multilinguagal_v2` doesn't support a language code. It detects the language on its own.