### PR TITLE
Fix: RTVIObserver now outputs a single bot started and stopped speaki…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where the `RTVIObserver` would report two bot started and
+  stopped speaking events for each bot turn.
+
 - Fixed an issue in `UltravoxSTTService` that caused improper audio processing
   and incorrect LLM frame output.
 

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -440,7 +440,9 @@ class RTVIObserver(BaseObserver):
 
         if isinstance(frame, (UserStartedSpeakingFrame, UserStoppedSpeakingFrame)):
             await self._handle_interruptions(frame)
-        elif isinstance(frame, (BotStartedSpeakingFrame, BotStoppedSpeakingFrame)):
+        elif isinstance(frame, (BotStartedSpeakingFrame, BotStoppedSpeakingFrame)) and (
+            direction == FrameDirection.UPSTREAM
+        ):
             await self._handle_bot_speaking(frame)
         elif isinstance(frame, (TranscriptionFrame, InterimTranscriptionFrame)):
             await self._handle_user_transcriptions(frame)


### PR DESCRIPTION
…ng event per turn

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The RTVIObserver was seeing two `BotStartedSpeakingFrame`s and `BotStoppedSpeakingFrame`s per turn. This is because the BaseOutputTransport pushes frames both upstream and downstream. I'm adding a frame direction check so only a single event is emitted.