### PR TITLE
Added Support for MLX Whisper models on Apple M-Series

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ langchain = [ "langchain~=0.3.14", "langchain-community~=0.3.14", "langchain-ope
 livekit = [ "livekit~=0.19.1", "livekit-api~=0.8.1", "tenacity~=9.0.0" ]
 lmnt = [ "websockets~=13.1" ]
 local = [ "pyaudio~=0.2.14" ]
+mlx-whisper = [ "mlx-whisper~=0.4.2" ]
 moondream = [ "einops~=0.8.0", "timm~=1.0.13", "transformers~=4.48.0" ]
 nim = []
 noisereduce = [ "noisereduce~=3.0.3" ]


### PR DESCRIPTION
This pull request introduces support for MLX Whisper models in the `pipecat` project. The changes include adding dependencies, importing necessary modules, defining new model classes, and creating a new service class for MLX Whisper. This class provides an option for Apple Silicon M-series to utilize the Metal GPU for local inference of MLX converted Whisper models.

Key changes:

### Dependency Additions
* Added `mlx-whisper~=0.4.2` to the dependencies in `pyproject.toml`.

### Import Adjustments
* Included `typing_extensions` for `TYPE_CHECKING` and `override` in `src/pipecat/services/whisper.py`.
* Added conditional import for `mlx_whisper` within `TYPE_CHECKING` to handle missing module errors gracefully.

### Model Class Definitions
* Introduced `MLXModel` class to define various MLX Whisper model options.

### Service Class Enhancements
* Created `WhisperSTTServiceMLX` class as a subclass of `WhisperSTTService` to support MLX Whisper models, including methods for initializing and running speech-to-text transcription.

### Error Handling
* Enhanced error handling in `_load` method to manage missing `faster_whisper` module gracefully.