### PR TITLE
Development runner: handle_sigint defaults to False

### DIFF
--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -145,7 +145,6 @@ async def _run_telephony_bot(websocket: WebSocket):
 
     # Just pass the WebSocket - let the bot handle parsing
     runner_args = WebSocketRunnerArguments(websocket=websocket)
-    runner_args.handle_sigint = False
 
     await bot_module.bot(runner_args)
 
@@ -223,7 +222,6 @@ def _setup_webrtc_routes(app: FastAPI, esp32_mode: bool = False, host: str = "lo
 
             bot_module = _get_bot_module()
             runner_args = SmallWebRTCRunnerArguments(webrtc_connection=pipecat_connection)
-            runner_args.handle_sigint = False
             background_tasks.add_task(bot_module.bot, runner_args)
 
         answer = pipecat_connection.get_answer()
@@ -266,7 +264,6 @@ def _setup_daily_routes(app: FastAPI):
             # Start the bot in the background with empty body for GET requests
             bot_module = _get_bot_module()
             runner_args = DailyRunnerArguments(room_url=room_url, token=token)
-            runner_args.handle_sigint = False
             asyncio.create_task(bot_module.bot(runner_args))
             return RedirectResponse(room_url)
 
@@ -311,7 +308,6 @@ def _setup_daily_routes(app: FastAPI):
             # Start the bot in the background with extracted body data
             bot_module = _get_bot_module()
             runner_args = DailyRunnerArguments(room_url=room_url, token=token, body=bot_body)
-            runner_args.handle_sigint = False
             asyncio.create_task(bot_module.bot(runner_args))
             # Match PCC /start endpoint response format:
             return {"dailyRoom": room_url, "dailyToken": token}

--- a/src/pipecat/runner/types.py
+++ b/src/pipecat/runner/types.py
@@ -25,7 +25,7 @@ class RunnerArguments:
     pipeline_idle_timeout_secs: int = field(init=False)
 
     def __post_init__(self):
-        self.handle_sigint = True
+        self.handle_sigint = False
         self.handle_sigterm = False
         self.pipeline_idle_timeout_secs = 300
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

@aconchillo this is what we talked about earlier today. Now this matches the `pipecatcloud` fallback types.

All examples that used runner_args.handle_sigint were set to False, so the new default should let them proceed without any changes.