### PR TITLE
FrameProcessor: introduce direct mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `enable_direct_mode` argument to `FrameProcessor`. The direct mode is
+  for processors which require very little I/O or compute resources, that is
+  processors that can perform their task almost immediately. These type of
+  processors don't need any of the internal tasks and queues usually created by
+  frame processors which means overall application performance might be slightly
+  increased. Use with care.
+
 - Added TTFB metrics for `HeyGenVideoService` and `TavusVideoService`.
 
 - Added `endpoint_id` parameter to `AzureSTTService`. ([Custom EndpointId](https://docs.azure.cn/en-us/ai-services/speech-service/how-to-recognize-speech?pivots=programming-language-python#use-a-custom-endpoint))
@@ -17,6 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `pyproject.toml` to once again pin `numba` to `>=0.61.2` in order to
   resolve package versioning issues.
+
+### Performance
+
+- Improved some frame processors performance by using the new frame processor
+  direct mode. In direct mode a frame processor will process frames right away
+  avoiding the need for internal queues and tasks. This is useful for some
+  simple processors. For example, in processors that wrap other processors
+  (e.g. `Pipeline`, `ParallelPipeline`), we add one processor before and one
+  after the wrapped processors (internally, you will see them as sources and
+  sinks). These sources and sinks don't do any special processing and they
+  basically forward frames. So, for these simple processors we now enable the
+  new direct mode which avoids creating any internal tasks (and queues) and
+  therefore improves performance.
 
 ### Other
 

--- a/src/pipecat/pipeline/parallel_pipeline.py
+++ b/src/pipecat/pipeline/parallel_pipeline.py
@@ -49,7 +49,7 @@ class ParallelPipelineSource(FrameProcessor):
             upstream_queue: Queue for collecting upstream frames from this branch.
             push_frame_func: Function to push frames to the parent parallel pipeline.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._up_queue = upstream_queue
         self._push_frame_func = push_frame_func
 
@@ -90,7 +90,7 @@ class ParallelPipelineSink(FrameProcessor):
             downstream_queue: Queue for collecting downstream frames from this branch.
             push_frame_func: Function to push frames to the parent parallel pipeline.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._down_queue = downstream_queue
         self._push_frame_func = push_frame_func
 

--- a/src/pipecat/pipeline/pipeline.py
+++ b/src/pipecat/pipeline/pipeline.py
@@ -32,7 +32,7 @@ class PipelineSource(FrameProcessor):
         Args:
             upstream_push_frame: Coroutine function to handle upstream frames.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._upstream_push_frame = upstream_push_frame
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
@@ -65,7 +65,7 @@ class PipelineSink(FrameProcessor):
         Args:
             downstream_push_frame: Coroutine function to handle downstream frames.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._downstream_push_frame = downstream_push_frame
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):

--- a/src/pipecat/pipeline/sync_parallel_pipeline.py
+++ b/src/pipecat/pipeline/sync_parallel_pipeline.py
@@ -49,7 +49,7 @@ class SyncParallelPipelineSource(FrameProcessor):
         Args:
             upstream_queue: Queue for collecting upstream frames from the pipeline.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._up_queue = upstream_queue
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
@@ -81,7 +81,7 @@ class SyncParallelPipelineSink(FrameProcessor):
         Args:
             downstream_queue: Queue for collecting downstream frames from the pipeline.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True)
         self._down_queue = downstream_queue
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -110,14 +110,14 @@ class PipelineTaskSource(FrameProcessor):
     pipeline.
     """
 
-    def __init__(self, up_queue: asyncio.Queue, **kwargs):
+    def __init__(self, up_queue: asyncio.Queue):
         """Initialize the pipeline task source.
 
         Args:
             up_queue: Queue for upstream frame processing.
             **kwargs: Additional arguments passed to the parent class.
         """
-        super().__init__(**kwargs)
+        super().__init__(enable_direct_mode=True)
         self._up_queue = up_queue
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
@@ -144,14 +144,14 @@ class PipelineTaskSink(FrameProcessor):
     act on them, for example, waiting to receive an EndFrame.
     """
 
-    def __init__(self, down_queue: asyncio.Queue, **kwargs):
+    def __init__(self, down_queue: asyncio.Queue):
         """Initialize the pipeline task sink.
 
         Args:
             down_queue: Queue for downstream frame processing.
             **kwargs: Additional arguments passed to the parent class.
         """
-        super().__init__(**kwargs)
+        super().__init__(enable_direct_mode=True)
         self._down_queue = down_queue
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR improves some frame processors performance by introducing a direct mode. In direct mode a frame processor will process frames right away avoiding the need for internal queues and tasks. This is useful for some simple processos. For example, in processors that wrap other processors (e.g. `Pipeline`, `ParallelPipeline`), we add one processor before and one after the wrapped processors (internally, you will see them as sources and sinks). These sources and sinks don't do any special processing and they basically forward frames. So, for these simple processors we now enable the new direct mode which avoids creating any internal tasks (and queues) and therefore improves performance.