### PR TITLE
transports(daily): queue events until join completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a `DailyTransport` issue that would cause events to be triggered before
+  join finished.
+
 ## [0.0.54] - 2025-01-27
 
 ### Added


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Currently, we can get events as soon as we join the signalling server but before `on_joined` is triggered. We now delay events after `on_joined` gets triggered to be more predictable.

Supersedes #1098 .