### PR TITLE
BaseOutputTransport: allow setting 10ms output audio chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `TransportParams.audio_out_10ms_chunks` parameter to allow controlling
+  the amount of audio being sent by the output transport. It defaults to 2, so
+  20ms audio chunks are sent.
+
 - Added `QwenLLMService` for Qwen integration with an OpenAI-compatible
   interface. Added foundational example `14q-function-calling-qwen.py`.
 

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -79,10 +79,11 @@ class BaseOutputTransport(FrameProcessor):
     async def start(self, frame: StartFrame):
         self._sample_rate = self._params.audio_out_sample_rate or frame.audio_out_sample_rate
 
-        # We will write 20ms audio at a time. If we receive long audio frames we
+        # We will write 10ms*CHUNKS of audio at a time (where CHUNKS is the
+        # `audio_out_10ms_chunks` parameter). If we receive long audio frames we
         # will chunk them. This will help with interruption handling.
         audio_bytes_10ms = int(self._sample_rate / 100) * self._params.audio_out_channels * 2
-        self._audio_chunk_size = audio_bytes_10ms * 2
+        self._audio_chunk_size = audio_bytes_10ms * self._params.audio_out_10ms_chunks
 
         # Start audio mixer.
         if self._params.audio_out_mixer:

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -31,6 +31,7 @@ class TransportParams(BaseModel):
     audio_out_sample_rate: Optional[int] = None
     audio_out_channels: int = 1
     audio_out_bitrate: int = 96000
+    audio_out_10ms_chunks: int = 2
     audio_out_mixer: Optional[BaseAudioMixer] = None
     audio_in_enabled: bool = False
     audio_in_sample_rate: Optional[int] = None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This allows modifying the default 20ms audio chunks. I've seen people having issues with websockets and 20ms. I believe we should probably also change the default for FastAPI to 40ms. For now, this gives the option to the user to change it.