### PR TITLE
Fixing the video transform demo to use 20ms audio.

### DIFF
--- a/examples/p2p-webrtc/video-transform/server/bot.py
+++ b/examples/p2p-webrtc/video-transform/server/bot.py
@@ -82,6 +82,7 @@ async def run_bot(webrtc_connection):
         vad_enabled=True,
         vad_analyzer=SileroVADAnalyzer(),
         vad_audio_passthrough=True,
+        audio_out_10ms_chunks=2,
     )
 
     pipecat_transport = SmallWebRTCTransport(


### PR DESCRIPTION
Fixing the video transform demo to use 20ms audio..

Just while we don't release the latest version of Pipecat.