### PR TITLE
daily runner util: remove arg parsing, add auto room, token generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the `pipecat.runner.daily` utility to only a take `DAILY_API_URL` and
+  `DAILY_SAMPLE_ROOM_URL` environment variables instead of argparsing `-u` and
+  `-k`, respectively.
+
 - Updated `daily-python` to 0.19.6.
 
 ### Fixed
@@ -25,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue in `TaskObserver` (a proxy to all observers) that was degrading
   global performance.
+
+### Deprecated
+
+- In the `pipecat.runner.daily`, the `configure_with_args()` function is
+  deprecated. Use the `configure()` function instead.
 
 ## [0.0.77] - 2025-07-31
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Simplifying the daily runner util:
- Removing the url/api key arg parsing. This feature is unnecessary given the env variable support. Args are already complex, so I'm opting to not add another later.
- When no URL is provided, we'll auto-generate a room a token at join time.
- Since there is no arg parsing anymore, I'm deprecating `configure_with_args`