### PR TITLE
Add direct muting to the STTMuteFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added two new frames `RequestSTTMuteFrame`, `RequestSTTUnmuteFrame`. These
+  frames tell the `STTMuteFilter` to directly mute or unmute the user and
+  take precedent over the mute strategies when an `RequestSTTMuteFrame` is
+  processed.
+
 - `BaseOutputTransport` now allows multiple destinations if the transport
   implementation supports it (e.g. Daily's custom tracks). With multiple
   destinations it is possible to send different audio or video tracks with a

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -696,6 +696,20 @@ class STTMuteFrame(SystemFrame):
 
 
 @dataclass
+class RequestSTTMuteFrame(Frame):
+    """Request to mute the STT service."""
+
+    pass
+
+
+@dataclass
+class RequestSTTUnmuteFrame(Frame):
+    """Request to unmute the STT service."""
+
+    pass
+
+
+@dataclass
 class TransportMessageUrgentFrame(SystemFrame):
     message: Any
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This came up in a conversation with someone from the community. It's a bit of a different way for the STTMuteFilter to be used, but it can help in cases where you want to proactively mute based on activity in the pipeline. For example, the user cited wanting to ignore user input for the goodbye message. You could imagine pushing a RequestSTTMuteFrame when triggering a goodbye message, which makes that flow easier to build.

You could alternatively build for the end message use case with a CUSTOM strategy. I'm torn about offering this functionality, as you can mistakenly leave the user muted, if you're not managing frames correctly.

One oddity. In writing tests, the STTMuteFrame comes before the RequestSTTMuteFrame. I don't really understand why this is the case. @aconchillo maybe you know?