### PR TITLE
Make fix-ruff.sh more flexible, use pyproject rules

### DIFF
--- a/scripts/fix-ruff.sh
+++ b/scripts/fix-ruff.sh
@@ -1,5 +1,10 @@
-ruff format src
-ruff format examples
-ruff format tests
-ruff format scripts
-ruff check --select I,D --fix
+
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Running ruff format..."
+ruff format "$PROJECT_ROOT"
+echo "Running ruff check..."
+ruff check --fix "$PROJECT_ROOT"


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Updates:
- allow the fix-ruff.sh script to be run from anywhere
- use the same linting rules from pyproject.toml