### PR TITLE
Expose has_function_calls_in_progress property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a property called `has_function_calls_in_progress` in
+  `LLMAssistantContextAggregator` that exposes whether a function call is in
+  progress.
+
 ### Fixed
 
 - Fixed an issue with `GroqTTSService` where it was not properly parsing the
   WAV file header.
 
-- Fixed an issue with `GoogleSTTService` where it was constantly reconnecting 
+- Fixed an issue with `GoogleSTTService` where it was constantly reconnecting
+
+- Fixed an issue with `GoogleSTTService` where it was constantly reconnecting
   before starting to receive audio from the user.
 
 - Fixed an issue where `GoogleLLMService`'s TTFB value was incorrect.

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -504,6 +504,15 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
         self._function_calls_in_progress: Dict[str, Optional[FunctionCallInProgressFrame]] = {}
         self._context_updated_tasks: Set[asyncio.Task] = set()
 
+    @property
+    def has_function_calls_in_progress(self) -> bool:
+        """Check if there are any function calls currently in progress.
+
+        Returns:
+            bool: True if function calls are in progress, False otherwise
+        """
+        return bool(self._function_calls_in_progress)
+
     async def handle_aggregation(self, aggregation: str):
         self._context.add_message({"role": "assistant", "content": aggregation})
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Used by Pipecat Flows. Use case is to understand when there are additional function calls pending.