### PR TITLE
LLMAssistantContextAggregator should push BotStoppedSpeakingFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where `LLMAssistantContextAggregator` would prevent a
+  `BotStoppedSpeakingFrame` from moving through the pipeline.
+
 ## [0.0.62] - 2025-04-01 "An April Fools' release"
 
 ### Added

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -149,7 +149,8 @@ class BaseLLMResponseAggregator(FrameProcessor):
     @abstractmethod
     def reset(self):
         """Reset the internals of this aggregator. This should not modify the
-        internal messages."""
+        internal messages.
+        """
         pass
 
     @abstractmethod
@@ -446,6 +447,7 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
             await self._handle_user_image_frame(frame)
         elif isinstance(frame, BotStoppedSpeakingFrame):
             await self.push_aggregation()
+            await self.push_frame(frame, direction)
         else:
             await self.push_frame(frame, direction)
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In testing the STTMuteFilter with GeminiMultimodalLiveLLMService, I found that the STTMuteFilter would not unmute after the bot stopped speaking. In tracking it down, it appears that the `LLMAssistantContextAggregator` handles the BotStoppedSpeakingFrame but does not push the frame.

This resolves the issue, but I'm not sure if the frame wasn't pushed for a reason.