### PR TITLE
Fixed an issue in `AudioBufferProcessor` that caused garbled audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in `AudioBufferProcessor` that caused garbled audio when
+  `enable_turn_audio` was enabled and audio resampling was required.
+
 - Fixed a dependency issue for uv users where an `llvmlite` version required python 3.9.
 
 - Fixed an issue in `MiniMaxHttpTTSService` where the `pitch` param was the


### PR DESCRIPTION
Fixed an issue in `AudioBufferProcessor` that caused garbled audio when `enable_turn_audio` was enabled and audio resampling was required.