### PR TITLE
Update OTel attribute names

### DIFF
--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -45,7 +45,7 @@ def add_tts_span_attributes(
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
-    span.set_attribute("service.name", service_name)
+    span.set_attribute("service", service_name)
     span.set_attribute("model", model)
     span.set_attribute("voice_id", voice_id)
     span.set_attribute("operation", operation_name)
@@ -55,7 +55,7 @@ def add_tts_span_attributes(
         span.set_attribute("text", text)
 
     if character_count is not None:
-        span.set_attribute("metrics.tts.character_count", character_count)
+        span.set_attribute("metrics.character_count", character_count)
 
     if ttfb_ms is not None:
         span.set_attribute("metrics.ttfb_ms", ttfb_ms)
@@ -99,7 +99,7 @@ def add_stt_span_attributes(
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
-    span.set_attribute("service.name", service_name)
+    span.set_attribute("service", service_name)
     span.set_attribute("model", model)
     span.set_attribute("vad_enabled", vad_enabled)
 
@@ -161,13 +161,13 @@ def add_llm_span_attributes(
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
-    span.set_attribute("service.name", service_name)
+    span.set_attribute("service", service_name)
     span.set_attribute("model", model)
     span.set_attribute("stream", stream)
 
     # Add optional attributes
     if messages:
-        span.set_attribute("messages", messages)
+        span.set_attribute("input", messages)
 
     if tools:
         span.set_attribute("tools", tools)

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -78,7 +78,7 @@ def _get_service_name(self, service_prefix: str) -> str:
         A default span name string like "type_classname" (e.g. llm_openaillmservice).
     """
     service_class_name = self.__class__.__name__.lower()
-    return f"{service_prefix}_{service_class_name}"
+    return f"{service_prefix}"
 
 
 def _add_token_usage_to_span(span, token_usage):
@@ -93,13 +93,19 @@ def _add_token_usage_to_span(span, token_usage):
 
     if isinstance(token_usage, dict):
         if "prompt_tokens" in token_usage:
-            span.set_attribute("llm.prompt_tokens", token_usage["prompt_tokens"])
+            span.set_attribute("llm.token_count.prompt_tokens", token_usage["prompt_tokens"])
         if "completion_tokens" in token_usage:
-            span.set_attribute("llm.completion_tokens", token_usage["completion_tokens"])
+            span.set_attribute(
+                "llm.token_count.completion_tokens", token_usage["completion_tokens"]
+            )
     else:
         # Handle LLMTokenUsage object
-        span.set_attribute("llm.prompt_tokens", getattr(token_usage, "prompt_tokens", 0))
-        span.set_attribute("llm.completion_tokens", getattr(token_usage, "completion_tokens", 0))
+        span.set_attribute(
+            "llm.token_count.prompt_tokens", getattr(token_usage, "prompt_tokens", 0)
+        )
+        span.set_attribute(
+            "llm.token_count.completion_tokens", getattr(token_usage, "completion_tokens", 0)
+        )
 
 
 def traced_tts(func: Optional[Callable] = None, *, name: Optional[str] = None) -> Callable:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This change does a few things:
- Keeps the service span to just common names like `stt`, `llm`, or `tts`. This is a change from including the service name in the service type. This is to align with the change where span names don't include identifiers
- Related, change `service.name` to just `service` as there is nothing else nested
- Remove service type identifiers from from attribute names like `metrics.tts.character_count`
- Follow the OTel naming recommendations from Langfuse: https://langfuse.com/docs/opentelemetry/get-started#property-mapping. The only change I'm making is for llm tokens. This will allow them to revert these changes: https://github.com/langfuse/langfuse/pull/6903/files.