### PR TITLE
FrameProcessor: fix race condition on FrameProcessorQueue

### DIFF
--- a/src/pipecat/utils/asyncio/watchdog_queue.py
+++ b/src/pipecat/utils/asyncio/watchdog_queue.py
@@ -20,7 +20,14 @@ from pipecat.utils.asyncio.task_manager import BaseTaskManager
 
 
 @dataclass
-class _WatchdogQueueCancelSentinel:
+class WatchdogQueueCancelSentinel:
+    """Sentinel object used in queues to force cancellation.
+
+    An instance of this class is typically inserted into a `WatchdogQueue` to
+    act as a marker for asyncio task cancellation.
+
+    """
+
     pass
 
 
@@ -61,7 +68,7 @@ class WatchdogQueue(asyncio.Queue):
         else:
             get_result = await super().get()
 
-        if isinstance(get_result, _WatchdogQueueCancelSentinel):
+        if isinstance(get_result, WatchdogQueueCancelSentinel):
             logger.trace(
                 "Received WatchdogQueueCancelFrame, throwing CancelledError to force cancelling"
             )
@@ -90,7 +97,7 @@ class WatchdogQueue(asyncio.Queue):
         forces the task to raise CancelledError when consumed, ensuring proper
         task termination.
         """
-        super().put_nowait(_WatchdogQueueCancelSentinel())
+        super().put_nowait(WatchdogQueueCancelSentinel())
 
     async def _watchdog_get(self):
         """Get item from queue while periodically resetting watchdog timer."""

--- a/tests/test_watchdog_queue.py
+++ b/tests/test_watchdog_queue.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2024-2025 Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import asyncio
+import unittest
+
+from pipecat.utils.asyncio.task_manager import TaskManager
+from pipecat.utils.asyncio.watchdog_priority_queue import WatchdogPriorityQueue
+from pipecat.utils.asyncio.watchdog_queue import WatchdogQueue
+
+
+class TestWatchdogQueue(unittest.IsolatedAsyncioTestCase):
+    async def test_simple_item(self):
+        queue = WatchdogQueue(TaskManager())
+        await queue.put(1)
+        await queue.put(2)
+        await queue.put(3)
+        self.assertEqual(await queue.get(), 1)
+        queue.task_done()
+        self.assertEqual(await queue.get(), 2)
+        queue.task_done()
+        self.assertEqual(await queue.get(), 3)
+        queue.task_done()
+
+    async def test_watchdog_sentinel(self):
+        queue = WatchdogQueue(TaskManager())
+        await queue.put(1)
+        self.assertEqual(await queue.get(), 1)
+        queue.task_done()
+        # The get should throw an exception.
+        queue.cancel()
+        try:
+            await queue.get()
+            assert False
+        except asyncio.CancelledError:
+            assert True
+
+
+class TestWatchdogPriorityQueue(unittest.IsolatedAsyncioTestCase):
+    async def test_simple_item(self):
+        queue = WatchdogPriorityQueue(TaskManager())
+        await queue.put((3, 1))
+        await queue.put((2, 1))
+        await queue.put((1, 1))
+        self.assertEqual(await queue.get(), (1, 1))
+        queue.task_done()
+        self.assertEqual(await queue.get(), (2, 1))
+        queue.task_done()
+        self.assertEqual(await queue.get(), (3, 1))
+        queue.task_done()
+
+    async def test_watchdog_sentinel(self):
+        queue = WatchdogPriorityQueue(TaskManager())
+        await queue.put((0, 1))
+        # The get should throw an exception because the watchdog sentinel has
+        # higher priority.
+        queue.cancel()
+        try:
+            await queue.get()
+            assert False
+        except asyncio.CancelledError:
+            assert True


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

We need to increment the counters before the await otherwise we could go to a different task that could add an item with the same counter.

Also, we need to handle non-frame items as well.
