### PR TITLE
Fix: GoogleTTSService was emitting two TTSStoppedFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. `OpenAISTTService`) to try to transcribe non-spoken audio, causing
   invalid transcriptions.
 
+- Fixed an issue where `GoogleTTSService` was emitting two `TTSStoppedFrames`.
+
 ## [0.0.61] - 2025-03-26
 
 ### Added

--- a/src/pipecat/services/google/google.py
+++ b/src/pipecat/services/google/google.py
@@ -1343,6 +1343,7 @@ class GoogleVertexLLMService(OpenAILLMService):
         **kwargs,
     ):
         """Initializes the VertexLLMService.
+
         Args:
             credentials (Optional[str]): JSON string of service account credentials.
             credentials_path (Optional[str]): Path to the service account JSON file.
@@ -1366,9 +1367,11 @@ class GoogleVertexLLMService(OpenAILLMService):
     @staticmethod
     def _get_api_token(credentials: Optional[str], credentials_path: Optional[str]) -> str:
         """Retrieves an authentication token using Google service account credentials.
+
         Args:
             credentials (Optional[str]): JSON string of service account credentials.
             credentials_path (Optional[str]): Path to the service account JSON file.
+
         Returns:
             str: OAuth token for API authentication.
         """
@@ -1557,8 +1560,6 @@ class GoogleTTSService(TTSService):
             logger.exception(f"{self} error generating TTS: {e}")
             error_message = f"TTS generation error: {str(e)}"
             yield ErrorFrame(error=error_message)
-        finally:
-            yield TTSStoppedFrame()
 
 
 class GoogleImageGenService(ImageGenService):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes https://github.com/pipecat-ai/pipecat/issues/1454

We mistakenly did yielded a `TTSStoppedFrame` in both the `run_tts` `try` block and the `finally` block. Now, it's just emitted in the `finally` block.