### PR TITLE
Fix PiperTTSService to send TTS input as JSON object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed
   down the pipeline. This resulted in warnings by the STT processor.
 - Fixed `PiperTTSService` to send text as a JSON object in the request body,
-  resolving compatibility with Piper's HTTP API.  
+  resolving compatibility with Piper's HTTP API.
 
 ## [0.0.77] - 2025-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed
   down the pipeline. This resulted in warnings by the STT processor.
+- Fixed PiperTTSService to send text as a JSON object in the request body,
+  resolving compatibility with Piper's HTTP API.  
 
 ## [0.0.77] - 2025-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed
   down the pipeline. This resulted in warnings by the STT processor.
-- Fixed PiperTTSService to send text as a JSON object in the request body,
+- Fixed `PiperTTSService` to send text as a JSON object in the request body,
   resolving compatibility with Piper's HTTP API.  
 
 ## [0.0.77] - 2025-07-31

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -84,8 +84,9 @@ class PiperTTSService(TTSService):
         try:
             await self.start_ttfb_metrics()
 
-            payload = {"text": text}
-            async with self._session.post(self._base_url, json=payload, headers=headers) as response:
+            async with self._session.post(
+                self._base_url, json={"text": text}, headers=headers
+            ) as response:
                 if response.status != 200:
                     error = await response.text()
                     logger.error(

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -84,7 +84,8 @@ class PiperTTSService(TTSService):
         try:
             await self.start_ttfb_metrics()
 
-            async with self._session.post(self._base_url, json=text, headers=headers) as response:
+            payload = {"text": text}
+            async with self._session.post(self._base_url, json=payload, headers=headers) as response:
                 if response.status != 200:
                     error = await response.text()
                     logger.error(


### PR DESCRIPTION
## Fix PiperTTSService request payload to match documented API

### Problem

The `PiperTTSService.run_tts` method currently sends a raw string as the POST payload:

```python
async with self._session.post(self._base_url, json=text, headers=headers) as response:
```

However, according to [Piper's HTTP API documentation](https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_HTTP.md), the expected format is a JSON object:

```json
{ "text": "..." }
```

This discrepancy causes the test `tests/test_piper_tts.py::test_run_piper_tts_success` to fail, as the service responds with an error when the payload format is incorrect.

### Fix
This PR updates the request to wrap text in the required dictionary format.

### Related Issues
* PR #2293 (merged recently) also modified this part of the code but did not fix the incorrect payload structure.
* This PR addresses the root cause of the failing test and restores compatibility with the Piper HTTP API.

### Outcome
* Fixes the failing unit test test_run_piper_tts_success.
* Ensures compliance with Piper’s HTTP API contract.
* No changes to external interfaces or breaking changes introduced.