### PR TITLE
GoogleSTTService: raise exception to reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `AzureRealtimeBetaLLMService` to support Azure's OpeanAI Realtime API. Added
   foundational example `19a-azure-realtime-beta.py`.
 
+## [Fixed]
+
+- Fixed an issue with `GoogleSTTService`, that would prevent reconnection, while
+  using it along with `STTMuteFilter`
+
 ## [0.0.58] - 2025-02-26
 
 ### Added

--- a/src/pipecat/services/google/google.py
+++ b/src/pipecat/services/google/google.py
@@ -1985,3 +1985,4 @@ class GoogleSTTService(STTService):
 
         except Exception as e:
             logger.error(f"Error processing Google STT responses: {e}")
+            raise


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
---

While using GoogleSTTService along with STTMuteFilter (strategy: ALWAYS), the stt processor will eventually throw an error (during long bot speeches):
```
Error processing Google STT responses: 409 Stream timed out after receiving no more client requests.
```
but it wont reconnect after this.