### PR TITLE
GoogleLLMContext: Allow _restructure_from_openai_messages to handle c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `test/utils.py` inside of pipecat package.
 
+### Changed
+
+- Updated `GoogleLLMContext` to support pushing `LLMMessagesUpdateFrame`s that
+  contain a combination of function calls, function call responses, system
+  messages, or just messages.
+
 ### Fixed
 
 - Fixed an issue where `ElevenLabsTTSService` messages would return a 1009


### PR DESCRIPTION
…ontext frames that contain function call data and / or messages

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Working in this area of the code really convinces me that we need a uniform standard for function calling, as we have for messages. What prompted this change was a Flows feature where you can [reset the context at any given node](https://github.com/pipecat-ai/pipecat-flows/pull/88). For a reset to work, the context needs to include to include:
- The latest pairs of function call & results (and multiples if they were consecutive)
- Next user (or system) message(s)

The issue was that the GoogleLLMContext `_restructure_from_openai_messages` function in Pipecat doesn't support receiving a context frame (LLMMessagesUpdateFrame) that contains function information and messages. Interestingly, OpenAI and Anthropic both support this.

I'm not in love with this change as it just builds on a fragile system, so I'm open to other approaches.

In general, it would have been much easier to work on this feature in Flows if we had a uniform format for messages and function calling. With that, a developer could just switch out the LLM package and now have to re-write the function calls for their code. It's very possible I'm overlooking details on this uniform format, so we should discuss what a viable path is.