### PR TITLE
Don't disconnect client in InputTransport when receive EndFrame

### DIFF
--- a/src/pipecat/transports/network/small_webrtc.py
+++ b/src/pipecat/transports/network/small_webrtc.py
@@ -413,7 +413,6 @@ class SmallWebRTCInputTransport(BaseInputTransport):
     async def stop(self, frame: EndFrame):
         await super().stop(frame)
         await self._stop_tasks()
-        await self._client.disconnect()
 
     async def cancel(self, frame: CancelFrame):
         await super().cancel(frame)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Tries to fix #1787 

If we disconnect `_client` in the Input transport after receiving `EndFrame`, we won't be able to play the enqueued `TTSFrames`. The client disconnection can happen in the Output transport instead. 