### PR TITLE
Improve ElevenLabs language checking logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the language checking logic in `ElevenLabsTTSService` and
+  `ElevenLabsHttpTTSService` to properly handle language codes based on model
+  compatibility, with appropriate warnings when language codes cannot be
+  applied.
+
 - Updated `GoogleLLMContext` to support pushing `LLMMessagesUpdateFrame`s that
   contain a combination of function calls, function call responses, system
   messages, or just messages.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I learned that the "v2" series of models are English only and don't accept language parameter. This change is updating to align to that fact. Also, I'm changing the default language to `None` so that ElevenLabs' defaults are used.