### PR TITLE
Add daily to the foundational examples requirements.txt

### DIFF
--- a/examples/foundational/requirements.txt
+++ b/examples/foundational/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[webrtc,deepgram,cartesia]
+pipecat-ai[webrtc,daily,deepgram,cartesia]
 pipecat-ai-small-webrtc-prebuilt


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

With the changed import, the quickstart is broken. As a quick fix, we can just suggest to download the `run.py` from the new location and run the local import.

Also, in testing the quickstart, I noticed that we now require the `daily` optional dependencies to be installed.