### PR TITLE
feature: add custom headers to AsyncOpenAI

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -116,6 +116,7 @@ class BaseOpenAILLMService(LLMService):
         base_url=None,
         organization=None,
         project=None,
+        default_headers: Mapping[str, str] | None = None,
         params: InputParams = InputParams(),
         **kwargs,
     ):
@@ -132,10 +133,10 @@ class BaseOpenAILLMService(LLMService):
         }
         self.set_model_name(model)
         self._client = self.create_client(
-            api_key=api_key, base_url=base_url, organization=organization, project=project, **kwargs
+            api_key=api_key, base_url=base_url, organization=organization, project=project, default_headers=default_headers, **kwargs
         )
 
-    def create_client(self, api_key=None, base_url=None, organization=None, project=None, **kwargs):
+    def create_client(self, api_key=None, base_url=None, organization=None, project=None, default_headers=None, **kwargs):
         return AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
@@ -146,6 +147,7 @@ class BaseOpenAILLMService(LLMService):
                     max_keepalive_connections=100, max_connections=1000, keepalive_expiry=None
                 )
             ),
+            default_headers=default_headers
         )
 
     def can_generate_metrics(self) -> bool:


### PR DESCRIPTION
This PR adds the `default_headers` argument to the `OpenAILLMService`.

Having the ability to use these headers is a requirement in our integration, i tried locally and it is forwarding the headers.

Let me know if it needs anything else.