### PR TITLE
Add FR and DE to Rime TTS language map

### DIFF
--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -51,6 +51,8 @@ def language_to_rime_language(language: Language) -> str:
     LANGUAGE_MAP = {
         Language.EN: "eng",
         Language.ES: "spa",
+        Language.FR: "fra",
+        Language.DE: "ger",
     }
     return LANGUAGE_MAP.get(language, "eng")
 


### PR DESCRIPTION
This PR adds `fr/fra` and `de/ger` to the supported languages for Rime TTS.

For reference, all available language-voice combinations can be found here: https://users.rime.ai/data/voices/all-v2.json