### PR TITLE
Increase BOT_VAD_STOP_SECS for services with slower speech patterns

### DIFF
--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -37,7 +37,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.transports.base_transport import TransportParams
 from pipecat.utils.time import nanoseconds_to_seconds
 
-BOT_VAD_STOP_SECS = 0.3
+BOT_VAD_STOP_SECS = 0.35
 
 
 class BaseOutputTransport(FrameProcessor):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In testing with GeminiMultimodalLiveLLMService, I see cases where the speech can take upwards of 0.31 to 0.32 seconds between speech. We want to avoid BotStoppedSpeakingFrame getting emitted when the bot is going to speak again right away. We also want the stopped speaking frame to come relatively soon after the bot stops speaking. For this reason, I'm nudging the value up ever so slightly.