### PR TITLE
Add dev to optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,22 @@ webrtc = [ "aiortc~=1.11.0", "opencv-python~=4.11.0.86" ]
 websocket = [ "websockets>=13.1,<15.0", "fastapi>=0.115.6,<0.117.0" ]
 whisper = [ "faster-whisper~=1.1.1" ]
 
+dev = [
+    "build~=1.2.2",
+    "coverage~=7.9.1",
+    "grpcio-tools~=1.67.1",
+    "pip-tools~=7.4.1",
+    "pre-commit~=4.2.0",
+    "pyright~=1.1.402",
+    "pytest~=8.4.1",
+    "pytest-asyncio~=1.0.0",
+    "pytest-aiohttp==1.1.0",
+    "ruff~=0.12.1",
+    "setuptools~=78.1.1",
+    "setuptools_scm~=8.3.1",
+    "python-dotenv~=1.1.1",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Adding `dev` to pyproject.toml so we can replace `pip install -r dev-requirements.txt` with `pip install -e .[dev]`

or, in uv land: `uv sync --extra dev`

This is a pre-req to updating our CI with uv, which will speed up times by 3-5x.