### PR TITLE
TranscriptProcessor: send TranscriptionUpdateFrame after interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue that could cause the `TranscriptionUpdateFrame` being pushed
+  because of an interruption to be discarded.
+
 - Fixed an issue that would cause `SegmentedSTTService` based services
   (e.g. `OpenAISTTService`) to try to transcribe non-spoken audio, causing
   invalid transcriptions.

--- a/tests/test_context_aggregators.py
+++ b/tests/test_context_aggregators.py
@@ -41,7 +41,10 @@ from pipecat.services.google.llm import (
     GoogleLLMContext,
     GoogleUserContextAggregator,
 )
-from pipecat.services.openai import OpenAIAssistantContextAggregator, OpenAIUserContextAggregator
+from pipecat.services.openai.llm import (
+    OpenAIAssistantContextAggregator,
+    OpenAIUserContextAggregator,
+)
 from pipecat.tests.utils import SleepFrame, run_test
 
 AGGREGATION_TIMEOUT = 0.1

--- a/tests/test_transcript_processor.py
+++ b/tests/test_transcript_processor.py
@@ -238,8 +238,8 @@ class TestUserTranscriptProcessor(unittest.IsolatedAsyncioTestCase):
             TTSTextFrame(text="world!"),
             SleepFrame(sleep=0.1),
             StartInterruptionFrame(),  # User interrupts here
-            BotStartedSpeakingFrame(),
             SleepFrame(sleep=0.1),
+            BotStartedSpeakingFrame(),
             TTSTextFrame(text="New"),
             TTSTextFrame(text="response"),
             SleepFrame(sleep=0.1),
@@ -251,8 +251,8 @@ class TestUserTranscriptProcessor(unittest.IsolatedAsyncioTestCase):
             BotStartedSpeakingFrame,
             TTSTextFrame,  # "Hello"
             TTSTextFrame,  # "world!"
+            StartInterruptionFrame,
             TranscriptionUpdateFrame,  # First message (emitted due to interruption)
-            StartInterruptionFrame,  # Interruption frame comes after the update
             BotStartedSpeakingFrame,
             TTSTextFrame,  # "New"
             TTSTextFrame,  # "response"


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This makes sure `TranscriptionUpdateFrame` is never discarded when there's an interruption.