### PR TITLE
Add Parallel Startup Option for Pipeline Services

### DIFF
--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -663,15 +663,10 @@ class PipelineTask(BasePipelineTask):
         )
         start_frame.metadata = self._params.start_metadata
 
-        pre_startup_services = self._collect_pre_startup_services(self._pipeline)
-        if pre_startup_services:
-            start_time = time.time()
-            if self._params.parallel_startup:
+        if self._params.parallel_startup:
+            pre_startup_services = self._collect_pre_startup_services(self._pipeline)
+            if pre_startup_services:
                 await asyncio.gather(*(s.start(start_frame) for s in pre_startup_services))
-            else:
-                for s in pre_startup_services:
-                    await s.start(start_frame)
-            logger.info(f"AI and transport services started in {time.time() - start_time:.2f}s")
 
         await self._source.queue_frame(start_frame, FrameDirection.DOWNSTREAM)
 

--- a/src/pipecat/services/ai_service.py
+++ b/src/pipecat/services/ai_service.py
@@ -153,7 +153,6 @@ class AIService(FrameProcessor):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, StartFrame):
-            await self.start(frame)
             if not self._has_started:
                 await self.start(frame)
         elif isinstance(frame, CancelFrame):

--- a/src/pipecat/services/ai_service.py
+++ b/src/pipecat/services/ai_service.py
@@ -44,6 +44,7 @@ class AIService(FrameProcessor):
         self._model_name: str = ""
         self._settings: Dict[str, Any] = {}
         self._session_properties: Dict[str, Any] = {}
+        self._has_started = False
 
     @property
     def model_name(self) -> str:
@@ -72,7 +73,7 @@ class AIService(FrameProcessor):
         Args:
             frame: The start frame containing initialization parameters.
         """
-        pass
+        self._has_started = True
 
     async def stop(self, frame: EndFrame):
         """Stop the AI service.
@@ -83,7 +84,7 @@ class AIService(FrameProcessor):
         Args:
             frame: The end frame.
         """
-        pass
+        self._has_started = False
 
     async def cancel(self, frame: CancelFrame):
         """Cancel the AI service.
@@ -94,7 +95,7 @@ class AIService(FrameProcessor):
         Args:
             frame: The cancel frame.
         """
-        pass
+        self._has_started = False
 
     async def _update_settings(self, settings: Mapping[str, Any]):
         from pipecat.services.openai_realtime_beta.events import (
@@ -153,6 +154,8 @@ class AIService(FrameProcessor):
 
         if isinstance(frame, StartFrame):
             await self.start(frame)
+            if not self._has_started:
+                await self.start(frame)
         elif isinstance(frame, CancelFrame):
             await self.cancel(frame)
         elif isinstance(frame, EndFrame):


### PR DESCRIPTION
#### Summary
- Introduced the `parallel_startup` parameter in `PipelineParams` and `PipelineTask` to enable experimental parallel initialization of pipeline services (such as `AIService`, input/output transports, etc.).
- When `parallel_startup` is set to `True`, all relevant services are started concurrently using `asyncio.gather`, instead of sequentially.
- This change aims to improve pipeline startup performance, especially for pipelines with multiple services.

#### Performance Improvement
- With parallel startup enabled, service initialization time was reduced significantly:
    - **Serial:** Services started in 2.23s, 2.57s, 3.11s
    - **Parallel:** Services started in 1.12s, 1.46s, 1.64s
- This demonstrates nearly a 2x improvement in startup time.
- I measured it three times on my MacBook.

#### Additional Notes
- The default value for `parallel_startup` remains `False` to ensure backward compatibility.
- This is an experimental feature and may require further testing for stability.