### PR TITLE
feature/support instructions in OpenAITTSService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ElevenLabs TTS services now support a sample rate of 8000.
 
+- Added support for `instructions` in `OpenAITTSService`
+
+- Added support for `base_url` in `OpenAIImageGenService` and `OpenAITTSService`
+
 ### Fixed
 
 - Fixed a `GoogleAssistantContextAggregator` issue where function calls

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -520,7 +520,9 @@ class OpenAITTSService(TTSService):
         self.set_model_name(model)
         self.set_voice(voice)
         self._instructions = instructions
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, websocket_base_url=websocket_base_url)
+        self._client = AsyncOpenAI(
+            api_key=api_key, base_url=base_url, websocket_base_url=websocket_base_url
+        )
 
     def can_generate_metrics(self) -> bool:
         return True

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -503,7 +503,6 @@ class OpenAITTSService(TTSService):
         *,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        websocket_base_url: Optional[str] = None,
         voice: str = "alloy",
         model: str = "gpt-4o-mini-tts",
         sample_rate: Optional[int] = None,
@@ -520,9 +519,7 @@ class OpenAITTSService(TTSService):
         self.set_model_name(model)
         self.set_voice(voice)
         self._instructions = instructions
-        self._client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, websocket_base_url=websocket_base_url
-        )
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     def can_generate_metrics(self) -> bool:
         return True

--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -391,6 +391,7 @@ class OpenAIImageGenService(ImageGenService):
         self,
         *,
         api_key: str,
+        base_url: Optional[str] = None,
         aiohttp_session: aiohttp.ClientSession,
         image_size: Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"],
         model: str = "dall-e-3",
@@ -398,7 +399,7 @@ class OpenAIImageGenService(ImageGenService):
         super().__init__()
         self.set_model_name(model)
         self._image_size = image_size
-        self._client = AsyncOpenAI(api_key=api_key)
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._aiohttp_session = aiohttp_session
 
     async def run_image_gen(self, prompt: str) -> AsyncGenerator[Frame, None]:
@@ -501,9 +502,12 @@ class OpenAITTSService(TTSService):
         self,
         *,
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        websocket_base_url: Optional[str] = None,
         voice: str = "alloy",
         model: str = "gpt-4o-mini-tts",
         sample_rate: Optional[int] = None,
+        instructions: Optional[str] = None,
         **kwargs,
     ):
         if sample_rate and sample_rate != self.OPENAI_SAMPLE_RATE:
@@ -515,8 +519,8 @@ class OpenAITTSService(TTSService):
 
         self.set_model_name(model)
         self.set_voice(voice)
-
-        self._client = AsyncOpenAI(api_key=api_key)
+        self._instructions = instructions
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, websocket_base_url=websocket_base_url)
 
     def can_generate_metrics(self) -> bool:
         return True
@@ -538,11 +542,17 @@ class OpenAITTSService(TTSService):
         try:
             await self.start_ttfb_metrics()
 
+            # Setup extra body parameters
+            extra_body = {}
+            if self._instructions:
+                extra_body["instructions"] = self._instructions
+
             async with self._client.audio.speech.with_streaming_response.create(
                 input=text or " ",  # Text must contain at least one character
                 model=self.model_name,
                 voice=VALID_VOICES[self._voice_id],
                 response_format="pcm",
+                extra_body=extra_body,
             ) as r:
                 if r.status_code != 200:
                     error = await r.text()


### PR DESCRIPTION
This PR brings two changes: 

### base_url support in OpenAITTSService and OpenAIImageGenService
While the env var `OPENAI_BASE_URL` is supported, that allows more granular configuration.

### Support `instructions` in OpenAITTSService
There is support for `instructions` in the realtime api, but not in the TTS service.
I used the client `extra_body` to achieve that, maybe we could also accept a whole `extra_body` parameter in OpenAITTSService, but this first draft is the minimum change necessary to get the instructions.