### PR TITLE
Push gladia translations as a TranscriptionFrame

### DIFF
--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -348,16 +348,31 @@ class GladiaSTTService(STTService):
                 if content["type"] == "transcript":
                     utterance = content["data"]["utterance"]
                     confidence = utterance.get("confidence", 0)
+                    language = utterance["language"]
                     transcript = utterance["text"]
                     if confidence >= self._confidence:
                         if content["data"]["is_final"]:
                             await self.push_frame(
-                                TranscriptionFrame(transcript, "", time_now_iso8601())
+                                TranscriptionFrame(transcript, "", time_now_iso8601(), language)
                             )
                         else:
                             await self.push_frame(
-                                InterimTranscriptionFrame(transcript, "", time_now_iso8601())
+                                InterimTranscriptionFrame(
+                                    transcript, "", time_now_iso8601(), language
+                                )
                             )
+                elif content["type"] == "translation":
+                    translated_utterance = content["data"]["translated_utterance"]
+                    original_language = content["data"]["original_language"]
+                    translated_language = translated_utterance["language"]
+                    confidence = translated_utterance.get("confidence", 0)
+                    translation = translated_utterance["text"]
+                    if translated_language != original_language and confidence >= self._confidence:
+                        await self.push_frame(
+                            TranscriptionFrame(
+                                translation, "", time_now_iso8601(), translated_language
+                            )
+                        )
         except websockets.exceptions.ConnectionClosed:
             # Expected when closing the connection
             pass


### PR DESCRIPTION
This PR will:

- Push translations received from the Gladia Service as a TranscriptionFrame
- Drop any translated utterances that are the same as the original language
- Make use of the language parameter on the TranscriptionFrame and InterimTranscriptionFrame