### PR TITLE
Fix: GeminiMultimodalLiveLLMService, add spaces between words in assi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TransportParams.audio_out_10ms_chunks`. Previously, it only worked with 20ms
   chunks.
 
+- Fixed an issue with `GeminiMultimodalLiveLLMService` where the assistant
+  context messages had no space between words.
+
 - Fixed an issue where `LLMAssistantContextAggregator` would prevent a
   `BotStoppedSpeakingFrame` from moving through the pipeline.
 

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -898,7 +898,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         GeminiMultimodalLiveContext.upgrade(context)
         user = GeminiMultimodalLiveUserContextAggregator(context, **user_kwargs)
 
-        default_assistant_kwargs = {"expect_stripped_words": False}
+        default_assistant_kwargs = {"expect_stripped_words": True}
         default_assistant_kwargs.update(assistant_kwargs)
         assistant = GeminiMultimodalLiveAssistantContextAggregator(
             context, **default_assistant_kwargs


### PR DESCRIPTION
…stant context messages

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Before this change:
```
{'role': 'assistant', 'content': "Hello,I'mGemini.I'mreadytoassistyou."}
```

After this change:
```
{'role': 'assistant', 'content': "Hello, I'm Gemini. I'm ready to assist you."}
```