### PR TITLE
Fix type checker error with missing function call in the small WebRTC transport example

### DIFF
--- a/examples/foundational/04-transports-small-webrtc.py
+++ b/examples/foundational/04-transports-small-webrtc.py
@@ -156,7 +156,7 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield  # Run app
-    coros = [pc.close() for pc in pcs_map.values()]
+    coros = [pc.disconnect() for pc in pcs_map.values()]
     await asyncio.gather(*coros)
     pcs_map.clear()
 

--- a/examples/p2p-webrtc/daily-interop-bridge/server.py
+++ b/examples/p2p-webrtc/daily-interop-bridge/server.py
@@ -74,7 +74,7 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield  # Run app
-    coros = [pc.close() for pc in pcs_map.values()]
+    coros = [pc.disconnect() for pc in pcs_map.values()]
     await asyncio.gather(*coros)
     pcs_map.clear()
 

--- a/examples/p2p-webrtc/video-transform/server/server.py
+++ b/examples/p2p-webrtc/video-transform/server/server.py
@@ -74,7 +74,7 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield  # Run app
-    coros = [pc.close() for pc in pcs_map.values()]
+    coros = [pc.disconnect() for pc in pcs_map.values()]
     await asyncio.gather(*coros)
     pcs_map.clear()
 

--- a/examples/p2p-webrtc/voice-agent/server.py
+++ b/examples/p2p-webrtc/voice-agent/server.py
@@ -69,7 +69,7 @@ async def serve_index():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield  # Run app
-    coros = [pc.close() for pc in pcs_map.values()]
+    coros = [pc.disconnect() for pc in pcs_map.values()]
     await asyncio.gather(*coros)
     pcs_map.clear()
 

--- a/src/pipecat/examples/run.py
+++ b/src/pipecat/examples/run.py
@@ -142,7 +142,7 @@ def run_example_webrtc(
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         yield  # Run app
-        coros = [pc.close() for pc in pcs_map.values()]
+        coros = [pc.disconnect() for pc in pcs_map.values()]
         await asyncio.gather(*coros)
         pcs_map.clear()
 


### PR DESCRIPTION
My local pyright wasn't happy with a call to `close()` in the small WebRTC transport example.

SmallWebRTCConnection doesn't have a `close()`. There's a `_close()` but I assume that's private due to its naming. The closest function that uses `_close()` is `disconnect()`. I assume then, that the intended resource freeing function call should be to `disconnect()`.