### PR TITLE
Remove message["name"] addition when pushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue in `AudioBufferProcessor` when using `SmallWebRTCTransport` where, if
   the microphone was muted, track timing was not respected.
 
+- Fixed an error that occurs when pushing an `LLMMessagesFrame`. Only some LLM
+  services, like Grok, are impacted by this issue. The fix is to remove the
+  optional `name` property that was being added to the message.
+
 - Fixed an issue in `AudioBufferProcessor` that caused garbled audio when
   `enable_turn_audio` was enabled and audio resampling was required.
 
-- Fixed a dependency issue for uv users where an `llvmlite` version required python 3.9.
+- Fixed a dependency issue for uv users where an `llvmlite` version required
+  python 3.9.
 
 - Fixed an issue in `MiniMaxHttpTTSService` where the `pitch` param was the
   incorrect type.

--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -111,8 +111,6 @@ class OpenAILLMContext:
         context = OpenAILLMContext()
 
         for message in messages:
-            if "name" not in message:
-                message["name"] = message["role"]
             context.add_message(message)
         return context
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

@kompfner found this in working through his context refactor. Another user reported in Discord that they see an error message like this when using Grok:
```
GrokLLMService#0::__input_frame_task_handler: unexpected exception: Error code: 400 - {'code': 'Client specified an invalid argument', 'error': 'Invalid request content: Only message of role user can have a name.'}
```

Not all services support an optional `name` field in the message. It's only used at the moment when you push an `LLMMessagesFrame`. Given it's limited use and that it's optional/not really utilized, we should remove it. This should help to remove a category of errors.