### PR TITLE
frames: added metadata field to Frame class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `metadata` field to `Frame` which makes it possible to pass custom
+  data to all frames.
+
 - Added `test/utils.py` inside of pipecat package.
 
 ### Fixed
 
-- Fixed an issue where `ElevenLabsTTSService` messages would return a 1009 websocket error by increasing the max message size limit to 16MB.
+- Fixed an issue where `ElevenLabsTTSService` messages would return a 1009
+  websocket error by increasing the max message size limit to 16MB.
 
 - Fixed a `DailyTransport` issue that would cause events to be triggered before
   join finished.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -47,11 +47,13 @@ class Frame:
     id: int = field(init=False)
     name: str = field(init=False)
     pts: Optional[int] = field(init=False)
+    metadata: dict = field(init=False)
 
     def __post_init__(self):
         self.id: int = obj_id()
         self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
         self.pts: Optional[int] = None
+        self.metadata: dict = {}
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Added a `metadata` field to `Frame` which makes it possible to pass custom data to all frames.
