### PR TITLE
Streaming implementation for Google TTS

### DIFF
--- a/src/pipecat/services/google/tts.py
+++ b/src/pipecat/services/google/tts.py
@@ -8,8 +8,6 @@ import asyncio
 import json
 import os
 
-from pipecat.utils.tracing.service_decorators import traced_tts
-
 # Suppress gRPC fork warnings
 os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "false"
 
@@ -320,7 +318,6 @@ class GoogleTTSService(TTSService):
 
         return ssml
 
-    @traced_tts
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:
         logger.debug(f"{self}: Generating TTS [{text}]")
 
@@ -342,6 +339,7 @@ class GoogleTTSService(TTSService):
             voice = texttospeech_v1.VoiceSelectionParams(
                 language_code=self._settings["language"], name=self._voice_id
             )
+            logger.info(f"Sample rate: {self.sample_rate}")
             audio_config = texttospeech_v1.AudioConfig(
                 audio_encoding=texttospeech_v1.AudioEncoding.LINEAR16,
                 sample_rate_hertz=self.sample_rate,


### PR DESCRIPTION
I went on and implemented [Streaming implementation for Google TTS ](https://github.com/pipecat-ai/pipecat/issues/1812)
It really makes a huge speed difference. However, the quality seems slightly degraded, as if the output is compressed. I couldn't find the reason for this. Sample rate is unchanged in my pipeline, 24000.
Additionally and unrelated, I had to change rate param to sample_rate as per https://cloud.google.com/text-to-speech/docs/reference/rpc/google.cloud.texttospeech.v1#google.cloud.texttospeech.v1.StreamingAudioConfig

Sorry if I missed something.