### PR TITLE
Add Exotel support to the development runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Exotel support to Pipecat's development runner. You can now connect
+  using the runner with `uv run bot.py -t exotel` and an ngrok connection to
+  HTTP port 7860.
+
 - Added `enable_direct_mode` argument to `FrameProcessor`. The direct mode is
   for processors which require very little I/O or compute resources, that is
   processors that can perform their task almost immediately. These type of


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Exotel works differently than other telephony providers. There is no proxy. Instead, you need to accept the direct websocket connection from Exotel, which is routed to the development apps via an ngrok connection on http://localhost:7860.