### PR TITLE
Fix Piper TTS Service

### DIFF
--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -22,7 +22,7 @@ from pipecat.services.tts_service import TTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
 
 
-# This assumes a running TTS service running: https://github.com/rhasspy/piper/blob/master/src/python_run/README_http.md
+# This assumes a running TTS service running: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_HTTP.md
 class PiperTTSService(TTSService):
     """Piper TTS service implementation.
 
@@ -79,12 +79,12 @@ class PiperTTSService(TTSService):
         """
         logger.debug(f"{self}: Generating TTS [{text}]")
         headers = {
-            "Content-Type": "text/plain",
+            "Content-Type": "application/json",
         }
         try:
             await self.start_ttfb_metrics()
 
-            async with self._session.post(self._base_url, data=text, headers=headers) as response:
+            async with self._session.post(self._base_url, json=text, headers=headers) as response:
                 if response.status != 200:
                     error = await response.text()
                     logger.error(


### PR DESCRIPTION
Update Piper TTS Service to work with the newer [Piper GPL](https://github.com/OHF-Voice/piper1-gpl) Version, that uses JSON as its payload.

# Issue
Pipecat returns an error when running the PiperTTSService:
```html
pipecat.services.piper.tts:run_tts:90 - PiperTTSService#0 error getting audio (status: 500, error: <!doctype html>
<html lang=en>
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>
)
```

When looking at Piper TTS HTTP Server Debug messages:
```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
INFO:werkzeug:127.0.0.1 - - POST / HTTP/1.1" 500 -
```

# Resolution
Send JSON data by changing the Content-Type and sending `json=text` in `session.post()`

# Additional Note
In the [Usage Example Docs](https://docs.pipecat.ai/server/services/tts/piper#usage-example) , the example uses `http://localhost:5000/api/tts` as its base URL, which has been changed to just `/` in the newer piper version. 
[Source](https://github.com/OHF-Voice/piper1-gpl/blob/0e29e407ade1dd39ef6d25745bbcbf186f497a9d/src/piper/http_server.py#L173)
Please update the documentation as well with the same. 