### PR TITLE
properly handle concurrent.futures.CancelledError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `RivaSTTService` issue that would result in an unhandled
+  `concurrent.futures.CancelledError` when a future is cancelled when reading
+  from the audio chunks from the incoming audio stream.
+
 - Fixed an issue in the `BaseOutputTransport`, mainly reproducible with
   `FastAPIWebsocketOutputTransport` when the audio mixer was enabled, where the
   loop could consume 100% CPU by continuously returning without delay, preventing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `DailyTransport` issue that would result in an unhandled
+  `concurrent.futures.CancelledError` when a future is cancelled.
+
 - Fixed a `RivaSTTService` issue that would result in an unhandled
   `concurrent.futures.CancelledError` when a future is cancelled when reading
   from the audio chunks from the incoming audio stream.

--- a/src/pipecat/services/riva/stt.py
+++ b/src/pipecat/services/riva/stt.py
@@ -168,7 +168,7 @@ class RivaSTTService(STTService):
 
         self._asr_service = riva.client.ASRService(auth)
 
-        self._queue = asyncio.Queue()
+        self._queue = None
         self._config = None
         self._thread_task = None
         self._response_task = None
@@ -239,6 +239,7 @@ class RivaSTTService(STTService):
         riva.client.add_custom_configuration_to_config(config, self._custom_configuration)
 
         self._config = config
+        self._queue = WatchdogQueue(self.task_manager)
 
         if not self._thread_task:
             self._thread_task = self.create_task(self._thread_task_handler())


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

When using futures we need to make sure we handle `concurrent.futures.CancelledError`. This would get triggered if the asyncio task running the future is cancelled with, but note that this is different than `asyncio.CancelledError` (but equivalent).