### PR TITLE
Fix issue with non-string tool call results when using Google models 

### DIFF
--- a/src/pipecat/services/google/google.py
+++ b/src/pipecat/services/google/google.py
@@ -601,13 +601,10 @@ class GoogleAssistantContextAggregator(OpenAIAssistantContextAggregator):
 
     async def handle_function_call_result(self, frame: FunctionCallResultFrame):
         if frame.result:
-            if not isinstance(frame.result, str):
-                return
-
-            response = {"response": frame.result}
+            result = json.dumps(frame.result)
 
             await self._update_function_call_result(
-                frame.function_name, frame.tool_call_id, response
+                frame.function_name, frame.tool_call_id, result
             )
         else:
             await self._update_function_call_result(


### PR DESCRIPTION
### Fix issue with non-string tool call results when using Google models (e.g., Gemini Flash)

When using tool calling with Google models (tested with Gemini Flash 2.0), `pipecat` silently discards tool call results that are not strings, leading to the agent waiting indefinitely for completion.

For example, if a tool function returns a dictionary (e.g., from a JSON API response), the result is ignored entirely. This behavior differs from other providers like OpenAI or Anthropic, where non-string results (e.g., dicts) are properly handled and serialized.

**Example:**
```python
async def fetch_calendar_api(function_name, tool_call_id, args, llm, context, result_callback):
    async with aiohttp.ClientSession() as session:
        async with session.post('url', json={"date_str": args["date_str"]}, headers={'accept': 'application/json', 'Content-Type': 'application/json'}) as response:
            appointments_data = await response.json()
            await result_callback(appointments_data)
```
In pipecat/src/pipecat/services/google/google.py, line 604 (handle_function_call_result), frame.result is strictly enforced to be a string, which causes dictionary or non-string results to be discarded.

By contrast, Anthropic (see line 715 in pipecat/src/pipecat/services/anthropic.py) serializes frame.result with json.dumps(), allowing arbitrary return types.

This PR modifies the Google handler to support non-string results by serializing them with json.dumps(), ensuring consistent behavior across providers.