### PR TITLE
Remove created LLMFullResponseEndFrames from async TTS providers

### DIFF
--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -63,7 +63,7 @@ async def main():
         )
 
         llm = GoogleLLMService(
-            model="gemini-1.5-flash-latest",
+            model="gemini-2.0-flash-exp",
             # model="gemini-exp-1114",
             api_key=os.getenv("GOOGLE_API_KEY"),
         )

--- a/src/pipecat/services/cartesia.py
+++ b/src/pipecat/services/cartesia.py
@@ -250,9 +250,7 @@ class CartesiaTTSService(WordTTSService, WebsocketService):
                 # because we are likely still playing out audio and need the
                 # timestamp to set send context frames.
                 self._context_id = None
-                await self.add_word_timestamps(
-                    [("TTSStoppedFrame", 0), ("LLMFullResponseEndFrame", 0), ("Reset", 0)]
-                )
+                await self.add_word_timestamps([("TTSStoppedFrame", 0), ("Reset", 0)])
             elif msg["type"] == "timestamps":
                 await self.add_word_timestamps(
                     list(zip(msg["word_timestamps"]["words"], msg["word_timestamps"]["start"]))

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -284,7 +284,7 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
         if isinstance(frame, (TTSStoppedFrame, StartInterruptionFrame)):
             self._started = False
             if isinstance(frame, TTSStoppedFrame):
-                await self.add_word_timestamps([("LLMFullResponseEndFrame", 0), ("Reset", 0)])
+                await self.add_word_timestamps([("Reset", 0)])
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)


### PR DESCRIPTION
Storybot uses ElevenLabs' websocket TTS generation. It generates audio one "story page" at a time. There are three story pages and one 'story prompt' in each LLM response.

If the delay between story pages is longer than `stop_frame_timeout_s` (because of image generation, for example), the ElevenLabs `WordTTSService` will emit a `TTSStoppedFrame`, and then when TTS starts again, it emits a `TTSStartedFrame`.

But that `TTSStoppedFrame` also causes the creation of a `LLMFullResponseEndFrame`. This breaks the assistant context aggregator running downstream.

I suppose I could increase my `stop_frame_timeout_s` value to accommodate for the image generation pauses, but that WordTTSService property isn't exposed in the subclasses. Regardless, I think it's incorrect to generate a `LLMFullResponseEndFrame` here, but I admittedly don't know enough about the surrounding context.

EDIT:

My LLM's full output looks like this literal string: `"This is sentence one. [break] This is sentence two. [break] This is sentence three. [break] This is the last sentence."` A processor right after the LLM processor breaks it into multiple text frames, resulting in this behavior:

```
LLMFullResponseStartFrame()
TextFrame("This is sentence one.")
 <4-8 second delay to generate an image based on that sentence>
TextFrame("This is sentence two.")
 <4-8 second delay to generate an image based on that sentence>
TextFrame("This is sentence three.")
 <4-8 second delay to generate an image based on that sentence>
TextFrame("This is the last sentence.")
LLMFullResponseEndFrame()
```

But those extra LLMFullResponseEndFrames make it look like this:

```
LLMFullResponseStartFrame()
TextFrame("This is sentence one.")
 <4-8 second delay to generate an image based on that sentence>
LLMFullResponseEndFrame(inserted by TTS 2 seconds into image gen)
TextFrame("This is sentence two.")
 <4-8 second delay to generate an image based on that sentence>
LLMFullResponseEndFrame(inserted by TTS 2 seconds into image gen)
TextFrame("This is sentence three.")
 <4-8 second delay to generate an image based on that sentence>
LLMFullResponseEndFrame(inserted by TTS 2 seconds into image gen)
TextFrame("This is the last sentence.")
LLMFullResponseEndFrame()
```

The fact that we have a mismatched number of LLMFullResponseStartFrames and LLMFullResponseEndFrames is what makes me call it a bug.