### PR TITLE
Support AWS Polly Lexicon Names parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `lexicon_names` parameter to `AWSPollyTTSService.InputParams`.
+
 - Added reconnection logic and audio buffer management to `GladiaSTTService`.
 
 - Added Polish support to `AWSTranscribeSTTService`.

--- a/src/pipecat/services/aws/tts.py
+++ b/src/pipecat/services/aws/tts.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import os
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, List, Optional
 
 from loguru import logger
 from pydantic import BaseModel
@@ -115,6 +115,7 @@ class AWSPollyTTSService(TTSService):
         pitch: Optional[str] = None
         rate: Optional[str] = None
         volume: Optional[str] = None
+        lexicon_names: Optional[List[str]] = None
 
     def __init__(
         self,
@@ -147,6 +148,7 @@ class AWSPollyTTSService(TTSService):
             "pitch": params.pitch,
             "rate": params.rate,
             "volume": params.volume,
+            "lexicon_names": params.lexicon_names,
         }
 
         self._resampler = create_default_resampler()
@@ -235,6 +237,7 @@ class AWSPollyTTSService(TTSService):
                 "Engine": self._settings["engine"],
                 # AWS only supports 8000 and 16000 for PCM. We select 16000.
                 "SampleRate": "16000",
+                "LexiconNames": self._settings["lexicon_names"],
             }
 
             # Filter out None values


### PR DESCRIPTION
Changes:
- add "LexiconNames" as an input param for AWS Polly tts.

Documentation reference
[AWS Managing Lexicons](https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html)
[SynthesizeSpeech request params](https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html)