### PR TITLE
Add body args support to development runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to pass `body` properties to the development runner using
+  the `--body`/`-b` command. The `body` accepts an object provided using valid
+  JSON format. Currently, the `body` is only accepted when using
+  `DailyTransport`.
+
 ### Fixed
 
 - Fixed an issue in `LiveKitTransport` where empty `AudioRawFrame`s were pushed


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Parity with Pipecat Cloud. You can pass in `body` via CLI and then the `bot()` method makes it available to the application code.

Just like PCC, this is compatible only with Daily at this point in time.

For now, SmallWebRTCTransport doesn't support this. But, SmallWebRTCTransport is not yet support for PCC. Once that's added, we'll add types and match support here too.