### PR TITLE
fix(piper-tts): typo

### DIFF
--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -74,12 +74,12 @@ class PiperTTSService(TTSService):
 
             async with self._session.post(self._base_url, data=text, headers=headers) as response:
                 if response.status != 200:
-                    eror = await response.text()
+                    error = await response.text()
                     logger.error(
-                        f"{self} error getting audio (status: {response.status}, error: {eror})"
+                        f"{self} error getting audio (status: {response.status}, error: {error})"
                     )
                     yield ErrorFrame(
-                        f"Error getting audio (status: {response.status}, error: {eror})"
+                        f"Error getting audio (status: {response.status}, error: {error})"
                     )
                     return
 


### PR DESCRIPTION
This pull request includes a small fix in the `run_tts` method in `src/pipecat/services/piper/tts.py`. The typo in the variable name `eror` was corrected to `error` to improve code readability and prevent potential confusion.