### PR TITLE
Improvements for the SmallWebRTCTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   producer. These processors can be useful to push frames from one part of a
   pipeline to a different one (e.g. when using `ParallelPipeline`).
 
+- Improvements for the `SmallWebRTCTransport`:
+  - Wait until the pipeline is ready before triggering the `connected` event.
+  - Queue messages if the data channel is not ready.
+  - Update the aiortc dependency to fix an issue where the 'video/rtx' MIME type 
+    was incorrectly handled as a codec retransmission.
+  - Avoid initial video delays.
+
 ### Fixed
 
 - Fixed `SmallWebRTCTransport` to support dynamic values for

--- a/examples/p2p-webrtc/video-transform/client/typescript/vite.config.js
+++ b/examples/p2p-webrtc/video-transform/client/typescript/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react-swc';
 export default defineConfig({
     plugins: [react()],
     server: {
+        allowedHosts: true, // Allows external connections like ngrok
         proxy: {
             // Proxy /api requests to the backend server
             '/api': {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ soundfile = [ "soundfile~=0.13.0" ]
 tavus=[]
 together = []
 ultravox = [ "transformers~=4.48.0", "vllm~=0.7.3" ]
-webrtc = [ "aiortc~=1.10.1", "opencv-python~=4.11.0.86" ]
+webrtc = [ "aiortc~=1.11.0", "opencv-python~=4.11.0.86" ]
 websocket = [ "websockets~=13.1", "fastapi~=0.115.6" ]
 whisper = [ "faster-whisper~=1.1.1" ]
 


### PR DESCRIPTION
 Improvements for the SmallWebRTCTransport:
- Wait until the pipeline is ready before triggering the connected event
 - Queuing the messages if the data channel is not ready.
 - Updating aiortc to fix an issue where 'video/rtx' MIMEType retransmission incorrectly handled as a codec
 - Discarding old frames to avoid initial video delays.
