### PR TITLE
Finished simli fix to allow bot stopped speaking

### DIFF
--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -35,6 +35,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=True,
+            camera_out_is_live=True,
             camera_out_width=512,
             camera_out_height=512,
             vad_enabled=True,


### PR DESCRIPTION
📝 Description of Changes
This PR addresses two issues in the SIMLI module of Pipecat that prevent the BotStoppedSpeaking signal from being triggered as expected.

🔧 Problem 1: Sink Queue Never Clears
In the foundational example, the SIMLI avatar video is used without setting camera_out_is_live to True.

As a result, image frames continue to be pushed into the sink_queue of the output layer.

Since the queue is never empty, the system assumes output is still ongoing, and the BotStoppedSpeaking signal never fires, even when the bot has finished speaking.

🔧 Problem 2: Continuous Silence in Idle Mode
When SIMLI enters idle mode, it continues to emit silence in the form of zero-energy audio frames.

This causes the bot to keep receiving audio, preventing it from detecting a natural stop in speech and blocking the BotStoppedSpeaking signal from being sent.

These changes ensure that both image and audio output behaviors are correctly handled, allowing the BotStoppedSpeaking signal to fire reliably when appropriate.