### PR TITLE
Add option to change the base URL for Google Generative AI.

### DIFF
--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -678,6 +678,7 @@ class GoogleLLMService(LLMService):
         system_instruction: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_config: Optional[Dict[str, Any]] = None,
+        http_options: Optional[Any] = None,
         **kwargs,
     ):
         """Initialize the Google LLM service.
@@ -689,6 +690,7 @@ class GoogleLLMService(LLMService):
             system_instruction: System instruction/prompt for the model.
             tools: List of available tools/functions.
             tool_config: Configuration for tool usage.
+            http_options: HTTP options for the client.
             **kwargs: Additional arguments passed to parent class.
         """
         super().__init__(**kwargs)
@@ -698,7 +700,8 @@ class GoogleLLMService(LLMService):
         self.set_model_name(model)
         self._api_key = api_key
         self._system_instruction = system_instruction
-        self._create_client(api_key)
+        self._http_options = http_options
+        self._create_client(api_key, http_options)
         self._settings = {
             "max_tokens": params.max_tokens,
             "temperature": params.temperature,
@@ -717,8 +720,8 @@ class GoogleLLMService(LLMService):
         """
         return True
 
-    def _create_client(self, api_key: str):
-        self._client = genai.Client(api_key=api_key)
+    def _create_client(self, api_key: str, http_options: Optional[Any] = None):
+        self._client = genai.Client(api_key=api_key, http_options=http_options)
 
     def _maybe_unset_thinking_budget(self, generation_params: Dict[str, Any]):
         try:

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -67,6 +67,7 @@ try:
         Content,
         FunctionCall,
         FunctionResponse,
+        HttpOptions,
         GenerateContentConfig,
         Part,
     )
@@ -678,7 +679,7 @@ class GoogleLLMService(LLMService):
         system_instruction: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_config: Optional[Dict[str, Any]] = None,
-        http_options: Optional[Any] = None,
+        http_options: Optional[HttpOptions] = None,
         **kwargs,
     ):
         """Initialize the Google LLM service.
@@ -720,7 +721,7 @@ class GoogleLLMService(LLMService):
         """
         return True
 
-    def _create_client(self, api_key: str, http_options: Optional[Any] = None):
+    def _create_client(self, api_key: str, http_options: Optional[HttpOptions] = None):
         self._client = genai.Client(api_key=api_key, http_options=http_options)
 
     def _maybe_unset_thinking_budget(self, generation_params: Dict[str, Any]):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This would be useful to support private instance or gateway of the API. There are issues where Gemini API suddenly reporting user location is not supported for the API use. Although using a server in a location supported by Gemini API. And this is also useful if the user wants to use an AI Gateway such as Cloudflare AI Gateway to monitor Gemini API usage.
https://github.com/googleapis/python-genai/issues/583.

Sample usage:
```
from google.genai import types

llm = GoogleLLMService(
        api_key=os.getenv("GOOGLE_API_KEY"),
        system_instruction=<system_instruction>,
        model="gemini-2.0-flash-lite",
        params=GoogleLLMService.InputParams(
            temperature="0.5",
            max_tokens=300
        ),
        http_options=types.HttpOptions(
            base_url=<new_base_url>
        )
    )
```

Issue references:
- https://www.googlecloudcommunity.com/gc/AI-ML/Gemini-API-suddenly-reporting-user-location-is-not-supported-for/m-p/797128
- https://www.googlecloudcommunity.com/gc/AI-ML/User-location-is-not-supported-for-the-API-use/m-p/796996/highlight/true
- https://stackoverflow.com/questions/77659552/google-generative-ai-api-error-user-location-is-not-supported-for-the-api-use
- https://www.googlecloudcommunity.com/gc/AI-ML/User-location-is-not-supported-for-the-API-use/m-p/797113
- https://www.reddit.com/r/GoogleGeminiAI/comments/1jrm74o/after_weeks_of_solid_performance_user_location_is/
- https://discuss.ai.google.dev/t/api-response-is-user-location-is-not-supported-for-the-api-use-what-can-i-do/47746