### PR TITLE
RTVI: ignore messages from another bot

### DIFF
--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -400,6 +400,8 @@ class RTVIObserverParams:
     """
     Parameters for configuring RTVI Observer behavior.
 
+    Protip: Set these all to `False` if the bot will talk to another bot.
+
     Attributes:
         bot_llm_enabled (bool): Indicates if the bot's LLM messages should be sent.
         bot_tts_enabled (bool): Indicates if the bot's TTS messages should be sent.
@@ -802,7 +804,7 @@ class RTVIProcessor(FrameProcessor):
             await self._message_queue.put(message)
         except ValidationError as e:
             await self.send_error(f"Invalid RTVI transport message: {e}")
-            logger.warning(f"Invalid RTVI transport message: {e}")
+            logger.warning(f"Invalid RTVI transport message '{transport_message}': {e}")
 
     async def _handle_message(self, message: RTVIMessage):
         try:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Ignore RTVI messages from another bot

Currently, RTVI observer only handles RTVI messages from a _client_.
When a bot talks to another bot*, it receives messages from a _bot_ and it does not aniticipate these types of messages. This was throwing lots and lots of errors and interrupting recordings.
This change ignores these messages.

*a bot talking to another bot is a common test scenario.