### PR TITLE
fixing google llm service error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue[#1192] in 11labs where we are trying to reconnect/disconnect the
   websocket connection even when the connection is already closed.
 
+- Fixed an issue where `has_regular_messages` condition was always been true in
+  `GoogleLLMContext` due to `Part` having `function_call` & `function_response` with
+  `None` values.
+
 ## [0.0.56] - 2025-02-06
 
 ### Changed

--- a/src/pipecat/services/google/google.py
+++ b/src/pipecat/services/google/google.py
@@ -604,9 +604,9 @@ class GoogleLLMContext(OpenAILLMContext):
         # Check if we only have function-related messages (no regular text)
         has_regular_messages = any(
             len(msg.parts) == 1
-            and hasattr(msg.parts[0], "text")
-            and not hasattr(msg.parts[0], "function_call")
-            and not hasattr(msg.parts[0], "function_response")
+            and not getattr(msg.parts[0], "text", None)
+            and getattr(msg.parts[0], "function_call", None)
+            and getattr(msg.parts[0], "function_response", None)
             for msg in self._messages
         )
 


### PR DESCRIPTION
Fixed an issue where `has_regular_messages` condition was always been true in `GoogleLLMContext` due to `Part` having `function_call` & `function_response` with `None` values.

<img width="468" alt="image" src="https://github.com/user-attachments/assets/04869932-15a0-4eb4-897e-4bb033f845eb" />
