### PR TITLE
Hotfix: Correct Gemini Live API class to fix 1007 payload error. 

### DIFF
--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -195,7 +195,7 @@ class VideoInputMessage(BaseModel):
 class TextInputMessage(BaseModel):
     """Message containing text input data."""
 
-    realtimeInput: RealtimeInput
+    text: str
 
     @classmethod
     def from_text(cls, text: str) -> "TextInputMessage":
@@ -207,7 +207,7 @@ class TextInputMessage(BaseModel):
         Returns:
             A TextInputMessage instance.
         """
-        return cls(realtimeInput=RealtimeInput(text=text))
+        return cls(text=text)
 
 
 class ClientContentMessage(BaseModel):

--- a/src/pipecat/services/gemini_multimodal_live/events.py
+++ b/src/pipecat/services/gemini_multimodal_live/events.py
@@ -195,7 +195,7 @@ class VideoInputMessage(BaseModel):
 class TextInputMessage(BaseModel):
     """Message containing text input data."""
 
-    text: str
+    realtimeInput: RealtimeInput
 
     @classmethod
     def from_text(cls, text: str) -> "TextInputMessage":
@@ -207,7 +207,7 @@ class TextInputMessage(BaseModel):
         Returns:
             A TextInputMessage instance.
         """
-        return cls(text=text)
+        return cls(realtimeInput=RealtimeInput(text=text))
 
 
 class ClientContentMessage(BaseModel):

--- a/src/pipecat/services/gemini_multimodal_live/gemini.py
+++ b/src/pipecat/services/gemini_multimodal_live/gemini.py
@@ -976,16 +976,13 @@ class GeminiMultimodalLiveLLMService(LLMService):
         with audio and video inputs, preventing temporal misalignment that can occur
         when different modalities are processed through separate API pathways.
 
-        After sending the text, we signal turn completion to trigger a model response
-        for text-only interactions.
+        For realtimeInput, turn completion is automatically inferred by the API based
+        on user activity, so no explicit turnComplete signal is needed.
 
         Args:
             text: The text to send as user input.
         """
         evt = events.TextInputMessage.from_text(text)
-        await self.send_client_event(evt)
-        # After sending text, we need to signal that the turn is complete.
-        evt = events.ClientContentMessage.model_validate({"clientContent": {"turnComplete": True}})
         await self.send_client_event(evt)
 
     async def _send_user_video(self, frame):


### PR DESCRIPTION
This was sending a 1007 payload error because turnComplete is only valid for clientContent. 

- Remove invalid `turnComplete` message from `_send_user_text` method
- `turnComplete` is only valid for `clientContent`, not `realtimeInput` messages
- `realtimeInput` text completion is automatically inferred by the API


