### PR TITLE
fix: Add missing transcription callbacks to TavusTransport for 0.0.77 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed
   down the pipeline. This resulted in warnings by the STT processor.
 
+- Fixed an issue with the `TavusVideoService` where an error was thrown due to
+  missing transcription callbacks.
+
 ## [0.0.77] - 2025-07-31
 
 ### Added

--- a/src/pipecat/transports/services/tavus.py
+++ b/src/pipecat/transports/services/tavus.py
@@ -245,6 +245,8 @@ class TavusTransportClient:
                 on_recording_started=partial(self._on_handle_callback, "on_recording_started"),
                 on_recording_stopped=partial(self._on_handle_callback, "on_recording_stopped"),
                 on_recording_error=partial(self._on_handle_callback, "on_recording_error"),
+                on_transcription_stopped=self._on_transcription_stopped,
+                on_transcription_error=self._on_transcription_error,
             )
             self._client = DailyTransportClient(
                 room_url, None, "Pipecat", self._params, daily_callbacks, self._bot_name
@@ -273,6 +275,20 @@ class TavusTransportClient:
     async def _on_handle_callback(self, event_name, *args, **kwargs):
         """Handle generic callback events."""
         logger.trace(f"[Callback] {event_name} called with args={args}, kwargs={kwargs}")
+
+    async def _on_transcription_stopped(self, stopped_by: str, stopped_by_error: bool):
+        """
+        Placeholder for transcription stopped callback.
+        Required by DailyCallbacks in Pipecat 0.0.77+ but not used by Tavus.
+        """
+        pass
+
+    async def _on_transcription_error(self, message: str):
+        """
+        Placeholder for transcription error callback.
+        Required by DailyCallbacks in Pipecat 0.0.77+ but not used by Tavus.
+        """
+        pass
 
     async def get_persona_name(self) -> str:
         """Get the persona name from the API.

--- a/src/pipecat/transports/services/tavus.py
+++ b/src/pipecat/transports/services/tavus.py
@@ -245,8 +245,8 @@ class TavusTransportClient:
                 on_recording_started=partial(self._on_handle_callback, "on_recording_started"),
                 on_recording_stopped=partial(self._on_handle_callback, "on_recording_stopped"),
                 on_recording_error=partial(self._on_handle_callback, "on_recording_error"),
-                on_transcription_stopped=self._on_transcription_stopped,
-                on_transcription_error=self._on_transcription_error,
+                on_transcription_stopped=partial(self._on_handle_callback, "on_transcription_stopped"),
+                on_transcription_error=partial(self._on_handle_callback, "on_transcription_error"),
             )
             self._client = DailyTransportClient(
                 room_url, None, "Pipecat", self._params, daily_callbacks, self._bot_name
@@ -275,20 +275,6 @@ class TavusTransportClient:
     async def _on_handle_callback(self, event_name, *args, **kwargs):
         """Handle generic callback events."""
         logger.trace(f"[Callback] {event_name} called with args={args}, kwargs={kwargs}")
-
-    async def _on_transcription_stopped(self, stopped_by: str, stopped_by_error: bool):
-        """
-        Placeholder for transcription stopped callback.
-        Required by DailyCallbacks in Pipecat 0.0.77+ but not used by Tavus.
-        """
-        pass
-
-    async def _on_transcription_error(self, message: str):
-        """
-        Placeholder for transcription error callback.
-        Required by DailyCallbacks in Pipecat 0.0.77+ but not used by Tavus.
-        """
-        pass
 
     async def get_persona_name(self) -> str:
         """Get the persona name from the API.

--- a/src/pipecat/transports/services/tavus.py
+++ b/src/pipecat/transports/services/tavus.py
@@ -245,7 +245,9 @@ class TavusTransportClient:
                 on_recording_started=partial(self._on_handle_callback, "on_recording_started"),
                 on_recording_stopped=partial(self._on_handle_callback, "on_recording_stopped"),
                 on_recording_error=partial(self._on_handle_callback, "on_recording_error"),
-                on_transcription_stopped=partial(self._on_handle_callback, "on_transcription_stopped"),
+                on_transcription_stopped=partial(
+                    self._on_handle_callback, "on_transcription_stopped"
+                ),
                 on_transcription_error=partial(self._on_handle_callback, "on_transcription_error"),
             )
             self._client = DailyTransportClient(


### PR DESCRIPTION
## Problem

TavusTransport is completely broken in Pipecat 0.0.77+ and fails to initialize with Pydantic validation errors.

### Error Message
```python
pydantic_core._pydantic_core.ValidationError: 2 validation errors for DailyCallbacks
on_transcription_stopped
  Field required [type=missing, input_value={...}]
on_transcription_error
  Field required [type=missing, input_value={...}]
```

## Impact

- **Severity**: HIGH - Complete failure, no workaround without this fix
- **Affected Users**: ALL users trying to use Tavus avatars with Pipecat 0.0.77+
- **Regression**: Yes - worked in 0.0.76, broken since 0.0.77

## Root Cause

PR #2292 (merged July 29, 2025) added two new required callbacks to `DailyCallbacks`:
- `on_transcription_stopped: Callable[[str, bool], Awaitable[None]]`
- `on_transcription_error: Callable[[str], Awaitable[None]]`

TavusTransportClient inherits from DailyTransportClient which uses DailyCallbacks, but doesn't provide these new required callbacks, causing validation to fail on initialization.

## Solution

This PR adds placeholder implementations of the required callbacks to TavusTransportClient:

```python
async def _on_transcription_stopped(self, stopped_by: str, stopped_by_error: bool):
    """Required by DailyCallbacks in 0.0.77+ but not used by Tavus."""
    pass

async def _on_transcription_error(self, message: str):
    """Required by DailyCallbacks in 0.0.77+ but not used by Tavus."""
    pass
```

These callbacks are not functionally needed by Tavus (which handles avatar video, not transcription) but are required to satisfy DailyCallbacks validation.

## Testing

### Before Fix
```python
# Fails with validation error
transport = TavusTransport(...)  # ValidationError: 2 validation errors
```

### After Fix
```python
# Works perfectly
transport = TavusTransport(
    bot_name="AI Assistant",
    api_key=api_key,
    replica_id=replica_id,
    session=session,
    params=TavusParams(...)
)
# ✅ Initializes successfully
```

## Test Coverage

- [x] TavusTransport initializes without errors
- [x] Pipeline creation with use_avatar=True works
- [x] No regression in existing functionality
- [x] Backwards compatible

## Related Issues

- Regression introduced by: #2292
- Related to DailyCallbacks changes in 0.0.77

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tested locally with Pipecat 0.0.77
- [x] No breaking changes
- [x] Minimal change - only adds required callbacks

## Additional Context

This is a minimal fix that only adds the missing required callbacks. Since Tavus handles avatar rendering and not transcription, these callbacks are intentionally left as no-ops. This maintains the existing behavior while satisfying the new validation requirements.

The alternative would be to make these callbacks optional in DailyCallbacks, but that would be a larger change affecting all Daily transports. This targeted fix resolves the immediate issue for TavusTransport users.