### PR TITLE
Update gladia.py

### DIFF
--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -136,6 +136,8 @@ class GladiaSTTService(STTService):
         maximum_duration_without_endpointing: Optional[int] = 10
         audio_enhancer: Optional[bool] = None
         words_accurate_timestamps: Optional[bool] = None
+        speech_threshold: Optional[float] = .99
+        
 
     def __init__(
         self,
@@ -145,6 +147,7 @@ class GladiaSTTService(STTService):
         confidence: float = 0.5,
         sample_rate: Optional[int] = None,
         params: InputParams = InputParams(),
+        
         **kwargs,
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
@@ -166,7 +169,7 @@ class GladiaSTTService(STTService):
             "maximum_duration_without_endpointing": params.maximum_duration_without_endpointing,
             "pre_processing": {
                 "audio_enhancer": params.audio_enhancer,
-                "speech_threshold": 0.99,
+                "speech_threshold": params.speech_threshold,
             },
             "realtime_processing": {
                 "words_accurate_timestamps": params.words_accurate_timestamps,

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -137,8 +137,6 @@ class GladiaSTTService(STTService):
         audio_enhancer: Optional[bool] = None
         words_accurate_timestamps: Optional[bool] = None
         speech_threshold: Optional[float] = .99
-        
-
     def __init__(
         self,
         *,
@@ -146,8 +144,7 @@ class GladiaSTTService(STTService):
         url: str = "https://api.gladia.io/v2/live",
         confidence: float = 0.5,
         sample_rate: Optional[int] = None,
-        params: InputParams = InputParams(),
-        
+        params: InputParams = InputParams(),        
         **kwargs,
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -148,7 +148,6 @@ class GladiaSTTService(STTService):
         **kwargs,
     ):
         super().__init__(sample_rate=sample_rate, **kwargs)
-
         self._api_key = api_key
         self._url = url
         self._settings = {

--- a/src/pipecat/services/gladia.py
+++ b/src/pipecat/services/gladia.py
@@ -166,6 +166,7 @@ class GladiaSTTService(STTService):
             "maximum_duration_without_endpointing": params.maximum_duration_without_endpointing,
             "pre_processing": {
                 "audio_enhancer": params.audio_enhancer,
+                "speech_threshold": 0.99,
             },
             "realtime_processing": {
                 "words_accurate_timestamps": params.words_accurate_timestamps,


### PR DESCRIPTION
# Gladia Speech Detection Parameters

According to the Gladia documentation (https://docs.gladia.io/api-reference/v2/live/init), the speech threshold parameter accepts values between 0 and 1, where:

- Values closer to 1 enable Gladia to better isolate speech from background noise
- This higher threshold helps filter out non-speech audio elements

The speech threshold parameter is notably used in Gladia's demo applications to provide cleaner speech recognition results in noisy environments.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.