### PR TITLE
fix for 26-gemini-multimodal-live.py

### DIFF
--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -77,7 +77,7 @@ async def main():
                     LLMMessagesAppendFrame(
                         messages=[
                             {
-                                "role": "assistant",
+                                "role": "user",
                                 "content": "Greet the user.",
                             }
                         ]


### PR DESCRIPTION
We were mistakenly sending an initial messages frame as "assistant" (which translates to "model" in our context management code) to the Gemini Multimodal Live API. The back end seems to have gotten more strict and now expects that last message to be a "user" message.
