### PR TITLE
HTTP TTS services stopped frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ stt = DeepgramSTTService(..., live_options=LiveOptions(model="nova-2-general"))
 
 ### Fixed
 
+- Fixed an issue that was causing HTTP TTS services to push `TTSStoppedFrame`
+  more than once.
+
 - Fixed a `FishAudioTTSService` issue where `TTSStoppedFrame` was not being
   pushed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `RimeHttpTTSService` needs an `aiohttp.ClientSession` to be passed to the
+  constructor as all the other HTTP-based services.
+
+- `RimeHttpTTSService` doesn't use a default voice anymore.
+
 - `DeepgramSTTService` now uses the new `nova-3` model by default. If you want
   to use the previous model you can pass `LiveOptions(model="nova-2-general")`.
   (see https://deepgram.com/learn/introducing-nova-3-speech-to-text-api)

--- a/src/pipecat/services/elevenlabs.py
+++ b/src/pipecat/services/elevenlabs.py
@@ -566,18 +566,16 @@ class ElevenLabsHttpTTSService(TTSService):
                     return
 
                 await self.start_tts_usage_metrics(text)
+
                 yield TTSStartedFrame()
 
                 async for chunk in response.content:
                     if chunk:
                         await self.stop_ttfb_metrics()
                         yield TTSAudioRawFrame(chunk, self.sample_rate, 1)
-
-                yield TTSStoppedFrame()
-
         except Exception as e:
             logger.error(f"Error in run_tts: {e}")
             yield ErrorFrame(error=str(e))
-
         finally:
+            await self.stop_ttfb_metrics()
             yield TTSStoppedFrame()

--- a/src/pipecat/services/playht.py
+++ b/src/pipecat/services/playht.py
@@ -397,6 +397,7 @@ class PlayHTHttpTTSService(TTSService):
             await self.start_tts_usage_metrics(text)
 
             yield TTSStartedFrame()
+
             async for chunk in playht_gen:
                 # skip the RIFF header.
                 if in_header:
@@ -416,6 +417,8 @@ class PlayHTHttpTTSService(TTSService):
                         await self.stop_ttfb_metrics()
                         frame = TTSAudioRawFrame(chunk, self.sample_rate, 1)
                         yield frame
-            yield TTSStoppedFrame()
         except Exception as e:
             logger.error(f"{self} error generating TTS: {e}")
+        finally:
+            await self.stop_ttfb_metrics()
+            yield TTSStoppedFrame()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

- `RimeHttpTTSService` needs an `aiohttp.ClientSession` to be passed to the constructor as all the other HTTP-based services.

- `RimeHttpTTSService` doesn't use a default voice ID anymore.

Fixes https://github.com/pipecat-ai/pipecat/issues/1247
