### PR TITLE
Fixed an issue in GoogleLLMService where interruptions did not work when an interruption strategy was used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in `GoogleLLMService` where interruptions did not work when an
+  interruption strategy was used.
+
 - Fixed an issue in the `TranscriptProcessor` where newline characters could
   cause the transcript output to be corrupted (e.g. missing all spaces).
 

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -84,21 +84,13 @@ class GoogleUserContextAggregator(OpenAIUserContextAggregator):
     Content and Part message format for user messages.
     """
 
-    async def push_aggregation(self):
-        """Push aggregated user text as a Google Content message."""
-        if len(self._aggregation) > 0:
-            self._context.add_message(Content(role="user", parts=[Part(text=self._aggregation)]))
+    async def handle_aggregation(self, aggregation: str):
+        """Add the aggregated user text to the context as a Google Content message.
 
-            # Reset the aggregation. Reset it before pushing it down, otherwise
-            # if the tasks gets cancelled we won't be able to clear things up.
-            self._aggregation = ""
-
-            # Push context frame
-            frame = OpenAILLMContextFrame(self._context)
-            await self.push_frame(frame)
-
-            # Reset our accumulator state.
-            await self.reset()
+        Args:
+            aggregation: The aggregated user text to add as a user message.
+        """
+        self._context.add_message(Content(role="user", parts=[Part(text=aggregation)]))
 
 
 class GoogleAssistantContextAggregator(OpenAIAssistantContextAggregator):


### PR DESCRIPTION
Fixed an issue in GoogleLLMService where interruptions did not work when an interruption strategy was used.

GoogleUserContextAggregator.push_aggregation() was completely overriding the base method, removing all interruption logic from LLMUserContextAggregator.

This fixes this [issue](https://github.com/pipecat-ai/pipecat/issues/2295)

Thank you @Aman-14 for the detailed description in the issue.