### PR TITLE
Block transcription frames in STTMuteFilter

### DIFF
--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -24,10 +24,12 @@ from pipecat.frames.frames import (
     FunctionCallInProgressFrame,
     FunctionCallResultFrame,
     InputAudioRawFrame,
+    InterimTranscriptionFrame,
     StartFrame,
     StartInterruptionFrame,
     StopInterruptionFrame,
     STTMuteFrame,
+    TranscriptionFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
@@ -175,6 +177,8 @@ class STTMuteFilter(FrameProcessor):
                 UserStartedSpeakingFrame,
                 UserStoppedSpeakingFrame,
                 InputAudioRawFrame,
+                TranscriptionFrame,
+                InterimTranscriptionFrame,
             ),
         ):
             # Only pass VAD-related frames when not muted


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

When using Daily hosted transcription the STTMuteFilter doesn't work as desired because `TranscriptionFrames` are still being pushed down the pipeline.

This will cause generations even when the VAD events are blocked because of the timeout mechanism in the context manager to handle receiving transcripts outside of `UserStartedSpeaking` and `UserStoppedSpeaking` events.

Blocking transcription frames properly mutes the user.