### PR TITLE
fix: add exception handling for FAL smart turn detection

### DIFF
--- a/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
@@ -176,6 +176,8 @@ class BaseSmartTurn(BaseTurnAnalyzer):
                     f"End of Turn complete due to stop_secs. Silence in ms: {self._silence_ms}"
                 )
                 state = EndOfTurnState.COMPLETE
+            except Exception as e:
+                logger.error(f"Error during prediction: {e}")
 
         else:
             logger.trace(f"params: {self._params}, stop_ms: {self._stop_ms}")


### PR DESCRIPTION
Sometimes FAL responds with a 500 error code. In this case we want to log the error but continue turn detection.