### PR TITLE
Fix Image.frombytes() mode param usage

### DIFF
--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -172,7 +172,7 @@ class OpenAILLMContext:
         self, *, format: str, size: tuple[int, int], image: bytes, text: str = None
     ):
         buffer = io.BytesIO()
-        Image.frombytes(format, size, image).save(buffer, format="JPEG")
+        Image.frombytes("RGB", size, image).save(buffer, format="JPEG")
         encoded_image = base64.b64encode(buffer.getvalue()).decode("utf-8")
 
         content = []

--- a/src/pipecat/services/anthropic.py
+++ b/src/pipecat/services/anthropic.py
@@ -553,7 +553,7 @@ class AnthropicLLMContext(OpenAILLMContext):
         self, *, format: str, size: tuple[int, int], image: bytes, text: str = None
     ):
         buffer = io.BytesIO()
-        Image.frombytes(format, size, image).save(buffer, format="JPEG")
+        Image.frombytes("RGB", size, image).save(buffer, format="JPEG")
         encoded_image = base64.b64encode(buffer.getvalue()).decode("utf-8")
 
         # Anthropic docs say that the image should be the first content block in the message.

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -63,7 +63,7 @@ class VideoInputMessage(BaseModel):
     @classmethod
     def from_image_frame(cls, frame: ImageRawFrame) -> "VideoInputMessage":
         buffer = io.BytesIO()
-        Image.frombytes(frame.format, frame.size, frame.image).save(buffer, format="JPEG")
+        Image.frombytes("RGB", frame.size, frame.image).save(buffer, format="JPEG")
         data = base64.b64encode(buffer.getvalue()).decode("utf-8")
         return cls(
             realtimeInput=RealtimeInput(mediaChunks=[MediaChunk(mimeType=f"image/jpeg", data=data)])

--- a/src/pipecat/services/google/google.py
+++ b/src/pipecat/services/google/google.py
@@ -719,7 +719,7 @@ class GoogleLLMContext(OpenAILLMContext):
         self, *, format: str, size: tuple[int, int], image: bytes, text: str = None
     ):
         buffer = io.BytesIO()
-        Image.frombytes(format, size, image).save(buffer, format="JPEG")
+        Image.frombytes("RGB", size, image).save(buffer, format="JPEG")
 
         parts = []
         if text:

--- a/src/pipecat/services/moondream.py
+++ b/src/pipecat/services/moondream.py
@@ -73,7 +73,7 @@ class MoondreamService(VisionService):
         logger.debug(f"Analyzing image: {frame}")
 
         def get_image_description(frame: VisionImageRawFrame):
-            image = Image.frombytes(frame.format, frame.size, frame.image)
+            image = Image.frombytes("RGB", frame.size, frame.image)
             image_embeds = self._model.encode_image(image)
             description = self._model.answer_question(
                 image_embeds=image_embeds, question=frame.text, tokenizer=self._tokenizer

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -377,7 +377,7 @@ class BaseOutputTransport(FrameProcessor):
         desired_size = (self._params.camera_out_width, self._params.camera_out_height)
 
         if frame.size != desired_size:
-            image = Image.frombytes(frame.format, frame.size, frame.image)
+            image = Image.frombytes("RGB", frame.size, frame.image)
             resized_image = image.resize(desired_size)
             logger.warning(f"{frame} does not have the expected size {desired_size}, resizing")
             frame = OutputImageRawFrame(


### PR DESCRIPTION
currently we're passing `frame.format` which typically contains file format strings like 'PNG' or 'JPEG' as the mode parameter to[ PIL.Image.frombytes()](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.frombytes)

This function actually expects image [modes](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes) like 'RGB', 'RGBA', etc

I standardized all Image.frombytes() calls to use 'RGB' mode instead, fixed this in six files:

- `src/pipecat/transports/base_output.py`
- `src/pipecat/services/gemini_multimodal_live/events.py`
- `src/pipecat/services/moondream.py`
- `src/pipecat/services/google/google.py`
- `src/pipecat/services/anthropic.py`
- `src/pipecat/processors/aggregators/openai_llm_context.py`

For most of the places where it's used, 'RGB' as the image mode works perfectly since it is immediately convert to JPEG anyway. However in `base_output.py`, I went with 'RGB' for consistency, though I wonder if preserving other modes is useful? Not sure if a png with an alpha channel can be passed here for example, and we might prefer RGBA in that case (to account for that, we might need to add a dedicated class member for storing image mode in `ImageRawFrame` perhaps)