### PR TITLE
ElevenLabsTTSService: Only reset the context_id when interruptions ar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pyneuphonic` package. This removes a package requirement, allowing Neuphonic
   to work with more services.
 
+- Updated `ElevenLabsTTSService` to handle the case where
+  `allow_interruptions=False`. Now, when interruptions are disabled, the same
+  context ID will be used throughout the conversation.
+
 - Updated the `deepgram` optional dependency to 4.7.0, which downgrades the
   `tasks cancelled error` to a debug log. This removes the log from appearing
   in Pipecat logs upon leaving.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -642,8 +642,14 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
                     yield TTSStartedFrame()
                     self._started = True
                     self._cumulative_time = 0
-                    # Create new context ID and register it
-                    self._context_id = str(uuid.uuid4())
+                    # If a context ID does not exist, create a new one and
+                    # register it. If an ID exists, that means the Pipeline is
+                    # configured for allow_interruptions=False, so continue
+                    # using the current ID. When interruptions are enabled
+                    # (e.g. allow_interruptions=True), user speech results in
+                    # an interruption, which resets the context ID.
+                    if not self._context_id:
+                        self._context_id = str(uuid.uuid4())
                     await self.create_audio_context(self._context_id)
 
                     # Initialize context with voice settings

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -650,7 +650,8 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
                     # an interruption, which resets the context ID.
                     if not self._context_id:
                         self._context_id = str(uuid.uuid4())
-                    await self.create_audio_context(self._context_id)
+                    if not self.audio_context_available(self._context_id):
+                        await self.create_audio_context(self._context_id)
 
                     # Initialize context with voice settings
                     msg = {"text": " ", "context_id": self._context_id}


### PR DESCRIPTION
…e enabled

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In the ElevenLabsTTSService code, the prior assumption was that interruptions were enabled. This means that the `_handle_interruption` function would reset the context ID and `run_tts` would create a new ID.

Now, ElevenLabsTTSService only creates a new context ID in `run_tts` if no current ID exists. The avoids the concurrency limit imposed by the ElevenLabs websocket API by reusing the same context ID throughout the conversation.