### PR TITLE
[rime client] Sending over trailing space to help indicate end of utt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default mode for `CartesiaTTSService` and
   `CartesiaHttpTTSService` to `sonic-2`.
 
+### Fixed
+
+- Fixed an issue in `RimeTTSService` where the last line of text sent didn't result in an audio output being generated.
+
 ## [0.0.58] - 2025-02-26
 
 ### Added

--- a/src/pipecat/services/rime.py
+++ b/src/pipecat/services/rime.py
@@ -249,7 +249,9 @@ class RimeTTSService(AudioContextWordTTSService):
     async def flush_audio(self):
         if not self._context_id or not self._websocket:
             return
+        
         logger.trace(f"{self}: flushing audio")
+        await self._get_websocket().send(json.dumps({"text": " "}))
         self._context_id = None
 
     async def _receive_messages(self):

--- a/src/pipecat/services/rime.py
+++ b/src/pipecat/services/rime.py
@@ -249,7 +249,7 @@ class RimeTTSService(AudioContextWordTTSService):
     async def flush_audio(self):
         if not self._context_id or not self._websocket:
             return
-        
+
         logger.trace(f"{self}: flushing audio")
         await self._get_websocket().send(json.dumps({"text": " "}))
         self._context_id = None


### PR DESCRIPTION
## problem 
Rime will currently wait if it receives a "." with no trailing space, to see if further text is sent that would indicate that the "." is within an utterance, rather than at the end. 
Eg. sending over the messages
```python
messages = [
 "This is the first sentence.",
" This is the second sentence."
] 
```
will result in only the "This is the first sentence." generating audio. The second sentence is in buffer. 

```python
messages = [
 " This is the third sentence. ",
] 
```
(with the trailing space) will then trigger rime to synthesize sentences 2 and 3.  

## Changed
We add a message to `flush_audio()` to send over a " ", helping the Rime websocket api know that the last completed phrase ending in punctuation can be sent the model for synthesis. 

