### PR TITLE
Add context_window_compression support to GeminiMultimodalLiveLLMService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `context_window_compression` InputParam to
+  `GeminiMultimodalLiveLLMService` which allows you to enable a sliding
+  context window for the session as well as set the token limit of the sliding
+  window.
+
 - Updated `SmallWebRTCConnection` to support `ice_servers` with credentials.
 
 - Added `VADUserStartedSpeakingFrame` and `VADUserStoppedSpeakingFrame`,

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -193,3 +193,10 @@ def parse_server_event(str):
     except Exception as e:
         print(f"Error parsing server event: {e}")
         return None
+
+
+class ContextWindowCompressionConfig(BaseModel):
+    """Configuration for context window compression."""
+
+    sliding_window: Optional[bool] = Field(default=True)
+    trigger_tokens: Optional[int] = Field(default=None)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Without this, the Gemini API will disconnect the session once the context limit is hit. From Google's docs:
> Session duration can be extended to unlimited by enabling session [compression](https://ai.google.dev/gemini-api/docs/live#context-window-compression). Without compression, audio-only sessions are limited to 15 minutes, and audio plus video sessions are limited to 2 minutes. Exceeding these limits without compression will terminate the connection.

Source: https://ai.google.dev/gemini-api/docs/live#maximum-session-duration