### PR TITLE
[Fix] Ultravox frame spacing issue

### DIFF
--- a/src/pipecat/services/ultravox/stt.py
+++ b/src/pipecat/services/ultravox/stt.py
@@ -425,7 +425,7 @@ class UltravoxSTTService(AIService):
                             if "content" in delta:
                                 new_text = delta["content"]
                                 if new_text:
-                                    yield LLMTextFrame(text=new_text.strip())
+                                    yield LLMTextFrame(text=new_text)
 
                     # Stop processing metrics after completion
                     await self.stop_processing_metrics()


### PR DESCRIPTION
#### Issue:
Currently, the `.strip()` removes any spacing in the text frames, as a result, the STT service reads everything as one word.