### PR TITLE
fix: Telnyx, catch error when user has hung up the call first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added logging and improved error handling to help diagnose and prevent potential 
+- Added logging and improved error handling to help diagnose and prevent potential
   Pipeline freezes.
 
 - Introduce task watchdog timers. Watchdog timers are used to detect if a
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LLMAssistantContextAggregator` that exposes whether a function call is in
   progress.
 
-- Added `SambaNovaLLMService` which provides llm api integration with an 
+- Added `SambaNovaLLMService` which provides llm api integration with an
   OpenAI-compatible interface.
 
 - Added `SambaNovaTTSService` which provides speech-to-text functionality using
@@ -84,14 +84,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed an issue in `FastAPIWebsocketClient` to ensure proper disconnection 
+- Fixed an issue in `FastAPIWebsocketClient` to ensure proper disconnection
   when the websocket is already closed.
 
 - Fixed an issue where the `UserStoppedSpeakingFrame` was not received if the
   transport was not receiving new audio frames.
 
-- Fixed an edge case where if the user interrupted the bot but no new aggregation 
+- Fixed an edge case where if the user interrupted the bot but no new aggregation
   was received, the bot would not resume speaking.
+
+- Fixed an issue with `TelnyxFrameSerializer` where it would throw an exception
+  when the user hung up the call.
 
 - Fixed an issue with `ElevenLabsTTSService` where the context was not being
   closed.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

With the current code, when a user hangs up, an error occurs:
```
2025-06-24 11:15:57.588 | ERROR    | pipecat.serializers.telnyx:_hang_up_call:202 - Failed to terminate Telnyx call v3:S_AwERIkXuL9vqBSvluFUDxUdIQRk4R_gz6OPajNQNrlcX2ReJ2nzw: Status 422, Response: {
  "errors": [
    {
      "code": "90018",
      "title": "Call has already ended",
      "detail": "This call is no longer active and can't receive commands."
    }
  ]
}
```

The root cause is that the user hangs up first. This doesn't happen with Twilio, so it's unique behavior with Telnyx. Unfortunately, the call status isn't communicated over the websocket (just the mediastream status, which is different from the call status, as far as I can tell). Instead, we'll handle the 422 error and corresponding error code (#90018) and just log a debug message.