### PR TITLE
CartesiaSTTService cleanup

### DIFF
--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -73,7 +73,7 @@ class CartesiaSTTService(STTService):
         self,
         *,
         api_key: str,
-        base_url: str = None,
+        base_url: str = "",
         sample_rate: int = 16000,
         live_options: Optional[CartesiaLiveOptions] = None,
         **kwargs,
@@ -101,6 +101,7 @@ class CartesiaSTTService(STTService):
             )
 
         self._settings = merged_options
+        self.set_model_name(merged_options["model"])
         self._api_key = api_key
         self._base_url = base_url or "api.cartesia.ai"
         self._connection = None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

One other observation: this service does not abide by the sample rate being set by the PipelineParams. In other services, we initialize to an Optional[int] of None and then let the StartFrame define the sample_rate. Should we not do the same here? The one caveat is that CartesiaSTTService supports 16khz only.

cc @aconchillo @filipi87 