### PR TITLE
serializers(twilio): handle transport message frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `TwilioSerializer` now supports transport message frames. With this we can
+  create Twilio emulators.
+
 - Added a new transport: `WebsocketClientTransport`.
 
 - Added a `metadata` field to `Frame` which makes it possible to pass custom


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`TwilioSerializer` now supports transport message frames. With this we can create Twilio emulators.