### PR TITLE
GrokLLMService uses grok-3-beta as default model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for Smart Turn Detection via the `turn_analyzer` transport
-  parameter. You can now choose between `SmartTurnAnalyzer()` for remote 
-  inference or `LocalCoreMLSmartTurnAnalyzer()` for on-device inference using 
+  parameter. You can now choose between `SmartTurnAnalyzer()` for remote
+  inference or `LocalCoreMLSmartTurnAnalyzer()` for on-device inference using
   Core ML.
 
 - `DeepgramTTSService` accepts `base_url` argument again, allowing you to
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transports like `SmallWebRTCTransport` and `FastAPIWebsocketTransport`.
 
 ### Changed
+
+- `GrokLLMService` now uses `grok-3-beta` as its default model.
 
 - Daily's REST helpers now include an `eject_at_token_exp` param, which ejects
   the user when their token expires. This new parameter defaults to False.

--- a/src/pipecat/services/grok/llm.py
+++ b/src/pipecat/services/grok/llm.py
@@ -42,7 +42,7 @@ class GrokLLMService(OpenAILLMService):
     Args:
         api_key (str): The API key for accessing Grok's API
         base_url (str, optional): The base URL for Grok API. Defaults to "https://api.x.ai/v1"
-        model (str, optional): The model identifier to use. Defaults to "grok-2"
+        model (str, optional): The model identifier to use. Defaults to "grok-3-beta"
         **kwargs: Additional keyword arguments passed to OpenAILLMService
     """
 
@@ -51,7 +51,7 @@ class GrokLLMService(OpenAILLMService):
         *,
         api_key: str,
         base_url: str = "https://api.x.ai/v1",
-        model: str = "grok-2",
+        model: str = "grok-3-beta",
         **kwargs,
     ):
         super().__init__(api_key=api_key, base_url=base_url, model=model, **kwargs)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.