### PR TITLE
Fixed an issue in `GoogleLLMContext` where it would inject the `syste…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where, in some edge cases, the `EmulateUserStartedSpeakingFrame`
   could be created even if we didn't have a transcription.
 
+- Fixed an issue in `GoogleLLMContext` where it would inject the
+  `system_message` as a "user" message into cases where it was not meant to;
+  it was only meant to do that when there were no "regular" (non-function-call)
+  messages in the context, to ensure that inference would run properly.
+
 ## [0.0.76] - 2025-07-11
 
 ### Added

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -627,9 +627,9 @@ class GoogleLLMContext(OpenAILLMContext):
         # Check if we only have function-related messages (no regular text)
         has_regular_messages = any(
             len(msg.parts) == 1
-            and not getattr(msg.parts[0], "text", None)
-            and getattr(msg.parts[0], "function_call", None)
-            and getattr(msg.parts[0], "function_response", None)
+            and getattr(msg.parts[0], "text", None)
+            and not getattr(msg.parts[0], "function_call", None)
+            and not getattr(msg.parts[0], "function_response", None)
             for msg in self._messages
         )
 


### PR DESCRIPTION
…m_message` as a "user" message into cases where it was not meant to; it was only meant to do that when there were no "regular" (non-function-call) messages in the context, to ensure that inference would run properly.

It looks like [the fix in this PR](https://github.com/pipecat-ai/pipecat/pull/1212) went beyond fixing the attribute-is-`None` case and accidentally flipped the `has_regular_messages` check, so that it would be `True` when there were _no_ regular messages.

I noticed this bug when working on https://github.com/pipecat-ai/pipecat-flows/pull/171.

This mechanism—the injection of `system_message` as a "user" message—was [originally introduced](https://github.com/pipecat-ai/pipecat/pull/1111) to solve for the Pipecat Flows `ContextStrategy.RESET` state, when we were using "system" messages as `task_messages`. Without this mechanism, the conversation would stall out after the context reset since inference can't run without some non-function-call messages in the context. I validated that, with the change in this PR, `ContextStrategy.RESET` works (and that disabling the mechanism does indeed stall it out).

That said, with the switch in the above Pipecat Flows PR to recommending (and maybe eventually enforcing) that for Gemini we make `task_messages` "user" messages, like we do for Anthropic and AWS, this mechanism may eventually not be necessary (maybe). But leaving it for now.