### PR TITLE
PipelineTask: only call event handlers if a filter is matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `on_frame_reached_upstream` and `on_frame_reached_downstream` event
   handlers to `PipelineTask`. Those events will be called when a frame reaches
-  the beginning or end of the pipeline respectively.
+  the beginning or end of the pipeline respectively. Note that by default, the
+  event handlers will not be called unless a filter is set with
+  `PipelineTask.set_reached_upstream_filter()` or
+  `PipelineTask.set_reached_downstream_filter()`.
 
 - Added support for Chirp voices in `GoogleTTSService`.
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -102,6 +102,8 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
         pipeline = Pipeline([identity])
         task = PipelineTask(pipeline)
         task.set_event_loop(asyncio.get_event_loop())
+        task.set_reached_upstream_filter((TextFrame,))
+        task.set_reached_downstream_filter((TextFrame,))
 
         @task.event_handler("on_frame_reached_upstream")
         async def on_frame_reached_upstream(task, frame):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Because of https://github.com/pipecat-ai/pipecat/pull/1376 event handlers will now be tasks. This means that we would create a task for every frame receive downstream or upstream. Usually, audio frames make it all the way down and we don't really want to create a task for each audio frame.

Even before, without tasks, I don't think we really wanted to call event handlers because most of the time those frames would just be ignored.

So, we now force the user to specify which frames they are interested in.
