### PR TITLE
SegmentedSTTService: allow audio to pass-through downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue with `SegmentedSTTService` based services
+  (e.g. `GroqSTTService`) that was not allow audio to pass-through downstream.
+
 - Fixed a `CartesiaTTSService` and `RimeTTSService` issue that would consider
   text between spelling out tags end of sentence.
 

--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -811,8 +811,6 @@ class STTService(AIService):
             return
 
         await self.process_generator(self.run_stt(frame.audio))
-        if self._audio_passthrough:
-            await self.push_frame(frame, direction)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Processes a frame of audio data, either buffering or transcribing it."""
@@ -823,6 +821,8 @@ class STTService(AIService):
             # push a TextFrame. We also push audio downstream in case someone
             # else needs it.
             await self.process_audio_frame(frame, direction)
+            if self._audio_passthrough:
+                await self.push_frame(frame, direction)
         elif isinstance(frame, STTUpdateSettingsFrame):
             await self._update_settings(frame.settings)
         elif isinstance(frame, STTMuteFrame):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

STT services based on `SegmentedSTTService` were not passing through audio even if `audio_passthrough` was True. This was preventing audio recording from working.