### PR TITLE
adding llm mute filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `AzureRealtimeBetaLLMService` to support Azure's OpeanAI Realtime API. Added
   foundational example `19a-azure-realtime-beta.py`.
 
+- Added `LLMMutefilter` as a general-purpose filter to mute transcript frames
+  to reach context aggregators and eventually the LLM service. This can be used
+  to prevent the LLM from processing unwanted audio or cases where we want to
+  mute the user's audio basis some condition like end of call or back to back 
+  user utterances like `Hello, Hi`, etc.
+
 ### Changed
 
 - Updated the default mode for `CartesiaTTSService` and

--- a/src/pipecat/processors/filters/llm_mute_filter.py
+++ b/src/pipecat/processors/filters/llm_mute_filter.py
@@ -1,0 +1,178 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Optional
+
+from loguru import logger
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    Frame,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    InterimTranscriptionFrame,
+    StartInterruptionFrame,
+    StopInterruptionFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.processors.filters.stt_mute_filter import STTMuteFilter
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.utils.string import detect_voice_mail
+
+
+class LLMMuteStrategy(Enum):
+    """Strategies determining when LLM should be muted.
+
+    Attributes:
+        FIRST_SPEECH: Mute only during first detected bot speech
+        MUTE_UNTIL_FIRST_BOT_COMPLETE: Start muted and remain muted until first bot speech completes
+        FUNCTION_CALL: Mute during function calls
+        ALWAYS: Mute during all bot speech
+        CUSTOM: Allow custom logic via callback
+    """
+
+    FIRST_SPEECH = "first_speech"
+    MUTE_UNTIL_FIRST_BOT_COMPLETE = "mute_until_first_bot_complete"
+    FUNCTION_CALL = "function_call"
+    ALWAYS = "always"
+    CUSTOM = "custom"
+
+
+@dataclass
+class LLMMuteConfig:
+    """Configuration for LLM muting behavior.
+
+    Args:
+        strategies: Set of muting strategies to apply
+        should_mute_callback: Optional callback for custom muting logic.
+            Only required when using LLMMuteStrategy.CUSTOM
+
+    Note:
+        MUTE_UNTIL_FIRST_BOT_COMPLETE and FIRST_SPEECH strategies should not be used together
+        as they handle the first bot speech differently.
+    """
+
+    strategies: set[LLMMuteStrategy]
+    # Optional callback for custom muting logic
+    should_mute_callback: Optional[Callable[["LLMMuteFilter"], Awaitable[bool]]] = None
+
+    def __post_init__(self):
+        if (
+            LLMMuteStrategy.MUTE_UNTIL_FIRST_BOT_COMPLETE in self.strategies
+            and LLMMuteStrategy.FIRST_SPEECH in self.strategies
+        ):
+            raise ValueError(
+                "MUTE_UNTIL_FIRST_BOT_COMPLETE and FIRST_SPEECH strategies should not be used together"
+            )
+
+
+class LLMMuteFilter(FrameProcessor):
+    def __init__(self, config: LLMMuteConfig, **kwargs):
+        super().__init__(**kwargs)
+        self._is_muted = False
+        self._user_tx = []
+        self._config = config
+        self._first_speech_handled = False
+        self._bot_is_speaking = False
+        self._function_call_in_progress = False
+        self._is_muted = False
+
+    @property
+    def is_muted(self) -> bool:
+        """Returns whether LLM generation is currently muted."""
+        return self._is_muted
+
+    async def _handle_mute_state(self, should_mute: bool):
+        """Handles both LLM generation mute and interruption control."""
+        self._is_muted = should_mute
+
+    # helper function to add user tx to user_words
+    async def _add_user_tx(self, frame: TranscriptionFrame):
+        self._user_tx.append(frame.text)
+
+        logger.info(f"User words: {self._user_tx=}")
+
+    @staticmethod
+    def _detect_voice_mail(frame: Frame) -> bool:
+        """Detect voice mail from TranscriptionFrame"""
+        if not isinstance(frame, TranscriptionFrame):
+            return False
+        voice_mail_detected = detect_voice_mail(frame.text)
+
+        logger.info(f"Voice mail detected: {voice_mail_detected=} for {frame=}")
+        return voice_mail_detected
+
+    async def _should_mute(self) -> bool:
+        """Determines if LLM should be muted based on current state and strategy."""
+        for strategy in self._config.strategies:
+            match strategy:
+                case LLMMuteStrategy.FUNCTION_CALL:
+                    if self._function_call_in_progress:
+                        return True
+
+                case LLMMuteStrategy.ALWAYS:
+                    if self._bot_is_speaking:
+                        return True
+
+                case LLMMuteStrategy.FIRST_SPEECH:
+                    if self._bot_is_speaking and not self._first_speech_handled:
+                        self._first_speech_handled = True
+                        return True
+
+                case LLMMuteStrategy.MUTE_UNTIL_FIRST_BOT_COMPLETE:
+                    if not self._first_speech_handled:
+                        return True
+
+                case LLMMuteStrategy.CUSTOM:
+                    if self._bot_is_speaking and self._config.should_mute_callback:
+                        should_mute = await self._config.should_mute_callback(self)
+                        if should_mute:
+                            return True
+
+        return False
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Processes incoming frames and manages muting state."""
+        await super().process_frame(frame, direction)
+
+        # Handle function call state changes
+        if isinstance(frame, FunctionCallInProgressFrame):
+            self._function_call_in_progress = True
+            await self._handle_mute_state(await self._should_mute())
+        elif isinstance(frame, FunctionCallResultFrame):
+            self._function_call_in_progress = False
+            await self._handle_mute_state(await self._should_mute())
+        # Handle bot speaking state changes
+        elif isinstance(frame, BotStartedSpeakingFrame):
+            self._bot_is_speaking = True
+            await self._handle_mute_state(await self._should_mute())
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            self._bot_is_speaking = False
+            await self._handle_mute_state(await self._should_mute())
+
+        # Handle frame propagation
+        if isinstance(
+            frame,
+            (
+                StartInterruptionFrame,
+                StopInterruptionFrame,
+                UserStartedSpeakingFrame,
+                UserStoppedSpeakingFrame,
+                TranscriptionFrame,
+                InterimTranscriptionFrame,
+            ),
+        ):
+            # Only pass VAD-related frames when not muted
+            if not self.is_muted or self._detect_voice_mail(frame):
+                if isinstance(frame, TranscriptionFrame):
+                    await self._add_user_tx(frame)
+                await self.push_frame(frame, direction)
+            else:
+                logger.debug(
+                    f"LLMMuteFilter: {frame.__class__.__name__} suppressed - STT currently muted"
+                )
+        else:
+            # Pass all other frames through
+            await self.push_frame(frame, direction)

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -23,3 +23,7 @@ ENDOFSENTENCE_PATTERN = re.compile(ENDOFSENTENCE_PATTERN_STR, re.VERBOSE)
 def match_endofsentence(text: str) -> int:
     match = ENDOFSENTENCE_PATTERN.search(text.rstrip())
     return match.end() if match else 0
+
+
+def detect_voice_mail(text: str) -> bool:
+    return bool(re.compile(r"(?i)voice[\s_-]*mail").search(text))

--- a/tests/test_llm_mute_filter.py
+++ b/tests/test_llm_mute_filter.py
@@ -1,0 +1,178 @@
+import unittest
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    DTMFFrame,
+    KeypadEntry,
+    TranscriptionFrame,
+)
+from pipecat.processors.filters.llm_mute_filter import LLMMuteConfig, LLMMuteFilter, LLMMuteStrategy
+from pipecat.tests.utils import SleepFrame, run_test
+
+
+class TestLLMMuteFilter(unittest.IsolatedAsyncioTestCase):
+    async def test_first_speech_strategy(self):
+        """When using the FIRST_SPEECH strategy:
+        - The first bot speech should trigger mute and suppress VAD frames.
+        - Once bot speech ends, new transcription frames pass through.
+        - Also verifies that only transcriptions from unmuted periods are recorded.
+        """
+        llm_filter = LLMMuteFilter(
+            stt_service=None, config=LLMMuteConfig(strategies={LLMMuteStrategy.FIRST_SPEECH})
+        )
+
+        frames_to_send = [
+            BotStartedSpeakingFrame(),  # Bot starts speaking → should trigger mute internally.
+            TranscriptionFrame(
+                text="Hello",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            SleepFrame(sleep=0.2),  # Sleep to simulate bot speech.
+            BotStoppedSpeakingFrame(),  # Bot stops → mute turns off.
+            SleepFrame(sleep=0.1),
+            TranscriptionFrame(
+                text="World",
+                user_id="None",
+                timestamp="None",
+            ),  # Allowed transcription → should be pushed and recorded.
+            DTMFFrame(button=KeypadEntry.FIVE),  # Non-VAD frame → always passed through.
+        ]
+
+        # Expected frames are those that are pushed (the suppressed TranscriptionFrame "Hello" is omitted).
+        expected_returned_frames = [
+            BotStartedSpeakingFrame,  # always passed (non-VAD)
+            BotStoppedSpeakingFrame,  # always passed (non-VAD)
+            TranscriptionFrame,  # only "World" passes since mute is off
+            DTMFFrame,  # always passed
+        ]
+
+        await run_test(
+            llm_filter,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_returned_frames,
+        )
+        self.assertEqual(llm_filter._user_tx, ["World"])
+
+    async def test_first_speech_strategy_all_tx_missing(self):
+        llm_filter = LLMMuteFilter(
+            stt_service=None, config=LLMMuteConfig(strategies={LLMMuteStrategy.FIRST_SPEECH})
+        )
+
+        frames_to_send = [
+            BotStartedSpeakingFrame(),  # Bot starts speaking → should trigger mute internally.
+            TranscriptionFrame(
+                text="Hello",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            TranscriptionFrame(
+                text="World",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            SleepFrame(sleep=0.6),  # Sleep to simulate bot speech.
+            BotStoppedSpeakingFrame(),  # Bot stops → mute turns off.
+            DTMFFrame(button=KeypadEntry.FIVE),  # Non-VAD frame → always passed through.
+        ]
+
+        # Expected frames are those that are pushed (the suppressed TranscriptionFrame "Hello" is omitted).
+        expected_returned_frames = [
+            BotStartedSpeakingFrame,  # always passed (non-VAD)
+            BotStoppedSpeakingFrame,  # always passed (non-VAD)
+            DTMFFrame,  # always passed
+        ]
+
+        await run_test(
+            llm_filter,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_returned_frames,
+        )
+        self.assertEqual(llm_filter._user_tx, [])
+
+    async def test_first_speech_strategy_voice_mail_case(self):
+        llm_filter = LLMMuteFilter(
+            stt_service=None, config=LLMMuteConfig(strategies={LLMMuteStrategy.FIRST_SPEECH})
+        )
+
+        frames_to_send = [
+            BotStartedSpeakingFrame(),  # Bot starts speaking → should trigger mute internally.
+            TranscriptionFrame(
+                text="Voice Mail",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            TranscriptionFrame(
+                text="World",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            SleepFrame(sleep=0.6),  # Sleep to simulate bot speech.
+            BotStoppedSpeakingFrame(),  # Bot stops → mute turns off.
+            DTMFFrame(button=KeypadEntry.FIVE),  # Non-VAD frame → always passed through.
+        ]
+
+        # Expected frames are those that are pushed (the suppressed TranscriptionFrame "Hello" is omitted).
+        expected_returned_frames = [
+            BotStartedSpeakingFrame,  # always passed (non-VAD)
+            TranscriptionFrame,  # only "Voice Mail" passes since mute is on
+            BotStoppedSpeakingFrame,  # always passed (non-VAD)
+            DTMFFrame,  # always passed
+        ]
+
+        await run_test(
+            llm_filter,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_returned_frames,
+        )
+        self.assertEqual(llm_filter._user_tx, ["Voice Mail"])
+
+    async def test_first_speech_strategy_all_tx_present(self):
+        """When using the FIRST_SPEECH strategy:
+        - The first bot speech should trigger mute and suppress VAD frames.
+        - Once bot speech ends, new transcription frames pass through.
+        - Also verifies that all transcriptions are recorded.
+        """
+        llm_filter = LLMMuteFilter(
+            stt_service=None, config=LLMMuteConfig(strategies={LLMMuteStrategy.FIRST_SPEECH})
+        )
+
+        frames_to_send = [
+            BotStartedSpeakingFrame(),  # Bot starts speaking → should trigger mute internally.
+            SleepFrame(sleep=0),  # Sleep to simulate bot speech.
+            BotStoppedSpeakingFrame(),  # Bot stops → mute turns off
+            TranscriptionFrame(
+                text="Hello",
+                user_id="None",
+                timestamp="None",
+            ),  # VAD frame; should be suppressed (while muted).
+            TranscriptionFrame(
+                text="World",
+                user_id="None",
+                timestamp="None",
+            ),  # Allowed transcription → should be pushed and recorded.
+            DTMFFrame(button=KeypadEntry.FIVE),  # Non-VAD frame → always passed through.
+        ]
+
+        # Expected frames are those that are pushed (the suppressed TranscriptionFrame "Hello" is omitted).
+        expected_returned_frames = [
+            BotStartedSpeakingFrame,  # always passed (non-VAD)
+            BotStoppedSpeakingFrame,  # always passed (non-VAD)
+            TranscriptionFrame,  # Hello passes
+            TranscriptionFrame,  # World passes
+            DTMFFrame,  # always passed
+        ]
+
+        await run_test(
+            llm_filter,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_returned_frames,
+        )
+        self.assertEqual(
+            llm_filter._user_tx,
+            [
+                "Hello",
+                "World",
+            ],
+        )


### PR DESCRIPTION
Added `LLMMutefilter` as a general-purpose filter to mute transcript frames to reach context aggregators and eventually the LLM service. This can be used to prevent the LLM from processing unwanted audio or cases where we want to mute the user's audio basis some condition like end of call or back to back user utterances like `Hello, Hi`, etc.