### PR TITLE
BaseOutputTransport: always initialize audio task

### DIFF
--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -369,7 +369,7 @@ class BaseOutputTransport(FrameProcessor):
         #
 
         def _create_audio_task(self):
-            if not self._audio_task and self._params.audio_out_enabled:
+            if not self._audio_task:
                 self._audio_queue = asyncio.Queue()
                 self._audio_task = self._transport.create_task(self._audio_task_handler())
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

We also use the audio task to also send synchronized images with audio.
