### PR TITLE
Fix Type Hint in OpenAIContext::call_function

### DIFF
--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -193,7 +193,7 @@ class OpenAILLMContext:
         *,
         function_name: str,
         tool_call_id: str,
-        arguments: str,
+        arguments: dict[str, Any],
         llm: FrameProcessor,
         run_llm: bool = True,
     ) -> None:


### PR DESCRIPTION
`dict[str, Any]` might be the wrong type, but `str` is almost always not the correct one

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Maybe `Any` is a better type hint, but this should _usually_ be `dict[str, Any]`.

One usage is [here](https://github.com/pipecat-ai/pipecat/blob/b45f7fee6f66f8cf632d10674e0ee2b2185caf31/src/pipecat/services/anthropic.py#L213):

> arguments=json.loads(json_accumulator) if json_accumulator else dict()

The OpenAI service also passes a parsed JSON.