### PR TITLE
refactor(webrtc): Improve ICE server configuration in SmallWebRTCConnection

### DIFF
--- a/src/pipecat/transports/network/webrtc_connection.py
+++ b/src/pipecat/transports/network/webrtc_connection.py
@@ -7,7 +7,7 @@
 import asyncio
 import json
 import time
-from typing import Any, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from av.frame import Frame
 from loguru import logger
@@ -88,12 +88,9 @@ class SmallWebRTCTrack:
 
 
 class SmallWebRTCConnection(BaseObject):
-    def __init__(self, ice_servers=None):
+    def __init__(self, ice_servers: Optional[List[RTCIceServer]] = None):
         super().__init__()
-        if ice_servers:
-            self.ice_servers = [RTCIceServer(urls=server) for server in ice_servers]
-        else:
-            self.ice_servers = []
+        self.ice_servers: List[RTCIceServer] = ice_servers or []
         self._connect_invoked = False
         self._track_map = {}
         self._track_getters = {


### PR DESCRIPTION
This PR refactors the `SmallWebRTCConnection` constructor to improve how ICE servers are handled.

**Changes:**

*   The `ice_servers` parameter in `SmallWebRTCConnection.__init__` now accepts `Optional[List[RTCIceServer]]` instead of inferring the type.
*   The initialization logic is simplified to directly use the provided list of `RTCIceServer` objects or defaults to an empty list if `None` is passed.

**Motivation:**

*   This change allows users to pass pre-configured `RTCIceServer` objects directly, which is particularly useful for more complex setups involving TURN servers that require credentials.
*   It improves type safety and makes the expected input clearer.