### PR TITLE
fix: WebsocketService retry logic incorrectly handling ConnectionClos…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 
 - Updated `pyproject.toml` to once again pin `numba` to `>=0.61.2` in order to
   resolve package versioning issues.
+
+### Fixed
+
+- Fixed an issue where retrying a websocket connection error would result in an
+  error.
 
 ### Other
 

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -12,6 +12,7 @@ from typing import Awaitable, Callable, Optional
 
 import websockets
 from loguru import logger
+from websockets.exceptions import ConnectionClosedOK
 from websockets.protocol import State
 
 from pipecat.frames.frames import ErrorFrame
@@ -82,12 +83,10 @@ class WebsocketService(ABC):
             try:
                 await self._receive_messages()
                 retry_count = 0  # Reset counter on successful message receive
-                if self._websocket and self._websocket.state is State.CLOSED:
-                    raise websockets.ConnectionClosedOK(
-                        self._websocket.close_rcvd,
-                        self._websocket.close_sent,
-                        self._websocket.close_rcvd_then_sent,
-                    )
+            except ConnectionClosedOK as e:
+                # Normal closure, don't retry
+                logger.debug(f"{self} connection closed normally: {e}")
+                break
             except Exception as e:
                 message = f"{self} error receiving messages: {e}"
                 logger.error(message)


### PR DESCRIPTION
…edOK exception

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In the asyncio websocket implementation:

> [recv()](https://websockets.readthedocs.io/en/stable/reference/asyncio/common.html#websockets.asyncio.connection.Connection.recv), [send()](https://websockets.readthedocs.io/en/stable/reference/asyncio/common.html#websockets.asyncio.connection.Connection.send), and similar methods raise the exceptions below when the connection is closed. This is the expected way to detect disconnections.

- `ConnectionClosed`: Raised when trying to interact with a closed connection.
- `ConnectionClosedOK`: Like [ConnectionClosed](https://websockets.readthedocs.io/en/stable/reference/exceptions.html#websockets.exceptions.ConnectionClosed), when the connection terminated properly.
A close code with code 1000 (OK) or 1001 (going away) or without a code was received and sent.

Source: https://websockets.readthedocs.io/en/stable/reference/exceptions.html#connection-closed

---

In the prior implementation, we were raising ConnectionClosedOK on normal connections. The new implementation will raise the ConnectionClosedOK automatically.