### PR TITLE
Update 28c option to output to log line only by default

### DIFF
--- a/examples/foundational/28c-transcription-processor-gemini.py
+++ b/examples/foundational/28c-transcription-processor-gemini.py
@@ -156,8 +156,11 @@ async def main():
 
         # Create transcript processor and handler
         transcript = TranscriptProcessor()
-        transcript_handler = TranscriptHandler(output_db="example.db")  # Output to log only
+        # Select a TranscriptHandler output method
+        # Uncomment out only one of the following lines:
+        transcript_handler = TranscriptHandler()  # Output to log only
         # transcript_handler = TranscriptHandler(output_file="transcript.txt") # Output to file and log
+        # transcript_handler = TranscriptHandler(output_db="example.db")  # Output to SQLite DB and log
 
         pipeline = Pipeline(
             [


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Making the DB option one of the TranscriptHandlers you need to opt-in to for this example. This prevents `example.db` from being creating in your directory.