### PR TITLE
TTSService: Remove newlines before sending text to TTS service to gen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The base `TTSService` class now strips leading newlines before sending text
+  to the TTS provider. This change is to solve issues where some TTS providers,
+  like Azure, would not output text due to newlines.
+
 - `GrokLLMSService` now uses `grok-2` as the default model.
 
 - `AnthropicLLMService` now uses `claude-3-7-sonnet-20250219` as the default

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -399,6 +399,9 @@ class TTSService(AIService):
             await self._push_tts_frames(text)
 
     async def _push_tts_frames(self, text: str):
+        # Remove leading newlines only
+        text = text.lstrip("\n")
+
         # Don't send only whitespace. This causes problems for some TTS models. But also don't
         # strip all whitespace, as whitespace can influence prosody.
         if not text.strip():


### PR DESCRIPTION
…erate

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This came up in chatting in Discord. It sounds like the newline can cause problems for services like Azure TTS. Most are not impacted by this, but this is a safe way to ensure that text going into the TTS service is cleaner.

For example, Anthropic will, at times, generate text like this:
```

Because they make up everything!
```

Instead, we should strip that leading newline.