### PR TITLE
fix: Add silence to the user recording buffer when using the mute filter

### DIFF
--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -237,6 +237,12 @@ class AudioBufferProcessor(FrameProcessor):
             # Add bot audio.
             resampled = await self._resample_audio(frame)
             self._bot_audio_buffer.extend(resampled)
+            # Sync the user's buffer to the bot's buffer by adding silence if needed
+            # This is needed when using the mute filter since it stop the InputAudioRawFrame
+            if len(self._bot_audio_buffer) > len(self._user_audio_buffer):
+                silence_size = len(self._bot_audio_buffer) - len(self._user_audio_buffer)
+                silence = b"\x00" * silence_size
+                self._user_audio_buffer.extend(silence)
 
     async def _handle_intermittent_stream(self, frame: Frame):
         if isinstance(frame, InputAudioRawFrame):


### PR DESCRIPTION
When using the AudioBufferProcessor with the mute filter there is an overlapping user and bot audio.
This is cause by the mute filter blocking the `InputAudioRawFrame`.

To fix it, we need to add some silence to the user buffer when receiving a `OutputAudioRawFrame` and the user buffer is smaller.

Before:

<img width="1051" alt="Screenshot 2025-06-11 at 10 33 33 AM" src="https://github.com/user-attachments/assets/fa03abab-9df1-4b44-bf9c-42c99368f35a" />


After:

<img width="1081" alt="Screenshot 2025-06-11 at 10 33 13 AM" src="https://github.com/user-attachments/assets/0579dae4-e1b0-4400-9143-25b36451d2b6" />

(Not the same recording, btw)
