### PR TITLE
Azure TTS fixed by clearing the audio queue before synthesizing the next text

### DIFF
--- a/src/pipecat/services/azure/tts.py
+++ b/src/pipecat/services/azure/tts.py
@@ -17,6 +17,7 @@ from pipecat.frames.frames import (
     TTSAudioRawFrame,
     TTSStartedFrame,
     TTSStoppedFrame,
+    TTSTextFrame,
 )
 from pipecat.services.azure.common import language_to_azure_language
 from pipecat.services.tts_service import TTSService
@@ -195,6 +196,44 @@ class AzureTTSService(AzureBaseTTSService):
 
     async def flush_audio(self):
         logger.trace(f"{self}: flushing audio")
+    
+    async def _push_tts_frames(self, text: str):
+        # Remove leading newlines only
+        text = text.lstrip("\n")
+
+        # Don't send only whitespace. This causes problems for some TTS models. But also don't
+        # strip all whitespace, as whitespace can influence prosody.
+        if not text.strip():
+            return
+
+        # This is just a flag that indicates if we sent something to the TTS
+        # service. It will be cleared if we sent text because of a TTSSpeakFrame
+        # or when we received an LLMFullResponseEndFrame
+        self._processing_text = True
+
+        await self.start_processing_metrics()
+
+        # Process all filter.
+        for filter in self._text_filters:
+            filter.reset_interruption()
+            text = filter.filter(text)
+        
+        # Clear the audio queue in case there's still audio in it, causing the next audio response
+        # to be cut off by the 'None' element returned at the end of the previous audio synthesis.
+        # Empty the audio queue before processing the new text
+        while not self._audio_queue.empty():
+            self._audio_queue.get_nowait()
+            self._audio_queue.task_done()
+
+        if text:
+            await self.process_generator(self.run_tts(text))
+
+        await self.stop_processing_metrics()
+
+        if self._push_text_frames:
+            # We send the original text after the audio. This way, if we are
+            # interrupted, the text is not added to the assistant context.
+            await self.push_frame(TTSTextFrame(text))
 
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"{self}: Generating TTS [{text}]")


### PR DESCRIPTION

---

#### 📝 Description of Changes

This PR fixes an issue where audio would get stuck in the queue when an interruption occurs during Azure TTS synthesis.

Previously, if Azure hadn’t finished outputting audio for the current text when an interruption occurred, the remaining audio frames would remain in the queue and never get played. The TTS processing logic breaks upon encountering a `None` in the audio queue — a signal that typically denotes the end of synthesis for a particular utterance.

However, if a `None` from a previously interrupted synthesis remains in the queue, it causes the next synthesized text to be skipped or delayed. For example, consider the following sequence in the audio queue after an interruption of "Text A" and the start of synthesis for "Text B":

```
["Text A audio 1", "Text A audio 2", None, "Text B audio 1", "Text B audio 2"]
```

In this case, when the processor hits the leftover `None`, it prematurely breaks and doesn't proceed to play the "Text B" audio, effectively causing audio to lag one step behind.

This PR ensures the queue is properly flushed or handled to avoid this desynchronization issue.

---

