### PR TITLE
feat: change default model name on live api

### DIFF
--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -165,7 +165,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         *,
         api_key: str,
         base_url: str = "",
-        model="models/gemini-2.0-flash-exp",
+        model="models/gemini-2.0-flash-live-001",
         voice_id: str = "Charon",
         start_audio_paused: bool = False,
         start_video_paused: bool = False,


### PR DESCRIPTION
- Changed the default model for gemini multimodal live LLM service because the model is no longer available and a new preview model has been released with billing for live API.

![image](https://github.com/user-attachments/assets/f0f4170f-dfb7-4a17-a4ec-e6f061086689)


- The people using the current version of pipecat 0.0.62 are facing the below error as this PR changes(#1545) has not been released yet
```
2025-04-10 11:35:13.520 | ERROR    | pipecat.services.gemini_multimodal_live.gemini:_connect:454 - GeminiMultimodalLiveLLMService#0 initialization error: server rejected WebSocket connection: HTTP 404
```

- **Impact**: This update ensures compatibility with the latest Gemini Multimodal Live LLM service, resolving the WebSocket connection errors and restoring full functionality to Pipecat users.​

- Requesting the team to release the changes as a **HOTFIX**.

