### PR TITLE
FishAudioTTSService: arg cleanup, add new InputParam and arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `normalize` and `model_id` to `FishAudioTTSService`.
+
 - Added `run_llm` field to `LLMMessagesAppendFrame` and `LLMMessagesUpdateFrame`
   frames. If true, a context frame will be pushed triggering the LLM to respond.
 
@@ -85,9 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- In `FishTTSService`, deprecated `model` and replaced with `reference_id`.
-  This change is to better align with Fish Audio's variable naming and to
-  reduce confusion about what functionality the variable controls.
+- In `FishAudioTTSService`, deprecated `model` and replaced with
+  `reference_id`. This change is to better align with Fish Audio's variable
+  naming and to reduce confusion about what functionality the variable
+  controls.
 
 ## [0.0.73] - 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `session_token` parameter to `AWSNovaSonicLLMService`.
 
-- Added Gemini Multimodal Live File API for uploading, fetching, listing, and 
-deleting files. See `26f-gemini-multimodal-live-files-api.py` for example usage.
+- Added Gemini Multimodal Live File API for uploading, fetching, listing, and
+  deleting files. See `26f-gemini-multimodal-live-files-api.py` for example usage.
 
 ### Changed
 
@@ -75,13 +75,19 @@ deleting files. See `26f-gemini-multimodal-live-files-api.py` for example usage.
 
 ### Fixed
 
-- Fixed an issue where audio would get stuck in the queue when an interrupt occurs 
+- Fixed an issue where audio would get stuck in the queue when an interrupt occurs
   during Azure TTS synthesis.
 
 - Fixed a race condition that occurs in Python 3.10+ where the task could miss
   the `CancelledError` and continue running indefinitely, freezing the pipeline.
 
 - Fixed a `AWSNovaSonicLLMService` issue introduced in 0.0.72.
+
+### Deprecated
+
+- In `FishTTSService`, deprecated `model` and replaced with `reference_id`.
+  This change is to better align with Fish Audio's variable naming and to
+  reduce confusion about what functionality the variable controls.
 
 ## [0.0.73] - 2025-06-26
 

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -71,7 +71,8 @@ class FishAudioTTSService(InterruptibleTTSService):
         self,
         *,
         api_key: str,
-        model: str,  # This is the reference_id
+        reference_id: Optional[str] = None,  # This is the voice ID
+        model: Optional[str] = None,  # Deprecated
         output_format: FishAudioOutputFormat = "pcm",
         sample_rate: Optional[int] = None,
         params: Optional[InputParams] = None,
@@ -81,7 +82,13 @@ class FishAudioTTSService(InterruptibleTTSService):
 
         Args:
             api_key: Fish Audio API key for authentication.
-            model: Reference ID of the voice model to use for synthesis.
+            reference_id: Reference ID of the voice model to use for synthesis.
+            model: Deprecated. Reference ID of the voice model to use for synthesis.
+
+              .. deprecated:: 0.0.74
+                The `model` parameter is deprecated and will be removed in version 0.1.0.
+                Use `reference_id` instead to specify the voice model.
+
             output_format: Audio output format. Defaults to "pcm".
             sample_rate: Audio sample rate. If None, uses default.
             params: Additional input parameters for voice customization.
@@ -95,6 +102,26 @@ class FishAudioTTSService(InterruptibleTTSService):
         )
 
         params = params or FishAudioTTSService.InputParams()
+
+        # Validation for model and reference_id parameters
+        if model and reference_id:
+            raise ValueError(
+                "Cannot specify both 'model' and 'reference_id'. Use 'reference_id' only."
+            )
+
+        if model is None and reference_id is None:
+            raise ValueError("Must specify 'reference_id' (or deprecated 'model') parameter.")
+
+        if model:
+            import warnings
+
+            warnings.warn(
+                "Parameter 'model' is deprecated and will be removed in a future version. "
+                "Use 'reference_id' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            reference_id = model
 
         self._api_key = api_key
         self._base_url = "wss://api.fish.audio/v1/tts/live"
@@ -111,10 +138,8 @@ class FishAudioTTSService(InterruptibleTTSService):
                 "speed": params.prosody_speed,
                 "volume": params.prosody_volume,
             },
-            "reference_id": model,
+            "reference_id": reference_id,
         }
-
-        self.set_model_name(model)
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -123,16 +148,6 @@ class FishAudioTTSService(InterruptibleTTSService):
             True, as Fish Audio service supports metrics generation.
         """
         return True
-
-    async def set_model(self, model: str):
-        """Set the TTS model (reference ID).
-
-        Args:
-            model: The reference ID of the voice model to use.
-        """
-        self._settings["reference_id"] = model
-        await super().set_model(model)
-        logger.info(f"Switching TTS model to: [{model}]")
 
     async def start(self, frame: StartFrame):
         """Start the Fish Audio TTS service.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fish Audio has changed their naming:
- `model` is now `reference_id`, so we're deprecating `model` and using `reference_id` instead
- Also, we're adding the arg called `model_id` which is the actual model and a new param to `InputParams` called `normalize`.

Replacing #2031 which started this work.