### PR TITLE
Deepgram STT: Passthrough user_id when speaker diarization is enabled

### DIFF
--- a/src/pipecat/processors/transcript_processor.py
+++ b/src/pipecat/processors/transcript_processor.py
@@ -61,8 +61,9 @@ class UserTranscriptProcessor(BaseTranscriptProcessor):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, TranscriptionFrame):
+            content = f"{frame.user_id}: {frame.text}" if frame.user_id else frame.text
             message = TranscriptionMessage(
-                role="user", content=frame.text, timestamp=frame.timestamp
+                role="user", content=content, timestamp=frame.timestamp
             )
             await self._emit_update([message])
 

--- a/src/pipecat/processors/transcript_processor.py
+++ b/src/pipecat/processors/transcript_processor.py
@@ -62,9 +62,7 @@ class UserTranscriptProcessor(BaseTranscriptProcessor):
 
         if isinstance(frame, TranscriptionFrame):
             content = f"{frame.user_id}: {frame.text}" if frame.user_id else frame.text
-            message = TranscriptionMessage(
-                role="user", content=content, timestamp=frame.timestamp
-            )
+            message = TranscriptionMessage(role="user", content=content, timestamp=frame.timestamp)
             await self._emit_update([message])
 
         await self.push_frame(frame, direction)

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -202,9 +202,7 @@ class DeepgramSTTService(STTService):
             await self.stop_ttfb_metrics()
             FrameClass = InterimTranscriptionFrame if not is_final else TranscriptionFrame
             if not self._settings.get("diarize"):
-                await self.push_frame(
-                    FrameClass(transcript, "", time_now_iso8601(), language)
-                )
+                await self.push_frame(FrameClass(transcript, "", time_now_iso8601(), language))
             else:
                 spoken_words = [
                     [word.speaker, word.punctuated_word]
@@ -226,7 +224,6 @@ class DeepgramSTTService(STTService):
 
             if is_final:
                 await self.stop_processing_metrics()
-
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)

--- a/tests/test_transcript_processor.py
+++ b/tests/test_transcript_processor.py
@@ -63,7 +63,7 @@ class TestUserTranscriptProcessor(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(update_frame.messages), 1)
         message = update_frame.messages[0]
         self.assertEqual(message.role, "user")
-        self.assertEqual(message.content, "Hello, world!")
+        self.assertEqual(message.content, "test_user: Hello, world!")
         self.assertEqual(message.timestamp, timestamp)
 
     async def test_event_handler(self):
@@ -105,12 +105,12 @@ class TestUserTranscriptProcessor(unittest.IsolatedAsyncioTestCase):
 
         # Check first message
         self.assertEqual(received_updates[0].role, "user")
-        self.assertEqual(received_updates[0].content, "First message")
+        self.assertEqual(received_updates[0].content, "test_user: First message")
         self.assertEqual(received_updates[0].timestamp, timestamp)
 
         # Check second message
         self.assertEqual(received_updates[1].role, "user")
-        self.assertEqual(received_updates[1].content, "Second message")
+        self.assertEqual(received_updates[1].content, "test_user: Second message")
         self.assertEqual(received_updates[1].timestamp, timestamp)
 
     async def test_text_aggregation(self):
@@ -421,7 +421,7 @@ class TestUserTranscriptProcessor(unittest.IsolatedAsyncioTestCase):
         # Verify both processors triggered the same handler
         self.assertEqual(len(received_updates), 2)
         self.assertEqual(received_updates[0].role, "user")
-        self.assertEqual(received_updates[0].content, "User message")
+        self.assertEqual(received_updates[0].content, "user1: User message")
         self.assertEqual(received_updates[1].role, "assistant")
         self.assertEqual(received_updates[1].content, "Assistant message")
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
While there is currently an option to enable Deepgrams speaker diarization, this information is currently unused and dropped.
This PR passes the speaker/user information by pushing one `(Interim)TranscriptionFrame` per speaker-turn instead.
It also adds the `user_id` to the `TranscriptionMessage.content` if it is present (though I'm inclined to remove that again to not break any downstream tasks).