### PR TITLE
Fixed an issue in AudioBufferProcessor when using SmallWebRTCTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in `AudioBufferProcessor` when using `SmallWebRTCTransport` where, if
+  the microphone was muted, track timing was not respected.
+
 - Fixed an issue in `AudioBufferProcessor` that caused garbled audio when
   `enable_turn_audio` was enabled and audio resampling was required.
 

--- a/src/pipecat/transports/network/webrtc_connection.py
+++ b/src/pipecat/transports/network/webrtc_connection.py
@@ -137,9 +137,9 @@ class SmallWebRTCTrack:
         """Receive the next frame from the track.
 
         Returns:
-            The next frame if the track is enabled, None otherwise.
+            The next frame, except for video tracks, where it returns the frame only if the track is enabled, otherwise, returns None.
         """
-        if not self._enabled:
+        if not self._enabled and self._track.kind == "video":
             return None
         return await self._track.recv()
 


### PR DESCRIPTION
Fixed an issue in `AudioBufferProcessor` when using `SmallWebRTCTransport` where, if the microphone was muted, track timing was not respected.