### PR TITLE
Add text input handling to unify context for realtimeInput stream of GeminiMultimodalLiveService

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1074,12 +1074,12 @@ class InputImageRawFrame(SystemFrame, ImageRawFrame):
         return f"{self.name}(pts: {pts}, source: {self.transport_source}, size: {self.size}, format: {self.format})"
 
 
-@dataclass  
+@dataclass
 class InputTextRawFrame(SystemFrame, TextFrame):
     """Raw text input frame from transport.
-    
+
     Text input usually coming from user typing or programmatic text injection
-    that should be sent to LLM services as input, similar to how InputAudioRawFrame 
+    that should be sent to LLM services as input, similar to how InputAudioRawFrame
     and InputImageRawFrame represent user audio and video input.
     """
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1074,6 +1074,20 @@ class InputImageRawFrame(SystemFrame, ImageRawFrame):
         return f"{self.name}(pts: {pts}, source: {self.transport_source}, size: {self.size}, format: {self.format})"
 
 
+@dataclass  
+class InputTextRawFrame(SystemFrame, TextFrame):
+    """Raw text input frame from transport.
+    
+    Text input usually coming from user typing or programmatic text injection
+    that should be sent to LLM services as input, similar to how InputAudioRawFrame 
+    and InputImageRawFrame represent user audio and video input.
+    """
+
+    def __str__(self):
+        pts = format_pts(self.pts)
+        return f"{self.name}(pts: {pts}, source: {self.transport_source}, text: [{self.text}])"
+
+
 @dataclass
 class UserAudioRawFrame(InputAudioRawFrame):
     """Raw audio input frame associated with a specific user.

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -114,13 +114,15 @@ class RealtimeInputConfig(BaseModel):
 
 
 class RealtimeInput(BaseModel):
-    """Contains realtime input media chunks.
+    """Contains realtime input media chunks and text.
 
     Parameters:
         mediaChunks: List of media chunks for realtime processing.
+        text: Text for realtime processing.
     """
 
-    mediaChunks: List[MediaChunk]
+    mediaChunks: Optional[List[MediaChunk]] = None
+    text: Optional[str] = None
 
 
 class ClientContent(BaseModel):
@@ -188,6 +190,24 @@ class VideoInputMessage(BaseModel):
         return cls(
             realtimeInput=RealtimeInput(mediaChunks=[MediaChunk(mimeType=f"image/jpeg", data=data)])
         )
+
+
+class TextInputMessage(BaseModel):
+    """Message containing text input data."""
+
+    realtimeInput: RealtimeInput
+
+    @classmethod
+    def from_text(cls, text: str) -> "TextInputMessage":
+        """Create a text input message from a string.
+
+        Args:
+            text: The text to send.
+
+        Returns:
+            A TextInputMessage instance.
+        """
+        return cls(realtimeInput=RealtimeInput(text=text))
 
 
 class ClientContentMessage(BaseModel):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -971,9 +971,7 @@ class GeminiMultimodalLiveLLMService(LLMService):
         evt = events.TextInputMessage.from_text(text)
         await self.send_client_event(evt)
         # After sending text, we need to signal that the turn is complete.
-        evt = events.ClientContentMessage.model_validate(
-            {"clientContent": {"turnComplete": True}}
-        )
+        evt = events.ClientContentMessage.model_validate({"clientContent": {"turnComplete": True}})
         await self.send_client_event(evt)
 
     async def _send_user_video(self, frame):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -32,6 +32,7 @@ from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
     InputImageRawFrame,
+    InputTextRawFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesAppendFrame,
@@ -733,8 +734,9 @@ class GeminiMultimodalLiveLLMService(LLMService):
                 # Support just one tool call per context frame for now
                 tool_result_message = context.messages[-1]
                 await self._tool_result(tool_result_message)
-        elif isinstance(frame, LLMTextFrame):
+        elif isinstance(frame, InputTextRawFrame):
             await self._send_user_text(frame.text)
+            await self.push_frame(frame, direction)
         elif isinstance(frame, InputAudioRawFrame):
             await self._send_user_audio(frame)
             await self.push_frame(frame, direction)
@@ -967,7 +969,19 @@ class GeminiMultimodalLiveLLMService(LLMService):
             self._user_audio_buffer = self._user_audio_buffer[-length:]
 
     async def _send_user_text(self, text: str):
-        """Send user text to Gemini Live API."""
+        """Send user text via Gemini Live API's realtime input stream.
+        
+        This method sends text through the realtimeInput stream (via TextInputMessage)
+        rather than the clientContent stream. This ensures text input is synchronized
+        with audio and video inputs, preventing temporal misalignment that can occur
+        when different modalities are processed through separate API pathways.
+        
+        After sending the text, we signal turn completion to trigger a model response
+        for text-only interactions.
+        
+        Args:
+            text: The text to send as user input.
+        """
         evt = events.TextInputMessage.from_text(text)
         await self.send_client_event(evt)
         # After sending text, we need to signal that the turn is complete.

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -968,7 +968,6 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
     async def _send_user_text(self, text: str):
         """Send user text to Gemini Live API."""
-        logger.debug(f"Sending text to Gemini: {text}")
         evt = events.TextInputMessage.from_text(text)
         await self.send_client_event(evt)
         # After sending text, we need to signal that the turn is complete.

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -970,15 +970,15 @@ class GeminiMultimodalLiveLLMService(LLMService):
 
     async def _send_user_text(self, text: str):
         """Send user text via Gemini Live API's realtime input stream.
-        
+
         This method sends text through the realtimeInput stream (via TextInputMessage)
         rather than the clientContent stream. This ensures text input is synchronized
         with audio and video inputs, preventing temporal misalignment that can occur
         when different modalities are processed through separate API pathways.
-        
+
         After sending the text, we signal turn completion to trigger a model response
         for text-only interactions.
-        
+
         Args:
             text: The text to send as user input.
         """


### PR DESCRIPTION
## Summary
This pull request fixes a contextual disconnect in the Gemini Multimodal Live API integration.  
Previously, text inputs went through the **clientContent** stream, while audio and video used **realtimeInput**.  
Because the Gemini API processes these streams concurrently, their contexts are not guaranteed to interleave, which can cause text to drift out of sync with simultaneous audio/video.

The PR adds a pathway that sends text through **realtimeInput**, so text, audio, and video now share the same context stream for coherent, synchronized interactions.

---

## Changes Implemented

### `src/pipecat/services/gemini_multimodal_live/events.py`
- **RealtimeInput** model: added optional `text` field (parity with `BidiGenerateContentRealtimeInput`).
- Added **TextInputMessage** class to carry text into the `realtimeInput` stream.

### `src/pipecat/services/gemini_multimodal_live/gemini.py`
- Added new branch in `process_frame` to treat `LLMTextFrame` as a primary input.
- Implemented `_send_user_text` to forward text via `realtimeInput`.
- After sending text, emit a `clientContent` message with `turnComplete: true` to trigger a model response for text‑only turns.

---

## Backward Compatibility
Fully preserved.  
Existing workflows that send text through `LLMMessagesAppendFrame` (via **clientContent**) continue to function unchanged.  
This PR simply introduces an **additional** real‑time text pathway.
