### PR TITLE
Enable Interruption Support for LLMUserResponseAggregator

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -1013,17 +1013,14 @@ class LLMUserResponseAggregator(LLMUserContextAggregator):
         """
         super().__init__(context=OpenAILLMContext(messages), params=params, **kwargs)
 
-    async def push_aggregation(self):
-        """Push the aggregated user input as an LLMMessagesFrame."""
-        if len(self._aggregation) > 0:
-            await self.handle_aggregation(self._aggregation)
+    async def _process_aggregation(self):
+        """Process the current aggregation and push it downstream."""
+        aggregation = self._aggregation
+        await self.reset()
+        await self.handle_aggregation(aggregation)
+        frame = LLMMessagesFrame(self._context.messages)
+        await self.push_frame(frame)
 
-            # Reset the aggregation. Reset it before pushing it down, otherwise
-            # if the tasks gets cancelled we won't be able to clear things up.
-            await self.reset()
-
-            frame = LLMMessagesFrame(self._context.messages)
-            await self.push_frame(frame)
 
 
 class LLMAssistantResponseAggregator(LLMAssistantContextAggregator):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
This fixes an issue reported on this discord [here](https://discord.com/channels/1239284677165056021/1398681452912181278/1400167964178911373)

**Problem:**

In `LLMUserContextAggregator`, the function `push_aggregation` was updated to handle the newly added Interruption Strategies. When using `LLMUserResponseAggregator `, it subclasses `LLMUserContextAggregator` and overrides `push_aggregation` without calling the super. this means the logic to handle Interruption Strategies isn't present.

**Solution:**

Theres a few ways to fix this, I opted for overriding `_process_aggregation` in the subclass. It looks like the logic that existed in the older `push_aggregation` got moved there and the same result is ultimately achieved. 