### PR TITLE
Clarify the mute/unmute log line in STTMuteFilter

### DIFF
--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -108,7 +108,7 @@ class STTMuteFilter(FrameProcessor):
     async def _handle_mute_state(self, should_mute: bool):
         """Handles both STT muting and interruption control."""
         if should_mute != self.is_muted:
-            logger.debug(f"STT {'muting' if should_mute else 'unmuting'}")
+            logger.debug(f"STTMuteFilter {'muting' if should_mute else 'unmuting'}")
             self._is_muted = should_mute
             await self.push_frame(STTMuteFrame(mute=should_mute))
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This is a nitpick change. The logs used to say:
```
STT unmuting
STT service unmuted
```

The first line was ambiguous. Now they say:
```
STTMuteFilter unmuting
STT service unmuted
```