### PR TITLE
Add `additional_span_attributes` param to PipelineTask for extra otel…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adds a parameter called `additional_span_attributes` to PipelineTask that
+  lets you add any additional attributes you'd like to the conversation span.
+
 ### Fixed
 
 - Fixed an issue with `CartesiaSTTService` initialization.

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -35,7 +35,11 @@ from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
 from pipecat.pipeline.base_pipeline import BasePipeline
 from pipecat.pipeline.base_task import BaseTask
 from pipecat.pipeline.task_observer import TaskObserver
-from pipecat.processors.frame_processor import FrameDirection, FrameProcessor, FrameProcessorSetup
+from pipecat.processors.frame_processor import (
+    FrameDirection,
+    FrameProcessor,
+    FrameProcessorSetup,
+)
 from pipecat.utils.asyncio import BaseTaskManager, TaskManager
 from pipecat.utils.tracing.setup import is_tracing_available
 from pipecat.utils.tracing.turn_trace_observer import TurnTraceObserver
@@ -184,7 +188,8 @@ class PipelineTask(BaseTask):
             the idle timeout is reached.
         enable_turn_tracking: Whether to enable turn tracking.
         enable_turn_tracing: Whether to enable turn tracing.
-
+        conversation_id: Optional custom ID for the conversation.
+        additional_span_attributes: Optional dictionary of attributes to propagate as OpenTelemetry conversation span attributes.
     """
 
     def __init__(
@@ -205,6 +210,7 @@ class PipelineTask(BaseTask):
         enable_turn_tracking: bool = True,
         enable_tracing: bool = False,
         conversation_id: Optional[str] = None,
+        additional_span_attributes: Optional[dict] = None,
     ):
         super().__init__()
         self._pipeline = pipeline
@@ -217,6 +223,7 @@ class PipelineTask(BaseTask):
         self._enable_turn_tracking = enable_turn_tracking
         self._enable_tracing = enable_tracing and is_tracing_available()
         self._conversation_id = conversation_id
+        self._additional_span_attributes = additional_span_attributes or {}
         if self._params.observers:
             import warnings
 
@@ -235,7 +242,9 @@ class PipelineTask(BaseTask):
             observers.append(self._turn_tracking_observer)
         if self._enable_tracing and self._turn_tracking_observer:
             self._turn_trace_observer = TurnTraceObserver(
-                self._turn_tracking_observer, conversation_id=self._conversation_id
+                self._turn_tracking_observer,
+                conversation_id=self._conversation_id,
+                additional_span_attributes=self._additional_span_attributes,
             )
             observers.append(self._turn_trace_observer)
         self._finished = False

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -35,11 +35,7 @@ from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
 from pipecat.pipeline.base_pipeline import BasePipeline
 from pipecat.pipeline.base_task import BaseTask
 from pipecat.pipeline.task_observer import TaskObserver
-from pipecat.processors.frame_processor import (
-    FrameDirection,
-    FrameProcessor,
-    FrameProcessorSetup,
-)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor, FrameProcessorSetup
 from pipecat.utils.asyncio import BaseTaskManager, TaskManager
 from pipecat.utils.tracing.setup import is_tracing_available
 from pipecat.utils.tracing.turn_trace_observer import TurnTraceObserver
@@ -189,7 +185,8 @@ class PipelineTask(BaseTask):
         enable_turn_tracking: Whether to enable turn tracking.
         enable_turn_tracing: Whether to enable turn tracing.
         conversation_id: Optional custom ID for the conversation.
-        additional_span_attributes: Optional dictionary of attributes to propagate as OpenTelemetry conversation span attributes.
+        additional_span_attributes: Optional dictionary of attributes to propagate as
+            OpenTelemetry conversation span attributes.
     """
 
     def __init__(

--- a/src/pipecat/utils/tracing/turn_trace_observer.py
+++ b/src/pipecat/utils/tracing/turn_trace_observer.py
@@ -10,9 +10,7 @@ from loguru import logger
 
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
-from pipecat.utils.tracing.conversation_context_provider import (
-    ConversationContextProvider,
-)
+from pipecat.utils.tracing.conversation_context_provider import ConversationContextProvider
 from pipecat.utils.tracing.setup import is_tracing_available
 from pipecat.utils.tracing.turn_context_provider import TurnContextProvider
 


### PR DESCRIPTION
… attributes

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
This adds a parameter to PipelineTask that lets you add any additional attributes you'd like to the conversation span (for Pipecat Cloud, we need the ability to tag by session ID, but other folks might want to add a user ID, etc.)