### PR TITLE
Rename ServerMessageFrame to RTVIServerMessageFrame and move to rtvi.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a new frame, `ServerMessageFrame`, and RTVI message `RTVIServerMessage`
-  which provides a generic mechanism for sending custom messages from server to
-  client. The `ServerMessageFrame` is processed by the `RTVIObserver` and will
-  be delivered to the client's `onServerMessage` callback or `ServerMessage`
-  event.
+- Added a new frame, `RTVIServerMessageFrame`, and RTVI message
+  `RTVIServerMessage` which provides a generic mechanism for sending custom
+  messages from server to client. The `RTVIServerMessageFrame` is processed by
+  the `RTVIObserver` and will be delivered to the client's `onServerMessage`
+  callback or `ServerMessage` event.
 
 ## [0.0.58] - 2025-02-26
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -706,16 +706,6 @@ class VisionImageRawFrame(InputImageRawFrame):
         return f"{self.name}(pts: {pts}, text: [{self.text}], size: {self.size}, format: {self.format})"
 
 
-@dataclass
-class ServerMessageFrame(SystemFrame):
-    """A frame for sending server messages to the client."""
-
-    data: Any
-
-    def __str__(self):
-        return f"{self.name}(data: {self.data})"
-
-
 #
 # Control frames
 #

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -38,7 +38,6 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     LLMTextFrame,
     MetricsFrame,
-    ServerMessageFrame,
     StartFrame,
     SystemFrame,
     TranscriptionFrame,
@@ -382,6 +381,16 @@ class RTVIServerMessage(BaseModel):
     data: Any
 
 
+@dataclass
+class RTVIServerMessageFrame(SystemFrame):
+    """A frame for sending server messages to the client."""
+
+    data: Any
+
+    def __str__(self):
+        return f"{self.name}(data: {self.data})"
+
+
 class RTVIFrameProcessor(FrameProcessor):
     def __init__(self, direction: FrameDirection = FrameDirection.DOWNSTREAM, **kwargs):
         super().__init__(**kwargs)
@@ -717,7 +726,7 @@ class RTVIObserver(BaseObserver):
                 mark_as_seen = False
         elif isinstance(frame, MetricsFrame):
             await self._handle_metrics(frame)
-        elif isinstance(frame, ServerMessageFrame):
+        elif isinstance(frame, RTVIServerMessageFrame):
             message = RTVIServerMessage(data=frame.data)
             await self.push_transport_message_urgent(message)
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

@aconchillo this is what you requested in the other PR.