### PR TITLE
Gladia informal translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DailyTransport.stop_transcription()` to be able to start and stop Daily
   transcription dynamically (maybe with different settings).
 
+- Added the option `informal` to `TranslationConfig` on Gladia config.
+  Allowing to force informal language forms when available.
+
 ### Changed
 
 - Reverted the default model for `GeminiMultimodalLiveLLMService` back to

--- a/src/pipecat/services/gladia/config.py
+++ b/src/pipecat/services/gladia/config.py
@@ -74,7 +74,7 @@ class TranslationConfig(BaseModel):
         target_languages: List of target language codes for translation
         model: Translation model to use ("base" or "enhanced")
         match_original_utterances: Whether to align translations with original utterances
-        informal: Force informal language forms when available 
+        informal: Force informal language forms when available
     """
 
     target_languages: Optional[List[str]] = None

--- a/src/pipecat/services/gladia/config.py
+++ b/src/pipecat/services/gladia/config.py
@@ -74,11 +74,13 @@ class TranslationConfig(BaseModel):
         target_languages: List of target language codes for translation
         model: Translation model to use ("base" or "enhanced")
         match_original_utterances: Whether to align translations with original utterances
+        informal: Force informal language forms when available 
     """
 
     target_languages: Optional[List[str]] = None
     model: Optional[str] = None
     match_original_utterances: Optional[bool] = None
+    informal: Optional[bool] = None
 
 
 class RealtimeProcessingConfig(BaseModel):


### PR DESCRIPTION
Added the option `informal` to `TranslationConfig`  Gladia STT.
Allowing to force informal language forms when available.