### PR TITLE
Gemini multimodal live context window compression & session resumption

### DIFF
--- a/examples/foundational/26a-gemini-multimodal-live-transcription.py
+++ b/examples/foundational/26a-gemini-multimodal-live-transcription.py
@@ -18,10 +18,10 @@ from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.processors.transcript_processor import TranscriptProcessor
-from pipecat.services.gemini_multimodal_live.gemini import GeminiMultimodalLiveLLMService
+from pipecat.services.gemini_multimodal_live.gemini import GeminiMultimodalLiveLLMService, GeminiMultimodalModalities, ContextWindowCompressionParams, InputParams, GeminiMediaResolution, SessionResumptionParams
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.network.fastapi_websocket import FastAPIWebsocketParams
-from pipecat.transports.services.daily import DailyParams
+from pipecat.transports.services.daily import DailyParams, DailyTransport
 
 load_dotenv(override=True)
 
@@ -64,10 +64,19 @@ async def run_example(transport: BaseTransport, _: argparse.Namespace, handle_si
     logger.info(f"Starting bot")
 
     llm = GeminiMultimodalLiveLLMService(
+        model="models/gemini-2.5-flash-preview-native-audio-dialog",
         api_key=os.getenv("GOOGLE_API_KEY"),
         voice_id="Aoede",  # Puck, Charon, Kore, Fenrir, Aoede
         # system_instruction="Talk like a pirate."
         # inference_on_context_initialization=False,
+        # params=InputParams(
+        #     session_resumption=SessionResumptionParams(
+        #     ),
+        #     context_window_compression=ContextWindowCompressionParams(
+        #         enabled=True,
+        #     ),
+        #     media_resolution=GeminiMediaResolution.LOW
+        # ),
     )
 
     context = OpenAILLMContext(

--- a/examples/foundational/26a-gemini-multimodal-live-transcription.py
+++ b/examples/foundational/26a-gemini-multimodal-live-transcription.py
@@ -64,7 +64,7 @@ async def run_example(transport: BaseTransport, _: argparse.Namespace, handle_si
     logger.info(f"Starting bot")
 
     llm = GeminiMultimodalLiveLLMService(
-        model="models/gemini-2.5-flash-preview-native-audio-dialog",
+        # model="models/gemini-2.5-flash-preview-native-audio-dialog",
         api_key=os.getenv("GOOGLE_API_KEY"),
         voice_id="Aoede",  # Puck, Charon, Kore, Fenrir, Aoede
         # system_instruction="Talk like a pirate."

--- a/examples/foundational/requirements.txt
+++ b/examples/foundational/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[webrtc,daily,deepgram,cartesia]
+pipecat-ai[webrtc,daily,deepgram,cartesia,silero]
 pipecat-ai-small-webrtc-prebuilt

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -115,6 +115,20 @@ class AudioTranscriptionConfig(BaseModel):
     pass
 
 
+class ContextWindowCompressionConfig(BaseModel):
+    """Configuration for context window compression."""
+
+    sliding_window: Optional[dict] = Field(default=True)
+    trigger_tokens: Optional[int] = Field(default=None)
+
+
+class SessionResumptionConfig(BaseModel):
+    """Configuration for session resumption."""
+
+    transparent: Optional[bool] = Field(default=None)
+    handle: Optional[str] = Field(default=None)
+
+
 class Setup(BaseModel):
     model: str
     system_instruction: Optional[SystemInstruction] = None
@@ -123,6 +137,8 @@ class Setup(BaseModel):
     input_audio_transcription: Optional[AudioTranscriptionConfig] = None
     output_audio_transcription: Optional[AudioTranscriptionConfig] = None
     realtime_input_config: Optional[RealtimeInputConfig] = None
+    context_window_compression: Optional[ContextWindowCompressionConfig] = None
+    session_resumption: Optional[SessionResumptionConfig] = None
 
 
 class Config(BaseModel):
@@ -228,9 +244,9 @@ class GoAway(BaseModel):
 class SessionResumptionUpdate(BaseModel):
     """Update of the session resumption state. Only sent if BidiGenerateContentSetup.session_resumption was set."""
 
-    newHandle: str
-    resumable: bool
-    lastConsumedClientMessageIndex: int
+    newHandle: Optional[str] = None
+    resumable: Optional[bool] = None
+    lastConsumedClientMessageIndex: Optional[int] = None
 
 
 class ServerEvent(BaseModel):
@@ -249,10 +265,3 @@ def parse_server_event(str):
     except Exception as e:
         print(f"Error parsing server event: {e}")
         return None
-
-
-class ContextWindowCompressionConfig(BaseModel):
-    """Configuration for context window compression."""
-
-    sliding_window: Optional[bool] = Field(default=True)
-    trigger_tokens: Optional[int] = Field(default=None)

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -164,6 +164,11 @@ class BidiGenerateContentTranscription(BaseModel):
     text: str
 
 
+class Duration(BaseModel):
+    seconds: int
+    nanos: int
+
+
 class ServerContent(BaseModel):
     modelTurn: Optional[ModelTurn] = None
     interrupted: Optional[bool] = None
@@ -214,11 +219,27 @@ class UsageMetadata(BaseModel):
     toolUsePromptTokensDetails: Optional[List[ModalityTokenCount]] = None
 
 
+class GoAway(BaseModel):
+    """Server will not be able to service client soon."""
+
+    timeLeft: str
+
+
+class SessionResumptionUpdate(BaseModel):
+    """Update of the session resumption state. Only sent if BidiGenerateContentSetup.session_resumption was set."""
+
+    newHandle: str
+    resumable: bool
+    lastConsumedClientMessageIndex: int
+
+
 class ServerEvent(BaseModel):
     setupComplete: Optional[SetupComplete] = None
     serverContent: Optional[ServerContent] = None
     toolCall: Optional[ToolCall] = None
     usageMetadata: Optional[UsageMetadata] = None
+    goAway: Optional[GoAway] = None
+    sessionResumptionUpdate: Optional[SessionResumptionUpdate] = None
 
 
 def parse_server_event(str):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -667,6 +667,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
                 config.setup.tools = self.get_llm_adapter().from_standard_tools(self._tools)
 
             logger.debug(f"settings {self._settings}")
+            logger.debug(f"config {config.model_dump(exclude_none=True)}")
 
             # Send the configuration
             await self.send_client_event(config)
@@ -936,11 +937,11 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
     @traced_gemini_live(operation="llm_go_away")
     async def _handle_evt_go_away(self, evt):
-        logger.info(f"Gemini is going away in {evt.goAway.timeLeft}")
+        logger.debug(f"Gemini is going away in {evt.goAway.timeLeft}")
 
     @traced_gemini_live(operation="llm_session_resumption_update")
     async def _handle_evt_session_resumption_update(self, evt):
-        logger.info(f"Gemini session resumption update: {evt.sessionResumptionUpdate}")
+        logger.debug(f"Gemini session resumption update: {evt.sessionResumptionUpdate}")
 
     @traced_gemini_live(operation="llm_response")
     async def _handle_evt_turn_complete(self, evt):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -700,7 +700,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         except Exception as e:
             if self._disconnecting:
                 return
-            # logger.error(f"Error sending message to websocket: {e}")
+            logger.error(f"Error sending message to websocket: {e}")
             # In server-to-server contexts, a WebSocket error should be quite rare. Given how hard
             # it is to recover from a send-side error with proper state management, and that exponential
             # backoff for retries can have cost/stability implications for a service cluster, let's just

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -282,6 +282,12 @@ class ContextWindowCompressionParams(BaseModel):
     )  # None = use default (80% of context window)
 
 
+class SessionResumptionParams(BaseModel):
+    """Parameters for session resumption."""
+
+    transparent: Optional[bool] = Field(default=None)
+    handle: Optional[str] = Field(default=None)
+
 class InputParams(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=0.0, le=2.0)
     max_tokens: Optional[int] = Field(default=4096, ge=1)
@@ -298,6 +304,7 @@ class InputParams(BaseModel):
     )
     vad: Optional[GeminiVADParams] = Field(default=None)
     context_window_compression: Optional[ContextWindowCompressionParams] = Field(default=None)
+    session_resumption: Optional[SessionResumptionParams] = Field(default=None)
     extra: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
@@ -400,6 +407,9 @@ class GeminiMultimodalLiveLLMService(LLMService):
             "language": self._language_code,
             "media_resolution": params.media_resolution,
             "vad": params.vad,
+            "session_resumption": params.session_resumption.model_dump()
+            if params.session_resumption
+            else None,
             "context_window_compression": params.context_window_compression.model_dump()
             if params.context_window_compression
             else {},
@@ -598,6 +608,20 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
                 config_data["setup"]["context_window_compression"] = compression_config
 
+            if self._settings.get("session_resumption"):
+                session_resumption_config = {}
+
+                transparent = self._settings.get("session_resumption").get("transparent")
+                handle = self._settings.get("session_resumption").get("handle")
+
+                if transparent is not None:
+                    session_resumption_config["transparent"] = transparent
+
+                if handle is not None:
+                    session_resumption_config["handle"] = handle
+
+                config_data["setup"]["session_resumption"] = session_resumption_config
+
             # Add VAD configuration if provided
             if self._settings.get("vad"):
                 vad_config = {}
@@ -642,6 +666,8 @@ class GeminiMultimodalLiveLLMService(LLMService):
                 logger.debug(f"Gemini is configuring to use tools{self._tools}")
                 config.setup.tools = self.get_llm_adapter().from_standard_tools(self._tools)
 
+            logger.debug(f"settings {self._settings}")
+
             # Send the configuration
             await self.send_client_event(config)
 
@@ -673,7 +699,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         except Exception as e:
             if self._disconnecting:
                 return
-            logger.error(f"Error sending message to websocket: {e}")
+            # logger.error(f"Error sending message to websocket: {e}")
             # In server-to-server contexts, a WebSocket error should be quite rare. Given how hard
             # it is to recover from a send-side error with proper state management, and that exponential
             # backoff for retries can have cost/stability implications for a service cluster, let's just
@@ -704,6 +730,10 @@ class GeminiMultimodalLiveLLMService(LLMService):
                 await self._handle_evt_output_transcription(evt)
             elif evt.toolCall:
                 await self._handle_evt_tool_call(evt)
+            elif evt.goAway:
+                await self._handle_evt_go_away(evt)
+            elif evt.sessionResumptionUpdate:
+                await self._handle_evt_session_resumption_update(evt)
             elif False:  # !!! todo: error events?
                 await self._handle_evt_error(evt)
                 # errors are fatal, so exit the receive loop
@@ -903,6 +933,14 @@ class GeminiMultimodalLiveLLMService(LLMService):
         ]
 
         await self.run_function_calls(function_calls_llm)
+
+    @traced_gemini_live(operation="llm_go_away")
+    async def _handle_evt_go_away(self, evt):
+        logger.info(f"Gemini is going away in {evt.goAway.timeLeft}")
+
+    @traced_gemini_live(operation="llm_session_resumption_update")
+    async def _handle_evt_session_resumption_update(self, evt):
+        logger.info(f"Gemini session resumption update: {evt.sessionResumptionUpdate}")
 
     @traced_gemini_live(operation="llm_response")
     async def _handle_evt_turn_complete(self, evt):


### PR DESCRIPTION
This PR addresses the following problems:

1. `ContextWindowCompressionConfig` was not being set correctly on `Setup` event. The `context_window_compression` field was missing on the model so it wasn't being sent to the server even if the client set it. Also fixed the type for `sliding_window` from `bool` to `dict` to match the reference https://ai.google.dev/api/live#contextwindowcompressionconfig 
2. Adding support for `SessionResumptionConfig` https://ai.google.dev/api/live#sessionresumptionconfig
3. Adding support for handling `GoAway` event https://ai.google.dev/api/live#goaway

I've opted to simply log the `SessionResumptionUpdate` and `GoAway` events and will leave future work to actually attempt the reconnection for later

This log shows the `SessionResumptionUpdate` event

```
2025-06-07 04:27:20.357 | DEBUG    | pipecat.services.gemini_multimodal_live.gemini:_handle_evt_session_resumption_update:944 - Gemini session resumption update: newHandle='CihvdGNnNThrcHM2eXZlenNiZzFyaTZqbmw4ZHk5dmh2ZnZ3aGRtaWRy' resumable=True lastConsumedClientMessageIndex=None
```

Partly addresses https://github.com/pipecat-ai/pipecat/issues/1606