### PR TITLE
Add auto_hang_up to Telnyx serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the Telnyx call when an `EndFrame` or `CancelFrame` is received. It is
   enabled by default and is configurable via the `auto_hang_up` `InputParam`.
 
+### Fixed
+
+- Fixed an issue where `TwilioFrameSerializer` would send two hang up commands:
+  one for the `EndFrame` and one for the `CancelFrame`.
+
 ## [0.0.64] - 2025-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added automatic hangup logic to the Telnyx serializer. This feature hangs up
+  the Telnyx call when an `EndFrame` or `CancelFrame` is received. It is
+  enabled by default and is configurable via the `auto_hang_up` `InputParam`.
+
 ## [0.0.64] - 2025-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the Telnyx call when an `EndFrame` or `CancelFrame` is received. It is
   enabled by default and is configurable via the `auto_hang_up` `InputParam`.
 
+### Changed
+
+- In `TwilioFrameSerializer`, `call_sid` is Optional so as to avoid a breaking
+  changed. `call_sid` is required to automatically hang up.
+
 ### Fixed
 
 - Fixed an issue where `TwilioFrameSerializer` would send two hang up commands:

--- a/examples/telnyx-chatbot/README.md
+++ b/examples/telnyx-chatbot/README.md
@@ -63,20 +63,35 @@ This project is a FastAPI-based chatbot that integrates with Telnyx to handle We
    ngrok http 8765
    ```
 
-2. **Update the Telnyx TeXML applications Webhook**:
+2. **Purchase a number**
 
-   - Go to your TeXML configuration page
-   - Provide the ngrok URL to the Webhook URL field and ensure the POST method is selected
-   - Click Save at the bottom of the page
+   If you haven't already, purchase a number from Telnyx.
 
-3. **Configure streams.xml**:
+   - Log in to the Telnyx developer portal: https://portal.telnyx.com/
+   - Buy a number: https://portal.telnyx.com/#/numbers/buy-numbers
+
+3. **Update the Telnyx TeXML applications Webhook**:
+
+   - Go to your TeXML configuration page: https://portal.telnyx.com/#/call-control/texml
+   - Create a new TeXML app, if one doesn't exist already:
+     - Add an application name
+     - Under Webhooks, select POST as the "Voice Method"
+     - Select "Custom URL" under Webhook URL Method
+     - Enter your ngrok URL in the "Webhook URL" field (e.g. https://your-name.ngrok.io)
+     - Click "Create" to save
+       Note: You'll see subsequent pages to set up SIP and Outbound, both are not required, so just skip.
+   - Navigate to "Manage Numbers" (https://portal.telnyx.com/#/numbers/my-numbers) and under SIP connection, select the pencil icon to edit and select the TeXML application that you just created.
+
+   Now your number is ready to call.
+
+4. **Configure streams.xml**:
    - Copy the template file to create your local version:
      ```sh
      cp templates/streams.xml.template templates/streams.xml
      ```
    - In `templates/streams.xml`, replace `<your server url>` with your ngrok URL (without `https://`)
-   - The final URL should look like: `wss://abc123.ngrok.io/ws`
-   - The encoding (`bidirectionalCodec`) should be `PCMU` or `PCMA` depending on your needs. Based on selected encoding, set the outbound_encoding in `server.py` when the bot is initialized.
+   - The final URL should look like: `wss://abc123.ngrok.io/ws`. This needs to be the same URL that you added to your TeXML app above.
+   - The encoding (`bidirectionalCodec`) should be `PCMU` or `PCMA` depending on your needs. Based on selected encoding, set the outbound_encoding in `server.py` when the bot is initialized. (No changes are required by default.)
    - The inbound encoding can be controlled from the application configuration for inbound calls and dial/transfer commands for outbound calls.
 
 ## Running the Application

--- a/examples/telnyx-chatbot/bot.py
+++ b/examples/telnyx-chatbot/bot.py
@@ -33,9 +33,18 @@ logger.add(sys.stderr, level="DEBUG")
 async def run_bot(
     websocket_client,
     stream_id: str,
+    call_control_id: str,
     outbound_encoding: str,
     inbound_encoding: str,
 ):
+    serializer = TelnyxFrameSerializer(
+        stream_id=stream_id,
+        outbound_encoding=outbound_encoding,
+        inbound_encoding=inbound_encoding,
+        call_control_id=call_control_id,
+        api_key=os.getenv("TELNYX_API_KEY"),
+    )
+
     transport = FastAPIWebsocketTransport(
         websocket=websocket_client,
         params=FastAPIWebsocketParams(
@@ -44,7 +53,7 @@ async def run_bot(
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             vad_audio_passthrough=True,
-            serializer=TelnyxFrameSerializer(stream_id, outbound_encoding, inbound_encoding),
+            serializer=serializer,
         ),
     )
 

--- a/examples/telnyx-chatbot/server.py
+++ b/examples/telnyx-chatbot/server.py
@@ -37,9 +37,10 @@ async def websocket_endpoint(websocket: WebSocket):
     call_data = json.loads(await start_data.__anext__())
     print(call_data, flush=True)
     stream_id = call_data["stream_id"]
+    call_control_id = call_data["start"]["call_control_id"]
     outbound_encoding = call_data["start"]["media_format"]["encoding"]
     print("WebSocket connection accepted")
-    await run_bot(websocket, stream_id, outbound_encoding, "PCMU")
+    await run_bot(websocket, stream_id, call_control_id, outbound_encoding, "PCMU")
 
 
 if __name__ == "__main__":

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -90,6 +90,7 @@ class TwilioFrameSerializer(FrameSerializer):
         self._sample_rate = 0  # Pipeline input rate
 
         self._resampler = create_default_resampler()
+        self._hangup_attempted = False
 
     @property
     def type(self) -> FrameSerializerType:
@@ -120,7 +121,12 @@ class TwilioFrameSerializer(FrameSerializer):
         Returns:
             Serialized data as string or bytes, or None if the frame isn't handled.
         """
-        if self._params.auto_hang_up and isinstance(frame, (EndFrame, CancelFrame)):
+        if (
+            self._params.auto_hang_up
+            and not self._hangup_attempted
+            and isinstance(frame, (EndFrame, CancelFrame))
+        ):
+            self._hangup_attempted = True
             await self._hang_up_call()
             return None
         elif isinstance(frame, StartInterruptionFrame):

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -66,7 +66,7 @@ class TwilioFrameSerializer(FrameSerializer):
     def __init__(
         self,
         stream_sid: str,
-        call_sid: str,
+        call_sid: Optional[str] = None,
         account_sid: Optional[str] = None,
         auth_token: Optional[str] = None,
         params: InputParams = InputParams(),
@@ -75,9 +75,9 @@ class TwilioFrameSerializer(FrameSerializer):
 
         Args:
             stream_sid: The Twilio Media Stream SID.
-            call_sid: The associated Twilio Call SID.
-            account_sid: Twilio account SID.
-            auth_token: Twilio auth token.
+            call_sid: The associated Twilio Call SID (optional, but required for auto hang-up).
+            account_sid: Twilio account SID (required for auto hang-up).
+            auth_token: Twilio auth token (required for auto hang-up).
             params: Configuration parameters.
         """
         self._stream_sid = stream_sid
@@ -160,15 +160,26 @@ class TwilioFrameSerializer(FrameSerializer):
 
             account_sid = self._account_sid
             auth_token = self._auth_token
+            call_sid = self._call_sid
 
-            if not account_sid or not auth_token:
+            if not call_sid or not account_sid or not auth_token:
+                missing = []
+                if not call_sid:
+                    missing.append("call_sid")
+                if not account_sid:
+                    missing.append("account_sid")
+                if not auth_token:
+                    missing.append("auth_token")
+
                 logger.warning(
-                    "Cannot hang up Twilio call: account_sid and auth_token must be provided"
+                    f"Cannot hang up Twilio call: missing required parameters: {', '.join(missing)}"
                 )
                 return
 
             # Twilio API endpoint for updating calls
-            endpoint = f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Calls/{self._call_sid}.json"
+            endpoint = (
+                f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Calls/{call_sid}.json"
+            )
 
             # Create basic auth from account_sid and auth_token
             auth = aiohttp.BasicAuth(account_sid, auth_token)
@@ -180,12 +191,12 @@ class TwilioFrameSerializer(FrameSerializer):
             async with aiohttp.ClientSession() as session:
                 async with session.post(endpoint, auth=auth, data=params) as response:
                     if response.status == 200:
-                        logger.info(f"Successfully terminated Twilio call {self._call_sid}")
+                        logger.info(f"Successfully terminated Twilio call {call_sid}")
                     else:
                         # Get the error details for better debugging
                         error_text = await response.text()
                         logger.error(
-                            f"Failed to terminate Twilio call {self._call_sid}: "
+                            f"Failed to terminate Twilio call {call_sid}: "
                             f"Status {response.status}, Response: {error_text}"
                         )
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Adding the auto hang up option to Telnyx to match the Twilio Serializer.

Also:
- Adding logic to only send the command once—both for Telnyx and Twilio
- Making the Twilio call_sid optional, as this was breaking 😞 
- Improving the telnyx-chatbot README to make it easier for anyone who hasn't worked with Telnyx before
- Updated telnyx-chatbot example to provide the required inputs