### PR TITLE
Fix: Make LLMTokenUsage more robust

### DIFF
--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -960,11 +960,17 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
         usage = evt.usageMetadata
 
+        # Ensure we have valid integers for all token counts
+        prompt_tokens = usage.promptTokenCount or 0
+        completion_tokens = usage.responseTokenCount or 0
+        total_tokens = usage.totalTokenCount or (prompt_tokens + completion_tokens)
+
         tokens = LLMTokenUsage(
-            prompt_tokens=usage.promptTokenCount,
-            completion_tokens=usage.responseTokenCount,
-            total_tokens=usage.totalTokenCount,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
         )
+
         await self.start_llm_usage_metrics(tokens)
 
     def create_context_aggregator(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

There was a report from Discord:
```
2025-05-18 11:10:42.230 | ERROR    | pipecat.utils.asyncio:run_coroutine:113 - GeminiMultimodalLiveLLMService#0::_receive_task_handler: unexpected exception: 1 validation error for LLMTokenUsage
completion_tokens
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.10/v/int_type
```

It looks like Gemini Live can turn None for some of the token values. This is to protect against that case.