### PR TITLE
Deprecate stt_service parameter in STTMuteFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `STTMuteFilter` constructor's `stt_service` parameter is now deprecated and
+  will be removed in a future version. The filter now manages mute state
+  internally instead of querying the STT service.
+
 - `RTVI.observer()` is now deprecated, instantiate an `RTVIObserver` directly
   instead.
 

--- a/examples/foundational/24-stt-mute-filter.py
+++ b/examples/foundational/24-stt-mute-filter.py
@@ -61,7 +61,6 @@ async def main():
         stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
         # Configure the mute processor with both strategies
         stt_mute_processor = STTMuteFilter(
-            stt_service=stt,
             config=STTMuteConfig(
                 strategies={STTMuteStrategy.FIRST_SPEECH, STTMuteStrategy.FUNCTION_CALL}
             ),

--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -11,7 +11,6 @@ such as during function calls, bot speech, or custom conditions. It helps manage
 the STT service should be active or inactive during a conversation.
 """
 
-import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Awaitable, Callable, Optional
@@ -77,10 +76,14 @@ class STTMuteFilter(FrameProcessor):
         **kwargs: Additional arguments passed to parent class
     """
 
-    def __init__(self, config: STTMuteConfig, stt_service: Optional[STTService] = None, **kwargs):
+    def __init__(
+        self, *, config: STTMuteConfig, stt_service: Optional[STTService] = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self._config = config
         if stt_service is not None:
+            import warnings
+
             warnings.warn(
                 "The stt_service parameter is deprecated and will be removed in a future version. "
                 "STTMuteFilter now manages mute state internally.",

--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -11,6 +11,7 @@ such as during function calls, bot speech, or custom conditions. It helps manage
 the STT service should be active or inactive during a conversation.
 """
 
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Awaitable, Callable, Optional
@@ -71,28 +72,36 @@ class STTMuteFilter(FrameProcessor):
     feature. When STT is muted, interruptions are automatically disabled.
 
     Args:
-        stt_service: Service handling speech-to-text functionality
         config: Configuration specifying muting strategies
+        stt_service: STT service instance (deprecated, will be removed in future version)
         **kwargs: Additional arguments passed to parent class
     """
 
-    def __init__(self, stt_service: STTService, config: STTMuteConfig, **kwargs):
+    def __init__(self, config: STTMuteConfig, stt_service: Optional[STTService] = None, **kwargs):
         super().__init__(**kwargs)
-        self._stt_service = stt_service
         self._config = config
+        if stt_service is not None:
+            warnings.warn(
+                "The stt_service parameter is deprecated and will be removed in a future version. "
+                "STTMuteFilter now manages mute state internally.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._first_speech_handled = False
         self._bot_is_speaking = False
         self._function_call_in_progress = False
+        self._is_muted = False
 
     @property
     def is_muted(self) -> bool:
         """Returns whether STT is currently muted."""
-        return self._stt_service.is_muted
+        return self._is_muted
 
     async def _handle_mute_state(self, should_mute: bool):
         """Handles both STT muting and interruption control."""
         if should_mute != self.is_muted:
             logger.debug(f"STT {'muting' if should_mute else 'unmuting'}")
+            self._is_muted = should_mute
             await self.push_frame(STTMuteFrame(mute=should_mute))
 
     async def _should_mute(self) -> bool:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The `STTMuteFilter` currently takes an `STTService` parameter but only uses it to check mute state. This is unnecessary coupling since the filter can manage this state internally.

This PR:
- Makes the `stt_service` parameter optional
- Adds a deprecation warning when the parameter is provided
- Implements internal mute state tracking
- Maintains full backwards compatibility

I've tested using the 24 example that this doesn't introduce a regression.