### PR TITLE
Fix missing video_in_enabled in vision bot.py for Moondream template

### DIFF
--- a/examples/moondream-chatbot/bot.py
+++ b/examples/moondream-chatbot/bot.py
@@ -143,6 +143,7 @@ async def main():
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
+                video_in_enabled=True,
                 video_out_enabled=True,
                 video_out_width=1024,
                 video_out_height=576,


### PR DESCRIPTION
The parameter video_in_enabled=True was missing in DailyParams, which prevented image capture  from working. Without this parameter, UserImageRequestFrame would be sent but no actual image data would be captured from participants.

This fix enables the "Let me take a look" functionality to work as  intended by allowing the transport to capture video frames for vision processing with Moondream.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.