### PR TITLE
Tavus / Deepgram TTS compatibility

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -102,10 +102,10 @@ class DeepgramTTSService(TTSService):
                 await self.stop_ttfb_metrics()
                 chunk = audio_buffer.read(chunk_size)
                 if not chunk:
-                    yield TTSStoppedFrame()
                     break
                 frame = TTSAudioRawFrame(audio=chunk, sample_rate=self.sample_rate, num_channels=1)
                 yield frame
+            yield TTSStoppedFrame()
 
         except Exception as e:
             logger.exception(f"{self} exception: {e}")


### PR DESCRIPTION
Previously, DeepgramTTS service was sending a `TTSStoppedFrame` frame right after a `TTSAudioRawFrame`, which caused choppiness in the audio sent to the Tavus room. This (along with a reduction in the batch size) resolves the issue