### PR TITLE
Wrong deprecation warning when importing ai_services.py

### DIFF
--- a/src/pipecat/services/ai_services.py
+++ b/src/pipecat/services/ai_services.py
@@ -18,5 +18,5 @@ from .vision_service import *
 sys.modules[__name__] = DeprecatedModuleProxy(
     globals(),
     "ai_services",
-    "ai_service.[image_service,llm_service,stt_service,tts_service,vision_service]",
+    "[ai_service,image_service,llm_service,stt_service,tts_service,vision_service]",
 )


### PR DESCRIPTION
fix: correct deprecation warning in ai_services module

The deprecation warning generated when importing `ai_services` appears to be incorrect.

```
DeprecationWarning: Module `pipecat.services.ai_services` is deprecated, use `pipecat.services.ai_service.[image_service,llm_service,stt_service,tts_service,vision_service]` instead.
  from pipecat.services.ai_services import InterruptibleTTSService
```

This should be:
```
DeprecationWarning: Module `pipecat.services.ai_services` is deprecated, use `pipecat.services.[ai_service,image_service,llm_service,stt_service,tts_service,vision_service]` instead.
  from pipecat.services.ai_services import InterruptibleTTSService
```