### PR TITLE
fix: LiveKitTransport, don't push empty AudioRawFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed
+  down the pipeline. This resulted in warnings by the STT processor.
+
 ## [0.0.77] - 2025-07-31
 
 ### Added

--- a/src/pipecat/transports/services/livekit.py
+++ b/src/pipecat/transports/services/livekit.py
@@ -605,6 +605,11 @@ class LiveKitInputTransport(BaseInputTransport):
                 pipecat_audio_frame = await self._convert_livekit_audio_to_pipecat(
                     audio_frame_event
                 )
+
+                # Skip frames with no audio data
+                if len(pipecat_audio_frame.audio) == 0:
+                    continue
+
                 input_audio_frame = UserAudioRawFrame(
                     user_id=participant_id,
                     audio=pipecat_audio_frame.audio,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Reports in Discord of users seeing:
```
WARNING  | pipecat.services.stt_service:process_audio_frame:157 - Empty audio frame received for STT service: DeepgramSTTService#0 0
```

This was due to LiveKit pushing empty audio frames. The new warning in the STTService was flagging empty audio frames. This fix updates LiveKitInputTransport to only push non-zero AudioRawFrames.