### PR TITLE
NeuphonicTTSService: change the default url value to the global endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the default `url` for `NeuphonicTTSService` to
+  `wss://api.neuphonic.com` as it provides better global performance. You can
+  set the URL to other URLs, such as the previous default:
+  `wss://eu-west-1.api.neuphonic.com`.
+
 - Update `daily-python` to 0.19.5.
 
 - `STTMuteFilter` now pushes the `STTMuteFrame` upstream and downstream, to

--- a/src/pipecat/services/neuphonic/tts.py
+++ b/src/pipecat/services/neuphonic/tts.py
@@ -107,7 +107,7 @@ class NeuphonicTTSService(InterruptibleTTSService):
         *,
         api_key: str,
         voice_id: Optional[str] = None,
-        url: str = "wss://eu-west-1.api.neuphonic.com",
+        url: str = "wss://api.neuphonic.com",
         sample_rate: Optional[int] = 22050,
         encoding: str = "pcm_linear",
         params: Optional[InputParams] = None,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes https://github.com/pipecat-ai/pipecat/issues/2306