### PR TITLE
First draft at integrating operator dialout example

### DIFF
--- a/examples/phone-chatbot/bot_daily.py
+++ b/examples/phone-chatbot/bot_daily.py
@@ -125,7 +125,7 @@ async def main(
 
             #### **Step 2: Leave a Voicemail Message**
             - Immediately say:  
-            *"Hello, this is a message for Pipecat example user. This is the customer support team from the countries number one e-commerce site ringing about your order. Please call back on 123-456-7891. Thank you."*
+            *"Hello, this is a message for Pipecat example user. This is the customer support team from the country's number one e-commerce site ringing about your order. Please call back on 123-456-7891. Thank you."*
             - **IMMEDIATELY AFTER LEAVING THE MESSAGE, CALL `terminate_call`.**
             - **DO NOT SPEAK AFTER CALLING `terminate_call`.**
             - **FAILURE TO CALL `terminate_call` IMMEDIATELY IS A MISTAKE.**

--- a/examples/phone-chatbot/bot_runner.py
+++ b/examples/phone-chatbot/bot_runner.py
@@ -74,7 +74,13 @@ action using the Twilio Client library.
 
 
 async def _create_daily_room(
-    room_url, callId, callDomain=None, dialoutNumber=None, vendor="daily", detect_voicemail=False
+    room_url,
+    callId,
+    callDomain=None,
+    dialoutNumber=None,
+    vendor="daily",
+    detect_voicemail=False,
+    operatorNumber=None,
 ):
     if not room_url:
         # Create base properties with SIP settings
@@ -85,7 +91,7 @@ async def _create_daily_room(
         )
 
         # Only enable dialout if dialoutNumber is provided
-        if dialoutNumber:
+        if dialoutNumber or operatorNumber:
             properties.enable_dialout = True
 
         params = DailyRoomParams(properties=properties)
@@ -114,6 +120,8 @@ async def _create_daily_room(
         bot_proc = f"python3 -m bot_daily -u {room.url} -t {token} -i {callId} -d {callDomain}{' -v' if detect_voicemail else ''}"
         if dialoutNumber:
             bot_proc += f" -o {dialoutNumber}"
+        if operatorNumber:
+            bot_proc += f" -op {operatorNumber}"
     else:
         bot_proc = f"python3 -m bot_twilio -u {room.url} -t {token} -i {callId} -s {room.config.sip_endpoint}"
 
@@ -187,6 +195,7 @@ async def daily_start_bot(request: Request) -> JSONResponse:
         detect_voicemail = data.get("detectVoicemail", False)
         callId = data.get("callId", None)
         callDomain = data.get("callDomain", None)
+        operatorNumber = data.get("operatorNumber", None)
         dialoutNumber = data.get("dialoutNumber", None)
     except Exception:
         raise HTTPException(
@@ -194,7 +203,7 @@ async def daily_start_bot(request: Request) -> JSONResponse:
         )
 
     room: DailyRoomObject = await _create_daily_room(
-        room_url, callId, callDomain, dialoutNumber, "daily", detect_voicemail
+        room_url, callId, callDomain, dialoutNumber, "daily", detect_voicemail, operatorNumber
     )
 
     # Grab a token for the user to join with

--- a/examples/phone-chatbot/runner_code/__init__.py
+++ b/examples/phone-chatbot/runner_code/__init__.py
@@ -1,0 +1,13 @@
+from .room_manager import RoomManager, RoomRequest, RoomType
+from .room_state_manager import RoomState, RoomStateManager
+from .webhook_handler import JoinPayload, WebhookHandler
+
+__all__ = [
+    "RoomManager",
+    "RoomRequest",
+    "RoomType",
+    "RoomStateManager",
+    "RoomState",
+    "WebhookHandler",
+    "JoinPayload",
+]

--- a/examples/phone-chatbot/runner_code/room_manager.py
+++ b/examples/phone-chatbot/runner_code/room_manager.py
@@ -1,0 +1,188 @@
+import os
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from pipecat.transports.services.helpers.daily_rest import (
+    DailyRESTHelper,
+    DailyRoomObject,
+    DailyRoomParams,
+    DailyRoomProperties,
+    DailyRoomSipParams,
+)
+
+
+class RoomType(Enum):
+    VOICEMAIL_DETECTION = "voicemail_detection"
+    DIALOUT_WITH_VOICEMAIL = "dialout_with_voicemail"
+    USER_DIALIN = "user_dialin"
+    OPERATOR_ROOM = "operator_room"
+
+
+@dataclass
+class RoomRequest:
+    detect_voicemail: bool = False
+    dialout_number: Optional[str] = None
+    operator_number: Optional[str] = None
+    call_id: Optional[str] = None
+    call_domain: Optional[str] = None
+    from_number: Optional[str] = None
+    to_number: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "RoomRequest":
+        return cls(
+            detect_voicemail=data.get("detectVoicemail", False),
+            dialout_number=data.get("dialoutNumber"),
+            operator_number=data.get("operatorNumber"),
+            call_id=data.get("callId"),
+            call_domain=data.get("callDomain"),
+            from_number=data.get("From"),
+            to_number=data.get("To"),
+        )
+
+
+class RoomManager:
+    def __init__(self, daily_helpers: Dict[str, DailyRESTHelper], room_url: Optional[str] = None):
+        self.daily_helpers = daily_helpers
+        self.room_url = room_url
+        self.operator_number = "+12097844759"  # Consider moving this to config
+        self.max_session_time = 5 * 60  # 5 minutes
+
+    def determine_room_type(self, request: RoomRequest) -> RoomType:
+        """Determine the type of room based on the request parameters."""
+        if request.to_number:
+            if request.to_number == self.operator_number:
+                return RoomType.OPERATOR_ROOM
+            return RoomType.USER_DIALIN
+        elif request.dialout_number:
+            return RoomType.DIALOUT_WITH_VOICEMAIL
+        else:
+            return RoomType.VOICEMAIL_DETECTION
+
+    async def create_room(self, request: RoomRequest) -> Dict[str, Any]:
+        """Create a room based on the request type."""
+        room_type = self.determine_room_type(request)
+
+        if room_type == RoomType.OPERATOR_ROOM:
+            room = await self._create_operator_room()
+            result = {
+                "room": room,
+                "room_url": room.url,
+                "sipUri": room.config.sip_endpoint,
+                "is_operator_room": True,  # Flag to indicate this is an operator room
+            }
+        else:
+            room = await self._create_standard_room(request, room_type)
+            result = {
+                "room": room,
+                "room_url": room.url,
+                "sipUri": room.config.sip_endpoint,
+                "is_operator_room": False,
+            }
+
+        # Get token for the room
+        token = await self.daily_helpers["rest"].get_token(room.url, self.max_session_time)
+        if not token:
+            raise HTTPException(status_code=500, detail="Failed to get room token")
+
+        # Only spawn bot for non-operator rooms
+        if room_type != RoomType.OPERATOR_ROOM:
+            await self._spawn_bot(room=room, token=token, request=request, room_type=room_type)
+        return result
+
+    async def _create_operator_room(self) -> DailyRoomObject:
+        """Create a room specifically for operator handling."""
+        properties = DailyRoomProperties(
+            sip=DailyRoomSipParams(
+                display_name="operator-user", video=False, sip_mode="dial-in", num_endpoints=1
+            )
+        )
+        return await self._create_or_get_room(properties)
+
+    async def _create_standard_room(
+        self, request: RoomRequest, room_type: RoomType
+    ) -> DailyRoomObject:
+        """Create a standard room with appropriate properties."""
+        properties = DailyRoomProperties(
+            sip=DailyRoomSipParams(
+                display_name="dialin-user", video=False, sip_mode="dial-in", num_endpoints=1
+            )
+        )
+
+        # Enable dialout if needed
+        if room_type in [
+            RoomType.DIALOUT_WITH_VOICEMAIL,
+            RoomType.VOICEMAIL_DETECTION,
+            RoomType.USER_DIALIN,
+        ]:
+            properties.enable_dialout = True
+
+        return await self._create_or_get_room(properties)
+
+    async def _create_or_get_room(self, properties: DailyRoomProperties) -> DailyRoomObject:
+        """Create a new room or get existing one based on URL."""
+        if not self.room_url:
+            params = DailyRoomParams(properties=properties)
+            return await self.daily_helpers["rest"].create_room(params=params)
+
+        try:
+            room = await self.daily_helpers["rest"].get_room_from_url(self.room_url)
+            return room
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to get room {self.room_url}: {str(e)}"
+            )
+
+    async def _spawn_bot(
+        self, room: DailyRoomObject, token: str, request: RoomRequest, room_type: RoomType
+    ) -> None:
+        """Spawn the appropriate bot for the room."""
+        # Check required parameters
+        if not room.url or not token:
+            raise HTTPException(
+                status_code=500,
+                detail="Missing required parameters: room URL and token are required",
+            )
+
+        # For dialin or voicemail detection, we need call_id and call_domain
+        if room_type in [RoomType.USER_DIALIN]:
+            if not request.call_id or not request.call_domain:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Missing required parameters: call_id and call_domain are required for dialin",
+                )
+
+        # Get the parent directory (where bot_daily.py is located)
+        current_dir = os.path.dirname(os.path.abspath(__file__))  # Gets runner_code directory
+        parent_dir = os.path.dirname(current_dir)  # Gets the directory containing bot_daily.py
+
+        # Construct command with required arguments
+        bot_cmd = [
+            "python3",
+            os.path.join(parent_dir, "bot_daily.py"),
+            "-u",
+            room.url,
+            "-t",
+            token,
+        ]
+
+        # Add optional arguments
+        if request.call_id:
+            bot_cmd.extend(["-i", request.call_id])
+        if request.call_domain:
+            bot_cmd.extend(["-d", request.call_domain])
+        if request.detect_voicemail:
+            bot_cmd.append("-v")
+        if request.dialout_number:
+            bot_cmd.extend(["-o", request.dialout_number])
+        if request.operator_number:
+            bot_cmd.extend(["-op", request.operator_number])
+
+        try:
+            subprocess.Popen(bot_cmd, cwd=os.path.dirname(os.path.abspath(__file__)))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to start bot: {str(e)}")

--- a/examples/phone-chatbot/runner_code/room_state_manager.py
+++ b/examples/phone-chatbot/runner_code/room_state_manager.py
@@ -1,0 +1,151 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import httpx
+from fastapi import HTTPException
+
+from pipecat.transports.services.helpers.daily_rest import DailyRESTHelper, DailyRoomObject
+
+
+@dataclass
+class RoomState:
+    """Represents the state of a room including call information."""
+
+    room_url: str
+    room_object: Optional[DailyRoomObject] = None
+    call_id: Optional[str] = None
+    call_domain: Optional[str] = None
+    sip_uri: Optional[str] = None
+
+
+class RoomStateManager:
+    def __init__(self, daily_api_key: str, daily_api_url: str, daily_helpers: Dict):
+        self.daily_api_key = daily_api_key
+        self.daily_api_url = daily_api_url
+        self.daily_helpers = daily_helpers
+        self._created_rooms: Dict[str, RoomState] = {}
+        self._joined_rooms: Dict[str, RoomState] = {}
+        self._updated_rooms: set[str] = set()
+        self._operator_room_url: Optional[str] = None  # Track operator room specifically
+
+    def store_created_room(
+        self,
+        room: DailyRoomObject,
+        call_id: Optional[str] = None,
+        call_domain: Optional[str] = None,
+        is_operator_room: bool = False,
+    ) -> None:
+        """Store information about a newly created room."""
+        # Extract the correct SIP URI format
+        sip_uri = None
+        if hasattr(room.config, "sip_uri") and isinstance(room.config.sip_uri, dict):
+            endpoint = room.config.sip_uri.get("endpoint")
+            if endpoint:
+                sip_uri = f"sip:{endpoint}"
+
+        self._created_rooms[room.url] = RoomState(
+            room_url=room.url,
+            room_object=room,
+            call_id=call_id,
+            call_domain=call_domain,
+            sip_uri=sip_uri,
+        )
+
+        if is_operator_room:
+            self._operator_room_url = room.url
+            print(f"+++++ Stored operator room URL: {room.url}")
+
+    def store_joined_room(self, room_url: str) -> None:
+        """Store information about a room that has been joined."""
+        self._joined_rooms[room_url] = RoomState(room_url=room_url)
+
+    def get_created_room(self, room_url: str) -> Optional[RoomState]:
+        """Get information about a created room."""
+        return self._created_rooms.get(room_url)
+
+    def get_joined_room(self, room_url: str) -> Optional[RoomState]:
+        """Get information about a joined room."""
+        return self._joined_rooms.get(room_url)
+
+    def is_room_updated(self, room_url: str) -> bool:
+        """Check if a room has already been updated."""
+        return room_url in self._updated_rooms
+
+    def mark_room_updated(self, room_url: str) -> None:
+        """Mark a room as having been updated."""
+        self._updated_rooms.add(room_url)
+
+    def get_operator_room_url(self) -> Optional[str]:
+        """Get the URL of the operator room if it exists."""
+        return self._operator_room_url
+
+    async def handle_room_join(self, room_url: str) -> None:
+        """Handle the event of a participant joining a room."""
+        # If we have an operator room and it matches the join event, use that
+        if self._operator_room_url == room_url:
+            # This is the operator room join
+            created_room = self._created_rooms[room_url]
+        else:
+            # This is the non-operator room join
+            print(f"Non-operator room join for URL: {room_url}")
+            if room_url not in self._created_rooms:
+                print(f"Room {room_url} not found in created rooms")
+                return
+            created_room = self._created_rooms[room_url]
+
+        if self.is_room_updated(room_url):
+            print("Room already updated, skipping...")
+            return
+
+        if not created_room.call_id or not created_room.call_domain or not created_room.sip_uri:
+            print("Missing required room data for update")
+            return
+
+        await self._send_dialin_update(created_room)
+        self.mark_room_updated(room_url)
+
+        # Now send app message to the non-operator room (we're using room_url here
+        # because we want to send to the original room, not the operator room)
+        if room_url != self._operator_room_url:  # Only send if this is NOT the operator room
+            # Extract room name from URL (e.g., get 'hello' from 'https://bdom.daily.co/hello')
+            room_name = room_url.split("/")[-1]
+
+            app_message_url = f"{self.daily_api_url}/rooms/{room_name}/send-app-message"
+            headers = {
+                "Authorization": f"Bearer {self.daily_api_key}",
+                "Content-Type": "application/json",
+            }
+            payload = {"data": {"test": 1}, "recipient": "*"}
+
+            print(f"+++++ Sending app message to non-operator room: {room_name}")
+            async with httpx.AsyncClient() as client:
+                response = await client.post(app_message_url, headers=headers, json=payload)
+
+            if response.status_code != 200:
+                print(f"Error sending app message: {response.status_code}, {response.text}")
+                raise HTTPException(status_code=response.status_code, detail=response.text)
+
+            print("+++++ App message sent successfully!")
+
+    async def _send_dialin_update(self, room: RoomState) -> None:
+        """Send an API request to update the dial-in status."""
+        print(f"Sending dial-in update for room: {room.room_url}")
+
+        dialin_url = f"{self.daily_api_url}/dialin/pinlessCallUpdate"
+        headers = {
+            "Authorization": f"Bearer {self.daily_api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "callId": room.call_id,
+            "callDomain": room.call_domain,
+            "sipUri": room.sip_uri,
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(dialin_url, headers=headers, json=payload)
+
+        if response.status_code != 200:
+            print(f"Error from Daily API: {response.status_code}, {response.text}")
+            raise HTTPException(status_code=response.status_code, detail=response.text)

--- a/examples/phone-chatbot/runner_code/webhook_handler.py
+++ b/examples/phone-chatbot/runner_code/webhook_handler.py
@@ -1,0 +1,72 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+
+
+@dataclass
+class JoinPayload:
+    room: str
+    session_id: str
+    participant_id: str
+    participant_name: Optional[str]
+
+
+class WebhookHandler:
+    def __init__(self, room_state_manager, daily_domain: str = "bdom.daily.co"):
+        self.room_state_manager = room_state_manager
+        self.daily_domain = daily_domain
+
+    def _build_room_url(self, room_name: str) -> str:
+        """Build the full room URL from a room name."""
+        return f"https://{self.daily_domain}/{room_name}"
+
+    def _parse_join_payload(self, data: dict) -> JoinPayload:
+        """Parse and validate the join webhook payload."""
+        payload = data.get("payload", {})
+        if not payload.get("room"):
+            raise HTTPException(status_code=400, detail="Missing 'room' in payload")
+
+        return JoinPayload(
+            room=payload["room"],
+            session_id=payload.get("session_id", ""),
+            participant_id=payload.get("participant_id", ""),
+            participant_name=payload.get("participant_name"),
+        )
+
+    async def handle_join_webhook(self, request: Request) -> JSONResponse:
+        """Handle the joined_room webhook."""
+        print("Processing participant join webhook")
+        try:
+            data = await request.json()
+            if "test" in data:
+                return JSONResponse({"test": True})
+
+            # Parse and validate payload
+            payload = self._parse_join_payload(data)
+            room_url = self._build_room_url(payload.room)
+
+            # Store joined room state
+            self.room_state_manager.store_joined_room(room_url)
+
+            # Wait briefly to ensure all systems are ready
+            await asyncio.sleep(5)
+
+            # Handle the room join event
+            await self.room_state_manager.handle_room_join(room_url)
+
+            return JSONResponse(
+                {
+                    "message": "Joined room event processed",
+                    "room_url": room_url,
+                    "session_id": payload.session_id,
+                }
+            )
+
+        except Exception as e:
+            print(f"Error handling join webhook: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to process room join webhook: {str(e)}"
+            )


### PR DESCRIPTION
This adds to the phone chatbot example. The next blog post is focusing on transferring calls. There are many ways to 'transfer' calls. One of the ways many customers want to do it is to add an operator to the call by dialing out. So in this case:

1. Customer rings bot
2. Customer has conversation with bot
3. Customer escalates call and asks to speak to manager
4. Bot starts dialout to operator (manager / supervisor)
5. Operator joins the call
6. Bot summarizes call to manager / supervisor (while customer is on the call)
7. Bot waits in the call
8. Customer and operator have a conversation

This example will also allow us to use the voicemail detection + transfer example together. For example:
1. Bot dials out
2. If talking to voicemail, it will detect it and leave a message and put down the call
3. If talking to a human, it will have a conversation
4. Then bot can escalate to operator and dial out to operators number

Still a work in progress, but I wanted to get @markbackman’s thoughts on the approach. I initially considered breaking this into a separate file since we’ll be adding more transfer examples later (e.g., SIP transfer, blind transfer without context, warm transfer where a second bot joins a different room and retrieves call context via RAG). That said, this approach seems extendable without too many issues.