### PR TITLE
TTS: Skip generation when there is no text

### DIFF
--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -158,7 +158,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
                 voice_config["__experimental_controls"]["emotion"] = self._settings["emotion"]
 
         msg = {
-            "transcript": text or " ",  # Text must contain at least one character
+            "transcript": text,
             "continue": continue_transcript,
             "context_id": self._context_id,
             "model_id": self.model_name,
@@ -287,7 +287,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
                 self._context_id = str(uuid.uuid4())
                 await self.create_audio_context(self._context_id)
 
-            msg = self._build_msg(text=text or " ")  # Text must contain at least one character
+            msg = self._build_msg(text=text)
 
             try:
                 await self._get_websocket().send(msg)

--- a/src/pipecat/services/openai/tts.py
+++ b/src/pipecat/services/openai/tts.py
@@ -105,7 +105,7 @@ class OpenAITTSService(TTSService):
                 extra_body["instructions"] = self._instructions
 
             async with self._client.audio.speech.with_streaming_response.create(
-                input=text or " ",  # Text must contain at least one character
+                input=text,
                 model=self.model_name,
                 voice=VALID_VOICES[self._voice_id],
                 response_format="pcm",

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -269,7 +269,8 @@ class TTSService(AIService):
             filter.reset_interruption()
             text = filter.filter(text)
 
-        await self.process_generator(self.run_tts(text))
+        if text:
+            await self.process_generator(self.run_tts(text))
 
         await self.stop_processing_metrics()
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Most TTS services don't like messages with empty text. This change centralizes the logic in TTSService to only generate audio from text when there is text.