### PR TITLE
Improve quickstart logging, runner startup message

### DIFF
--- a/examples/quickstart/bot.py
+++ b/examples/quickstart/bot.py
@@ -26,7 +26,14 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 
+print("🚀 Starting Pipecat bot...")
+print("⏳ Loading AI models (30-40 seconds first run, <2 seconds after)\n")
+
+logger.info("Loading Silero VAD model...")
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+
+logger.info("✅ Silero VAD model loaded")
+logger.info("Loading pipeline components...")
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -37,7 +44,13 @@ from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
+
+logger.info("✅ Pipeline components loaded")
+
+logger.info("Loading WebRTC transport...")
 from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+
+logger.info("✅ All components loaded successfully!")
 
 load_dotenv(override=True)
 

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -438,17 +438,16 @@ def main():
     if args.transport == "webrtc":
         print()
         if args.esp32:
-            print(
-                f"🚀 WebRTC server starting at http://{args.host}:{args.port}/client (ESP32 mode)"
-            )
+            print(f"🚀 Bot ready! (ESP32 mode)")
+            print(f"   → Open http://{args.host}:{args.port}/client in your browser")
         else:
-            print(f"🚀 WebRTC server starting at http://{args.host}:{args.port}/client")
-        print(f"   Open this URL in your browser to connect!")
+            print(f"🚀 Bot ready!")
+            print(f"   → Open http://{args.host}:{args.port}/client in your browser")
         print()
     elif args.transport == "daily":
         print()
-        print(f"🚀 Daily server starting at http://{args.host}:{args.port}")
-        print(f"   Open this URL in your browser to start a session!")
+        print(f"🚀 Bot ready!")
+        print(f"   → Open http://{args.host}:{args.port} in your browser to start a session")
         print()
 
     # Create the app with transport-specific setup


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Two things:
1. On first run of the quickstart, there is no log feedback for upwards of 40 seconds. We have (at least) two options I can think of to provide feedback: 1) add logging the quickstart file, 2) add a preload.py script. I'm opting for the logging since there's only one file to run and the added complexity is minimal. The preload script visually is better, but it's a more complex file and an extra step. I'm opting for simplicity.
2. In the runner, I want the old message was:
```

🚀 WebRTC server starting at http://localhost:7860/client
   Open this URL in your browser to connect!

```

The new message will be:
```

🚀 Bot ready!
   → Open http://localhost:7860/client in your browser

```

This is visually easier to scan and more actionable.

With these changes, a user will see:
```
🚀 Starting Pipecat bot...
⏳ Loading AI models (30-40 seconds first run, <2 seconds after)

2025-08-02 08:43:56.419 | INFO     | __main__:<module>:32 - Loading Silero VAD model...
2025-08-02 08:43:56.433 | INFO     | pipecat:<module>:14 - ᓚᘏᗢ Pipecat 0.0.78.dev17 (Python 3.12.10 (main, May 30 2025, 05:53:56) [Clang 20.1.4 ]) ᓚᘏᗢ
2025-08-02 08:43:57.087 | INFO     | __main__:<module>:35 - ✅ Silero VAD model loaded
2025-08-02 08:43:57.087 | INFO     | __main__:<module>:36 - Loading pipeline components...
2025-08-02 08:43:57.887 | INFO     | __main__:<module>:48 - ✅ Pipeline components loaded
2025-08-02 08:43:57.887 | INFO     | __main__:<module>:50 - Loading WebRTC transport...
2025-08-02 08:43:58.362 | INFO     | __main__:<module>:53 - ✅ All components loaded successfully!

🚀 Bot ready!
   → Open http://localhost:7860/client in your browser

Looking for dist directory at: /Users/mbackman/src/pipecat/.venv/lib/python3.12/site-packages/pipecat_ai_small_webrtc_prebuilt/client/dist
INFO:     Started server process [4887]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:7860 (Press CTRL+C to quit)
```

These logs are printed as the imports are loaded, so the user has feedback throughout the process.