### PR TITLE
FrameProcessor: fix system frame higher priorty and use a PriortyQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `pyproject.toml` to once again pin `numba` to `>=0.61.2` in order to
   resolve package versioning issues.
 
+### Fixed
+
+- Fixed an issue that would cause system frames to not be processed with higher
+  priority than other frames. This could cause slower interruption times.
+
 ### Other
 
 - Improving the latency of the `HeyGenVideoService`.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ You can get started with Pipecat running on your local machine, then move your a
 
 ### Prerequisites
 
-**Python Version:** 3.10+
+**Minimum Python Version:** 3.10
+**Recommended Python Version:** 3.11-3.12
 
 ### Setup Steps
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR fixes an issue that's causing system frames to not be considered higher priority. The problem is that to insert an item to the queue we were doing:

```
await self.__process_queue.put((frame, direction, callback))
```

But then, when we check to see if the inserted frame has higher priority we do:

```
async def put(self, item: Any):
    if isinstance(item, SystemFrame):
        await self.__system_queue.put(item)
     else:
        await self.__main_queue.put(item)
```

Note that `item` is a tuple, so `isinstance_item, SystemFrame)` is never satisfied.

To fix this we would just need to check the proper item in the tuple but I went a bit further and simplified the whole thing to use a PriorityQueue instead.
