### PR TITLE
fixing disconnect issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RTVIBotLLMProcessor`) are now deprecated, instantiate an `RTVIObserver`
   instead.
 
+### Fixed
+
+- Fixed an issue[#1192] in 11labs where we are trying to reconnect/disconnect the
+  websocket connection even when the connection is already closed.
+
 ## [0.0.56] - 2025-02-06
 
 ### Changed

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -388,7 +388,10 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
     async def _keepalive_task_handler(self):
         while True:
             await asyncio.sleep(10)
-            await self._send_text("")
+            try:
+                await self._send_text("")
+            except websockets.ConnectionClosed as e:
+                logger.warning(f"{self} keepalive error: {e}")
 
     async def _send_text(self, text: str):
         if self._websocket:

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -392,6 +392,7 @@ class ElevenLabsTTSService(WordTTSService, WebsocketService):
                 await self._send_text("")
             except websockets.ConnectionClosed as e:
                 logger.warning(f"{self} keepalive error: {e}")
+                break
 
     async def _send_text(self, text: str):
         if self._websocket:

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -85,6 +85,8 @@ class WebsocketService(ABC):
                 await self._receive_messages()
                 logger.debug(f"{self} connection established successfully")
                 retry_count = 0  # Reset counter on successful message receive
+            except websockets.ConnectionClosed as e:
+                logger.warning(f"{self} connection closed: {e}")
             except Exception as e:
                 retry_count += 1
                 if retry_count >= MAX_RETRIES:

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -87,6 +87,7 @@ class WebsocketService(ABC):
                 retry_count = 0  # Reset counter on successful message receive
             except websockets.ConnectionClosed as e:
                 logger.warning(f"{self} connection closed: {e}")
+                break
             except Exception as e:
                 retry_count += 1
                 if retry_count >= MAX_RETRIES:


### PR DESCRIPTION
Fixed an issue[#1192] in 11labs where we are trying to reconnect/disconnect the websocket connection even when the connection is already closed.