### PR TITLE
allow LLM services to manage watchdog timers

### DIFF
--- a/src/pipecat/utils/asyncio.py
+++ b/src/pipecat/utils/asyncio.py
@@ -288,14 +288,15 @@ class TaskManager(BaseTaskManager):
             logger.warning(f"Unable to start watchdog timer: task {name} does not exist")
 
     def reset_watchdog(self, task: asyncio.Task):
-        """Resets the given task watchdog timer. If not reset, a warning will be
-        logged indicating the task is stalling.
+        """Resets the given task watchdog timer. If not reset on time, a warning
+        will be logged indicating the task is stalling.
 
         """
         name = task.get_name()
         if name in self._tasks:
-            self._tasks[name].watchdog_start.clear()
-            self._tasks[name].watchdog_timer.set()
+            if self._tasks[name].watchdog_start.is_set():
+                self._tasks[name].watchdog_start.clear()
+                self._tasks[name].watchdog_timer.set()
         else:
             logger.warning(f"Unable to reset watchdog timer: task {name} does not exist")
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

LLMs might take more than 5 seconds (the watchdog timer default) to generate the full response. In Pipecat we start pushing tokens as soon as we receive them but that doesn't mean the LLM is done. With this PR the LLMs have control of the watchdog timers and use them in the token generation instead.