### PR TITLE
Fix: assigns string code instead of Language enum to BaseWhisperSTTService._language

### DIFF
--- a/src/pipecat/services/whisper/base_stt.py
+++ b/src/pipecat/services/whisper/base_stt.py
@@ -186,7 +186,7 @@ class BaseWhisperSTTService(SegmentedSTTService):
             language: The Language enum value to use for transcription.
         """
         logger.info(f"Switching STT language to: [{language}]")
-        self._language = language
+        self._language = self.language_to_service_language(language)
 
     @traced_stt
     async def _handle_transcription(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
To fix the issue described here https://github.com/pipecat-ai/pipecat/issues/2421

Root cause: `BaseWhisperSTTService.__init__` maps `Language` → `str` via `language_to_service_language`, but `BaseWhisperSTTService.set_language` assigns the `Language` enum directly to `self._language`, which caused the error when sending that value to the API. (Here I tested Groq only - but think it's an inconsistent pattern need to be fixed for all).