### PR TITLE
DailyTransport: added on_active_speaker_changed event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `on_active_speaker_changed` event handler to the `DailyTransport` class.
+
 - Added `enable_ssml_parsing` and `enable_logging` to `InputParams` in
   `ElevenLabsTTSService`.
 


### PR DESCRIPTION
Added `on_active_speaker_changed` event handler to the `DailyTransport` class.

My personal use-case for this is simple; as long as we're missing out on the `user_id` for the transcription- and translation frames from the gladia service. A "guesstimate" on the person is still better then an empty string user_id.

This will allow some custom mapping of our own processing the frames. Might be of use to someone else as well.