### PR TITLE
fix: Improve TranscriptProcessor detection for transcript type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in the `TranscriptProcessor` where newline characters could
+  cause the transcript output to be corrupted (e.g. missing all spaces).
+
 - Fixed an issue in `AudioBufferProcessor` when using `SmallWebRTCTransport` where, if
   the microphone was muted, track timing was not respected.
 

--- a/src/pipecat/processors/transcript_processor.py
+++ b/src/pipecat/processors/transcript_processor.py
@@ -140,11 +140,13 @@ class AssistantTranscriptProcessor(BaseTranscriptProcessor):
                 Result: "Hello there how are you"
         """
         if self._current_text_parts and self._aggregation_start_time:
+            # Check specifically for space characters, previously isspace() was used
+            # but that includes all whitespace characters (e.g. \n), not just spaces.
             has_leading_spaces = any(
-                part and part[0].isspace() for part in self._current_text_parts[1:]
+                part and part[0] == " " for part in self._current_text_parts[1:]
             )
             has_trailing_spaces = any(
-                part and part[-1].isspace() for part in self._current_text_parts[:-1]
+                part and part[-1] == " " for part in self._current_text_parts[:-1]
             )
 
             # If there are embedded spaces in the fragments, use direct concatenation


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The `isspace()` function checks for any whitespace character, not just spaces. When an LLM outputs text that contains newline characters (`\n`), this is incorrectly detected as a space, resulting in an incorrect transcript aggregation strategy.

Instead, the check is now explicitly for spaces.

Note: if newlines were output by the LLM, the TranscriptProcessor should not clean them up. The job of the TranscriptProcessor is to output the text received without modification. The `text_filters` feature of the TTSService can be used to modify the text. For example, setting `text_filters=[MarkdownTextFilter()]` will strip newline characters.