### PR TITLE
Keep span identifiers in attributes only

### DIFF
--- a/src/pipecat/utils/tracing/turn_trace_observer.py
+++ b/src/pipecat/utils/tracing/turn_trace_observer.py
@@ -82,7 +82,7 @@ class TurnTraceObserver(BaseObserver):
         self._conversation_id = conversation_id
 
         # Create a new span for this conversation
-        self._conversation_span = self._tracer.start_span(f"conversation-{conversation_id}")
+        self._conversation_span = self._tracer.start_span("conversation")
 
         # Set span attributes
         self._conversation_span.set_attribute("conversation.id", conversation_id)
@@ -143,7 +143,7 @@ class TurnTraceObserver(BaseObserver):
             parent_context = context_provider.get_current_conversation_context()
 
         # Create a new span for this turn
-        self._current_span = self._tracer.start_span(f"turn-{turn_number}", context=parent_context)
+        self._current_span = self._tracer.start_span("turn", context=parent_context)
         self._current_turn_number = turn_number
 
         # Set span attributes


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

With this change, the span name will be either `conversation` for the top-level span and `turn` for the child span. Then, each of those spans will have an attribute:
- `conversation.id` for the conversation ID
- `turn.number` for the turn number