### PR TITLE
introduce TaskManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- It is now possible to specify the asyncio event loop that a `PipelineTask` and
+  all the processors should run on by passing it as a new argument to the
+  `PipelineRunner`. This could allow running pipelines in multiple threads each
+  one with its own event loop.
+
+- Added a new `utils.TaskManager`. Instead of a global task manager we now have
+  a task manager per `PipelineTask`. In the previous version the task manager
+  was global, so running multiple simultaneous `PipelineTask`s could result in
+  dangling task warnings which were not actually true. In order, for all the
+  processors to know about the task manager, we pass it through the
+  `StartFrame`. This means that processors should create tasks when they receive
+  a `StartFrame` but not before (because they don't have a task manager yet).
+
 - Added `TelnyxFrameSerializer` to support Telnyx calls. A full running example
   has also been added to `examples/telnyx-chatbot`.
 

--- a/examples/foundational/06-listen-and-respond.py
+++ b/examples/foundational/06-listen-and-respond.py
@@ -38,6 +38,8 @@ logger.add(sys.stderr, level="DEBUG")
 
 class MetricsLogger(FrameProcessor):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
         if isinstance(frame, MetricsFrame):
             for d in frame.data:
                 if isinstance(d, TTFBMetricsData):

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -117,12 +117,15 @@ class CompletenessCheck(FrameProcessor):
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
+
         if isinstance(frame, TextFrame) and frame.text == "YES":
             logger.debug("Completeness check YES")
             await self.push_frame(UserStoppedSpeakingFrame())
             await self._notifier.notify()
         elif isinstance(frame, TextFrame) and frame.text == "NO":
             logger.debug("Completeness check NO")
+        else:
+            await self.push_frame(frame, direction)
 
 
 class OutputGate(FrameProcessor):

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -166,7 +166,7 @@ class OutputGate(FrameProcessor):
 
     async def _start(self):
         self._frames_buffer = []
-        self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
+        self._gate_task = self.create_task(self._gate_task_handler())
 
     async def _stop(self):
         await self.cancel_task(self._gate_task)

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -371,7 +371,7 @@ class OutputGate(FrameProcessor):
 
     async def _start(self):
         self._frames_buffer = []
-        self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
+        self._gate_task = self.create_task(self._gate_task_handler())
 
     async def _stop(self):
         await self.cancel_task(self._gate_task)

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -328,6 +328,8 @@ class CompletenessCheck(FrameProcessor):
             await self._notifier.notify()
         elif isinstance(frame, TextFrame) and frame.text == "NO":
             logger.debug("!!! Completeness check NO")
+        else:
+            await self.push_frame(frame, direction)
 
 
 class OutputGate(FrameProcessor):

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -456,6 +456,8 @@ class CompletenessCheck(FrameProcessor):
                     # logger.debug("!!! CompletenessCheck idle wait START")
                     self._wakeup_time = time.time() + self.wait_time
                     self._idle_task = self.create_task(self._idle_task_handler())
+        else:
+            await self.push_frame(frame, direction)
 
     async def _idle_task_handler(self):
         try:

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -455,7 +455,7 @@ class CompletenessCheck(FrameProcessor):
                 else:
                     # logger.debug("!!! CompletenessCheck idle wait START")
                     self._wakeup_time = time.time() + self.wait_time
-                    self._idle_task = self.get_event_loop().create_task(self._idle_task_handler())
+                    self._idle_task = self.create_task(self._idle_task_handler())
 
     async def _idle_task_handler(self):
         try:
@@ -597,7 +597,7 @@ class OutputGate(FrameProcessor):
 
     async def _start(self):
         self._frames_buffer = []
-        self._gate_task = self.get_event_loop().create_task(self._gate_task_handler())
+        self._gate_task = self.create_task(self._gate_task_handler())
 
     async def _stop(self):
         await self.cancel_task(self._gate_task)

--- a/examples/foundational/25-google-audio-in.py
+++ b/examples/foundational/25-google-audio-in.py
@@ -212,7 +212,7 @@ class InputTranscriptionFrameEmitter(FrameProcessor):
         elif isinstance(frame, LLMFullResponseEndFrame):
             await self.push_frame(LLMDemoTranscriptionFrame(text=self._aggregation.strip()))
             self._aggregation = ""
-        elif isinstance(frame, MetricsFrame):
+        else:
             await self.push_frame(frame, direction)
 
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -12,6 +12,7 @@ from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.clocks.base_clock import BaseClock
 from pipecat.metrics.metrics import MetricsData
 from pipecat.transcriptions.language import Language
+from pipecat.utils.asyncio import TaskManager
 from pipecat.utils.time import nanoseconds_to_str
 from pipecat.utils.utils import obj_count, obj_id
 
@@ -412,6 +413,7 @@ class StartFrame(SystemFrame):
     """This is the first frame that should be pushed down a pipeline."""
 
     clock: BaseClock
+    task_manager: TaskManager
     allow_interruptions: bool = False
     enable_metrics: bool = False
     enable_usage_metrics: bool = False

--- a/src/pipecat/pipeline/base_task.py
+++ b/src/pipecat/pipeline/base_task.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import AsyncIterable, Iterable
 
@@ -24,6 +25,11 @@ class BaseTask(ABC):
         pass
 
     @abstractmethod
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop):
+        """Sets the event loop that this task will run on."""
+        pass
+
+    @abstractmethod
     def has_finished(self) -> bool:
         """Indicates whether the tasks has finished. That is, all processors
         have stopped.
@@ -41,28 +47,20 @@ class BaseTask(ABC):
 
     @abstractmethod
     async def cancel(self):
-        """
-        Stops the running pipeline immediately.
-        """
+        """Stops the running pipeline immediately."""
         pass
 
     @abstractmethod
     async def run(self):
-        """
-        Starts running the given pipeline.
-        """
+        """Starts running the given pipeline."""
         pass
 
     @abstractmethod
     async def queue_frame(self, frame: Frame):
-        """
-        Queue a frame to be pushed down the pipeline.
-        """
+        """Queue a frame to be pushed down the pipeline."""
         pass
 
     @abstractmethod
     async def queue_frames(self, frames: Iterable[Frame] | AsyncIterable[Frame]):
-        """
-        Queues multiple frames to be pushed down the pipeline.
-        """
+        """Queues multiple frames to be pushed down the pipeline."""
         pass

--- a/src/pipecat/pipeline/sync_parallel_pipeline.py
+++ b/src/pipecat/pipeline/sync_parallel_pipeline.py
@@ -78,16 +78,18 @@ class SyncParallelPipeline(BasePipeline):
             down_queue = asyncio.Queue()
             source = SyncParallelPipelineSource(up_queue)
             sink = SyncParallelPipelineSink(down_queue)
-            processors: List[FrameProcessor] = [source] + processors + [sink]
+
+            # Create pipeline
+            pipeline = Pipeline(processors)
+            source.link(pipeline)
+            pipeline.link(sink)
+            self._pipelines.append(pipeline)
 
             # Keep track of sources and sinks. We also keep the output queue of
             # the source and the sinks so we can use it later.
             self._sources.append({"processor": source, "queue": down_queue})
             self._sinks.append({"processor": sink, "queue": up_queue})
 
-            # Create pipeline
-            pipeline = Pipeline(processors)
-            self._pipelines.append(pipeline)
         logger.debug(f"Finished creating {self} pipelines")
 
     #

--- a/src/pipecat/pipeline/sync_parallel_pipeline.py
+++ b/src/pipecat/pipeline/sync_parallel_pipeline.py
@@ -105,7 +105,9 @@ class SyncParallelPipeline(BasePipeline):
 
     async def cleanup(self):
         await super().cleanup()
+        await asyncio.gather(*[s["processor"].cleanup() for s in self._sources])
         await asyncio.gather(*[p.cleanup() for p in self._pipelines])
+        await asyncio.gather(*[s["processor"].cleanup() for s in self._sinks])
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -30,7 +30,7 @@ from pipecat.pipeline.base_pipeline import BasePipeline
 from pipecat.pipeline.base_task import BaseTask
 from pipecat.pipeline.task_observer import TaskObserver
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.utils.asyncio import cancel_task, create_task, wait_for_task
+from pipecat.utils.asyncio import TaskManager
 from pipecat.utils.utils import obj_count, obj_id
 
 HEARTBEAT_SECONDS = 1.0
@@ -122,7 +122,9 @@ class PipelineTask(BaseTask):
         self._sink = PipelineTaskSink(self._down_queue)
         pipeline.link(self._sink)
 
-        self._observer = TaskObserver(params.observers)
+        self._task_manager = TaskManager()
+
+        self._observer = TaskObserver(observers=params.observers, task_manager=self._task_manager)
 
     @property
     def id(self) -> int:
@@ -133,6 +135,9 @@ class PipelineTask(BaseTask):
     def name(self) -> str:
         """Returns the name of this task."""
         return self._name
+
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop):
+        self._task_manager.set_event_loop(loop)
 
     def has_finished(self) -> bool:
         """Indicates whether the tasks has finished. That is, all processors
@@ -159,15 +164,17 @@ class PipelineTask(BaseTask):
         # we want to cancel right away.
         await self._source.push_frame(CancelFrame())
         # Only cancel the push task. Everything else will be cancelled in run().
-        await cancel_task(self._process_push_task)
+        await self._task_manager.cancel_task(self._process_push_task)
 
     async def run(self):
         """
         Starts running the given pipeline.
         """
+        if self.has_finished():
+            return
         try:
             push_task = self._create_tasks()
-            await wait_for_task(push_task)
+            await self._task_manager.wait_for_task(push_task)
         except asyncio.CancelledError:
             # We are awaiting on the push task and it might be cancelled
             # (e.g. Ctrl-C). This means we will get a CancelledError here as
@@ -176,6 +183,7 @@ class PipelineTask(BaseTask):
             pass
         await self._cancel_tasks()
         await self._cleanup()
+        self._print_dangling_tasks()
         self._finished = True
 
     async def queue_frame(self, frame: Frame):
@@ -196,41 +204,39 @@ class PipelineTask(BaseTask):
                 await self.queue_frame(frame)
 
     def _create_tasks(self):
-        loop = asyncio.get_running_loop()
-        self._process_up_task = create_task(
-            loop, self._process_up_queue(), f"{self}::_process_up_queue"
+        self._process_up_task = self._task_manager.create_task(
+            self._process_up_queue(), f"{self}::_process_up_queue"
         )
-        self._process_down_task = create_task(
-            loop, self._process_down_queue(), f"{self}::_process_down_queue"
+        self._process_down_task = self._task_manager.create_task(
+            self._process_down_queue(), f"{self}::_process_down_queue"
         )
-        self._process_push_task = create_task(
-            loop, self._process_push_queue(), f"{self}::_process_push_queue"
+        self._process_push_task = self._task_manager.create_task(
+            self._process_push_queue(), f"{self}::_process_push_queue"
         )
 
         return self._process_push_task
 
     def _maybe_start_heartbeat_tasks(self):
         if self._params.enable_heartbeats:
-            loop = asyncio.get_running_loop()
-            self._heartbeat_push_task = create_task(
-                loop, self._heartbeat_push_handler(), f"{self}::_heartbeat_push_handler"
+            self._heartbeat_push_task = self._task_manager.create_task(
+                self._heartbeat_push_handler(), f"{self}::_heartbeat_push_handler"
             )
-            self._heartbeat_monitor_task = create_task(
-                loop, self._heartbeat_monitor_handler(), f"{self}::_heartbeat_monitor_handler"
+            self._heartbeat_monitor_task = self._task_manager.create_task(
+                self._heartbeat_monitor_handler(), f"{self}::_heartbeat_monitor_handler"
             )
 
     async def _cancel_tasks(self):
         await self._maybe_cancel_heartbeat_tasks()
 
-        await cancel_task(self._process_up_task)
-        await cancel_task(self._process_down_task)
+        await self._task_manager.cancel_task(self._process_up_task)
+        await self._task_manager.cancel_task(self._process_down_task)
 
         await self._observer.stop()
 
     async def _maybe_cancel_heartbeat_tasks(self):
         if self._params.enable_heartbeats:
-            await cancel_task(self._heartbeat_push_task)
-            await cancel_task(self._heartbeat_monitor_task)
+            await self._task_manager.cancel_task(self._heartbeat_push_task)
+            await self._task_manager.cancel_task(self._heartbeat_monitor_task)
 
     def _initial_metrics_frame(self) -> MetricsFrame:
         processors = self._pipeline.processors_with_metrics()
@@ -260,12 +266,13 @@ class PipelineTask(BaseTask):
         self._maybe_start_heartbeat_tasks()
 
         start_frame = StartFrame(
+            clock=self._clock,
+            task_manager=self._task_manager,
             allow_interruptions=self._params.allow_interruptions,
             enable_metrics=self._params.enable_metrics,
             enable_usage_metrics=self._params.enable_usage_metrics,
             report_only_initial_ttfb=self._params.report_only_initial_ttfb,
             observer=self._observer,
-            clock=self._clock,
         )
         await self._source.queue_frame(start_frame, FrameDirection.DOWNSTREAM)
 
@@ -356,6 +363,11 @@ class PipelineTask(BaseTask):
                 logger.warning(
                     f"{self}: heartbeat frame not received for more than {wait_time} seconds"
                 )
+
+    def _print_dangling_tasks(self):
+        tasks = [t.get_name() for t in self._task_manager.current_tasks()]
+        if tasks:
+            logger.warning(f"Dangling tasks detected: {tasks}")
 
     def __str__(self):
         return self.name

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -173,7 +173,7 @@ class PipelineTask(BaseTask):
         if self.has_finished():
             return
         try:
-            push_task = self._create_tasks()
+            push_task = await self._create_tasks()
             await self._task_manager.wait_for_task(push_task)
         except asyncio.CancelledError:
             # We are awaiting on the push task and it might be cancelled
@@ -203,7 +203,7 @@ class PipelineTask(BaseTask):
             for frame in frames:
                 await self.queue_frame(frame)
 
-    def _create_tasks(self):
+    async def _create_tasks(self):
         self._process_up_task = self._task_manager.create_task(
             self._process_up_queue(), f"{self}::_process_up_queue"
         )
@@ -213,6 +213,8 @@ class PipelineTask(BaseTask):
         self._process_push_task = self._task_manager.create_task(
             self._process_push_queue(), f"{self}::_process_push_queue"
         )
+
+        await self._observer.start()
 
         return self._process_push_task
 

--- a/src/pipecat/pipeline/task_observer.py
+++ b/src/pipecat/pipeline/task_observer.py
@@ -58,8 +58,9 @@ class TaskObserver(BaseObserver):
     def __init__(self, *, observers: List[BaseObserver] = [], task_manager: TaskManager):
         self._id: int = obj_id()
         self._name: str = f"{self.__class__.__name__}#{obj_count(self)}"
-        self._proxies: List[Proxy] = self._create_proxies(observers)
+        self._observers = observers
         self._task_manager = task_manager
+        self._proxies: List[Proxy] = []
 
     @property
     def id(self) -> int:
@@ -68,6 +69,10 @@ class TaskObserver(BaseObserver):
     @property
     def name(self) -> str:
         return self._name
+
+    async def start(self):
+        """Starts all proxy observer tasks."""
+        self._proxies = self._create_proxies(self._observers)
 
     async def stop(self):
         """Stops all proxy observer tasks."""

--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -121,6 +121,8 @@ class STTMuteFilter(FrameProcessor):
         return False
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
         """Processes incoming frames and manages muting state."""
         # Handle function call state changes
         if isinstance(frame, FunctionCallInProgressFrame):

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -764,11 +764,11 @@ class RTVIProcessor(FrameProcessor):
 
         # A task to process incoming action frames.
         self._action_queue = asyncio.Queue()
-        self._action_task = self.create_task(self._action_task_handler())
+        self._action_task: Optional[asyncio.Task] = None
 
         # A task to process incoming transport messages.
         self._message_queue = asyncio.Queue()
-        self._message_task = self.create_task(self._message_task_handler())
+        self._message_task: Optional[asyncio.Task] = None
 
         self._register_event_handler("on_bot_started")
         self._register_event_handler("on_client_ready")
@@ -863,6 +863,8 @@ class RTVIProcessor(FrameProcessor):
             await self._pipeline.cleanup()
 
     async def _start(self, frame: StartFrame):
+        self._action_task = self.create_task(self._action_task_handler())
+        self._message_task = self.create_task(self._message_task_handler())
         await self._call_event_handler("on_bot_started")
 
     async def _stop(self, frame: EndFrame):

--- a/src/pipecat/processors/logger.py
+++ b/src/pipecat/processors/logger.py
@@ -31,6 +31,8 @@ class FrameLogger(FrameProcessor):
         self._ignored_frame_types = tuple(ignored_frame_types) if ignored_frame_types else None
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
         if self._ignored_frame_types and not isinstance(frame, self._ignored_frame_types):
             dir = "<" if direction is FrameDirection.UPSTREAM else ">"
             msg = f"{dir} {self._prefix}: {frame}"

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -186,10 +186,12 @@ class GladiaSTTService(STTService):
         await super().stop(frame)
         await self._send_stop_recording()
         await self._websocket.close()
+        await self.wait_for_task(self._receive_task)
 
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)
         await self._websocket.close()
+        await self.cancel_task(self._receive_task)
 
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
         await self.start_processing_metrics()

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -35,7 +35,6 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.transports.base_transport import TransportParams
-from pipecat.utils.asyncio import wait_for_task
 from pipecat.utils.time import nanoseconds_to_seconds
 
 
@@ -88,9 +87,9 @@ class BaseOutputTransport(FrameProcessor):
         # for these tasks before cancelling the camera and audio tasks below
         # because they might be still rendering.
         if self._sink_task:
-            await wait_for_task(self._sink_task)
+            await self.wait_for_task(self._sink_task)
         if self._sink_clock_task:
-            await wait_for_task(self._sink_clock_task)
+            await self.wait_for_task(self._sink_clock_task)
 
         # We can now cancel the camera task.
         await self._cancel_camera_task()

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -51,13 +51,11 @@ class BaseTransport(ABC):
         name: Optional[str] = None,
         input_name: Optional[str] = None,
         output_name: Optional[str] = None,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         self._id: int = obj_id()
         self._name = name or f"{self.__class__.__name__}#{obj_count(self)}"
         self._input_name = input_name
         self._output_name = output_name
-        self._loop = loop or asyncio.get_running_loop()
         self._event_handlers: dict = {}
 
     @property

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -46,7 +46,7 @@ from pipecat.transcriptions.language import Language
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.utils.asyncio import cancel_task, create_task
+from pipecat.utils.asyncio import TaskManager
 
 try:
     from daily import CallClient, Daily, EventHandler
@@ -179,7 +179,6 @@ class DailyTransportClient(EventHandler):
         bot_name: str,
         params: DailyParams,
         callbacks: DailyCallbacks,
-        loop: asyncio.AbstractEventLoop,
         transport_name: str,
     ):
         super().__init__()
@@ -193,7 +192,6 @@ class DailyTransportClient(EventHandler):
         self._bot_name: str = bot_name
         self._params: DailyParams = params
         self._callbacks = callbacks
-        self._loop = loop
         self._transport_name = transport_name
 
         self._participant_id: str = ""
@@ -204,6 +202,8 @@ class DailyTransportClient(EventHandler):
         self._joined = False
         self._joined_event = asyncio.Event()
         self._leave_counter = 0
+
+        self._task_manager: Optional[TaskManager] = None
 
         # We use the executor to cleanup the client. We just do it from one
         # place, so only one thread is really needed.
@@ -220,11 +220,7 @@ class DailyTransportClient(EventHandler):
         # future) we will deadlock because completions use event handlers (which
         # are holding the GIL).
         self._callback_queue = asyncio.Queue()
-        self._callback_task = create_task(
-            self._loop,
-            self._callback_task_handler(),
-            f"{self._transport_name}::DailyTransportClient::_callback_task_handler",
-        )
+        self._callback_task = None
 
         self._camera: VirtualCameraDevice | None = None
         if self._params.camera_out_enabled:
@@ -267,9 +263,6 @@ class DailyTransportClient(EventHandler):
     def participant_id(self) -> str:
         return self._participant_id
 
-    def set_callbacks(self, callbacks: DailyCallbacks):
-        self._callbacks = callbacks
-
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):
         if not self._joined:
             return
@@ -278,7 +271,7 @@ class DailyTransportClient(EventHandler):
         if isinstance(frame, (DailyTransportMessageFrame, DailyTransportMessageUrgentFrame)):
             participant_id = frame.participant_id
 
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.send_app_message(
             frame.message, participant_id, completion=completion_callback(future)
         )
@@ -292,7 +285,7 @@ class DailyTransportClient(EventHandler):
         num_channels = self._params.audio_in_channels
         num_frames = int(sample_rate / 100) * 2  # 20ms of audio
 
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._speaker.read_frames(num_frames, completion=completion_callback(future))
         audio = await future
 
@@ -311,7 +304,7 @@ class DailyTransportClient(EventHandler):
         if not self._mic:
             return None
 
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._mic.write_frames(frames, completion=completion_callback(future))
         await future
 
@@ -320,6 +313,14 @@ class DailyTransportClient(EventHandler):
             return None
 
         self._camera.write_frame(frame.image)
+
+    async def setup(self, frame: StartFrame):
+        if not self._task_manager:
+            self._task_manager = frame.task_manager
+            self._callback_task = self._task_manager.create_task(
+                self._callback_task_handler(),
+                f"{self}::callback_task",
+            )
 
     async def join(self):
         # Transport already joined, ignore.
@@ -370,7 +371,7 @@ class DailyTransportClient(EventHandler):
 
         logger.info(f"Enabling transcription with settings {self._params.transcription_settings}")
 
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.start_transcription(
             settings=self._params.transcription_settings.model_dump(exclude_none=True),
             completion=completion_callback(future),
@@ -381,7 +382,7 @@ class DailyTransportClient(EventHandler):
             return
 
     async def _join(self):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
 
         self._client.join(
             self._room_url,
@@ -466,24 +467,24 @@ class DailyTransportClient(EventHandler):
     async def _stop_transcription(self):
         if not self._token:
             return
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.stop_transcription(completion=completion_callback(future))
         error = await future
         if error:
             logger.error(f"Unable to stop transcription: {error}")
 
     async def _leave(self):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.leave(completion=completion_callback(future))
         return await asyncio.wait_for(future, timeout=10)
 
     async def cleanup(self):
-        if self._callback_task:
-            await cancel_task(self._callback_task)
+        if self._callback_task and self._task_manager:
+            await self._task_manager.cancel_task(self._callback_task)
             self._callback_task = None
         # Make sure we don't block the event loop in case `client.release()`
         # takes extra time.
-        await self._loop.run_in_executor(self._executor, self._cleanup)
+        await self._get_event_loop().run_in_executor(self._executor, self._cleanup)
 
     def _cleanup(self):
         if self._client:
@@ -497,39 +498,39 @@ class DailyTransportClient(EventHandler):
         return self._client.participant_counts()
 
     async def start_dialout(self, settings):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.start_dialout(settings, completion=completion_callback(future))
         await future
 
     async def stop_dialout(self, participant_id):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.stop_dialout(participant_id, completion=completion_callback(future))
         await future
 
     async def send_dtmf(self, settings):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.send_dtmf(settings, completion=completion_callback(future))
         await future
 
     async def sip_call_transfer(self, settings):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.sip_call_transfer(settings, completion=completion_callback(future))
         await future
 
     async def sip_refer(self, settings):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.sip_refer(settings, completion=completion_callback(future))
         await future
 
     async def start_recording(self, streaming_settings, stream_id, force_new):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.start_recording(
             streaming_settings, stream_id, force_new, completion=completion_callback(future)
         )
         await future
 
     async def stop_recording(self, stream_id):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.stop_recording(stream_id, completion=completion_callback(future))
         await future
 
@@ -537,7 +538,7 @@ class DailyTransportClient(EventHandler):
         if not self._joined:
             return
 
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.send_prebuilt_chat_message(
             message, user_name=user_name, completion=completion_callback(future)
         )
@@ -574,14 +575,14 @@ class DailyTransportClient(EventHandler):
         )
 
     async def update_transcription(self, participants=None, instance_id=None):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.update_transcription(
             participants, instance_id, completion=completion_callback(future)
         )
         await future
 
     async def update_subscriptions(self, participant_settings=None, profile_settings=None):
-        future = self._loop.create_future()
+        future = self._get_event_loop().create_future()
         self._client.update_subscriptions(
             participant_settings=participant_settings,
             profile_settings=profile_settings,
@@ -681,7 +682,7 @@ class DailyTransportClient(EventHandler):
 
     def _call_async_callback(self, callback, *args):
         future = asyncio.run_coroutine_threadsafe(
-            self._callback_queue.put((callback, *args)), self._loop
+            self._callback_queue.put((callback, *args)), self._get_event_loop()
         )
         future.result()
 
@@ -691,6 +692,14 @@ class DailyTransportClient(EventHandler):
             await self._joined_event.wait()
             (callback, *args) = await self._callback_queue.get()
             await callback(*args)
+
+    def _get_event_loop(self) -> asyncio.AbstractEventLoop:
+        if not self._task_manager:
+            raise Exception(f"{self}: missing task manager (pipeline not started?)")
+        return self._task_manager.get_event_loop()
+
+    def __str__(self):
+        return f"{self._transport_name}::DailyTransportClient"
 
 
 class DailyInputTransport(BaseInputTransport):
@@ -715,6 +724,8 @@ class DailyInputTransport(BaseInputTransport):
     async def start(self, frame: StartFrame):
         # Parent start.
         await super().start(frame)
+        # Setup client.
+        await self._client.setup(frame)
         # Join the room.
         await self._client.join()
         # Create audio task. It reads audio frames from Daily and push them
@@ -837,6 +848,8 @@ class DailyOutputTransport(BaseOutputTransport):
     async def start(self, frame: StartFrame):
         # Parent start.
         await super().start(frame)
+        # Setup client.
+        await self._client.setup(frame)
         # Join the room.
         await self._client.join()
 
@@ -875,9 +888,8 @@ class DailyTransport(BaseTransport):
         params: DailyParams = DailyParams(),
         input_name: str | None = None,
         output_name: str | None = None,
-        loop: asyncio.AbstractEventLoop | None = None,
     ):
-        super().__init__(input_name=input_name, output_name=output_name, loop=loop)
+        super().__init__(input_name=input_name, output_name=output_name)
 
         callbacks = DailyCallbacks(
             on_joined=self._on_joined,
@@ -905,9 +917,7 @@ class DailyTransport(BaseTransport):
         )
         self._params = params
 
-        self._client = DailyTransportClient(
-            room_url, token, bot_name, params, callbacks, self._loop, self.name
-        )
+        self._client = DailyTransportClient(room_url, token, bot_name, params, callbacks, self.name)
         self._input: DailyInputTransport | None = None
         self._output: DailyOutputTransport | None = None
 
@@ -1042,7 +1052,7 @@ class DailyTransport(BaseTransport):
             await self._output.push_error(error_frame)
         else:
             logger.error("Both input and output are None while trying to push error")
-            raise RuntimeError("No valid input or output channel to push error")
+            raise Exception("No valid input or output channel to push error")
 
     async def _on_app_message(self, message: Any, sender: str):
         if self._input:

--- a/src/pipecat/utils/asyncio.py
+++ b/src/pipecat/utils/asyncio.py
@@ -9,106 +9,121 @@ from typing import Coroutine, Optional, Set
 
 from loguru import logger
 
-_TASKS: Set[asyncio.Task] = set()
 
+class TaskManager:
+    def __init__(self) -> None:
+        self._tasks: Set[asyncio.Task] = set()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
-def create_task(loop: asyncio.AbstractEventLoop, coroutine: Coroutine, name: str) -> asyncio.Task:
-    """
-    Creates and schedules a new asyncio Task that runs the given coroutine.
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
 
-    The task is added to a global set of created tasks.
+    def get_event_loop(self) -> asyncio.AbstractEventLoop:
+        if not self._loop:
+            raise Exception("TaskManager missing event loop, use TaskManager.set_event_loop().")
+        return self._loop
 
-    Args:
-        loop (asyncio.AbstractEventLoop): The event loop to use for creating the task.
-        coroutine (Coroutine): The coroutine to be executed within the task.
-        name (str): The name to assign to the task for identification.
+    def create_task(self, coroutine: Coroutine, name: str) -> asyncio.Task:
+        """
+        Creates and schedules a new asyncio Task that runs the given coroutine.
 
-    Returns:
-        asyncio.Task: The created task object.
-    """
+        The task is added to a global set of created tasks.
 
-    async def run_coroutine():
+        Args:
+            loop (asyncio.AbstractEventLoop): The event loop to use for creating the task.
+            coroutine (Coroutine): The coroutine to be executed within the task.
+            name (str): The name to assign to the task for identification.
+
+        Returns:
+            asyncio.Task: The created task object.
+        """
+
+        async def run_coroutine():
+            try:
+                await coroutine
+            except asyncio.CancelledError:
+                logger.trace(f"{name}: task cancelled")
+                # Re-raise the exception to ensure the task is cancelled.
+                raise
+            except Exception as e:
+                logger.exception(f"{name}: unexpected exception: {e}")
+
+        if not self._loop:
+            raise Exception("TaskManager missing event loop, use TaskManager.set_event_loop().")
+
+        task = self._loop.create_task(run_coroutine())
+        task.set_name(name)
+        self._add_task(task)
+        logger.trace(f"{name}: task created")
+        return task
+
+    async def wait_for_task(self, task: asyncio.Task, timeout: Optional[float] = None):
+        """Wait for an asyncio.Task to complete with optional timeout handling.
+
+        This function awaits the specified asyncio.Task and handles scenarios for
+        timeouts, cancellations, and other exceptions. It also ensures that the task
+        is removed from the set of registered tasks upon completion or failure.
+
+        Args:
+            task (asyncio.Task): The asyncio Task to wait for.
+            timeout (Optional[float], optional): The maximum number of seconds
+                to wait for the task to complete. If None, waits indefinitely.
+                Defaults to None.
+        """
+        name = task.get_name()
         try:
-            await coroutine
+            if timeout:
+                await asyncio.wait_for(task, timeout=timeout)
+            else:
+                await task
+        except asyncio.TimeoutError:
+            logger.warning(f"{name}: timed out waiting for task to finish")
         except asyncio.CancelledError:
-            logger.trace(f"{name}: task cancelled")
-            # Re-raise the exception to ensure the task is cancelled.
-            raise
+            logger.trace(f"{name}: unexpected task cancellation (maybe Ctrl-C?)")
         except Exception as e:
-            logger.exception(f"{name}: unexpected exception: {e}")
+            logger.exception(f"{name}: unexpected exception while stopping task: {e}")
+        finally:
+            self._remove_task(task)
 
-    task = loop.create_task(run_coroutine())
-    task.set_name(name)
-    _TASKS.add(task)
-    logger.trace(f"{name}: task created")
-    return task
+    async def cancel_task(self, task: asyncio.Task, timeout: Optional[float] = None):
+        """Cancels the given asyncio Task and awaits its completion with an
+        optional timeout.
 
+        This function removes the task from the set of registered tasks upon
+        completion or failure.
 
-async def wait_for_task(task: asyncio.Task, timeout: Optional[float] = None):
-    """Wait for an asyncio.Task to complete with optional timeout handling.
+        Args:
+            task (asyncio.Task): The task to be cancelled.
+            timeout (Optional[float]): The optional timeout in seconds to wait for the task to cancel.
 
-    This function awaits the specified asyncio.Task and handles scenarios for
-    timeouts, cancellations, and other exceptions. It also ensures that the task
-    is removed from the set of registered tasks upon completion or failure.
-
-    Args:
-        task (asyncio.Task): The asyncio Task to wait for.
-        timeout (Optional[float], optional): The maximum number of seconds
-            to wait for the task to complete. If None, waits indefinitely.
-            Defaults to None.
-    """
-    name = task.get_name()
-    try:
-        if timeout:
-            await asyncio.wait_for(task, timeout=timeout)
-        else:
-            await task
-    except asyncio.TimeoutError:
-        logger.warning(f"{name}: timed out waiting for task to finish")
-    except asyncio.CancelledError:
-        logger.trace(f"{name}: unexpected task cancellation (maybe Ctrl-C?)")
-    except Exception as e:
-        logger.exception(f"{name}: unexpected exception while stopping task: {e}")
-    finally:
+        """
+        name = task.get_name()
+        task.cancel()
         try:
-            _TASKS.remove(task)
+            if timeout:
+                await asyncio.wait_for(task, timeout=timeout)
+            else:
+                await task
+        except asyncio.TimeoutError:
+            logger.warning(f"{name}: timed out waiting for task to cancel")
+        except asyncio.CancelledError:
+            # Here are sure the task is cancelled properly.
+            pass
+        except Exception as e:
+            logger.exception(f"{name}: unexpected exception while cancelling task: {e}")
+        finally:
+            self._remove_task(task)
+
+    def current_tasks(self) -> Set[asyncio.Task]:
+        """Returns the list of currently created/registered tasks."""
+        return self._tasks
+
+    def _add_task(self, task: asyncio.Task):
+        self._tasks.add(task)
+
+    def _remove_task(self, task: asyncio.Task):
+        name = task.get_name()
+        try:
+            self._tasks.remove(task)
         except KeyError as e:
             logger.trace(f"{name}: unable to remove task (already removed?): {e}")
-
-
-async def cancel_task(task: asyncio.Task, timeout: Optional[float] = None):
-    """Cancels the given asyncio Task and awaits its completion with an
-    optional timeout.
-
-    This function removes the task from the set of registered tasks upon
-    completion or failure.
-
-    Args:
-        task (asyncio.Task): The task to be cancelled.
-        timeout (Optional[float]): The optional timeout in seconds to wait for the task to cancel.
-
-    """
-    name = task.get_name()
-    task.cancel()
-    try:
-        if timeout:
-            await asyncio.wait_for(task, timeout=timeout)
-        else:
-            await task
-    except asyncio.TimeoutError:
-        logger.warning(f"{name}: timed out waiting for task to cancel")
-    except asyncio.CancelledError:
-        # Here are sure the task is cancelled properly.
-        pass
-    except Exception as e:
-        logger.exception(f"{name}: unexpected exception while cancelling task: {e}")
-    finally:
-        try:
-            _TASKS.remove(task)
-        except KeyError as e:
-            logger.trace(f"{name}: unable to remove task (already removed?): {e}")
-
-
-def current_tasks() -> Set[asyncio.Task]:
-    """Returns the list of currently created/registered tasks."""
-    return _TASKS

--- a/src/pipecat/utils/utils.py
+++ b/src/pipecat/utils/utils.py
@@ -6,9 +6,12 @@
 
 import collections
 import itertools
+import threading
 
 _COUNTS = collections.defaultdict(itertools.count)
+_COUNTS_LOCK = threading.Lock()
 _ID = itertools.count()
+_ID_LOCK = threading.Lock()
 
 
 def obj_id() -> int:
@@ -21,7 +24,8 @@ def obj_id() -> int:
     >>> obj_id()
     2
     """
-    return next(_ID)
+    with _ID_LOCK:
+        return next(_ID)
 
 
 def obj_count(obj) -> int:
@@ -35,4 +39,5 @@ def obj_count(obj) -> int:
     >>> obj_count(new_type())
     0
     """
-    return next(_COUNTS[obj.__class__.__name__])
+    with _COUNTS_LOCK:
+        return next(_COUNTS[obj.__class__.__name__])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -57,6 +57,7 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
     async def test_task_single(self):
         pipeline = Pipeline([IdentityFilter()])
         task = PipelineTask(pipeline)
+        task.set_event_loop(asyncio.get_event_loop())
 
         await task.queue_frame(TextFrame(text="Hello!"))
         await task.queue_frames([TextFrame(text="Bye!"), EndFrame()])
@@ -81,6 +82,7 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
                 enable_heartbeats=True, heartbeats_period_secs=0.2, observers=[heartbeats_observer]
             ),
         )
+        task.set_event_loop(asyncio.get_event_loop())
 
         expected_heartbeats = 1.0 / 0.2
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This replaces the current global task manager by a `TaskManager` per `PipelineTask`. This avoids having warnings about dangling tasks that have been created by a different `PipelineTask` that is still running.

Also, the `TaskManager` is passed through the `StartFrame`, so two things need to happen:

- Frame processors need to call `super().process_frame()`, otherwise things won't be initialized properly.
- If you want to use the `TaskManager` to create tasks you need to create tasks after `StartFrame` is processed.

It is now possible to specify the event loop a `PipelineTask` should run in. This allows complex applications where `PipelineTask`s can run in multiple threads.

Because we now support multiple threads, the global `obj_id()` and `obj_count()` functions now require a lock.
