### PR TITLE
[Rime] - Update url for Websockets API

### DIFF
--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -74,7 +74,7 @@ class RimeTTSService(AudioContextWordTTSService):
         *,
         api_key: str,
         voice_id: str,
-        url: str = "wss://users-ws.rime.ai/ws2",
+        url: str = "wss://users.rime.ai/ws2",
         model: str = "mistv2",
         sample_rate: Optional[int] = None,
         params: InputParams = InputParams(),


### PR DESCRIPTION
## Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

**Issue**: Pipecat users are sending websocket requests to a (now) deprecated url, `users-ws.rime.ai`, which will not reflect upgrades to the Rime ws api.

Rime has migrated their Websockets api to the base url `user.rime.ai` along with all other tts endpoints. 

The [docs](https://docs.rime.ai/api-reference/endpoint/websockets) have been updated as well to reflect this. 
