### PR TITLE
Make `PipelineTask.add_observer()` synchronous. This allows callers t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `PipelineTask.add_observer()` synchronous. This allows callers to call it before doing the
+  work of running the `PipelineTask` (i.e. without invoking `PipelineTask.set_event_loop()` first).
+
 - Pipecat 0.0.69 forced `uvloop` event loop on Linux on macOS. Unfortunately,
   this is causing issue in some systems. So, `uvloop` is not enabled by default
   anymore. If you want to use `uvloop` you can just set the `asyncio` event

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -310,8 +310,8 @@ class PipelineTask(BaseTask):
         """Return the turn trace observer if enabled."""
         return self._turn_trace_observer
 
-    async def add_observer(self, observer: BaseObserver):
-        await self._observer.add_observer(observer)
+    def add_observer(self, observer: BaseObserver):
+        self._observer.add_observer(observer)
 
     async def remove_observer(self, observer: BaseObserver):
         await self._observer.remove_observer(observer)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -117,7 +117,8 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
 
     async def test_task_add_observer(self):
         frame_received = False
-        frame_add_count = 0
+        frame_count_1 = 0
+        frame_count_2 = 0
 
         class CustomObserver(BaseObserver):
             async def on_push_frame(self, data: FramePushed):
@@ -126,28 +127,41 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
                 if isinstance(data.frame, TextFrame):
                     frame_received = True
 
-        class CustomAddObserver(BaseObserver):
+        class CustomAddObserver1(BaseObserver):
             async def on_push_frame(self, data: FramePushed):
-                nonlocal frame_add_count
+                nonlocal frame_count_1
 
                 if isinstance(data.source, IdentityFilter) and isinstance(data.frame, TextFrame):
-                    frame_add_count += 1
+                    frame_count_1 += 1
+
+        class CustomAddObserver2(BaseObserver):
+            async def on_push_frame(self, data: FramePushed):
+                nonlocal frame_count_2
+
+                if isinstance(data.source, IdentityFilter) and isinstance(data.frame, TextFrame):
+                    frame_count_2 += 1
 
         identity = IdentityFilter()
         pipeline = Pipeline([identity])
         task = PipelineTask(pipeline, observers=[CustomObserver()])
+
+        # Add a new observer right away, before doing anything else with the task.
+        observer1 = CustomAddObserver1()
+        task.add_observer(observer1)
+
         task.set_event_loop(asyncio.get_event_loop())
 
         async def delayed_add_observer():
-            observer = CustomAddObserver()
-            # Wait after the pipeline is started and add an observer.
+            observer2 = CustomAddObserver2()
+            # Wait after the pipeline is started and add another observer.
             await asyncio.sleep(0.1)
-            task.add_observer(observer)
+            task.add_observer(observer2)
             # Push a TextFrame and wait for the observer to pick it up.
             await task.queue_frame(TextFrame(text="Hello Downstream!"))
             await asyncio.sleep(0.1)
-            # Remove the observer
-            await task.remove_observer(observer)
+            # Remove both observers.
+            await task.remove_observer(observer1)
+            await task.remove_observer(observer2)
             # Push another TextFrame. This time the counter should not
             # increments since we have removed the observer.
             await task.queue_frame(TextFrame(text="Hello Downstream!"))
@@ -158,7 +172,8 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
         await asyncio.gather(task.run(), delayed_add_observer())
 
         assert frame_received
-        assert frame_add_count == 1
+        assert frame_count_1 == 1
+        assert frame_count_2 == 1
 
     async def test_task_started_ended_event_handler(self):
         start_received = False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -142,7 +142,7 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
             observer = CustomAddObserver()
             # Wait after the pipeline is started and add an observer.
             await asyncio.sleep(0.1)
-            await task.add_observer(observer)
+            task.add_observer(observer)
             # Push a TextFrame and wait for the observer to pick it up.
             await task.queue_frame(TextFrame(text="Hello Downstream!"))
             await asyncio.sleep(0.1)


### PR DESCRIPTION
…o call it before `run()`ning the `PipelineTask` first. Without this change, if they tried to do that, they would get an error because the `TaskManager`'s event loop hadn't been set yet.