### PR TITLE
serializers: don't update twilio/telnyx sample rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resampled to the desired output sample rate.
 
 - Fixed an issue with the `TwilioFrameSerializer` and `TelnyxFrameSerializer`
-  where `frame.audio_out_sample_rate` was incorrectly used in place of
-  `frame.audio_in_sample_rate`, which caused audio input detection to fail when
-  using different input and output sample rates.
+  where `twilio_sample_rate` and `telnyx_sample_rate` were incorrectly
+  initialized to `audio_in_sample_rate`. Those values currently default to 8000
+  and should be set manually from the serializer constructor if a different
+  value is needed.
 
 ## [0.0.55] - 2025-02-05
 

--- a/examples/canonical-metrics/bot.py
+++ b/examples/canonical-metrics/bot.py
@@ -65,7 +65,6 @@ async def main():
             # English
             #
             voice_id="cgSgspJ2msm6clMCkdW9",
-            aiohttp_session=session,
             #
             # Spanish
             #

--- a/examples/chatbot-audio-recording/bot.py
+++ b/examples/chatbot-audio-recording/bot.py
@@ -82,7 +82,6 @@ async def main():
             # English
             #
             voice_id="cgSgspJ2msm6clMCkdW9",
-            aiohttp_session=session,
             #
             # Spanish
             #

--- a/examples/foundational/04-utterance-and-speech.py
+++ b/examples/foundational/04-utterance-and-speech.py
@@ -51,7 +51,6 @@ async def main():
         )
 
         elevenlabs_tts = ElevenLabsTTSService(
-            aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
         )

--- a/examples/foundational/08-bots-arguing.py
+++ b/examples/foundational/08-bots-arguing.py
@@ -48,7 +48,6 @@ async def main():
             region=os.getenv("AZURE_SPEECH_REGION"),
         )
         tts2 = ElevenLabsTTSService(
-            aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             voice_id="jBpfuIE2acCO8z3wKNLl",
         )

--- a/examples/phone-chatbot/bot_daily.py
+++ b/examples/phone-chatbot/bot_daily.py
@@ -8,7 +8,7 @@ from loguru import logger
 from openai.types.chat import ChatCompletionToolParam
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import EndFrame, EndTaskFrame
+from pipecat.frames.frames import EndTaskFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -99,14 +99,14 @@ async def main(
             - **ASSUME IT IS A VOICEMAIL. DO NOT WAIT FOR MORE CONFIRMATION.**
 
             #### **Step 2: Leave a Voicemail Message**
-            - Immediately say:  
+            - Immediately say:
             *"Hello, this is a message for Pipecat example user. This is Chatbot. Please call back on 123-456-7891. Thank you."*
             - **IMMEDIATELY AFTER LEAVING THE MESSAGE, CALL `terminate_call`.**
             - **DO NOT SPEAK AFTER CALLING `terminate_call`.**
             - **FAILURE TO CALL `terminate_call` IMMEDIATELY IS A MISTAKE.**
 
             #### **Step 3: If Speaking to a Human**
-            - If the call is answered by a human, say:  
+            - If the call is answered by a human, say:
             *"Oh, hello! I'm a friendly chatbot. Is there anything I can help you with?"*
             - Keep responses **brief and helpful**.
             - If the user no longer needs assistance, **call `terminate_call` immediately.**

--- a/src/pipecat/serializers/telnyx.py
+++ b/src/pipecat/serializers/telnyx.py
@@ -31,7 +31,7 @@ from pipecat.serializers.base_serializer import FrameSerializer, FrameSerializer
 
 class TelnyxFrameSerializer(FrameSerializer):
     class InputParams(BaseModel):
-        telnyx_sample_rate: Optional[int] = None  # Default Telnyx rate (8kHz)
+        telnyx_sample_rate: int = 8000  # Default Telnyx rate (8kHz)
         sample_rate: Optional[int] = None  # Pipeline input rate
         inbound_encoding: str = "PCMU"
         outbound_encoding: str = "PCMU"
@@ -48,7 +48,7 @@ class TelnyxFrameSerializer(FrameSerializer):
         params.inbound_encoding = inbound_encoding
         self._params = params
 
-        self._telnyx_sample_rate = 0  # Fixed rate for Telnyx (8kHz)
+        self._telnyx_sample_rate = self._params.telnyx_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
         self._resampler = create_default_resampler()
@@ -58,8 +58,6 @@ class TelnyxFrameSerializer(FrameSerializer):
         return FrameSerializerType.TEXT
 
     async def setup(self, frame: StartFrame):
-        # Configure rates for input path: Telnyx (8kHz encoded) -> Pipeline (PCM)
-        self._telnyx_sample_rate = self._params.telnyx_sample_rate or frame.audio_in_sample_rate
         self._sample_rate = self._params.sample_rate or frame.audio_in_sample_rate
 
     async def serialize(self, frame: Frame) -> str | bytes | None:

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -27,14 +27,14 @@ from pipecat.serializers.base_serializer import FrameSerializer, FrameSerializer
 
 class TwilioFrameSerializer(FrameSerializer):
     class InputParams(BaseModel):
-        twilio_sample_rate: Optional[int] = None  # Default Twilio rate (8kHz)
+        twilio_sample_rate: int = 8000  # Default Twilio rate (8kHz)
         sample_rate: Optional[int] = None  # Pipeline input rate
 
     def __init__(self, stream_sid: str, params: InputParams = InputParams()):
         self._stream_sid = stream_sid
         self._params = params
 
-        self._twilio_sample_rate = 0  # Fixed rate for Twilio (8kHz)
+        self._twilio_sample_rate = self._params.twilio_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
         self._resampler = create_default_resampler()
@@ -44,8 +44,6 @@ class TwilioFrameSerializer(FrameSerializer):
         return FrameSerializerType.TEXT
 
     async def setup(self, frame: StartFrame):
-        # Configure rates for input path: Twilio (8kHz μ-law) -> Pipeline (PCM)
-        self._twilio_sample_rate = self._params.twilio_sample_rate or frame.audio_in_sample_rate
         self._sample_rate = self._params.sample_rate or frame.audio_in_sample_rate
 
     async def serialize(self, frame: Frame) -> str | bytes | None:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

We don't want to propagate the pipeline input/output sample rates into the serializers, instead we need to do that explicitly from the serializer constructor.

For example, `TwilioFrameSerializer` has `twilio_sample_rate` and `sample_rate`:

- The `twilio_sample_rate` inidicate the sample rate that Twilio will send and receive.
- The `sample_rate` indicates the sample rate of the input transport.

So if `twilio_sample_rate` is 8000 and `sample_rate` is 16000, one we receive audio from Twilio we will resample it to 16000. Then, through the pipeline we will work with 16000. At the end, the serializer will convert 16000 to 8000 which is what Twilio is expecting.


