### PR TITLE
fix: use a different aggregation timeout for emulated user speech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Two package dependencies have been updated:
-  - `numpy` now supports 1.26.0 and newer
-  - `transformers` now supports 4.48.0 and newer
-
 ### Added
 
 - Added `SpeechControlParamsFrame`, a new `SystemFrame` that notifies
   downstream processors of the VAD and Turn analyzer params. This frame is
   pushed by the `BaseInputTransport` at Start and any time a
   `VADParamsUpdateFrame` is received.
+
+### Changed
+
+- Two package dependencies have been updated:
+  - `numpy` now supports 1.26.0 and newer
+  - `transformers` now supports 4.48.0 and newer
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `numpy` now supports 1.26.0 and newer
   - `transformers` now supports 4.48.0 and newer
 
+### Added
+
+- Added `VADParamsNotificationFrame`, a new `SystemFrame` that notifies
+  downstream processors when VAD parameters are set or updated. This frame is
+  pushed by the `BaseInputTransport` during initial VAD configuration and
+  whenever a `VADParamsUpdateFrame` is received.
+
 ### Fixed
 
 - Fixed an issue where using audio input with a sample rate requiring resampling
@@ -24,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue in ParallelPipeline that caused errors when attempting to drain
   the queues.
+
+- Fixed an issue with emulated VAD timeout inconsistency in
+  `LLMUserContextAggregator`. Previously, emulated VAD scenarios (where
+  transcription is received without VAD detection) used a hardcoded
+  `aggregation_timeout` (default 0.5s) instead of matching the VAD's
+  `stop_secs` parameter (default 0.8s). This created different user experiences
+  between real VAD and emulated VAD scenarios. Now, emulated VAD timeouts
+  automatically synchronize with the VAD's `stop_secs` parameter.
 
 - Fix a pipeline freeze when using AWS Nova Sonic, which would occur if the
   user started early, while the bot was still working through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `VADParamsNotificationFrame`, a new `SystemFrame` that notifies
-  downstream processors when VAD parameters are set or updated. This frame is
-  pushed by the `BaseInputTransport` during initial VAD configuration and
-  whenever a `VADParamsUpdateFrame` is received.
+- Added `SpeechControlParamsFrame`, a new `SystemFrame` that notifies
+  downstream processors of the VAD and Turn analyzer params. This frame is
+  pushed by the `BaseInputTransport` at Start and any time a
+  `VADParamsUpdateFrame` is received.
 
 ### Fixed
 

--- a/src/pipecat/audio/turn/base_turn_analyzer.py
+++ b/src/pipecat/audio/turn/base_turn_analyzer.py
@@ -76,6 +76,16 @@ class BaseTurnAnalyzer(ABC):
         """
         pass
 
+    @property
+    @abstractmethod
+    def params(self):
+        """Get the current turn analyzer parameters.
+
+        Returns:
+            Current turn analyzer configuration parameters.
+        """
+        pass
+
     @abstractmethod
     def append_audio(self, buffer: bytes, is_speech: bool) -> EndOfTurnState:
         """Appends audio data for analysis.

--- a/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
@@ -87,6 +87,15 @@ class BaseSmartTurn(BaseTurnAnalyzer):
         """
         return self._speech_triggered
 
+    @property
+    def params(self) -> SmartTurnParams:
+        """Get the current smart turn parameters.
+
+        Returns:
+            Current smart turn configuration parameters.
+        """
+        return self._params
+
     def append_audio(self, buffer: bytes, is_speech: bool) -> EndOfTurnState:
         """Append audio data for turn analysis.
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -616,6 +616,7 @@ class StartFrame(SystemFrame):
         enable_usage_metrics: Whether to enable usage metrics collection.
         interruption_strategies: List of interruption handling strategies.
         report_only_initial_ttfb: Whether to report only initial time-to-first-byte.
+        has_turn_analyzer: Whether a turn analyzer is configured in the pipeline.
     """
 
     audio_in_sample_rate: int = 16000
@@ -625,6 +626,7 @@ class StartFrame(SystemFrame):
     enable_usage_metrics: bool = False
     interruption_strategies: List[BaseInterruptionStrategy] = field(default_factory=list)
     report_only_initial_ttfb: bool = False
+    has_turn_analyzer: bool = False
 
 
 @dataclass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1145,6 +1145,20 @@ class OutputDTMFUrgentFrame(DTMFFrame, SystemFrame):
     pass
 
 
+@dataclass
+class VADParamsNotificationFrame(SystemFrame):
+    """Frame for notifying processors of VAD parameter changes.
+
+    This frame is pushed downstream when VAD parameters are set or updated,
+    allowing processors to adjust their behavior accordingly.
+
+    Parameters:
+        params: Current VAD parameters.
+    """
+
+    params: VADParams
+
+
 #
 # Control frames
 #

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -28,6 +28,7 @@ from typing import (
 )
 
 from pipecat.audio.interruptions.base_interruption_strategy import BaseInterruptionStrategy
+from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.metrics.metrics import MetricsData
 from pipecat.transcriptions.language import Language
@@ -616,7 +617,6 @@ class StartFrame(SystemFrame):
         enable_usage_metrics: Whether to enable usage metrics collection.
         interruption_strategies: List of interruption handling strategies.
         report_only_initial_ttfb: Whether to report only initial time-to-first-byte.
-        has_turn_analyzer: Whether a turn analyzer is configured in the pipeline.
     """
 
     audio_in_sample_rate: int = 16000
@@ -626,7 +626,6 @@ class StartFrame(SystemFrame):
     enable_usage_metrics: bool = False
     interruption_strategies: List[BaseInterruptionStrategy] = field(default_factory=list)
     report_only_initial_ttfb: bool = False
-    has_turn_analyzer: bool = False
 
 
 @dataclass
@@ -1148,17 +1147,20 @@ class OutputDTMFUrgentFrame(DTMFFrame, SystemFrame):
 
 
 @dataclass
-class VADParamsNotificationFrame(SystemFrame):
-    """Frame for notifying processors of VAD parameter changes.
+class SpeechControlParamsFrame(SystemFrame):
+    """Frame for notifying processors of speech control parameter changes.
 
-    This frame is pushed downstream when VAD parameters are set or updated,
-    allowing processors to adjust their behavior accordingly.
+    This includes parameters for both VAD (Voice Activity Detection) and
+    turn-taking analysis. It allows downstream processors to adjust their
+    behavior based on updated interaction control settings.
 
     Parameters:
-        params: Current VAD parameters.
+        vad_params: Current VAD parameters.
+        turn_params: Current turn-taking analysis parameters.
     """
 
-    params: VADParams
+    vad_params: Optional[VADParams] = None
+    turn_params: Optional[SmartTurnParams] = None
 
 
 #

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -659,7 +659,12 @@ class LLMUserContextAggregator(LLMContextResponseAggregator):
                 elif self._turn_params:
                     timeout = self._params.turn_emulated_vad_timeout
                 else:
-                    timeout = self._vad_params.stop_secs
+                    # Use VAD stop_secs when no turn analyzer is present, fallback if no VAD params
+                    timeout = (
+                        self._vad_params.stop_secs
+                        if self._vad_params
+                        else self._params.turn_emulated_vad_timeout
+                    )
                 await asyncio.wait_for(self._aggregation_event.wait(), timeout)
                 await self._maybe_emulate_user_speaking()
             except asyncio.TimeoutError:

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -275,6 +275,8 @@ class BaseInputTransport(FrameProcessor):
 
         # Specific system frames
         if isinstance(frame, StartFrame):
+            # Update StartFrame with turn analyzer info before pushing
+            frame.has_turn_analyzer = bool(self._params.turn_analyzer)
             # Push StartFrame before start(), because we want StartFrame to be
             # processed by every processor before any other frame is processed.
             await self.push_frame(frame, direction)

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -41,6 +41,7 @@ from pipecat.frames.frames import (
     SystemFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    VADParamsNotificationFrame,
     VADParamsUpdateFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -278,6 +279,9 @@ class BaseInputTransport(FrameProcessor):
             # processed by every processor before any other frame is processed.
             await self.push_frame(frame, direction)
             await self.start(frame)
+            if self._params.vad_analyzer:
+                notification = VADParamsNotificationFrame(params=self._params.vad_analyzer.params)
+                await self.push_frame(notification)
         elif isinstance(frame, CancelFrame):
             await self.cancel(frame)
             await self.push_frame(frame, direction)
@@ -310,6 +314,8 @@ class BaseInputTransport(FrameProcessor):
         elif isinstance(frame, VADParamsUpdateFrame):
             if self.vad_analyzer:
                 self.vad_analyzer.set_params(frame.params)
+                notification = VADParamsNotificationFrame(params=frame.params)
+                await self.push_frame(notification)
         elif isinstance(frame, FilterUpdateSettingsFrame) and self._params.audio_in_filter:
             await self._params.audio_in_filter.process_frame(frame)
         # Other frames

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -198,7 +198,7 @@ class BaseInputTransport(FrameProcessor):
 
         if self._params.vad_analyzer or self._params.turn_analyzer:
             vad_params = self._params.vad_analyzer.params if self._params.vad_analyzer else None
-            turn_params = self._params.turn_analyzer._params if self._params.turn_analyzer else None
+            turn_params = self._params.turn_analyzer.params if self._params.turn_analyzer else None
 
             speech_frame = SpeechControlParamsFrame(vad_params=vad_params, turn_params=turn_params)
             await self.push_frame(speech_frame)
@@ -320,7 +320,7 @@ class BaseInputTransport(FrameProcessor):
                 self.vad_analyzer.set_params(frame.params)
                 speech_frame = SpeechControlParamsFrame(
                     vad_params=frame.params,
-                    turn_params=self._params.turn_analyzer._params
+                    turn_params=self._params.turn_analyzer.params
                     if self._params.turn_analyzer
                     else None,
                 )

--- a/tests/test_context_aggregators.py
+++ b/tests/test_context_aggregators.py
@@ -19,13 +19,12 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     OpenAILLMContextAssistantTimestampFrame,
-    StartFrame,
+    SpeechControlParamsFrame,
     StartInterruptionFrame,
     TextFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
-    VADParamsNotificationFrame,
 )
 from pipecat.processors.aggregators.llm_response import (
     LLMAssistantAggregatorParams,
@@ -287,7 +286,7 @@ class BaseTestUserContextAggregator:
             context, params=LLMUserAggregatorParams(aggregation_timeout=AGGREGATION_TIMEOUT)
         )
         frames_to_send = [
-            VADParamsNotificationFrame(params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
+            SpeechControlParamsFrame(vad_params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
             UserStartedSpeakingFrame(),
             TranscriptionFrame(text="Hello Pipecat!", user_id="cat", timestamp=""),
             SleepFrame(),
@@ -296,7 +295,7 @@ class BaseTestUserContextAggregator:
             SleepFrame(sleep=AGGREGATION_SLEEP),
         ]
         expected_down_frames = [
-            VADParamsNotificationFrame,
+            SpeechControlParamsFrame,
             UserStartedSpeakingFrame,
             UserStoppedSpeakingFrame,
             *self.EXPECTED_CONTEXT_FRAMES,
@@ -377,12 +376,12 @@ class BaseTestUserContextAggregator:
         )  # No aggregation timeout; this tests VAD emulation
 
         frames_to_send = [
-            VADParamsNotificationFrame(params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
+            SpeechControlParamsFrame(vad_params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
             TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""),
             SleepFrame(sleep=AGGREGATION_SLEEP),
         ]
         expected_down_frames = [
-            VADParamsNotificationFrame,
+            SpeechControlParamsFrame,
             *self.EXPECTED_CONTEXT_FRAMES,
         ]
         expected_up_frames = [EmulateUserStartedSpeakingFrame, EmulateUserStoppedSpeakingFrame]
@@ -407,13 +406,13 @@ class BaseTestUserContextAggregator:
             context
         )  # No aggregation timeout; this tests VAD emulation
         frames_to_send = [
-            VADParamsNotificationFrame(params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
+            SpeechControlParamsFrame(vad_params=VADParams(stop_secs=AGGREGATION_TIMEOUT)),
             InterimTranscriptionFrame(text="Hello ", user_id="cat", timestamp=""),
             SleepFrame(),
             TranscriptionFrame(text="Hello Pipecat!", user_id="cat", timestamp=""),
             SleepFrame(sleep=AGGREGATION_SLEEP),
         ]
-        expected_down_frames = [VADParamsNotificationFrame, *self.EXPECTED_CONTEXT_FRAMES]
+        expected_down_frames = [SpeechControlParamsFrame, *self.EXPECTED_CONTEXT_FRAMES]
         expected_up_frames = [EmulateUserStartedSpeakingFrame, EmulateUserStoppedSpeakingFrame]
         start_metadata = {"has_turn_analyzer": False}
         await run_test(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR fixes: #2160.

The root cause of this issue is that emulated user speech (e.g. no VAD speech detection but the arrival of a TranscriptionFrame) results in pushing an aggregation after the `aggregation_timeout`. The `aggregation_timeout` is 0.5s and the default VAD `stop_secs` is 0.8s, so this often results in a completion occurring before desired. There are two new cases to handle, both of which occur when there is VAD emulation:

1. No turn analyzer present: In this case, the `_aggregation_task_handler` has a separate timeout for the emulated speech case where the timeout is set according to the `VADParams` `stop_secs`. This ensures a common UX for cases where there's both VAD detected speech and VAD emulation.
2. Turn analyzer present: In this case, we can't simply use the `VADParams` `stop_secs` because the `stop_secs` value is usually set very low (e.g. 0.2sec). Instead, we set a separate `LLMUserAggregatorParams` called `turn_emulated_vad_timeout` that defaults to 0.8sec (matching the `VADParams` `stop_secs` default). This default is likely sufficient, but if not, then it's configurable through the user aggregator. It's not ideal to have another value to set, but I don't see a better solution.

This requires two updates to frames:
1. The `StartFrame` gets a new field called `has_turn_analyzer` which defaults to False and is updated by the `BaseInputTransport` before it's pushed downstream.
2. A new `VADParamsNotificationFrame` is added which contains the `VADParams`. This frame is what informs the `LLMUserContextAggregator` of the `VADParams` `stop_secs`. It's emitted by the `BaseInputTransport` both when handling the `StartFrame` and when a `VADParamsUpdateFrame` is handled. This ensures that the `LLMUserContextAggregator` has the correct values.

Also, there's one miscellaneous fix for `.pre-commit-config.yaml`. The update is so that the pre-commit hook uses the pyproject.toml linting rules.