### PR TITLE
Add eject_at_token_exp to Daily REST helpers, modify default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Daily's REST helpers now include an `eject_at_token_exp` param, which ejects
+  the user when their token expires. This new parameter defaults to False.
+  Also, the default value for `enable_prejoin_ui` changed to False and
+  `eject_at_room_exp` changed to False.
+
 - `OpenAILLMService` and `OpenPipeLLMService` now use `gpt-4.1` as their
   default model.
 

--- a/src/pipecat/transports/services/helpers/daily_rest.py
+++ b/src/pipecat/transports/services/helpers/daily_rest.py
@@ -68,9 +68,9 @@ class DailyRoomProperties(BaseModel, extra="allow"):
 
     exp: Optional[float] = None
     enable_chat: bool = False
-    enable_prejoin_ui: bool = True
+    enable_prejoin_ui: bool = False
     enable_emoji_reactions: bool = False
-    eject_at_room_exp: bool = True
+    eject_at_room_exp: bool = False
     enable_dialout: Optional[bool] = None
     enable_recording: Optional[Literal["cloud", "local", "raw-tracks"]] = None
     geo: Optional[str] = None
@@ -291,6 +291,7 @@ class DailyRESTHelper:
         self,
         room_url: str,
         expiry_time: float = 60 * 60,
+        eject_at_token_exp: bool = False,
         owner: bool = True,
         params: Optional[DailyMeetingTokenParams] = None,
     ) -> str:
@@ -324,12 +325,16 @@ class DailyRESTHelper:
         if params is None:
             params = DailyMeetingTokenParams(
                 properties=DailyMeetingTokenProperties(
-                    room_name=room_name, is_owner=owner, exp=expiration
+                    room_name=room_name,
+                    is_owner=owner,
+                    exp=expiration,
+                    eject_at_token_exp=eject_at_token_exp,
                 )
             )
         else:
             params.properties.room_name = room_name
             params.properties.exp = expiration
+            params.properties.eject_at_token_exp = eject_at_token_exp
             params.properties.is_owner = owner
 
         json = params.model_dump(exclude_none=True)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

It's common to expire user access based on tokens, so we're not providing a convenience to eject at token expiration.

Also, I'm adjusting the default values for two DailyRoomProperties to better align with Pipecat:
- `enable_prejoin_ui` defaults to False. This property is most useful when it comes to video conferencing calls. It serves no purpose if you're not using Daily Prebuilt.
- `eject_at_room_exp` now defaults to False. This property ejects all participants from the room when the room expires. Without a default room exp, it doesn't make sense to have this property set to True by default.