### PR TITLE
Enable usage of Application Default Credentials in Google services

### DIFF
--- a/src/pipecat/services/google/llm_vertex.py
+++ b/src/pipecat/services/google/llm_vertex.py
@@ -17,6 +17,8 @@ from loguru import logger
 from pipecat.services.openai.llm import OpenAILLMService
 
 try:
+    from google.auth import default
+    from google.auth.exceptions import GoogleAuthError
     from google.auth.transport.requests import Request
     from google.oauth2 import service_account
 
@@ -98,6 +100,13 @@ class GoogleVertexLLMService(OpenAILLMService):
             creds = service_account.Credentials.from_service_account_file(
                 credentials_path, scopes=["https://www.googleapis.com/auth/cloud-platform"]
             )
+        else:
+            try:
+                creds, project_id = default(
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                )
+            except GoogleAuthError:
+                pass
 
         if not creds:
             raise ValueError("No valid credentials provided.")

--- a/src/pipecat/services/google/tts.py
+++ b/src/pipecat/services/google/tts.py
@@ -27,6 +27,8 @@ from pipecat.services.tts_service import TTSService
 from pipecat.transcriptions.language import Language
 
 try:
+    from google.auth import default
+    from google.auth.exceptions import GoogleAuthError
     from google.cloud import texttospeech_v1
     from google.oauth2 import service_account
 
@@ -251,6 +253,16 @@ class GoogleTTSService(TTSService):
         elif credentials_path:
             # Use service account JSON file if provided
             creds = service_account.Credentials.from_service_account_file(credentials_path)
+        else:
+            try:
+                creds, project_id = default(
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                )
+            except GoogleAuthError:
+                pass
+
+        if not creds:
+            raise ValueError("No valid credentials provided.")
 
         return texttospeech_v1.TextToSpeechAsyncClient(credentials=creds)
 


### PR DESCRIPTION
This PR adds support for Application Default Credentials (ADC) in Google service implementations (Vertex LLM, Speech-to-Text, and Text-to-Speech). Previously, these services required explicitly providing service account credentials either as a JSON string or file path.

While this approach works, it's not ideal in situations where IAM service accounts are configured at the environment level. This change enables more secure and flexible authentication patterns, especially in production environments:
- GCP environments: Automatically uses the attached service account
- Local development: Uses credentials from `gcloud auth login`

I welcome all feedback, and look forward to contributing more to pipecat!