### PR TITLE
Support polish language in Amazon Transcribe

### DIFF
--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -266,6 +266,7 @@ class AWSTranscribeSTTService(STTService):
             Language.JA: "ja-JP",
             Language.KO: "ko-KR",
             Language.ZH: "zh-CN",
+            Language.PL: "pl-PL",
         }
         return language_map.get(language)
 


### PR DESCRIPTION
Hi,

I'm currently testing pipecat for my usecase that requires supporting Polish language transcription through Amazon  Transcribe. 
I'm Polish native, so tested it and looks like works.