### PR TITLE
fixing a race condition with bot join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue with `DailyTransport` would miss the `on_participant_joined` event
+  if the participant joined the room before the bot joined.
+
 ## [0.0.54] - 2025-01-27
 
 ### Added


### PR DESCRIPTION
There has been a race condition in daily webrtc, where the participant joins the room before the bot, making the `on_participant_joined` event getting missed, is this intended or there is a bug here? Seems like a bug to me, since we are using transport with bot and missing events hampers the bot.