### PR TITLE
Fixes 2277 - SSML reserved characters causes Azure TTS to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `on_transcription_stopped` and `on_transcription_error` to Daily
   callbacks.
 
+- Added SSML reserved character escaping to `AzureBaseTTSService` to properly handle special characters in text sent to Azure TTS. This fixes an issue where characters like `&`, `<`, `>`, `"`, and `'` in LLM-generated text would cause TTS failures.
+- 
 ### Changed
 
 - Changed the default `url` for `NeuphonicTTSService` to

--- a/src/pipecat/services/azure/tts.py
+++ b/src/pipecat/services/azure/tts.py
@@ -68,6 +68,16 @@ class AzureBaseTTSService(TTSService):
     construction, voice configuration, and parameter management.
     """
 
+    # Define SSML escape mappings based on SSML reserved characters
+    # See - https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-structure
+    SSML_ESCAPE_CHARS = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&apos;",
+    }
+
     class InputParams(BaseModel):
         """Input parameters for Azure TTS voice configuration.
 
@@ -126,14 +136,6 @@ class AzureBaseTTSService(TTSService):
             "style": params.style,
             "style_degree": params.style_degree,
             "volume": params.volume,
-        }
-
-        # Define SSML escape mappings based on SSML reserved characters
-        # See - https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-structure
-        self.ssml_escape_chars = {
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;'
         }
 
         self._api_key = api_key
@@ -210,7 +212,14 @@ class AzureBaseTTSService(TTSService):
         return ssml
 
     def _escape_text(self, text: str) -> str:
-        """Escape special characters in text for SSML.
+        """Escapes XML/SSML reserved characters according to Microsoft documentation.
+
+        This method escapes the following characters:
+        - & becomes &amp;
+        - < becomes &lt;
+        - > becomes &gt;
+        - " becomes &quot;
+        - ' becomes &apos;
 
         Args:
             text: The text to escape.
@@ -219,7 +228,7 @@ class AzureBaseTTSService(TTSService):
             The escaped text.
         """
         escaped_text = text
-        for char, escape_code in self.ssml_escape_chars.items():
+        for char, escape_code in AzureBaseTTSService.SSML_ESCAPE_CHARS.items():
             escaped_text = escaped_text.replace(char, escape_code)
         return escaped_text
 


### PR DESCRIPTION
This is related to issue #2277. 

The current implementation of AzureTTS generates SSML markup for Azure by directly embedding the LLM generated text to it. However, SSML has reserved. characters and according to Microsoft documentation (https://github.com/pipecat-ai/pipecat/compare/main...yohan-altrium:pipecat:fix/2277-azure-tts-ssml-reserved-characters?expand=1), Azure expects the & sign, and < and > signs to be escaped and replaced with entity format. (Note: Microsoft does not seem to require us to escape quotes).

This pull request fixes this issue by maintaining a list of characters to be escaped in `AzureBaseTTSService`, and escaping the text to replace those sensitive characters with the correct entity format.  