### PR TITLE
add support for user and bot turn audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `on_user_turn_audio_data` and `on_bot_turn_audio_data` to
+  `AudioBufferProcessor`. This gives the ability to grab the audio of only that
+  turn for both the user and the bot.
+
 - Added new base class `BaseObject` which is now the base class of
   `FrameProcessor`, `PipelineRunner`, `PipelineTask` and `BaseTransport`. The
   new `BaseObject` adds supports for event handlers.

--- a/examples/chatbot-audio-recording/bot.py
+++ b/examples/chatbot-audio-recording/bot.py
@@ -32,11 +32,15 @@ load_dotenv(override=True)
 logger.remove(0)
 logger.add(sys.stderr, level="DEBUG")
 
+# Create the recordings directory if it doesn't exist
+os.makedirs("recordings", exist_ok=True)
+
 
 async def save_audio(audio: bytes, sample_rate: int, num_channels: int, name: str):
     if len(audio) > 0:
-        filename = (
-            f"{name}_conversation_recording{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.wav"
+        filename = os.path.join(
+            "recordings",
+            f"{name}_conversation_recording{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.wav",
         )
         with io.BytesIO() as buffer:
             with wave.open(buffer, "wb") as wf:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR adds a couple of new events `on_user_turn_audio_data` and `on_bot_turn_audio_data` to be able to grab the audio of the user and bot on each turn.