### PR TITLE
fix: elevenlabs tts increase websocket max message size limit to 16MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where `ElevenLabsTTSService` messages would return a 1009 websocket error by increasing the max message size limit to 16MB.
+
 - Fixed a `DailyTransport` issue that would cause events to be triggered before
   join finished.
 

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -334,7 +334,8 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
                     f"Language code [{language}] not applied. Language codes can only be used with multilingual models: {', '.join(sorted(ELEVENLABS_MULTILINGUAL_MODELS))}"
                 )
 
-            self._websocket = await websockets.connect(url)
+            # Set max websocket message size to 16MB for large audio responses
+            self._websocket = await websockets.connect(url, max_size=16 * 1024 * 1024)
 
             # According to ElevenLabs, we should always start with a single space.
             msg: Dict[str, Any] = {


### PR DESCRIPTION
A potential cause of issues between pipecat and elevenlabs is having the default websocket max message size of 1mb, bumping up to match the maximum used on our end of 16mb