### PR TITLE
fix(deepgram-stt): set model name to Deepgram STT

### DIFF
--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -90,6 +90,7 @@ class DeepgramSTTService(STTService):
         if "language" in merged_options and isinstance(merged_options["language"], Language):
             merged_options["language"] = merged_options["language"].value
 
+        self.set_model_name(merged_options["model"])
         self._settings = merged_options
         self._addons = addons
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I am working with Pipecat 0.0.68 and I enabled the new telemetry config. I noticed that the model is not set for Deepgram STT (see `gen_ai.request.model`):

```json
{
  "gen_ai.operation.name": "stt",
  "gen_ai.request.model": "",
  "gen_ai.system": "deepgram",
  "is_final": true,
  "metrics.ttfb_ms": 0.0025191307067871094,
  "settings.channels": 1,
  "settings.encoding": "linear16",
  "settings.interim_results": true,
  "settings.language": "es-mx",
  "settings.model": "nova-2",
  "settings.profanity_filter": true,
  "settings.punctuate": true,
  "settings.sample_rate": 8000,
  "settings.smart_format": true,
  "settings.vad_events": false,
  "transcript": "Sí, sí.",
  "vad_enabled": false
}
```