### PR TITLE
Fix: Cartesia's spelling feature adds whole word to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `daily-python` to 0.17.0 to fix an issue that was preventing to run on
   older platforms.
 
+- Fixed an issue where `CartesiaTTSService`'s spell feature would result in
+  the spelled word in the context appearing as "F,O,O,B,A,R" instead of
+  "FOOBAR".
+
 - Fixed an issue in the Azure TTS services where the language was being set
   incorrectly.
 

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -166,6 +166,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
             "output_format": self._settings["output_format"],
             "language": self._settings["language"],
             "add_timestamps": add_timestamps,
+            "use_original_timestamps": True,
         }
         return json.dumps(msg)
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The context now reflects:
```
{"role": "assistant", "content": "Just to confirm, is your email <sp>first.lastname@gmail.com</sp>?"}
```

Assuming the `<sp>` tags are OK in the context, then this is good to go. If not, we can figure out what to do.