### PR TITLE
Add workflow to sync quickstart to pipecat-quickstart repo

### DIFF
--- a/.github/workflows/sync-quickstart.yaml
+++ b/.github/workflows/sync-quickstart.yaml
@@ -1,0 +1,56 @@
+name: Sync Quickstart to pipecat-quickstart repo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/quickstart/**'
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  sync-quickstart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout quickstart repo
+        uses: actions/checkout@v4
+        with:
+          repository: pipecat-ai/pipecat-quickstart
+          token: ${{ secrets.QUICKSTART_SYNC_TOKEN }}
+          path: quickstart-repo
+
+      - name: Sync files (excluding READMEs)
+        run: |
+          # Copy code files only, skip READMEs
+          cp examples/quickstart/bot.py quickstart-repo/
+          cp examples/quickstart/requirements.txt quickstart-repo/
+          cp examples/quickstart/env.example quickstart-repo/
+
+          # Copy any other files that aren't README.md
+          find examples/quickstart -type f \
+            -not -name "README.md" \
+            -not -name "*.md" \
+            -exec cp {} quickstart-repo/ \;
+
+      - name: Commit and push changes
+        run: |
+          cd quickstart-repo
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add .
+
+          # Only commit if there are changes
+          if ! git diff --staged --quiet; then
+            git commit -m "Sync from pipecat main repo
+            
+            Updated files from examples/quickstart/
+            Commit: ${{ github.sha }}
+            "
+            git push
+          else
+            echo "No changes to sync"
+          fi


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

We'll treat the quickstart example in the pipecat repo as the source of truth and will sync the files to: https://github.com/pipecat-ai/pipecat-quickstart.

The two examples will have custom READMEs which won't be synced.

Token created as Github PAT.