### PR TITLE
Fix implementation of ttfb_ms metric

### DIFF
--- a/src/pipecat/processors/metrics/frame_processor_metrics.py
+++ b/src/pipecat/processors/metrics/frame_processor_metrics.py
@@ -28,18 +28,18 @@ class FrameProcessorMetrics:
         self._should_report_ttfb = True
 
     @property
-    def ttfb_ms(self) -> Optional[float]:
-        """Get the current TTFB value in milliseconds.
+    def ttfb(self) -> Optional[float]:
+        """Get the current TTFB value in seconds.
 
         Returns:
-            Optional[int]: The TTFB value in milliseconds, or None if not measured
+            Optional[float]: The TTFB value in seconds, or None if not measured
         """
         if self._last_ttfb_time > 0:
-            return self._last_ttfb_time * 1000
+            return self._last_ttfb_time
 
         # If TTFB is in progress, calculate current value
         if self._start_ttfb_time > 0:
-            return (time.time() - self._start_ttfb_time) * 1000
+            return time.time() - self._start_ttfb_time
 
         return None
 

--- a/src/pipecat/processors/metrics/frame_processor_metrics.py
+++ b/src/pipecat/processors/metrics/frame_processor_metrics.py
@@ -28,18 +28,18 @@ class FrameProcessorMetrics:
         self._should_report_ttfb = True
 
     @property
-    def ttfb_ms(self) -> Optional[int]:
+    def ttfb_ms(self) -> Optional[float]:
         """Get the current TTFB value in milliseconds.
 
         Returns:
             Optional[int]: The TTFB value in milliseconds, or None if not measured
         """
         if self._last_ttfb_time > 0:
-            return int(self._last_ttfb_time * 1000)
+            return self._last_ttfb_time * 1000
 
         # If TTFB is in progress, calculate current value
         if self._start_ttfb_time > 0:
-            return int((time.time() - self._start_ttfb_time) * 1000)
+            return (time.time() - self._start_ttfb_time) * 1000
 
         return None
 

--- a/src/pipecat/processors/metrics/frame_processor_metrics.py
+++ b/src/pipecat/processors/metrics/frame_processor_metrics.py
@@ -28,18 +28,18 @@ class FrameProcessorMetrics:
         self._should_report_ttfb = True
 
     @property
-    def ttfb_ms(self) -> Optional[float]:
-        """Get the current TTFB value in seconds.
+    def ttfb_ms(self) -> Optional[int]:
+        """Get the current TTFB value in milliseconds.
 
         Returns:
-            Optional[float]: The TTFB value in seconds, or None if not measured
+            Optional[int]: The TTFB value in milliseconds, or None if not measured
         """
         if self._last_ttfb_time > 0:
-            return self._last_ttfb_time
+            return int(self._last_ttfb_time * 1000)
 
         # If TTFB is in progress, calculate current value
         if self._start_ttfb_time > 0:
-            return time.time() - self._start_ttfb_time
+            return int((time.time() - self._start_ttfb_time) * 1000)
 
         return None
 

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -60,7 +60,7 @@ def add_tts_span_attributes(
     settings: Optional[Dict[str, Any]] = None,
     character_count: Optional[int] = None,
     operation_name: str = "tts",
-    ttfb_ms: Optional[float] = None,
+    ttfb: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add TTS-specific attributes to a span.
@@ -74,7 +74,7 @@ def add_tts_span_attributes(
         settings: Service configuration settings
         character_count: Number of characters in the text
         operation_name: Name of the operation (default: "tts")
-        ttfb_ms: Time to first byte in milliseconds
+        ttfb: Time to first byte in seconds
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
@@ -91,8 +91,8 @@ def add_tts_span_attributes(
     if character_count is not None:
         span.set_attribute("metrics.character_count", character_count)
 
-    if ttfb_ms is not None:
-        span.set_attribute("metrics.ttfb_ms", ttfb_ms)
+    if ttfb is not None:
+        span.set_attribute("metrics.ttfb", ttfb)
 
     # Add settings if provided
     if settings:
@@ -116,7 +116,7 @@ def add_stt_span_attributes(
     language: Optional[str] = None,
     settings: Optional[Dict[str, Any]] = None,
     vad_enabled: bool = False,
-    ttfb_ms: Optional[float] = None,
+    ttfb: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add STT-specific attributes to a span.
@@ -131,7 +131,7 @@ def add_stt_span_attributes(
         language: Detected or configured language
         settings: Service configuration settings
         vad_enabled: Whether voice activity detection is enabled
-        ttfb_ms: Time to first byte in milliseconds
+        ttfb: Time to first byte in seconds
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
@@ -150,8 +150,8 @@ def add_stt_span_attributes(
     if language:
         span.set_attribute("language", language)
 
-    if ttfb_ms is not None:
-        span.set_attribute("metrics.ttfb_ms", ttfb_ms)
+    if ttfb is not None:
+        span.set_attribute("metrics.ttfb", ttfb)
 
     # Add settings if provided
     if settings:
@@ -178,7 +178,7 @@ def add_llm_span_attributes(
     system: Optional[str] = None,
     parameters: Optional[Dict[str, Any]] = None,
     extra_parameters: Optional[Dict[str, Any]] = None,
-    ttfb_ms: Optional[float] = None,
+    ttfb: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add LLM-specific attributes to a span.
@@ -196,7 +196,7 @@ def add_llm_span_attributes(
         system: System message
         parameters: Service parameters
         extra_parameters: Additional parameters
-        ttfb_ms: Time to first byte in milliseconds
+        ttfb: Time to first byte in seconds
         **kwargs: Additional attributes to add
     """
     # Add standard attributes
@@ -225,8 +225,8 @@ def add_llm_span_attributes(
     if system:
         span.set_attribute("system", system)
 
-    if ttfb_ms is not None:
-        span.set_attribute("metrics.ttfb_ms", ttfb_ms)
+    if ttfb is not None:
+        span.set_attribute("metrics.ttfb", ttfb)
 
     # Add parameters if provided
     if parameters:

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -60,7 +60,7 @@ def add_tts_span_attributes(
     settings: Optional[Dict[str, Any]] = None,
     character_count: Optional[int] = None,
     operation_name: str = "tts",
-    ttfb_ms: Optional[float] = None,
+    ttfb_ms: Optional[int] = None,
     **kwargs,
 ) -> None:
     """Add TTS-specific attributes to a span.
@@ -116,7 +116,7 @@ def add_stt_span_attributes(
     language: Optional[str] = None,
     settings: Optional[Dict[str, Any]] = None,
     vad_enabled: bool = False,
-    ttfb_ms: Optional[float] = None,
+    ttfb_ms: Optional[int] = None,
     **kwargs,
 ) -> None:
     """Add STT-specific attributes to a span.
@@ -178,7 +178,7 @@ def add_llm_span_attributes(
     system: Optional[str] = None,
     parameters: Optional[Dict[str, Any]] = None,
     extra_parameters: Optional[Dict[str, Any]] = None,
-    ttfb_ms: Optional[float] = None,
+    ttfb_ms: Optional[int] = None,
     **kwargs,
 ) -> None:
     """Add LLM-specific attributes to a span.

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -60,7 +60,7 @@ def add_tts_span_attributes(
     settings: Optional[Dict[str, Any]] = None,
     character_count: Optional[int] = None,
     operation_name: str = "tts",
-    ttfb_ms: Optional[int] = None,
+    ttfb_ms: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add TTS-specific attributes to a span.
@@ -116,7 +116,7 @@ def add_stt_span_attributes(
     language: Optional[str] = None,
     settings: Optional[Dict[str, Any]] = None,
     vad_enabled: bool = False,
-    ttfb_ms: Optional[int] = None,
+    ttfb_ms: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add STT-specific attributes to a span.
@@ -178,7 +178,7 @@ def add_llm_span_attributes(
     system: Optional[str] = None,
     parameters: Optional[Dict[str, Any]] = None,
     extra_parameters: Optional[Dict[str, Any]] = None,
-    ttfb_ms: Optional[int] = None,
+    ttfb_ms: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Add LLM-specific attributes to a span.

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -152,7 +152,7 @@ def traced_tts(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                     raise
                 finally:
                     # Update TTFB metric at the end
-                    ttfb_ms = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                    ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
                     if ttfb_ms is not None:
                         span.set_attribute("metrics.ttfb_ms", ttfb_ms)
 
@@ -238,7 +238,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                 ) as current_span:
                     try:
                         # Get TTFB metric if available
-                        ttfb_ms = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                        ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
 
                         # Use settings from the service if available
                         settings = getattr(self, "_settings", {})
@@ -460,7 +460,7 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             self.start_llm_usage_metrics = original_start_llm_usage_metrics
 
                         # Update TTFB metric
-                        ttfb_ms = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                        ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
                         if ttfb_ms is not None:
                             current_span.set_attribute("metrics.ttfb_ms", ttfb_ms)
             except Exception as e:

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -152,7 +152,7 @@ def traced_tts(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                     raise
                 finally:
                     # Update TTFB metric at the end
-                    ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                    ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
                     if ttfb_ms is not None:
                         span.set_attribute("metrics.ttfb_ms", ttfb_ms)
 
@@ -238,7 +238,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                 ) as current_span:
                     try:
                         # Get TTFB metric if available
-                        ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                        ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
 
                         # Use settings from the service if available
                         settings = getattr(self, "_settings", {})
@@ -460,7 +460,7 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             self.start_llm_usage_metrics = original_start_llm_usage_metrics
 
                         # Update TTFB metric
-                        ttfb_ms: Optional[int] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                        ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
                         if ttfb_ms is not None:
                             current_span.set_attribute("metrics.ttfb_ms", ttfb_ms)
             except Exception as e:

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -152,9 +152,9 @@ def traced_tts(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                     raise
                 finally:
                     # Update TTFB metric at the end
-                    ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
-                    if ttfb_ms is not None:
-                        span.set_attribute("metrics.ttfb_ms", ttfb_ms)
+                    ttfb: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb", None)
+                    if ttfb is not None:
+                        span.set_attribute("metrics.ttfb", ttfb)
 
         if is_async_generator:
 
@@ -238,7 +238,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                 ) as current_span:
                     try:
                         # Get TTFB metric if available
-                        ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
+                        ttfb: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb", None)
 
                         # Use settings from the service if available
                         settings = getattr(self, "_settings", {})
@@ -252,7 +252,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             language=str(language) if language else None,
                             vad_enabled=getattr(self, "vad_enabled", False),
                             settings=settings,
-                            ttfb_ms=ttfb_ms,
+                            ttfb=ttfb,
                         )
 
                         # Call the original function
@@ -460,9 +460,9 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             self.start_llm_usage_metrics = original_start_llm_usage_metrics
 
                         # Update TTFB metric
-                        ttfb_ms: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb_ms", None)
-                        if ttfb_ms is not None:
-                            current_span.set_attribute("metrics.ttfb_ms", ttfb_ms)
+                        ttfb: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb", None)
+                        if ttfb is not None:
+                            current_span.set_attribute("metrics.ttfb", ttfb)
             except Exception as e:
                 logging.error(f"Error in LLM tracing (continuing without tracing): {e}")
                 # If tracing fails, fall back to the original function

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -238,7 +238,9 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                 ) as current_span:
                     try:
                         # Get TTFB metric if available
-                        ttfb: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb", None)
+                        ttfb: Optional[float] = getattr(
+                            getattr(self, "_metrics", None), "ttfb", None
+                        )
 
                         # Use settings from the service if available
                         settings = getattr(self, "_settings", {})
@@ -460,7 +462,9 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             self.start_llm_usage_metrics = original_start_llm_usage_metrics
 
                         # Update TTFB metric
-                        ttfb: Optional[float] = getattr(getattr(self, "_metrics", None), "ttfb", None)
+                        ttfb: Optional[float] = getattr(
+                            getattr(self, "_metrics", None), "ttfb", None
+                        )
                         if ttfb is not None:
                             current_span.set_attribute("metrics.ttfb", ttfb)
             except Exception as e:


### PR DESCRIPTION
Fixes: `ttfb_ms` was providing seconds instead of milliseconds