### PR TITLE
task manager dictionary and cleanup PipelineTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `PipelineTask` issue that would cause tasks to not be cancelled if
+  task was cancelled from outside of Pipecat.
+
 - Fixed a `TaskManager` that was causing dangling tasks to be reported.
 
 - Fixed an issue that could cause data to be sent to the transports when they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `TaskManager` that was causing dangling tasks to be reported.
+
 - Fixed an issue that could cause data to be sent to the transports when they
   were still not ready.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

A couple of changes:

- If for some reason Pipeline task is cancelled from outside Pipecat we were not cleaning up things properly.
- Also, we use a dictionary instead of a set of tasks. For some reason we were having issues and dangling tasks were being reported after being removed from the set. Anyways, using a dictionary fixes the issue.