### PR TITLE
Remove inline script from foundational 43a

### DIFF
--- a/examples/foundational/43a-heygen-video-service.py
+++ b/examples/foundational/43a-heygen-video-service.py
@@ -4,12 +4,6 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-# /// script
-# dependencies = [
-#   "pipecat-ai[daily,webrtc,websocket,runner,silero,deepgram,google,cartesia,heygen]>=0.0.77",
-# ]
-# ///
-
 import os
 
 import aiohttp


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Removing the inline script dependencies. Because the scripts are required to use .toml syntax, there's no way to install packages from main. This disrupts the development and eval workflows. We'll follow up with added guidance about how to run these files.