### PR TITLE
[Rime] Add new params to RimeTTSService

### DIFF
--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -68,6 +68,8 @@ class RimeTTSService(AudioContextWordTTSService):
         language: Optional[Language] = Language.EN
         speed_alpha: Optional[float] = 1.0
         reduce_latency: Optional[bool] = False
+        pause_between_brackets: Optional[bool] = False
+        phonemize_between_brackets: Optional[bool] = False
 
     def __init__(
         self,
@@ -117,6 +119,8 @@ class RimeTTSService(AudioContextWordTTSService):
             else "eng",
             "speedAlpha": params.speed_alpha,
             "reduceLatency": params.reduce_latency,
+            "pauseBetweenBrackets": json.dumps(params.pause_between_brackets),
+            "phonemizeBetweenBrackets": json.dumps(params.phonemize_between_brackets),
         }
 
         # State tracking


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Adding the following params to the RimeTTSService params, which are supported by the rime websockets api: 

* [pauseBetweenBrackets](https://docs.rime.ai/api-reference/endpoint/websockets-json#param-pause-between-brackets)
* [phonemizeBetweenBrackets](https://docs.rime.ai/api-reference/endpoint/websockets-json#param-phonemize-between-brackets)

We json serialize the bool values as the rime api currently expects `true/false`, and is case-sensitive (patch to rime ws backend incoming) 