### PR TITLE
Revert breaking change in RTVI protocol for function calling

### DIFF
--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -254,7 +254,7 @@ class RTVIBotReady(BaseModel):
 class RTVILLMFunctionCallMessageData(BaseModel):
     function_name: str
     tool_call_id: str
-    arguments: Mapping[str, Any]
+    args: Mapping[str, Any]
 
 
 class RTVILLMFunctionCallMessage(BaseModel):
@@ -700,7 +700,7 @@ class RTVIProcessor(FrameProcessor):
         fn = RTVILLMFunctionCallMessageData(
             function_name=params.function_name,
             tool_call_id=params.tool_call_id,
-            arguments=params.arguments,
+            args=params.arguments,
         )
         message = RTVILLMFunctionCallMessage(data=fn)
         await self._push_transport_message(message, exclude_none=False)


### PR DESCRIPTION
This PR is a fix for issue #1734 

[In this previous PR](https://github.com/pipecat-ai/pipecat/pull/1667/files#diff-ae622e884761fa9fb9db374ec23206c76e1d2919a8eac9029becfe8893a75837L254) we introduced a breaking change for RTVI clients by changing the "args" in the message sent to "arguments".  This PR reverts back to using "args"