### PR TITLE
Set grok-2 as default model for GrokLLMSService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `exponential_backoff_time()` to `utils.network` module.
 
 ### Changed
+
+- `GrokLLMSService` now uses `grok-2` as the default model.
 
 - `AnthropicLLMService` now uses `claude-3-7-sonnet-20250219` as the default
   model.

--- a/src/pipecat/services/grok.py
+++ b/src/pipecat/services/grok.py
@@ -125,7 +125,7 @@ class GrokLLMService(OpenAILLMService):
     Args:
         api_key (str): The API key for accessing Grok's API
         base_url (str, optional): The base URL for Grok API. Defaults to "https://api.x.ai/v1"
-        model (str, optional): The model identifier to use. Defaults to "grok-beta"
+        model (str, optional): The model identifier to use. Defaults to "grok-2"
         **kwargs: Additional keyword arguments passed to OpenAILLMService
     """
 
@@ -134,7 +134,7 @@ class GrokLLMService(OpenAILLMService):
         *,
         api_key: str,
         base_url: str = "https://api.x.ai/v1",
-        model: str = "grok-beta",
+        model: str = "grok-2",
         **kwargs,
     ):
         super().__init__(api_key=api_key, base_url=base_url, model=model, **kwargs)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

grok-2 is now the default. We'll update to grok-3 once available.