### PR TITLE
input transports now always push audio frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `TransportParams.camera_*` parameters are now deprecated, use
+  `TransportParams.video_*` instead.
+
 - `TransportParams.vad_enabled` parameter is now deprecated, use
   `TransportParams.audio_in_enabled` and `TransportParams.vad_analyzer` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `TransportParams.vad_enabled` parameter is now deprecated, use
+  `TransportParams.audio_in_enabled` and `TransportParams.vad_analyzer` instead.
+
 - `TransportParams.vad_audio_passthrough` parameter is now deprecated, use
   `TransportParams.audio_in_passthrough` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `MCPClient`; a way to connect to MCP servers and use the MCP servers' tools.
+- Added `TransportParams.audio_in_passthrough`. If set (the default), incoming
+  audio will be pushed downstream.
+
+- Added `MCPClient`; a way to connect to MCP servers and use the MCP servers'
+  tools.
+
+### Changed
+
+- Input transports now always push audio downstream unless disabled with
+  `TransportParams.audio_in_passthrough`. After many Pipecat releases, we
+  realized this is the common use case. There are use cases where the input
+  transport already provides STT and you also don't want recordings, in which
+  case there's no need to push audio to the rest of the pipeline, but this is
+  not a very common case.
+
+### Deprecated
+
+- `TransportParams.vad_audio_passthrough` parameter is now deprecated, use
+  `TransportParams.audio_in_passthrough` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- STT services now passthrough audio frames by default. This allows you to add
+  audio recording without worrying about what's wrong in your pipeline when it
+  doesn't work the first time.
+
 - Input transports now always push audio downstream unless disabled with
   `TransportParams.audio_in_passthrough`. After many Pipecat releases, we
   realized this is the common use case. There are use cases where the input

--- a/examples/canonical-metrics/bot.py
+++ b/examples/canonical-metrics/bot.py
@@ -43,7 +43,7 @@ async def main():
             DailyParams(
                 audio_out_enabled=True,
                 audio_in_enabled=True,
-                camera_out_enabled=False,
+                video_out_enabled=False,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/canonical-metrics/bot.py
+++ b/examples/canonical-metrics/bot.py
@@ -45,7 +45,6 @@ async def main():
                 audio_in_enabled=True,
                 camera_out_enabled=False,
                 vad_enabled=True,
-                vad_audio_passthrough=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/canonical-metrics/bot.py
+++ b/examples/canonical-metrics/bot.py
@@ -44,7 +44,6 @@ async def main():
                 audio_out_enabled=True,
                 audio_in_enabled=True,
                 camera_out_enabled=False,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/chatbot-audio-recording/bot.py
+++ b/examples/chatbot-audio-recording/bot.py
@@ -68,7 +68,6 @@ async def main():
                 audio_in_enabled=True,
                 camera_out_enabled=False,
                 vad_enabled=True,
-                vad_audio_passthrough=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/chatbot-audio-recording/bot.py
+++ b/examples/chatbot-audio-recording/bot.py
@@ -66,7 +66,7 @@ async def main():
             DailyParams(
                 audio_out_enabled=True,
                 audio_in_enabled=True,
-                camera_out_enabled=False,
+                video_out_enabled=False,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/chatbot-audio-recording/bot.py
+++ b/examples/chatbot-audio-recording/bot.py
@@ -67,7 +67,6 @@ async def main():
                 audio_out_enabled=True,
                 audio_in_enabled=True,
                 camera_out_enabled=False,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/deployment/flyio-example/bot.py
+++ b/examples/deployment/flyio-example/bot.py
@@ -41,7 +41,7 @@ async def main(room_url: str, token: str):
             api_key=daily_api_key,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         ),

--- a/examples/deployment/flyio-example/bot.py
+++ b/examples/deployment/flyio-example/bot.py
@@ -42,7 +42,6 @@ async def main(room_url: str, token: str):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         ),

--- a/examples/deployment/modal-example/bot.py
+++ b/examples/deployment/modal-example/bot.py
@@ -32,9 +32,9 @@ async def main(room_url: str, token: str):
         token,
         "bot",
         DailyParams(
+            audio_in_enabled=True,
             audio_out_enabled=True,
             transcription_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/deployment/pipecat-cloud-example/bot.py
+++ b/examples/deployment/pipecat-cloud-example/bot.py
@@ -50,9 +50,9 @@ async def main(room_url: str, token: str):
         token,
         "bot",
         DailyParams(
+            audio_in_enabled=True,
             audio_out_enabled=True,
             transcription_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/fal-smart-turn/server/bot.py
+++ b/examples/fal-smart-turn/server/bot.py
@@ -247,7 +247,6 @@ async def bot(args: DailySessionArguments):
                 camera_out_height=576,
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-                vad_audio_passthrough=True,
                 turn_analyzer=FalSmartTurnAnalyzer(
                     api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session
                 ),
@@ -281,7 +280,6 @@ async def local_daily():
                     camera_out_height=576,
                     vad_enabled=True,
                     vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-                    vad_audio_passthrough=True,
                     turn_analyzer=FalSmartTurnAnalyzer(
                         api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session
                     ),

--- a/examples/fal-smart-turn/server/bot.py
+++ b/examples/fal-smart-turn/server/bot.py
@@ -243,9 +243,9 @@ async def bot(args: DailySessionArguments):
                 audio_in_enabled=True,
                 audio_in_filter=KrispFilter(),
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=576,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=576,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
                 turn_analyzer=FalSmartTurnAnalyzer(
                     api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session
@@ -276,9 +276,9 @@ async def local_daily():
                 params=DailyParams(
                     audio_in_enabled=True,
                     audio_out_enabled=True,
-                    camera_out_enabled=True,
-                    camera_out_width=1024,
-                    camera_out_height=576,
+                    video_out_enabled=True,
+                    video_out_width=1024,
+                    video_out_height=576,
                     vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
                     turn_analyzer=FalSmartTurnAnalyzer(
                         api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session

--- a/examples/fal-smart-turn/server/bot.py
+++ b/examples/fal-smart-turn/server/bot.py
@@ -240,12 +240,12 @@ async def bot(args: DailySessionArguments):
             args.token,
             "Smart Turn Bot",
             params=DailyParams(
+                audio_in_enabled=True,
                 audio_in_filter=KrispFilter(),
                 audio_out_enabled=True,
                 camera_out_enabled=True,
                 camera_out_width=1024,
                 camera_out_height=576,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
                 turn_analyzer=FalSmartTurnAnalyzer(
                     api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session
@@ -274,11 +274,11 @@ async def local_daily():
                 token,
                 "Smart Turn Bot",
                 params=DailyParams(
+                    audio_in_enabled=True,
                     audio_out_enabled=True,
                     camera_out_enabled=True,
                     camera_out_width=1024,
                     camera_out_height=576,
-                    vad_enabled=True,
                     vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
                     turn_analyzer=FalSmartTurnAnalyzer(
                         api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session

--- a/examples/foundational/01-say-one-thing-piper.py
+++ b/examples/foundational/01-say-one-thing-piper.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -22,7 +23,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/01-say-one-thing-rime.py
+++ b/examples/foundational/01-say-one-thing-rime.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -22,7 +23,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/01-say-one-thing.py
+++ b/examples/foundational/01-say-one-thing.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -21,7 +22,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/01c-fastpitch.py
+++ b/examples/foundational/01c-fastpitch.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -21,7 +22,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/02-llm-say-one-thing.py
+++ b/examples/foundational/02-llm-say-one-thing.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -22,7 +23,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/03-still-frame.py
+++ b/examples/foundational/03-still-frame.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -22,7 +23,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/03-still-frame.py
+++ b/examples/foundational/03-still-frame.py
@@ -29,9 +29,9 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
     transport = SmallWebRTCTransport(
         webrtc_connection=webrtc_connection,
         params=TransportParams(
-            camera_out_enabled=True,
-            camera_out_width=1024,
-            camera_out_height=1024,
+            video_out_enabled=True,
+            video_out_width=1024,
+            video_out_height=1024,
         ),
     )
 

--- a/examples/foundational/03a-local-still-frame.py
+++ b/examples/foundational/03a-local-still-frame.py
@@ -33,9 +33,7 @@ async def main():
 
         transport = TkLocalTransport(
             tk_root,
-            TkTransportParams(
-                camera_out_enabled=True, camera_out_width=1024, camera_out_height=1024
-            ),
+            TkTransportParams(video_out_enabled=True, video_out_width=1024, video_out_height=1024),
         )
 
         imagegen = FalImageGenService(

--- a/examples/foundational/03b-still-frame-imagen.py
+++ b/examples/foundational/03b-still-frame-imagen.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -21,7 +22,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Create a transport using the WebRTC connection

--- a/examples/foundational/03b-still-frame-imagen.py
+++ b/examples/foundational/03b-still-frame-imagen.py
@@ -28,9 +28,9 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
     transport = SmallWebRTCTransport(
         webrtc_connection=webrtc_connection,
         params=TransportParams(
-            camera_out_enabled=True,
-            camera_out_width=1024,
-            camera_out_height=1024,
+            video_out_enabled=True,
+            video_out_width=1024,
+            video_out_height=1024,
         ),
     )
 

--- a/examples/foundational/05-sync-speech-and-image.py
+++ b/examples/foundational/05-sync-speech-and-image.py
@@ -77,9 +77,9 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         webrtc_connection=webrtc_connection,
         params=TransportParams(
             audio_out_enabled=True,
-            camera_out_enabled=True,
-            camera_out_width=1024,
-            camera_out_height=1024,
+            video_out_enabled=True,
+            video_out_width=1024,
+            video_out_height=1024,
         ),
     )
 

--- a/examples/foundational/05-sync-speech-and-image.py
+++ b/examples/foundational/05-sync-speech-and-image.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from dataclasses import dataclass
 
@@ -63,7 +64,7 @@ class MonthPrepender(FrameProcessor):
             await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     """Run the Calendar Month Narration bot using WebRTC transport.
 
     Args:

--- a/examples/foundational/05a-local-sync-speech-and-image.py
+++ b/examples/foundational/05a-local-sync-speech-and-image.py
@@ -153,9 +153,9 @@ async def main():
             tk_root,
             TkTransportParams(
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=1024,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=1024,
             ),
         )
 

--- a/examples/foundational/06-listen-and-respond.py
+++ b/examples/foundational/06-listen-and-respond.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -52,7 +53,7 @@ class MetricsLogger(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/06-listen-and-respond.py
+++ b/examples/foundational/06-listen-and-respond.py
@@ -62,7 +62,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/06-listen-and-respond.py
+++ b/examples/foundational/06-listen-and-respond.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/06a-image-sync.py
+++ b/examples/foundational/06a-image-sync.py
@@ -78,7 +78,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_out_enabled=True,
             camera_out_width=1024,
             camera_out_height=1024,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/06a-image-sync.py
+++ b/examples/foundational/06a-image-sync.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -67,7 +68,7 @@ class ImageSyncAggregator(FrameProcessor):
         await self.push_frame(frame)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/06a-image-sync.py
+++ b/examples/foundational/06a-image-sync.py
@@ -80,7 +80,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_out_height=1024,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/06a-image-sync.py
+++ b/examples/foundational/06a-image-sync.py
@@ -75,9 +75,9 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=True,
-            camera_out_width=1024,
-            camera_out_height=1024,
+            video_out_enabled=True,
+            video_out_width=1024,
+            video_out_height=1024,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07-interruptible.py
+++ b/examples/foundational/07-interruptible.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07-interruptible.py
+++ b/examples/foundational/07-interruptible.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07-interruptible.py
+++ b/examples/foundational/07-interruptible.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07a-interruptible-vad.py
+++ b/examples/foundational/07a-interruptible-vad.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07b-interruptible-langchain.py
+++ b/examples/foundational/07b-interruptible-langchain.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -42,7 +43,7 @@ def get_session_history(session_id: str) -> BaseChatMessageHistory:
     return message_store[session_id]
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07b-interruptible-langchain.py
+++ b/examples/foundational/07b-interruptible-langchain.py
@@ -52,7 +52,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07b-interruptible-langchain.py
+++ b/examples/foundational/07b-interruptible-langchain.py
@@ -50,7 +50,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07c-interruptible-deepgram-vad.py
+++ b/examples/foundational/07c-interruptible-deepgram-vad.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from deepgram import LiveOptions
@@ -30,7 +31,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07c-interruptible-deepgram.py
+++ b/examples/foundational/07c-interruptible-deepgram.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07c-interruptible-deepgram.py
+++ b/examples/foundational/07c-interruptible-deepgram.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07c-interruptible-deepgram.py
+++ b/examples/foundational/07c-interruptible-deepgram.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07d-interruptible-elevenlabs-http.py
+++ b/examples/foundational/07d-interruptible-elevenlabs-http.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07d-interruptible-elevenlabs-http.py
+++ b/examples/foundational/07d-interruptible-elevenlabs-http.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07d-interruptible-elevenlabs-http.py
+++ b/examples/foundational/07d-interruptible-elevenlabs-http.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07e-interruptible-playht-http.py
+++ b/examples/foundational/07e-interruptible-playht-http.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07e-interruptible-playht-http.py
+++ b/examples/foundational/07e-interruptible-playht-http.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07e-interruptible-playht-http.py
+++ b/examples/foundational/07e-interruptible-playht-http.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07e-interruptible-playht.py
+++ b/examples/foundational/07e-interruptible-playht.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07e-interruptible-playht.py
+++ b/examples/foundational/07e-interruptible-playht.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07e-interruptible-playht.py
+++ b/examples/foundational/07e-interruptible-playht.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07f-interruptible-azure.py
+++ b/examples/foundational/07f-interruptible-azure.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07f-interruptible-azure.py
+++ b/examples/foundational/07f-interruptible-azure.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07f-interruptible-azure.py
+++ b/examples/foundational/07f-interruptible-azure.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07g-interruptible-openai.py
+++ b/examples/foundational/07g-interruptible-openai.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07g-interruptible-openai.py
+++ b/examples/foundational/07g-interruptible-openai.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07g-interruptible-openai.py
+++ b/examples/foundational/07g-interruptible-openai.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07h-interruptible-openpipe.py
+++ b/examples/foundational/07h-interruptible-openpipe.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07h-interruptible-openpipe.py
+++ b/examples/foundational/07h-interruptible-openpipe.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07h-interruptible-openpipe.py
+++ b/examples/foundational/07h-interruptible-openpipe.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 import time
 
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07i-interruptible-xtts.py
+++ b/examples/foundational/07i-interruptible-xtts.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07i-interruptible-xtts.py
+++ b/examples/foundational/07i-interruptible-xtts.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07i-interruptible-xtts.py
+++ b/examples/foundational/07i-interruptible-xtts.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07j-interruptible-gladia.py
+++ b/examples/foundational/07j-interruptible-gladia.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07j-interruptible-gladia.py
+++ b/examples/foundational/07j-interruptible-gladia.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07j-interruptible-gladia.py
+++ b/examples/foundational/07j-interruptible-gladia.py
@@ -36,7 +36,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07k-interruptible-lmnt.py
+++ b/examples/foundational/07k-interruptible-lmnt.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07k-interruptible-lmnt.py
+++ b/examples/foundational/07k-interruptible-lmnt.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07k-interruptible-lmnt.py
+++ b/examples/foundational/07k-interruptible-lmnt.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07l-interruptible-groq.py
+++ b/examples/foundational/07l-interruptible-groq.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07l-interruptible-groq.py
+++ b/examples/foundational/07l-interruptible-groq.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07l-interruptible-groq.py
+++ b/examples/foundational/07l-interruptible-groq.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07m-interruptible-polly.py
+++ b/examples/foundational/07m-interruptible-polly.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07m-interruptible-polly.py
+++ b/examples/foundational/07m-interruptible-polly.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07m-interruptible-polly.py
+++ b/examples/foundational/07m-interruptible-polly.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07n-interruptible-google.py
+++ b/examples/foundational/07n-interruptible-google.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07n-interruptible-google.py
+++ b/examples/foundational/07n-interruptible-google.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07n-interruptible-google.py
+++ b/examples/foundational/07n-interruptible-google.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07o-interruptible-assemblyai.py
+++ b/examples/foundational/07o-interruptible-assemblyai.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07o-interruptible-assemblyai.py
+++ b/examples/foundational/07o-interruptible-assemblyai.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07o-interruptible-assemblyai.py
+++ b/examples/foundational/07o-interruptible-assemblyai.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07p-interruptible-krisp.py
+++ b/examples/foundational/07p-interruptible-krisp.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07p-interruptible-krisp.py
+++ b/examples/foundational/07p-interruptible-krisp.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
             audio_in_filter=KrispFilter(),
         ),
     )

--- a/examples/foundational/07p-interruptible-krisp.py
+++ b/examples/foundational/07p-interruptible-krisp.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             audio_in_filter=KrispFilter(),
         ),

--- a/examples/foundational/07q-interruptible-rime-http.py
+++ b/examples/foundational/07q-interruptible-rime-http.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07q-interruptible-rime-http.py
+++ b/examples/foundational/07q-interruptible-rime-http.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07q-interruptible-rime-http.py
+++ b/examples/foundational/07q-interruptible-rime-http.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -25,7 +26,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07q-interruptible-rime.py
+++ b/examples/foundational/07q-interruptible-rime.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07q-interruptible-rime.py
+++ b/examples/foundational/07q-interruptible-rime.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07q-interruptible-rime.py
+++ b/examples/foundational/07q-interruptible-rime.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07r-interruptible-riva-nim.py
+++ b/examples/foundational/07r-interruptible-riva-nim.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07r-interruptible-riva-nim.py
+++ b/examples/foundational/07r-interruptible-riva-nim.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07r-interruptible-riva-nim.py
+++ b/examples/foundational/07r-interruptible-riva-nim.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07s-interruptible-google-audio-in.py
+++ b/examples/foundational/07s-interruptible-google-audio-in.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from dataclasses import dataclass
 
@@ -190,7 +191,7 @@ class TanscriptionContextFixup(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07s-interruptible-google-audio-in.py
+++ b/examples/foundational/07s-interruptible-google-audio-in.py
@@ -202,7 +202,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             # transcription_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07s-interruptible-google-audio-in.py
+++ b/examples/foundational/07s-interruptible-google-audio-in.py
@@ -198,9 +198,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            # No transcription at all. just audio input to Gemini!
-            # transcription_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07t-interruptible-fish.py
+++ b/examples/foundational/07t-interruptible-fish.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07t-interruptible-fish.py
+++ b/examples/foundational/07t-interruptible-fish.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07t-interruptible-fish.py
+++ b/examples/foundational/07t-interruptible-fish.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07u-interruptible-ultravox.py
+++ b/examples/foundational/07u-interruptible-ultravox.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -35,7 +36,7 @@ ultravox_processor = UltravoxSTTService(
 )
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07u-interruptible-ultravox.py
+++ b/examples/foundational/07u-interruptible-ultravox.py
@@ -43,7 +43,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
         ),
     )

--- a/examples/foundational/07u-interruptible-ultravox.py
+++ b/examples/foundational/07u-interruptible-ultravox.py
@@ -45,7 +45,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07v-interruptible-neuphonic-http.py
+++ b/examples/foundational/07v-interruptible-neuphonic-http.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07v-interruptible-neuphonic-http.py
+++ b/examples/foundational/07v-interruptible-neuphonic-http.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07v-interruptible-neuphonic-http.py
+++ b/examples/foundational/07v-interruptible-neuphonic-http.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07v-interruptible-neuphonic.py
+++ b/examples/foundational/07v-interruptible-neuphonic.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07v-interruptible-neuphonic.py
+++ b/examples/foundational/07v-interruptible-neuphonic.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07v-interruptible-neuphonic.py
+++ b/examples/foundational/07v-interruptible-neuphonic.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07w-interruptible-fal.py
+++ b/examples/foundational/07w-interruptible-fal.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/07w-interruptible-fal.py
+++ b/examples/foundational/07w-interruptible-fal.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/07w-interruptible-fal.py
+++ b/examples/foundational/07w-interruptible-fal.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/07x-interruptible-local.py
+++ b/examples/foundational/07x-interruptible-local.py
@@ -32,7 +32,6 @@ async def main():
         LocalAudioTransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         )
     )

--- a/examples/foundational/07x-interruptible-local.py
+++ b/examples/foundational/07x-interruptible-local.py
@@ -34,7 +34,6 @@ async def main():
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         )
     )
 

--- a/examples/foundational/09-mirror.py
+++ b/examples/foundational/09-mirror.py
@@ -39,7 +39,6 @@ class MirrorProcessor(FrameProcessor):
                 )
             )
         elif isinstance(frame, InputImageRawFrame):
-            print(f"Received image frame: {frame.size} {frame.format}")
             await self.push_frame(
                 OutputImageRawFrame(image=frame.image, size=frame.size, format=frame.format)
             )
@@ -55,11 +54,11 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_in_enabled=True,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 

--- a/examples/foundational/09-mirror.py
+++ b/examples/foundational/09-mirror.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -46,7 +47,7 @@ class MirrorProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/09a-local-mirror.py
+++ b/examples/foundational/09a-local-mirror.py
@@ -57,11 +57,11 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_in_enabled=True,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 
@@ -72,10 +72,10 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         tk_root,
         TkTransportParams(
             audio_out_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 

--- a/examples/foundational/09a-local-mirror.py
+++ b/examples/foundational/09a-local-mirror.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import tkinter as tk
 
@@ -49,7 +50,7 @@ class MirrorProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     p2p_transport = SmallWebRTCTransport(

--- a/examples/foundational/10-wake-phrase.py
+++ b/examples/foundational/10-wake-phrase.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/10-wake-phrase.py
+++ b/examples/foundational/10-wake-phrase.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/10-wake-phrase.py
+++ b/examples/foundational/10-wake-phrase.py
@@ -36,7 +36,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/11-sound-effects.py
+++ b/examples/foundational/11-sound-effects.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 import wave
 
@@ -77,7 +78,7 @@ class InboundSoundEffectWrapper(FrameProcessor):
             await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/11-sound-effects.py
+++ b/examples/foundational/11-sound-effects.py
@@ -85,7 +85,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/11-sound-effects.py
+++ b/examples/foundational/11-sound-effects.py
@@ -87,7 +87,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/12-describe-video.py
+++ b/examples/foundational/12-describe-video.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12-describe-video.py
+++ b/examples/foundational/12-describe-video.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/12-describe-video.py
+++ b/examples/foundational/12-describe-video.py
@@ -57,7 +57,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12-describe-video.py
+++ b/examples/foundational/12-describe-video.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from typing import Optional
 
@@ -46,7 +47,7 @@ class UserImageRequester(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     # Get WebRTC peer connection ID
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/12a-describe-video-gemini-flash.py
+++ b/examples/foundational/12a-describe-video-gemini-flash.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12a-describe-video-gemini-flash.py
+++ b/examples/foundational/12a-describe-video-gemini-flash.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/12a-describe-video-gemini-flash.py
+++ b/examples/foundational/12a-describe-video-gemini-flash.py
@@ -57,7 +57,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12a-describe-video-gemini-flash.py
+++ b/examples/foundational/12a-describe-video-gemini-flash.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from typing import Optional
 
@@ -46,7 +47,7 @@ class UserImageRequester(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     # Get WebRTC peer connection ID
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/12b-describe-video-gpt-4o.py
+++ b/examples/foundational/12b-describe-video-gpt-4o.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12b-describe-video-gpt-4o.py
+++ b/examples/foundational/12b-describe-video-gpt-4o.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/12b-describe-video-gpt-4o.py
+++ b/examples/foundational/12b-describe-video-gpt-4o.py
@@ -57,7 +57,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12b-describe-video-gpt-4o.py
+++ b/examples/foundational/12b-describe-video-gpt-4o.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from typing import Optional
 
@@ -46,7 +47,7 @@ class UserImageRequester(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     # Get WebRTC peer connection ID
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/12c-describe-video-anthropic.py
+++ b/examples/foundational/12c-describe-video-anthropic.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12c-describe-video-anthropic.py
+++ b/examples/foundational/12c-describe-video-anthropic.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/12c-describe-video-anthropic.py
+++ b/examples/foundational/12c-describe-video-anthropic.py
@@ -57,7 +57,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/12c-describe-video-anthropic.py
+++ b/examples/foundational/12c-describe-video-anthropic.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from typing import Optional
 
@@ -46,7 +47,7 @@ class UserImageRequester(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     # Get WebRTC peer connection ID
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/13-whisper-transcription.py
+++ b/examples/foundational/13-whisper-transcription.py
@@ -37,7 +37,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         webrtc_connection=webrtc_connection,
         params=TransportParams(
             audio_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/13-whisper-transcription.py
+++ b/examples/foundational/13-whisper-transcription.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -30,7 +31,7 @@ class TranscriptionLogger(FrameProcessor):
             print(f"Transcription: {frame.text}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/13-whisper-transcription.py
+++ b/examples/foundational/13-whisper-transcription.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/13a-whisper-local.py
+++ b/examples/foundational/13a-whisper-local.py
@@ -39,7 +39,6 @@ async def main():
             audio_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         )
     )
 

--- a/examples/foundational/13a-whisper-local.py
+++ b/examples/foundational/13a-whisper-local.py
@@ -37,7 +37,6 @@ async def main():
     transport = LocalAudioTransport(
         LocalAudioTransportParams(
             audio_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         )
     )

--- a/examples/foundational/13b-deepgram-transcription.py
+++ b/examples/foundational/13b-deepgram-transcription.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -31,7 +31,7 @@ class TranscriptionLogger(FrameProcessor):
             print(f"Transcription: {frame.text}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/13c-gladia-transcription.py
+++ b/examples/foundational/13c-gladia-transcription.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -30,7 +31,7 @@ class TranscriptionLogger(FrameProcessor):
             print(f"Transcription: {frame.text}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/13d-assemblyai-transcription.py
+++ b/examples/foundational/13d-assemblyai-transcription.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -30,7 +31,7 @@ class TranscriptionLogger(FrameProcessor):
             print(f"Transcription: {frame.text}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/13e-whisper-mlx.py
+++ b/examples/foundational/13e-whisper-mlx.py
@@ -59,7 +59,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         webrtc_connection=webrtc_connection,
         params=TransportParams(
             audio_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=STOP_SECS)),
         ),
     )

--- a/examples/foundational/13e-whisper-mlx.py
+++ b/examples/foundational/13e-whisper-mlx.py
@@ -61,7 +61,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=STOP_SECS)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/13e-whisper-mlx.py
+++ b/examples/foundational/13e-whisper-mlx.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-
+import argparse
 import time
 
 from dotenv import load_dotenv
@@ -52,7 +52,7 @@ class TranscriptionLogger(FrameProcessor):
             self._last_transcription_time = time.time()
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14-function-calling.py
+++ b/examples/foundational/14-function-calling.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14-function-calling.py
+++ b/examples/foundational/14-function-calling.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14-function-calling.py
+++ b/examples/foundational/14-function-calling.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14a-function-calling-anthropic.py
+++ b/examples/foundational/14a-function-calling-anthropic.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -31,7 +32,7 @@ async def get_weather(function_name, tool_call_id, arguments, llm, context, resu
     await result_callback(f"The weather in {location} is currently 72 degrees and sunny.")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14a-function-calling-anthropic.py
+++ b/examples/foundational/14a-function-calling-anthropic.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14a-function-calling-anthropic.py
+++ b/examples/foundational/14a-function-calling-anthropic.py
@@ -41,7 +41,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14b-function-calling-anthropic-video.py
+++ b/examples/foundational/14b-function-calling-anthropic-video.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 
@@ -57,7 +58,7 @@ async def get_image(function_name, tool_call_id, arguments, llm, context, result
     )
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     global webrtc_peer_id
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/14b-function-calling-anthropic-video.py
+++ b/examples/foundational/14b-function-calling-anthropic-video.py
@@ -68,7 +68,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,  # Make sure camera input is enabled
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14b-function-calling-anthropic-video.py
+++ b/examples/foundational/14b-function-calling-anthropic-video.py
@@ -71,7 +71,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,  # Make sure camera input is enabled
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14b-function-calling-anthropic-video.py
+++ b/examples/foundational/14b-function-calling-anthropic-video.py
@@ -69,7 +69,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,  # Make sure camera input is enabled
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14c-function-calling-together.py
+++ b/examples/foundational/14c-function-calling-together.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14c-function-calling-together.py
+++ b/examples/foundational/14c-function-calling-together.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14c-function-calling-together.py
+++ b/examples/foundational/14c-function-calling-together.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14d-function-calling-video.py
+++ b/examples/foundational/14d-function-calling-video.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 
@@ -57,7 +58,7 @@ async def get_image(function_name, tool_call_id, arguments, llm, context, result
     )
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     global webrtc_peer_id
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/14d-function-calling-video.py
+++ b/examples/foundational/14d-function-calling-video.py
@@ -68,7 +68,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,  # Make sure camera input is enabled
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14d-function-calling-video.py
+++ b/examples/foundational/14d-function-calling-video.py
@@ -71,7 +71,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,  # Make sure camera input is enabled
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14d-function-calling-video.py
+++ b/examples/foundational/14d-function-calling-video.py
@@ -69,7 +69,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,  # Make sure camera input is enabled
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -73,7 +73,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,  # Make sure camera input is enabled
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -70,7 +70,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,  # Make sure camera input is enabled
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 
@@ -59,7 +60,7 @@ async def get_image(function_name, tool_call_id, arguments, llm, context, result
     )
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     global webrtc_peer_id
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/14e-function-calling-gemini.py
+++ b/examples/foundational/14e-function-calling-gemini.py
@@ -71,7 +71,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,  # Make sure camera input is enabled
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14f-function-calling-groq.py
+++ b/examples/foundational/14f-function-calling-groq.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14f-function-calling-groq.py
+++ b/examples/foundational/14f-function-calling-groq.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14f-function-calling-groq.py
+++ b/examples/foundational/14f-function-calling-groq.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14g-function-calling-grok.py
+++ b/examples/foundational/14g-function-calling-grok.py
@@ -38,7 +38,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14g-function-calling-grok.py
+++ b/examples/foundational/14g-function-calling-grok.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -30,7 +31,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14g-function-calling-grok.py
+++ b/examples/foundational/14g-function-calling-grok.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14h-function-calling-azure.py
+++ b/examples/foundational/14h-function-calling-azure.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14h-function-calling-azure.py
+++ b/examples/foundational/14h-function-calling-azure.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14h-function-calling-azure.py
+++ b/examples/foundational/14h-function-calling-azure.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14i-function-calling-fireworks.py
+++ b/examples/foundational/14i-function-calling-fireworks.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14i-function-calling-fireworks.py
+++ b/examples/foundational/14i-function-calling-fireworks.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14i-function-calling-fireworks.py
+++ b/examples/foundational/14i-function-calling-fireworks.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14j-function-calling-nim.py
+++ b/examples/foundational/14j-function-calling-nim.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14j-function-calling-nim.py
+++ b/examples/foundational/14j-function-calling-nim.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14j-function-calling-nim.py
+++ b/examples/foundational/14j-function-calling-nim.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14l-function-calling-deepseek.py
+++ b/examples/foundational/14l-function-calling-deepseek.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14l-function-calling-deepseek.py
+++ b/examples/foundational/14l-function-calling-deepseek.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14l-function-calling-deepseek.py
+++ b/examples/foundational/14l-function-calling-deepseek.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14m-function-calling-openrouter.py
+++ b/examples/foundational/14m-function-calling-openrouter.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14m-function-calling-openrouter.py
+++ b/examples/foundational/14m-function-calling-openrouter.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14m-function-calling-openrouter.py
+++ b/examples/foundational/14m-function-calling-openrouter.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14n-function-calling-perplexity.py
+++ b/examples/foundational/14n-function-calling-perplexity.py
@@ -11,6 +11,7 @@ currently support function calling. The example shows basic chat completion func
 using Perplexity's API while maintaining compatibility with the OpenAI interface.
 """
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -31,7 +32,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14n-function-calling-perplexity.py
+++ b/examples/foundational/14n-function-calling-perplexity.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14n-function-calling-perplexity.py
+++ b/examples/foundational/14n-function-calling-perplexity.py
@@ -41,7 +41,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14o-function-calling-gemini-openai-format.py
+++ b/examples/foundational/14o-function-calling-gemini-openai-format.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14o-function-calling-gemini-openai-format.py
+++ b/examples/foundational/14o-function-calling-gemini-openai-format.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14o-function-calling-gemini-openai-format.py
+++ b/examples/foundational/14o-function-calling-gemini-openai-format.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14p-function-calling-gemini-vertex-ai.py
+++ b/examples/foundational/14p-function-calling-gemini-vertex-ai.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14p-function-calling-gemini-vertex-ai.py
+++ b/examples/foundational/14p-function-calling-gemini-vertex-ai.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14p-function-calling-gemini-vertex-ai.py
+++ b/examples/foundational/14p-function-calling-gemini-vertex-ai.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/14q-function-calling-qwen.py
+++ b/examples/foundational/14q-function-calling-qwen.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/14q-function-calling-qwen.py
+++ b/examples/foundational/14q-function-calling-qwen.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -32,7 +33,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/14q-function-calling-qwen.py
+++ b/examples/foundational/14q-function-calling-qwen.py
@@ -42,7 +42,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/15-switch-voices.py
+++ b/examples/foundational/15-switch-voices.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -52,7 +53,7 @@ async def barbershop_man_filter(frame) -> bool:
     return current_voice == "Barbershop Man"
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/15-switch-voices.py
+++ b/examples/foundational/15-switch-voices.py
@@ -62,7 +62,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/15-switch-voices.py
+++ b/examples/foundational/15-switch-voices.py
@@ -60,7 +60,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/15a-switch-languages.py
+++ b/examples/foundational/15a-switch-languages.py
@@ -55,7 +55,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/15a-switch-languages.py
+++ b/examples/foundational/15a-switch-languages.py
@@ -53,7 +53,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/15a-switch-languages.py
+++ b/examples/foundational/15a-switch-languages.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from deepgram import LiveOptions
@@ -45,7 +46,7 @@ async def spanish_filter(frame) -> bool:
     return current_language == "Spanish"
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/16-gpu-container-local-bot.py
+++ b/examples/foundational/16-gpu-container-local-bot.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/16-gpu-container-local-bot.py
+++ b/examples/foundational/16-gpu-container-local-bot.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/16-gpu-container-local-bot.py
+++ b/examples/foundational/16-gpu-container-local-bot.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -25,7 +26,7 @@ from pipecat.transports.services.daily import DailyTransportMessageFrame
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/17-detect-user-idle.py
+++ b/examples/foundational/17-detect-user-idle.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/17-detect-user-idle.py
+++ b/examples/foundational/17-detect-user-idle.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/17-detect-user-idle.py
+++ b/examples/foundational/17-detect-user-idle.py
@@ -36,7 +36,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/18-gstreamer-filesrc.py
+++ b/examples/foundational/18-gstreamer-filesrc.py
@@ -40,10 +40,10 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         webrtc_connection=webrtc_connection,
         params=TransportParams(
             audio_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 

--- a/examples/foundational/18-gstreamer-filesrc.py
+++ b/examples/foundational/18-gstreamer-filesrc.py
@@ -20,26 +20,13 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-# Parse command line arguments
-# This will be used to pass the input video file to the bot
-# You can run the bot with a command like:
-# python 18-gstreamer-filesrc.py -i path/to/video.mp4
-def parse_arguments():
-    parser = argparse.ArgumentParser(description="Daily AI SDK Bot Sample")
-    parser.add_argument("-i", "--input", type=str, required=True, help="Input video file")
-    return parser.parse_args()
-
-
-args = parse_arguments()
-
-
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, args: argparse.Namespace):
     logger.info(f"Starting bot with video input: {args.input}")
 
     transport = SmallWebRTCTransport(
         webrtc_connection=webrtc_connection,
         params=TransportParams(
-            audio_in_enabled=True,
+            audio_out_enabled=True,
             video_out_enabled=True,
             video_out_is_live=True,
             video_out_width=1280,
@@ -72,4 +59,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
 if __name__ == "__main__":
     from run import main
 
-    main()
+    parser = argparse.ArgumentParser(description="Pipecat Bot Runner")
+    parser.add_argument("-i", "--input", type=str, required=True, help="Input video file")
+
+    main(parser)

--- a/examples/foundational/18a-gstreamer-videotestsrc.py
+++ b/examples/foundational/18a-gstreamer-videotestsrc.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -19,7 +20,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot with video test source")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/18a-gstreamer-videotestsrc.py
+++ b/examples/foundational/18a-gstreamer-videotestsrc.py
@@ -26,10 +26,10 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         webrtc_connection=webrtc_connection,
         params=TransportParams(
             audio_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 

--- a/examples/foundational/19-openai-realtime-beta.py
+++ b/examples/foundational/19-openai-realtime-beta.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from datetime import datetime
 
@@ -65,7 +66,7 @@ weather_function = FunctionSchema(
 tools = ToolsSchema(standard_tools=[weather_function])
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/19-openai-realtime-beta.py
+++ b/examples/foundational/19-openai-realtime-beta.py
@@ -75,7 +75,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/19-openai-realtime-beta.py
+++ b/examples/foundational/19-openai-realtime-beta.py
@@ -73,7 +73,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/19a-azure-realtime-beta.py
+++ b/examples/foundational/19a-azure-realtime-beta.py
@@ -72,7 +72,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/19a-azure-realtime-beta.py
+++ b/examples/foundational/19a-azure-realtime-beta.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from datetime import datetime
 
@@ -64,7 +65,7 @@ weather_function = FunctionSchema(
 tools = ToolsSchema(standard_tools=[weather_function])
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/19a-azure-realtime-beta.py
+++ b/examples/foundational/19a-azure-realtime-beta.py
@@ -74,7 +74,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/20a-persistent-context-openai.py
+++ b/examples/foundational/20a-persistent-context-openai.py
@@ -172,7 +172,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/20a-persistent-context-openai.py
+++ b/examples/foundational/20a-persistent-context-openai.py
@@ -174,7 +174,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/20a-persistent-context-openai.py
+++ b/examples/foundational/20a-persistent-context-openai.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import glob
 import json
 import os
@@ -162,7 +163,7 @@ tools = [
 ]
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     global tts

--- a/examples/foundational/20b-persistent-context-openai-realtime.py
+++ b/examples/foundational/20b-persistent-context-openai-realtime.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import glob
 import json
@@ -164,7 +165,7 @@ tools = [
 ]
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/20b-persistent-context-openai-realtime.py
+++ b/examples/foundational/20b-persistent-context-openai-realtime.py
@@ -172,7 +172,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/20b-persistent-context-openai-realtime.py
+++ b/examples/foundational/20b-persistent-context-openai-realtime.py
@@ -174,7 +174,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/20c-persistent-context-anthropic.py
+++ b/examples/foundational/20c-persistent-context-anthropic.py
@@ -169,7 +169,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/20c-persistent-context-anthropic.py
+++ b/examples/foundational/20c-persistent-context-anthropic.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import glob
 import json
 import os
@@ -157,7 +158,7 @@ tools = [
 ]
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     global tts

--- a/examples/foundational/20c-persistent-context-anthropic.py
+++ b/examples/foundational/20c-persistent-context-anthropic.py
@@ -167,7 +167,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/20d-persistent-context-gemini.py
+++ b/examples/foundational/20d-persistent-context-gemini.py
@@ -235,7 +235,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_in_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/20d-persistent-context-gemini.py
+++ b/examples/foundational/20d-persistent-context-gemini.py
@@ -233,7 +233,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/20d-persistent-context-gemini.py
+++ b/examples/foundational/20d-persistent-context-gemini.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import glob
 import json
 import os
@@ -221,7 +222,7 @@ tools = [
 ]
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     global tts, webrtc_peer_id
     webrtc_peer_id = webrtc_connection.pc_id
 

--- a/examples/foundational/20d-persistent-context-gemini.py
+++ b/examples/foundational/20d-persistent-context-gemini.py
@@ -232,7 +232,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=True,
+            video_in_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.8)),
         ),
     )

--- a/examples/foundational/21-tavus-layer.py
+++ b/examples/foundational/21-tavus-layer.py
@@ -47,7 +47,7 @@ async def main():
             token=None,
             bot_name="Pipecat bot",
             params=DailyParams(
-                vad_enabled=True,
+                audio_in_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/foundational/21-tavus-layer.py
+++ b/examples/foundational/21-tavus-layer.py
@@ -49,7 +49,6 @@ async def main():
             params=DailyParams(
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
-                vad_audio_passthrough=True,
             ),
         )
 

--- a/examples/foundational/22-natural-conversation.py
+++ b/examples/foundational/22-natural-conversation.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -31,7 +32,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/22-natural-conversation.py
+++ b/examples/foundational/22-natural-conversation.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/22-natural-conversation.py
+++ b/examples/foundational/22-natural-conversation.py
@@ -41,7 +41,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 import time
@@ -200,7 +201,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -210,7 +210,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -208,7 +208,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -414,7 +414,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -412,7 +412,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 import time
@@ -404,7 +405,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -634,7 +634,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -636,7 +636,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 import time
@@ -626,7 +627,7 @@ class OutputGate(FrameProcessor):
                 break
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/23-bot-background-sound-daily.py
+++ b/examples/foundational/23-bot-background-sound-daily.py
@@ -49,10 +49,10 @@ async def main():
             token,
             "Respond bot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 audio_out_mixer=soundfile_mixer,
                 transcription_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/foundational/23-bot-background-sound-p2p.py
+++ b/examples/foundational/23-bot-background-sound-p2p.py
@@ -56,7 +56,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             audio_out_mixer=soundfile_mixer,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/23-bot-background-sound-p2p.py
+++ b/examples/foundational/23-bot-background-sound-p2p.py
@@ -14,6 +14,7 @@ Example:
     INPUT_AUDIO_PATH=my_audio.mp3 python 23-bot-background-sound.py
 """
 
+import argparse
 import asyncio
 import os
 
@@ -41,7 +42,7 @@ if not audio_path:
     raise ValueError("No INPUT_AUDIO_PATH specified in environment variables")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     soundfile_mixer = SoundfileMixer(

--- a/examples/foundational/23-bot-background-sound-p2p.py
+++ b/examples/foundational/23-bot-background-sound-p2p.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_mixer=soundfile_mixer,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/24-stt-mute-filter.py
+++ b/examples/foundational/24-stt-mute-filter.py
@@ -46,7 +46,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/24-stt-mute-filter.py
+++ b/examples/foundational/24-stt-mute-filter.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import asyncio
 import os
 
@@ -36,7 +37,7 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
     await result_callback({"conditions": "nice", "temperature": "75"})
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/24-stt-mute-filter.py
+++ b/examples/foundational/24-stt-mute-filter.py
@@ -44,7 +44,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/25-google-audio-in.py
+++ b/examples/foundational/25-google-audio-in.py
@@ -278,7 +278,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/25-google-audio-in.py
+++ b/examples/foundational/25-google-audio-in.py
@@ -276,7 +276,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/25-google-audio-in.py
+++ b/examples/foundational/25-google-audio-in.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from dataclasses import dataclass
 
@@ -268,7 +269,7 @@ class TranscriptionContextFixup(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -35,7 +35,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             camera_in_enabled=False,
             vad_enabled=True,
-            vad_audio_passthrough=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events.
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),

--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -24,7 +25,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Initialize the SmallWebRTCTransport with the connection

--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -34,7 +34,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_in_enabled=False,
-            vad_enabled=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events.
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),

--- a/examples/foundational/26-gemini-multimodal-live.py
+++ b/examples/foundational/26-gemini-multimodal-live.py
@@ -33,7 +33,7 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_in_enabled=False,
+            video_in_enabled=False,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events.
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),

--- a/examples/foundational/26a-gemini-multimodal-live-transcription.py
+++ b/examples/foundational/26a-gemini-multimodal-live-transcription.py
@@ -32,7 +32,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26a-gemini-multimodal-live-transcription.py
+++ b/examples/foundational/26a-gemini-multimodal-live-transcription.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -23,7 +24,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Initialize the SmallWebRTCTransport with the connection

--- a/examples/foundational/26a-gemini-multimodal-live-transcription.py
+++ b/examples/foundational/26a-gemini-multimodal-live-transcription.py
@@ -33,7 +33,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             vad_enabled=True,
-            vad_audio_passthrough=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26b-gemini-multimodal-live-function-calling.py
+++ b/examples/foundational/26b-gemini-multimodal-live-function-calling.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from datetime import datetime
 
@@ -46,7 +47,7 @@ for the weather, call this function.
 """
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Initialize the SmallWebRTCTransport with the connection

--- a/examples/foundational/26b-gemini-multimodal-live-function-calling.py
+++ b/examples/foundational/26b-gemini-multimodal-live-function-calling.py
@@ -56,7 +56,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             vad_enabled=True,
-            vad_audio_passthrough=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26b-gemini-multimodal-live-function-calling.py
+++ b/examples/foundational/26b-gemini-multimodal-live-function-calling.py
@@ -55,7 +55,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26c-gemini-multimodal-live-video.py
+++ b/examples/foundational/26c-gemini-multimodal-live-video.py
@@ -39,7 +39,6 @@ async def main():
             DailyParams(
                 audio_out_enabled=True,
                 vad_enabled=True,
-                vad_audio_passthrough=True,
                 # set stop_secs to something roughly similar to the internal setting
                 # of the Multimodal Live api, just to align events. This doesn't really
                 # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26c-gemini-multimodal-live-video.py
+++ b/examples/foundational/26c-gemini-multimodal-live-video.py
@@ -37,8 +37,8 @@ async def main():
             token,
             "Respond bot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_enabled=True,
                 # set stop_secs to something roughly similar to the internal setting
                 # of the Multimodal Live api, just to align events. This doesn't really
                 # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26d-gemini-multimodal-live-text.py
+++ b/examples/foundational/26d-gemini-multimodal-live-text.py
@@ -49,7 +49,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             vad_enabled=True,
-            vad_audio_passthrough=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26d-gemini-multimodal-live-text.py
+++ b/examples/foundational/26d-gemini-multimodal-live-text.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -39,7 +40,7 @@ Respond to what the user said in a creative and helpful way. Keep your responses
 """
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Initialize the SmallWebRTCTransport with the connection

--- a/examples/foundational/26d-gemini-multimodal-live-text.py
+++ b/examples/foundational/26d-gemini-multimodal-live-text.py
@@ -48,7 +48,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             # set stop_secs to something roughly similar to the internal setting
             # of the Multimodal Live api, just to align events. This doesn't really
             # matter because we can only use the Multimodal Live API's phrase

--- a/examples/foundational/26e-gemini-multimodal-google-search.py
+++ b/examples/foundational/26e-gemini-multimodal-google-search.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -40,7 +41,7 @@ Start each interaction by asking the user about which place they would like to k
 """
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # Initialize the SmallWebRTCTransport with the connection

--- a/examples/foundational/26e-gemini-multimodal-google-search.py
+++ b/examples/foundational/26e-gemini-multimodal-google-search.py
@@ -50,7 +50,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_in_enabled=True,
             audio_out_enabled=True,
             vad_enabled=True,
-            vad_audio_passthrough=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/26e-gemini-multimodal-google-search.py
+++ b/examples/foundational/26e-gemini-multimodal-google-search.py
@@ -49,7 +49,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_out_height=512,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -34,9 +34,9 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=True,
-            camera_out_width=512,
-            camera_out_height=512,
+            video_out_enabled=True,
+            video_out_width=512,
+            video_out_height=512,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -37,7 +37,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             camera_out_enabled=True,
             camera_out_width=512,
             camera_out_height=512,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/28-transcription-processor.py
+++ b/examples/foundational/28-transcription-processor.py
@@ -98,7 +98,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/28-transcription-processor.py
+++ b/examples/foundational/28-transcription-processor.py
@@ -96,7 +96,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/28-transcription-processor.py
+++ b/examples/foundational/28-transcription-processor.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 from typing import List, Optional
 
@@ -88,7 +89,7 @@ class TranscriptHandler:
             await self.save_message(msg)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/29-livekit-audio-chat.py
+++ b/examples/foundational/29-livekit-audio-chat.py
@@ -116,7 +116,6 @@ async def main():
                 audio_out_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 vad_enabled=True,
-                vad_audio_passthrough=True,
             ),
         )
 

--- a/examples/foundational/29-livekit-audio-chat.py
+++ b/examples/foundational/29-livekit-audio-chat.py
@@ -115,7 +115,6 @@ async def main():
                 audio_in_enabled=True,
                 audio_out_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
-                vad_enabled=True,
             ),
         )
 

--- a/examples/foundational/30-observer.py
+++ b/examples/foundational/30-observer.py
@@ -75,7 +75,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/30-observer.py
+++ b/examples/foundational/30-observer.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -67,7 +68,7 @@ class DebugObserver(BaseObserver):
             logger.info(f"🤖 BOT STOP SPEAKING: {src} {arrow} {dst} at {time_sec:.2f}s")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/30-observer.py
+++ b/examples/foundational/30-observer.py
@@ -77,7 +77,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/32-gemini-grounding-metadata.py
+++ b/examples/foundational/32-gemini-grounding-metadata.py
@@ -69,7 +69,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/32-gemini-grounding-metadata.py
+++ b/examples/foundational/32-gemini-grounding-metadata.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -59,7 +60,7 @@ class LLMSearchLoggerProcessor(FrameProcessor):
         await self.push_frame(frame)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/32-gemini-grounding-metadata.py
+++ b/examples/foundational/32-gemini-grounding-metadata.py
@@ -67,7 +67,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/33-gemini-rag.py
+++ b/examples/foundational/33-gemini-rag.py
@@ -162,7 +162,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/33-gemini-rag.py
+++ b/examples/foundational/33-gemini-rag.py
@@ -47,6 +47,7 @@ Customization options:
 - change the function calling logic
 """
 
+import argparse
 import json
 import os
 import time
@@ -152,7 +153,7 @@ async def query_knowledge_base(
     await result_callback(response.text)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/33-gemini-rag.py
+++ b/examples/foundational/33-gemini-rag.py
@@ -160,7 +160,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/34-audio-recording.py
+++ b/examples/foundational/34-audio-recording.py
@@ -93,7 +93,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/34-audio-recording.py
+++ b/examples/foundational/34-audio-recording.py
@@ -46,6 +46,7 @@ Note:
     handling merged and separate audio tracks respectively.
 """
 
+import argparse
 import datetime
 import io
 import os
@@ -85,7 +86,7 @@ async def save_audio_file(audio: bytes, filename: str, sample_rate: int, num_cha
         logger.info(f"Audio saved to {filename}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/34-audio-recording.py
+++ b/examples/foundational/34-audio-recording.py
@@ -95,7 +95,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/35-pattern-pair-voice-switching.py
+++ b/examples/foundational/35-pattern-pair-voice-switching.py
@@ -81,7 +81,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/35-pattern-pair-voice-switching.py
+++ b/examples/foundational/35-pattern-pair-voice-switching.py
@@ -83,7 +83,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/35-pattern-pair-voice-switching.py
+++ b/examples/foundational/35-pattern-pair-voice-switching.py
@@ -44,6 +44,7 @@ Note:
     such as formatting instructions, command recognition, or structured data extraction.
 """
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -73,7 +74,7 @@ VOICE_IDS = {
 }
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/36-user-email-gathering.py
+++ b/examples/foundational/36-user-email-gathering.py
@@ -38,7 +38,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/36-user-email-gathering.py
+++ b/examples/foundational/36-user-email-gathering.py
@@ -40,7 +40,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/36-user-email-gathering.py
+++ b/examples/foundational/36-user-email-gathering.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -30,7 +31,7 @@ async def store_user_emails(function_name, tool_call_id, args, llm, context, res
     print(f"User emails: {args}")
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     transport = SmallWebRTCTransport(

--- a/examples/foundational/37-mem0.py
+++ b/examples/foundational/37-mem0.py
@@ -134,7 +134,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/foundational/37-mem0.py
+++ b/examples/foundational/37-mem0.py
@@ -36,6 +36,7 @@ Requirements:
 The bot runs as part of a pipeline that processes audio frames and manages the conversation flow.
 """
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -112,7 +113,7 @@ async def get_initial_greeting(
         return "Hello! How can I help you today?"
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     """Main bot execution function.
 
     Sets up and runs the bot pipeline including:

--- a/examples/foundational/37-mem0.py
+++ b/examples/foundational/37-mem0.py
@@ -132,7 +132,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/foundational/38-smart-turn-fal.py
+++ b/examples/foundational/38-smart-turn-fal.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 import aiohttp
@@ -27,7 +28,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     async with aiohttp.ClientSession() as session:

--- a/examples/foundational/38-smart-turn-fal.py
+++ b/examples/foundational/38-smart-turn-fal.py
@@ -38,7 +38,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
                 audio_out_enabled=True,
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-                vad_audio_passthrough=True,
                 turn_analyzer=FalSmartTurnAnalyzer(
                     api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session
                 ),

--- a/examples/foundational/38-smart-turn-fal.py
+++ b/examples/foundational/38-smart-turn-fal.py
@@ -36,7 +36,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             params=TransportParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
                 turn_analyzer=FalSmartTurnAnalyzer(
                     api_key=os.getenv("FAL_SMART_TURN_API_KEY"), aiohttp_session=session

--- a/examples/foundational/38a-smart-turn-local-coreml.py
+++ b/examples/foundational/38a-smart-turn-local-coreml.py
@@ -52,7 +52,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
             turn_analyzer=LocalCoreMLSmartTurnAnalyzer(
                 smart_turn_model_path=smart_turn_model_path, params=SmartTurnParams()

--- a/examples/foundational/38a-smart-turn-local-coreml.py
+++ b/examples/foundational/38a-smart-turn-local-coreml.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -27,7 +28,7 @@ from pipecat.transports.network.webrtc_connection import SmallWebRTCConnection
 load_dotenv(override=True)
 
 
-async def run_bot(webrtc_connection: SmallWebRTCConnection):
+async def run_bot(webrtc_connection: SmallWebRTCConnection, _: argparse.Namespace):
     logger.info(f"Starting bot")
 
     # To use this locally, set the environment variable LOCAL_SMART_TURN_MODEL_PATH

--- a/examples/foundational/38a-smart-turn-local-coreml.py
+++ b/examples/foundational/38a-smart-turn-local-coreml.py
@@ -54,7 +54,6 @@ async def run_bot(webrtc_connection: SmallWebRTCConnection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            vad_audio_passthrough=True,
             turn_analyzer=LocalCoreMLSmartTurnAnalyzer(
                 smart_turn_model_path=smart_turn_model_path, params=SmartTurnParams()
             ),

--- a/examples/foundational/run.py
+++ b/examples/foundational/run.py
@@ -35,6 +35,9 @@ ice_servers = ["stun:stun.l.google.com:19302"]
 # Mount the frontend at /
 app.mount("/client", SmallWebRTCPrebuiltUI)
 
+# Store program arguments
+args: argparse.Namespace = argparse.Namespace()
+
 # Store the bot module and function info
 bot_module: Any = None
 run_bot_func: Optional[Callable] = None
@@ -116,7 +119,7 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
 
         # We've already checked that run_bot_func exists
         assert run_bot_func is not None
-        background_tasks.add_task(run_bot_func, pipecat_connection)
+        background_tasks.add_task(run_bot_func, pipecat_connection, args)
 
     answer = pipecat_connection.get_answer()
     # Updating the peer connection inside the map
@@ -142,8 +145,11 @@ async def run_standalone_bot() -> None:
         raise RuntimeError("No bot function available to run")
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Pipecat Bot Runner")
+def main(parser: Optional[argparse.ArgumentParser] = None):
+    global args
+
+    if not parser:
+        parser = argparse.ArgumentParser(description="Pipecat Bot Runner")
     parser.add_argument("bot_file", nargs="?", help="Path to the bot file", default=None)
     parser.add_argument(
         "--host", default="localhost", help="Host for HTTP server (default: localhost)"

--- a/examples/instant-voice/server/src/single_bot.py
+++ b/examples/instant-voice/server/src/single_bot.py
@@ -58,8 +58,8 @@ async def main():
         token,
         "Instant voice Chatbot",
         DailyParams(
+            audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/instant-voice/server/src/single_bot.py
+++ b/examples/instant-voice/server/src/single_bot.py
@@ -61,7 +61,6 @@ async def main():
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/moondream-chatbot/bot.py
+++ b/examples/moondream-chatbot/bot.py
@@ -143,9 +143,9 @@ async def main():
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=576,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=576,
                 transcription_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),

--- a/examples/moondream-chatbot/bot.py
+++ b/examples/moondream-chatbot/bot.py
@@ -141,12 +141,12 @@ async def main():
             token,
             "Chatbot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 camera_out_enabled=True,
                 camera_out_width=1024,
                 camera_out_height=576,
                 transcription_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/news-chatbot/server/news_bot.py
+++ b/examples/news-chatbot/server/news_bot.py
@@ -86,8 +86,8 @@ async def main():
             token,
             "Latest news!",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/news-chatbot/server/news_bot.py
+++ b/examples/news-chatbot/server/news_bot.py
@@ -89,7 +89,6 @@ async def main():
                 audio_out_enabled=True,
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
-                vad_audio_passthrough=True,
             ),
         )
 

--- a/examples/p2p-webrtc/daily-interop-bridge/bot.py
+++ b/examples/p2p-webrtc/daily-interop-bridge/bot.py
@@ -51,13 +51,13 @@ async def run_bot(webrtc_connection):
     pipecat_transport = SmallWebRTCTransport(
         webrtc_connection=webrtc_connection,
         params=TransportParams(
-            camera_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_in_enabled=True,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 
@@ -67,13 +67,13 @@ async def run_bot(webrtc_connection):
         None,
         "SmallWebRTC",
         params=DailyParams(
-            camera_in_enabled=True,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_width=1280,
-            camera_out_height=720,
+            video_in_enabled=True,
+            video_out_enabled=True,
+            video_out_is_live=True,
+            video_out_width=1280,
+            video_out_height=720,
         ),
     )
 

--- a/examples/p2p-webrtc/daily-interop-bridge/bot.py
+++ b/examples/p2p-webrtc/daily-interop-bridge/bot.py
@@ -58,7 +58,6 @@ async def run_bot(webrtc_connection):
             audio_out_enabled=True,
             camera_out_width=1280,
             camera_out_height=720,
-            vad_enabled=False,
         ),
     )
 
@@ -75,7 +74,6 @@ async def run_bot(webrtc_connection):
             audio_out_enabled=True,
             camera_out_width=1280,
             camera_out_height=720,
-            vad_enabled=False,
         ),
     )
 

--- a/examples/p2p-webrtc/video-transform/server/bot.py
+++ b/examples/p2p-webrtc/video-transform/server/bot.py
@@ -78,7 +78,6 @@ async def run_bot(webrtc_connection):
         audio_out_enabled=True,
         vad_enabled=True,
         vad_analyzer=SileroVADAnalyzer(),
-        vad_audio_passthrough=True,
         audio_out_10ms_chunks=2,
     )
 

--- a/examples/p2p-webrtc/video-transform/server/bot.py
+++ b/examples/p2p-webrtc/video-transform/server/bot.py
@@ -76,7 +76,6 @@ async def run_bot(webrtc_connection):
         camera_out_is_live=True,
         audio_in_enabled=True,
         audio_out_enabled=True,
-        vad_enabled=True,
         vad_analyzer=SileroVADAnalyzer(),
         audio_out_10ms_chunks=2,
     )

--- a/examples/p2p-webrtc/video-transform/server/bot.py
+++ b/examples/p2p-webrtc/video-transform/server/bot.py
@@ -27,10 +27,10 @@ load_dotenv(override=True)
 
 
 class EdgeDetectionProcessor(FrameProcessor):
-    def __init__(self, camera_out_width, camera_out_height: int):
+    def __init__(self, video_out_width, video_out_height: int):
         super().__init__()
-        self._camera_out_width = camera_out_width
-        self._camera_out_height = camera_out_height
+        self._video_out_width = video_out_width
+        self._video_out_height = video_out_height
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
@@ -45,7 +45,7 @@ class EdgeDetectionProcessor(FrameProcessor):
             img = cv2.cvtColor(cv2.Canny(img, 100, 200), cv2.COLOR_GRAY2BGR)
 
             # convert the size if needed
-            desired_size = (self._camera_out_width, self._camera_out_height)
+            desired_size = (self._video_out_width, self._video_out_height)
             if frame.size != desired_size:
                 resized_image = cv2.resize(img, desired_size)
                 frame = OutputImageRawFrame(resized_image.tobytes(), desired_size, frame.format)
@@ -71,13 +71,13 @@ Respond to what the user said in a creative and helpful way. Keep your responses
 
 async def run_bot(webrtc_connection):
     transport_params = TransportParams(
-        camera_in_enabled=True,
-        camera_out_enabled=True,
-        camera_out_is_live=True,
         audio_in_enabled=True,
         audio_out_enabled=True,
-        vad_analyzer=SileroVADAnalyzer(),
         audio_out_10ms_chunks=2,
+        video_in_enabled=True,
+        video_out_enabled=True,
+        video_out_is_live=True,
+        vad_analyzer=SileroVADAnalyzer(),
     )
 
     pipecat_transport = SmallWebRTCTransport(
@@ -111,7 +111,7 @@ async def run_bot(webrtc_connection):
             rtvi,
             llm,  # LLM
             EdgeDetectionProcessor(
-                transport_params.camera_out_width, transport_params.camera_out_height
+                transport_params.video_out_width, transport_params.video_out_height
             ),  # Sending the video back to the user
             pipecat_transport.output(),
             context_aggregator.assistant(),

--- a/examples/p2p-webrtc/voice-agent/bot.py
+++ b/examples/p2p-webrtc/voice-agent/bot.py
@@ -37,7 +37,6 @@ async def run_bot(webrtc_connection):
         params=TransportParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             audio_out_10ms_chunks=2,
         ),

--- a/examples/p2p-webrtc/voice-agent/bot.py
+++ b/examples/p2p-webrtc/voice-agent/bot.py
@@ -39,7 +39,6 @@ async def run_bot(webrtc_connection):
             audio_out_enabled=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
             audio_out_10ms_chunks=2,
         ),
     )

--- a/examples/patient-intake/bot.py
+++ b/examples/patient-intake/bot.py
@@ -299,8 +299,8 @@ async def main():
             token,
             "Chatbot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/phone-chatbot/bot_twilio.py
+++ b/examples/phone-chatbot/bot_twilio.py
@@ -49,7 +49,6 @@ async def main(room_url: str, token: str, callId: str, sipUri: str):
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         ),

--- a/examples/phone-chatbot/bot_twilio.py
+++ b/examples/phone-chatbot/bot_twilio.py
@@ -48,7 +48,7 @@ async def main(room_url: str, token: str, callId: str, sipUri: str):
             dialin_settings=None,  # Not required for Twilio
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         ),

--- a/examples/phone-chatbot/call_transfer.py
+++ b/examples/phone-chatbot/call_transfer.py
@@ -138,7 +138,7 @@ async def main(
             api_key=daily_api_key,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )
@@ -152,7 +152,7 @@ async def main(
             dialin_settings=daily_dialin_settings,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )

--- a/examples/phone-chatbot/call_transfer.py
+++ b/examples/phone-chatbot/call_transfer.py
@@ -139,7 +139,6 @@ async def main(
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )
@@ -154,7 +153,6 @@ async def main(
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )

--- a/examples/phone-chatbot/simple_dialin.py
+++ b/examples/phone-chatbot/simple_dialin.py
@@ -65,7 +65,6 @@ async def main(
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )
@@ -80,7 +79,6 @@ async def main(
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )

--- a/examples/phone-chatbot/simple_dialin.py
+++ b/examples/phone-chatbot/simple_dialin.py
@@ -64,7 +64,7 @@ async def main(
             api_key=daily_api_key,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )
@@ -78,7 +78,7 @@ async def main(
             dialin_settings=daily_dialin_settings,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
             transcription_enabled=True,
         )

--- a/examples/phone-chatbot/simple_dialout.py
+++ b/examples/phone-chatbot/simple_dialout.py
@@ -57,7 +57,6 @@ async def main(
         audio_in_enabled=True,
         audio_out_enabled=True,
         camera_out_enabled=False,
-        vad_enabled=True,
         vad_analyzer=SileroVADAnalyzer(),
         transcription_enabled=True,
     )

--- a/examples/phone-chatbot/simple_dialout.py
+++ b/examples/phone-chatbot/simple_dialout.py
@@ -56,7 +56,7 @@ async def main(
         api_key=daily_api_key,
         audio_in_enabled=True,
         audio_out_enabled=True,
-        camera_out_enabled=False,
+        video_out_enabled=False,
         vad_analyzer=SileroVADAnalyzer(),
         transcription_enabled=True,
     )

--- a/examples/phone-chatbot/voicemail_detection.py
+++ b/examples/phone-chatbot/voicemail_detection.py
@@ -165,7 +165,7 @@ async def main(
             api_key=daily_api_key,
             audio_in_enabled=True,
             audio_out_enabled=True,
-            camera_out_enabled=False,
+            video_out_enabled=False,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/phone-chatbot/voicemail_detection.py
+++ b/examples/phone-chatbot/voicemail_detection.py
@@ -168,7 +168,6 @@ async def main(
             camera_out_enabled=False,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,  # Important for audio collection
         ),
     )
 
@@ -244,7 +243,7 @@ async def main(
         If it sounds like a human (saying hello, asking questions, etc.), call the function switch_to_human_conversation.
 
         DO NOT say anything until you've determined if this is a voicemail or human.
-        
+
         If you are asked to terminate the call, **IMMEDIATELY** call the `terminate_call` function. **FAILURE TO CALL `terminate_call` IMMEDIATELY IS A MISTAKE.**"""
 
     # Initialize voicemail detection LLM

--- a/examples/phone-chatbot/voicemail_detection.py
+++ b/examples/phone-chatbot/voicemail_detection.py
@@ -166,7 +166,6 @@ async def main(
             audio_in_enabled=True,
             audio_out_enabled=True,
             camera_out_enabled=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
         ),
     )

--- a/examples/sentry-metrics/bot.py
+++ b/examples/sentry-metrics/bot.py
@@ -43,7 +43,6 @@ async def main():
                 audio_in_enabled=True,
                 camera_out_enabled=False,
                 vad_enabled=True,
-                vad_audio_passthrough=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
             ),

--- a/examples/sentry-metrics/bot.py
+++ b/examples/sentry-metrics/bot.py
@@ -41,7 +41,7 @@ async def main():
             DailyParams(
                 audio_out_enabled=True,
                 audio_in_enabled=True,
-                camera_out_enabled=False,
+                video_out_enabled=False,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
             ),

--- a/examples/sentry-metrics/bot.py
+++ b/examples/sentry-metrics/bot.py
@@ -42,7 +42,6 @@ async def main():
                 audio_out_enabled=True,
                 audio_in_enabled=True,
                 camera_out_enabled=False,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
             ),

--- a/examples/simple-chatbot/server/bot-gemini.py
+++ b/examples/simple-chatbot/server/bot-gemini.py
@@ -126,7 +126,6 @@ async def main():
                 camera_out_width=1024,
                 camera_out_height=576,
                 vad_enabled=True,
-                vad_audio_passthrough=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),
             ),
         )

--- a/examples/simple-chatbot/server/bot-gemini.py
+++ b/examples/simple-chatbot/server/bot-gemini.py
@@ -123,9 +123,9 @@ async def main():
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=576,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=576,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),
             ),
         )

--- a/examples/simple-chatbot/server/bot-gemini.py
+++ b/examples/simple-chatbot/server/bot-gemini.py
@@ -121,11 +121,11 @@ async def main():
             token,
             "Chatbot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 camera_out_enabled=True,
                 camera_out_width=1024,
                 camera_out_height=576,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.5)),
             ),
         )

--- a/examples/simple-chatbot/server/bot-openai.py
+++ b/examples/simple-chatbot/server/bot-openai.py
@@ -124,9 +124,9 @@ async def main():
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=576,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=576,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/simple-chatbot/server/bot-openai.py
+++ b/examples/simple-chatbot/server/bot-openai.py
@@ -122,11 +122,11 @@ async def main():
             token,
             "Chatbot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 camera_out_enabled=True,
                 camera_out_width=1024,
                 camera_out_height=576,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
                 transcription_enabled=True,
                 #

--- a/examples/storytelling-chatbot/src/bot.py
+++ b/examples/storytelling-chatbot/src/bot.py
@@ -49,13 +49,13 @@ async def main(room_url, token=None):
             token,
             "Storytelling Bot",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 camera_out_enabled=True,
                 camera_out_width=1024,
                 camera_out_height=1024,
                 transcription_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
-                vad_enabled=True,
             ),
         )
 

--- a/examples/storytelling-chatbot/src/bot.py
+++ b/examples/storytelling-chatbot/src/bot.py
@@ -51,9 +51,9 @@ async def main(room_url, token=None):
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                camera_out_enabled=True,
-                camera_out_width=1024,
-                camera_out_height=1024,
+                video_out_enabled=True,
+                video_out_width=1024,
+                video_out_height=1024,
                 transcription_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),

--- a/examples/studypal/studypal.py
+++ b/examples/studypal/studypal.py
@@ -112,9 +112,9 @@ async def main():
             token,
             "studypal",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
                 transcription_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/telnyx-chatbot/bot.py
+++ b/examples/telnyx-chatbot/bot.py
@@ -52,7 +52,6 @@ async def run_bot(
             add_wav_header=False,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
             serializer=serializer,
         ),
     )

--- a/examples/telnyx-chatbot/bot.py
+++ b/examples/telnyx-chatbot/bot.py
@@ -48,9 +48,9 @@ async def run_bot(
     transport = FastAPIWebsocketTransport(
         websocket=websocket_client,
         params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
             audio_out_enabled=True,
             add_wav_header=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             serializer=serializer,
         ),

--- a/examples/translation-chatbot/bot.py
+++ b/examples/translation-chatbot/bot.py
@@ -135,7 +135,6 @@ async def main():
                 audio_out_enabled=True,
                 vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
-                vad_audio_passthrough=True,
             ),
         )
 

--- a/examples/translation-chatbot/bot.py
+++ b/examples/translation-chatbot/bot.py
@@ -132,8 +132,8 @@ async def main():
             token,
             "Translator",
             DailyParams(
+                audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),
             ),
         )

--- a/examples/twilio-chatbot/bot.py
+++ b/examples/twilio-chatbot/bot.py
@@ -70,7 +70,6 @@ async def run_bot(websocket_client: WebSocket, stream_sid: str, call_sid: str, t
             add_wav_header=False,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
             serializer=serializer,
         ),
     )

--- a/examples/twilio-chatbot/bot.py
+++ b/examples/twilio-chatbot/bot.py
@@ -68,7 +68,6 @@ async def run_bot(websocket_client: WebSocket, stream_sid: str, call_sid: str, t
             audio_in_enabled=True,
             audio_out_enabled=True,
             add_wav_header=False,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             serializer=serializer,
         ),

--- a/examples/twilio-chatbot/client.py
+++ b/examples/twilio-chatbot/client.py
@@ -92,7 +92,6 @@ async def run_client(client_name: str, server_url: str, duration_secs: int):
             audio_out_enabled=True,
             add_wav_header=False,
             serializer=TwilioFrameSerializer(stream_sid),
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=1.5)),
         ),
     )

--- a/examples/twilio-chatbot/client.py
+++ b/examples/twilio-chatbot/client.py
@@ -94,7 +94,6 @@ async def run_client(client_name: str, server_url: str, duration_secs: int):
             serializer=TwilioFrameSerializer(stream_sid),
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=1.5)),
-            vad_audio_passthrough=True,
         ),
     )
 

--- a/examples/websocket-server/bot.py
+++ b/examples/websocket-server/bot.py
@@ -82,9 +82,9 @@ async def main():
     transport = WebsocketServerTransport(
         params=WebsocketServerParams(
             serializer=ProtobufFrameSerializer(),
+            audio_in_enabled=True,
             audio_out_enabled=True,
             add_wav_header=True,
-            vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
             session_timeout=60 * 3,  # 3 minutes
         )

--- a/examples/websocket-server/bot.py
+++ b/examples/websocket-server/bot.py
@@ -86,7 +86,6 @@ async def main():
             add_wav_header=True,
             vad_enabled=True,
             vad_analyzer=SileroVADAnalyzer(),
-            vad_audio_passthrough=True,
             session_timeout=60 * 3,  # 3 minutes
         )
     )

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -30,7 +30,7 @@ class STTService(AIService):
 
     def __init__(
         self,
-        audio_passthrough=False,
+        audio_passthrough=True,
         # STT input sample rate
         sample_rate: Optional[int] = None,
         **kwargs,

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -77,6 +77,24 @@ class BaseInputTransport(FrameProcessor):
                 )
             self._params.audio_in_passthrough = True
 
+        if self._params.camera_in_enabled or self._params.camera_out_enabled:
+            import warnings
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "Parameters 'camera_*' are deprecated, use 'video_*' instead.",
+                    DeprecationWarning,
+                )
+            self._params.video_in_enabled = self._params.camera_in_enabled
+            self._params.video_out_enabled = self._params.camera_out_enabled
+            self._params.video_out_is_live = self._params.camera_out_is_live
+            self._params.video_out_width = self._params.camera_out_width
+            self._params.video_out_height = self._params.camera_out_height
+            self._params.video_out_bitrate = self._params.camera_out_bitrate
+            self._params.video_out_framerate = self._params.camera_out_framerate
+            self._params.video_out_color_format = self._params.camera_out_color_format
+
     def enable_audio_in_stream_on_start(self, enabled: bool) -> None:
         logger.debug(f"Enabling audio on start. {enabled}")
         self._params.audio_in_stream_on_start = enabled

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -53,11 +53,10 @@ class BaseOutputTransport(FrameProcessor):
         self._sink_clock_task = None
 
         # Task to write/send audio and image frames.
-        self._camera_out_task = None
+        self._video_out_task = None
 
-        # These are the images that we should send to the camera at our desired
-        # framerate.
-        self._camera_images = None
+        # These are the images that we should send at our desired framerate.
+        self._video_images = None
 
         # Output sample rate. It will be initialized on StartFrame.
         self._sample_rate = 0
@@ -88,7 +87,7 @@ class BaseOutputTransport(FrameProcessor):
         # Start audio mixer.
         if self._params.audio_out_mixer:
             await self._params.audio_out_mixer.start(self._sample_rate)
-        self._create_camera_task()
+        self._create_video_task()
         self._create_sink_tasks()
 
     async def stop(self, frame: EndFrame):
@@ -98,26 +97,26 @@ class BaseOutputTransport(FrameProcessor):
 
         # At this point we have enqueued an EndFrame and we need to wait for
         # that EndFrame to be processed by the sink tasks. We also need to wait
-        # for these tasks before cancelling the camera and audio tasks below
+        # for these tasks before cancelling the video and audio tasks below
         # because they might be still rendering.
         if self._sink_task:
             await self.wait_for_task(self._sink_task)
         if self._sink_clock_task:
             await self.wait_for_task(self._sink_clock_task)
 
-        # We can now cancel the camera task.
-        await self._cancel_camera_task()
+        # We can now cancel the video task.
+        await self._cancel_video_task()
 
     async def cancel(self, frame: CancelFrame):
         # Since we are cancelling everything it doesn't matter if we cancel sink
         # tasks first or not.
         await self._cancel_sink_tasks()
-        await self._cancel_camera_task()
+        await self._cancel_video_task()
 
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):
         pass
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
         pass
 
     async def write_raw_audio_frames(self, frames: bytes):
@@ -181,11 +180,11 @@ class BaseOutputTransport(FrameProcessor):
             return
 
         if isinstance(frame, StartInterruptionFrame):
-            # Cancel sink and camera tasks.
+            # Cancel sink and video tasks.
             await self._cancel_sink_tasks()
-            await self._cancel_camera_task()
-            # Create sink and camera tasks.
-            self._create_camera_task()
+            await self._cancel_video_task()
+            # Create sink and video tasks.
+            self._create_video_task()
             self._create_sink_tasks()
             # Let's send a bot stopped speaking if we have to.
             await self._bot_stopped_speaking()
@@ -216,7 +215,7 @@ class BaseOutputTransport(FrameProcessor):
             return
 
         if self._params.video_out_is_live:
-            await self._camera_out_queue.put(frame)
+            await self._video_out_queue.put(frame)
         else:
             await self._sink_queue.put(frame)
 
@@ -261,9 +260,9 @@ class BaseOutputTransport(FrameProcessor):
 
     async def _sink_frame_handler(self, frame: Frame):
         if isinstance(frame, OutputImageRawFrame):
-            await self._set_camera_image(frame)
+            await self._set_video_image(frame)
         elif isinstance(frame, SpriteFrame):
-            await self._set_camera_images(frame.images)
+            await self._set_video_images(frame.images)
         elif isinstance(frame, TransportMessageFrame):
             await self.send_message(frame)
 
@@ -368,20 +367,20 @@ class BaseOutputTransport(FrameProcessor):
                 await self.write_raw_audio_frames(frame.audio)
 
     #
-    # Camera task
+    # Video task
     #
 
-    def _create_camera_task(self):
-        # Create camera output queue and task if needed.
-        if not self._camera_out_task and self._params.video_out_enabled:
-            self._camera_out_queue = asyncio.Queue()
-            self._camera_out_task = self.create_task(self._camera_out_task_handler())
+    def _create_video_task(self):
+        # Create video output queue and task if needed.
+        if not self._video_out_task and self._params.video_out_enabled:
+            self._video_out_queue = asyncio.Queue()
+            self._video_out_task = self.create_task(self._video_out_task_handler())
 
-    async def _cancel_camera_task(self):
-        # Stop camera output task.
-        if self._camera_out_task and self._params.video_out_enabled:
-            await self.cancel_task(self._camera_out_task)
-            self._camera_out_task = None
+    async def _cancel_video_task(self):
+        # Stop video output task.
+        if self._video_out_task and self._params.video_out_enabled:
+            await self.cancel_task(self._video_out_task)
+            self._video_out_task = None
 
     async def _draw_image(self, frame: OutputImageRawFrame):
         desired_size = (self._params.video_out_width, self._params.video_out_height)
@@ -397,50 +396,50 @@ class BaseOutputTransport(FrameProcessor):
                 resized_image.tobytes(), resized_image.size, resized_image.format
             )
 
-        await self.write_frame_to_camera(frame)
+        await self.write_raw_video_frame(frame)
 
-    async def _set_camera_image(self, image: OutputImageRawFrame):
-        self._camera_images = itertools.cycle([image])
+    async def _set_video_image(self, image: OutputImageRawFrame):
+        self._video_images = itertools.cycle([image])
 
-    async def _set_camera_images(self, images: List[OutputImageRawFrame]):
-        self._camera_images = itertools.cycle(images)
+    async def _set_video_images(self, images: List[OutputImageRawFrame]):
+        self._video_images = itertools.cycle(images)
 
-    async def _camera_out_task_handler(self):
-        self._camera_out_start_time = None
-        self._camera_out_frame_index = 0
-        self._camera_out_frame_duration = 1 / self._params.video_out_framerate
-        self._camera_out_frame_reset = self._camera_out_frame_duration * 5
+    async def _video_out_task_handler(self):
+        self._video_out_start_time = None
+        self._video_out_frame_index = 0
+        self._video_out_frame_duration = 1 / self._params.video_out_framerate
+        self._video_out_frame_reset = self._video_out_frame_duration * 5
         while True:
             if self._params.video_out_is_live:
-                await self._camera_out_is_live_handler()
-            elif self._camera_images:
-                image = next(self._camera_images)
+                await self._video_out_is_live_handler()
+            elif self._video_images:
+                image = next(self._video_images)
                 await self._draw_image(image)
-                await asyncio.sleep(self._camera_out_frame_duration)
+                await asyncio.sleep(self._video_out_frame_duration)
             else:
-                await asyncio.sleep(self._camera_out_frame_duration)
+                await asyncio.sleep(self._video_out_frame_duration)
 
-    async def _camera_out_is_live_handler(self):
-        image = await self._camera_out_queue.get()
+    async def _video_out_is_live_handler(self):
+        image = await self._video_out_queue.get()
 
         # We get the start time as soon as we get the first image.
-        if not self._camera_out_start_time:
-            self._camera_out_start_time = time.time()
-            self._camera_out_frame_index = 0
+        if not self._video_out_start_time:
+            self._video_out_start_time = time.time()
+            self._video_out_frame_index = 0
 
         # Calculate how much time we need to wait before rendering next image.
-        real_elapsed_time = time.time() - self._camera_out_start_time
-        real_render_time = self._camera_out_frame_index * self._camera_out_frame_duration
-        delay_time = self._camera_out_frame_duration + real_render_time - real_elapsed_time
+        real_elapsed_time = time.time() - self._video_out_start_time
+        real_render_time = self._video_out_frame_index * self._video_out_frame_duration
+        delay_time = self._video_out_frame_duration + real_render_time - real_elapsed_time
 
-        if abs(delay_time) > self._camera_out_frame_reset:
-            self._camera_out_start_time = time.time()
-            self._camera_out_frame_index = 0
+        if abs(delay_time) > self._video_out_frame_reset:
+            self._video_out_start_time = time.time()
+            self._video_out_frame_index = 0
         elif delay_time > 0:
             await asyncio.sleep(delay_time)
-            self._camera_out_frame_index += 1
+            self._video_out_frame_index += 1
 
         # Render image
         await self._draw_image(image)
 
-        self._camera_out_queue.task_done()
+        self._video_out_queue.task_done()

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -212,10 +212,10 @@ class BaseOutputTransport(FrameProcessor):
             self._audio_buffer = self._audio_buffer[self._audio_chunk_size :]
 
     async def _handle_image(self, frame: OutputImageRawFrame | SpriteFrame):
-        if not self._params.camera_out_enabled:
+        if not self._params.video_out_enabled:
             return
 
-        if self._params.camera_out_is_live:
+        if self._params.video_out_is_live:
             await self._camera_out_queue.put(frame)
         else:
             await self._sink_queue.put(frame)
@@ -373,18 +373,18 @@ class BaseOutputTransport(FrameProcessor):
 
     def _create_camera_task(self):
         # Create camera output queue and task if needed.
-        if not self._camera_out_task and self._params.camera_out_enabled:
+        if not self._camera_out_task and self._params.video_out_enabled:
             self._camera_out_queue = asyncio.Queue()
             self._camera_out_task = self.create_task(self._camera_out_task_handler())
 
     async def _cancel_camera_task(self):
         # Stop camera output task.
-        if self._camera_out_task and self._params.camera_out_enabled:
+        if self._camera_out_task and self._params.video_out_enabled:
             await self.cancel_task(self._camera_out_task)
             self._camera_out_task = None
 
     async def _draw_image(self, frame: OutputImageRawFrame):
-        desired_size = (self._params.camera_out_width, self._params.camera_out_height)
+        desired_size = (self._params.video_out_width, self._params.video_out_height)
 
         # TODO: we should refactor in the future to support dynamic resolutions
         # which is kind of what happens in P2P connections.
@@ -408,10 +408,10 @@ class BaseOutputTransport(FrameProcessor):
     async def _camera_out_task_handler(self):
         self._camera_out_start_time = None
         self._camera_out_frame_index = 0
-        self._camera_out_frame_duration = 1 / self._params.camera_out_framerate
+        self._camera_out_frame_duration = 1 / self._params.video_out_framerate
         self._camera_out_frame_reset = self._camera_out_frame_duration * 5
         while True:
-            if self._params.camera_out_is_live:
+            if self._params.video_out_is_live:
                 await self._camera_out_is_live_handler()
             elif self._camera_images:
                 image = next(self._camera_images)

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -39,6 +39,7 @@ class TransportParams(BaseModel):
     audio_in_channels: int = 1
     audio_in_filter: Optional[BaseAudioFilter] = None
     audio_in_stream_on_start: bool = True
+    audio_in_passthrough: bool = True
     vad_enabled: bool = False
     vad_audio_passthrough: bool = False
     vad_analyzer: Optional[VADAnalyzer] = None

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -40,6 +40,14 @@ class TransportParams(BaseModel):
     audio_in_filter: Optional[BaseAudioFilter] = None
     audio_in_stream_on_start: bool = True
     audio_in_passthrough: bool = True
+    video_in_enabled: bool = False
+    video_out_enabled: bool = False
+    video_out_is_live: bool = False
+    video_out_width: int = 1024
+    video_out_height: int = 768
+    video_out_bitrate: int = 800000
+    video_out_framerate: int = 30
+    video_out_color_format: str = "RGB"
     vad_enabled: bool = False
     vad_audio_passthrough: bool = False
     vad_analyzer: Optional[VADAnalyzer] = None

--- a/src/pipecat/transports/local/tk.py
+++ b/src/pipecat/transports/local/tk.py
@@ -137,7 +137,7 @@ class TkOutputTransport(BaseOutputTransport):
                 self._executor, self._out_stream.write, frames
             )
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
         self.get_event_loop().call_soon(self._write_frame_to_tk, frame)
 
     def _write_frame_to_tk(self, frame: OutputImageRawFrame):

--- a/src/pipecat/transports/network/small_webrtc.py
+++ b/src/pipecat/transports/network/small_webrtc.py
@@ -328,9 +328,9 @@ class SmallWebRTCClient:
             self._audio_output_track = RawAudioTrack(sample_rate=self._out_sample_rate)
             self._webrtc_connection.replace_audio_track(self._audio_output_track)
 
-        if self._params.camera_out_enabled:
+        if self._params.video_out_enabled:
             self._video_output_track = RawVideoTrack(
-                width=self._params.camera_out_width, height=self._params.camera_out_height
+                width=self._params.video_out_width, height=self._params.video_out_height
             )
             self._webrtc_connection.replace_video_track(self._video_output_track)
 
@@ -391,7 +391,7 @@ class SmallWebRTCInputTransport(BaseInputTransport):
         await self._client.connect()
         if not self._receive_audio_task and self._params.audio_in_enabled:
             self._receive_audio_task = self.create_task(self._receive_audio())
-        if not self._receive_video_task and self._params.camera_in_enabled:
+        if not self._receive_video_task and self._params.video_in_enabled:
             self._receive_video_task = self.create_task(self._receive_video())
 
     async def _stop_tasks(self):
@@ -465,7 +465,7 @@ class SmallWebRTCInputTransport(BaseInputTransport):
         self._image_requests[request_id] = frame
 
         # If we're not already receiving video, try to get a frame now
-        if not self._receive_video_task and self._params.camera_in_enabled:
+        if not self._receive_video_task and self._params.video_in_enabled:
             # Start video reception if it's not already running
             self._receive_video_task = self.create_task(self._receive_video())
 

--- a/src/pipecat/transports/network/small_webrtc.py
+++ b/src/pipecat/transports/network/small_webrtc.py
@@ -389,9 +389,7 @@ class SmallWebRTCInputTransport(BaseInputTransport):
         await super().start(frame)
         await self._client.setup(self._params, frame)
         await self._client.connect()
-        if not self._receive_audio_task and (
-            self._params.audio_in_enabled or self._params.vad_enabled
-        ):
+        if not self._receive_audio_task and self._params.audio_in_enabled:
             self._receive_audio_task = self.create_task(self._receive_audio())
         if not self._receive_video_task and self._params.camera_in_enabled:
             self._receive_video_task = self.create_task(self._receive_video())

--- a/src/pipecat/transports/network/small_webrtc.py
+++ b/src/pipecat/transports/network/small_webrtc.py
@@ -288,7 +288,7 @@ class SmallWebRTCClient:
         if self._can_send() and self._audio_output_track:
             await self._audio_output_track.add_audio_bytes(data)
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
         if self._can_send() and self._video_output_track:
             self._video_output_track.add_video_frame(frame)
 
@@ -500,8 +500,8 @@ class SmallWebRTCOutputTransport(BaseOutputTransport):
     async def write_raw_audio_frames(self, frames: bytes):
         await self._client.write_raw_audio_frames(frames)
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
-        await self._client.write_frame_to_camera(frame)
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
+        await self._client.write_raw_video_frame(frame)
 
 
 class SmallWebRTCTransport(BaseTransport):

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -373,7 +373,7 @@ class DailyTransportClient(EventHandler):
         self._mic.write_frames(frames, completion=completion_callback(future))
         await future
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
         if not self._camera:
             return None
 
@@ -1035,8 +1035,8 @@ class DailyOutputTransport(BaseOutputTransport):
     async def write_raw_audio_frames(self, frames: bytes):
         await self._client.write_raw_audio_frames(frames)
 
-    async def write_frame_to_camera(self, frame: OutputImageRawFrame):
-        await self._client.write_frame_to_camera(frame)
+    async def write_raw_video_frame(self, frame: OutputImageRawFrame):
+        await self._client.write_raw_video_frame(frame)
 
 
 class DailyTransport(BaseTransport):

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -399,7 +399,7 @@ class DailyTransportClient(EventHandler):
                 non_blocking=True,
             )
 
-        if (self._params.audio_in_enabled or self._params.vad_enabled) and not self._speaker:
+        if self._params.audio_in_enabled and not self._speaker:
             self._speaker = Daily.create_speaker_device(
                 self._speaker_name(),
                 sample_rate=self._in_sample_rate,
@@ -846,7 +846,7 @@ class DailyInputTransport(BaseInputTransport):
     def start_audio_in_streaming(self):
         # Create audio task. It reads audio frames from Daily and push them
         # internally for VAD processing.
-        if not self._audio_in_task and (self._params.audio_in_enabled or self._params.vad_enabled):
+        if not self._audio_in_task and self._params.audio_in_enabled:
             logger.debug(f"Start receiving audio")
             self._audio_in_task = self.create_task(self._audio_in_task_handler())
 
@@ -863,9 +863,6 @@ class DailyInputTransport(BaseInputTransport):
         await self._client.setup(frame)
         # Join the room.
         await self._client.join()
-        # Inialize WebRTC VAD if needed.
-        if self._params.vad_enabled and not self._params.vad_analyzer:
-            self._vad_analyzer = WebRTCVADAnalyzer(sample_rate=self.sample_rate)
         if self._params.audio_in_stream_on_start:
             self.start_audio_in_streaming()
 
@@ -875,7 +872,7 @@ class DailyInputTransport(BaseInputTransport):
         # Leave the room.
         await self._client.leave()
         # Stop audio thread.
-        if self._audio_in_task and (self._params.audio_in_enabled or self._params.vad_enabled):
+        if self._audio_in_task and self._params.audio_in_enabled:
             await self.cancel_task(self._audio_in_task)
             self._audio_in_task = None
 
@@ -885,7 +882,7 @@ class DailyInputTransport(BaseInputTransport):
         # Leave the room.
         await self._client.leave()
         # Stop audio thread.
-        if self._audio_in_task and (self._params.audio_in_enabled or self._params.vad_enabled):
+        if self._audio_in_task and self._params.audio_in_enabled:
             await self.cancel_task(self._audio_in_task)
             self._audio_in_task = None
 

--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -383,12 +383,12 @@ class DailyTransportClient(EventHandler):
         self._in_sample_rate = self._params.audio_in_sample_rate or frame.audio_in_sample_rate
         self._out_sample_rate = self._params.audio_out_sample_rate or frame.audio_out_sample_rate
 
-        if self._params.camera_out_enabled and not self._camera:
+        if self._params.video_out_enabled and not self._camera:
             self._camera = Daily.create_camera_device(
                 self._camera_name(),
-                width=self._params.camera_out_width,
-                height=self._params.camera_out_height,
-                color_format=self._params.camera_out_color_format,
+                width=self._params.video_out_width,
+                height=self._params.video_out_height,
+                color_format=self._params.video_out_color_format,
             )
 
         if self._params.audio_out_enabled and not self._mic:
@@ -487,7 +487,7 @@ class DailyTransportClient(EventHandler):
             client_settings={
                 "inputs": {
                     "camera": {
-                        "isEnabled": self._params.camera_out_enabled,
+                        "isEnabled": self._params.video_out_enabled,
                         "settings": {
                             "deviceId": self._camera_name(),
                         },
@@ -510,8 +510,8 @@ class DailyTransportClient(EventHandler):
                             "maxQuality": "low",
                             "encodings": {
                                 "low": {
-                                    "maxBitrate": self._params.camera_out_bitrate,
-                                    "maxFramerate": self._params.camera_out_framerate,
+                                    "maxBitrate": self._params.video_out_bitrate,
+                                    "maxFramerate": self._params.video_out_framerate,
                                 }
                             },
                         }

--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -368,7 +368,7 @@ class LiveKitInputTransport(BaseInputTransport):
         await super().start(frame)
         await self._client.setup(frame)
         await self._client.connect()
-        if not self._audio_in_task and (self._params.audio_in_enabled or self._params.vad_enabled):
+        if not self._audio_in_task and self._params.audio_in_enabled:
             self._audio_in_task = self.create_task(self._audio_in_task_handler())
         logger.info("LiveKitInputTransport started")
 
@@ -382,7 +382,7 @@ class LiveKitInputTransport(BaseInputTransport):
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)
         await self._client.disconnect()
-        if self._audio_in_task and (self._params.audio_in_enabled or self._params.vad_enabled):
+        if self._audio_in_task and self._params.audio_in_enabled:
             await self.cancel_task(self._audio_in_task)
 
     async def cleanup(self):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In this PR we change a couple of things:

- Input transport always push audio frames down the pipeline unless `audio_in_passthrough` is set to False.
- We deprecate `vad_audio_passthrough` in favor of `audio_in_passthrough`.
- We deprecate `vad_enabled` in favor of `audio_in_enabled` and `vad_analyzer`.