### PR TITLE
transports(websocket): close connection from last transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `FastAPIWebsocketTransport` and `WebsocketClientTransport` issue that
+  would cause the transport to be closed prematurely, preventing the internally
+  queued audio to be sent. The same issue could also cause an infinite loop
+  while using an output mixer and when sending an `EndFrame`, preventing the bot
+  to finish.
+
 - Fixed an issue that could cause the `TranscriptionUpdateFrame` being pushed
   because of an interruption to be discarded.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR fixes a `FastAPIWebsocketTransport` and `WebsocketClientTransport` issue that would cause the transport to be closed prematurely, preventing the internally queued audio to be sent. The same issue could also cause an infinite loop while using an output mixer and when sending an `EndFrame`, preventing the bot to finish.

The reason is that as soon as we got an `EndFrame` in the input transport we were causing the websocket. Instead, if the pipeline also has an output transport we should wait for the output transport to finish.