### PR TITLE
Fixed transport destination issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where `OutputAudioRawFrame.transport_destination` was being 
+  reset to `None` instead of retaining its intended value before sending the 
+  audio frame to `write_audio_frame`.
+
 ## [0.0.69] - 2025-06-02 "AI Engineer World's Fair release" ✨
 
 ### Added

--- a/src/pipecat/processors/aggregators/user_response.py
+++ b/src/pipecat/processors/aggregators/user_response.py
@@ -23,4 +23,4 @@ class UserResponseAggregator(LLMUserResponseAggregator):
             await self.push_frame(frame)
 
             # Reset our accumulator state.
-            self.reset()
+            await self.reset()

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -83,7 +83,7 @@ class GoogleUserContextAggregator(OpenAIUserContextAggregator):
             await self.push_frame(frame)
 
             # Reset our accumulator state.
-            self.reset()
+            await self.reset()
 
 
 class GoogleAssistantContextAggregator(OpenAIAssistantContextAggregator):

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -351,6 +351,7 @@ class BaseOutputTransport(FrameProcessor):
                     sample_rate=self._sample_rate,
                     num_channels=frame.num_channels,
                 )
+                chunk.transport_destination = self._destination
                 await self._audio_queue.put(chunk)
                 self._audio_buffer = self._audio_buffer[self._audio_chunk_size :]
 


### PR DESCRIPTION
Fixed an issue where OutputAudioRawFrame.transport_destination was being reset to None instead of retaining its intended value before sending the audio frame to the transports.