### PR TITLE
WatchdogPriorityQueue: this is now a base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `WatchdogPriorityQueue` now requires the items to be inserted to always be
+  tuples and the size of the tuple needs to be specified in the constructor when
+  creating the queue with the `tuple_size` argument.
+
 - Updated Moondream to revision `2025-01-09`.
 
 - Updated `PlayHTHttpTTSService` to no longer use the `pyht` client to remove
@@ -59,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   therefore improves performance.
 
 ### Fixed
+
+- Fixed a `WatchdogPriorityQueue` issue that could cause an exception when
+  compating watchdog cancel sentinel items with other items in the queue.
 
 - Fixed an issue that would cause system frames to not be processed with higher
   priority than other frames. This could cause slower interruption times.

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -97,13 +97,11 @@ class FrameProcessorQueue(WatchdogPriorityQueue):
             manager (BaseTaskManager): The task manager used by the internal watchdog queues.
 
         """
-        super().__init__(manager)
+        super().__init__(manager, tuple_size=3)
         self.__high_counter = 0
         self.__low_counter = 0
 
-    async def put(
-        self, item: WatchdogPriorityCancelSentinel | Tuple[Frame, FrameDirection, FrameCallback]
-    ):
+    async def put(self, item: Tuple[Frame, FrameDirection, FrameCallback]):
         """Put an item into the priority queue.
 
         System frames (`SystemFrame`) have higher priority than any other
@@ -114,10 +112,6 @@ class FrameProcessorQueue(WatchdogPriorityQueue):
             item (Any): The item to enqueue.
 
         """
-        if isinstance(item, WatchdogPriorityCancelSentinel):
-            await super().put(item)
-            return
-
         frame, _, _ = item
         if isinstance(frame, SystemFrame):
             self.__high_counter += 1

--- a/tests/test_watchdog_queue.py
+++ b/tests/test_watchdog_queue.py
@@ -41,7 +41,7 @@ class TestWatchdogQueue(unittest.IsolatedAsyncioTestCase):
 
 class TestWatchdogPriorityQueue(unittest.IsolatedAsyncioTestCase):
     async def test_simple_item(self):
-        queue = WatchdogPriorityQueue(TaskManager())
+        queue = WatchdogPriorityQueue(TaskManager(), tuple_size=2)
         await queue.put((3, 1))
         await queue.put((2, 1))
         await queue.put((1, 1))
@@ -53,7 +53,7 @@ class TestWatchdogPriorityQueue(unittest.IsolatedAsyncioTestCase):
         queue.task_done()
 
     async def test_watchdog_sentinel(self):
-        queue = WatchdogPriorityQueue(TaskManager())
+        queue = WatchdogPriorityQueue(TaskManager(), tuple_size=2)
         await queue.put((0, 1))
         # The get should throw an exception because the watchdog sentinel has
         # higher priority.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Sub-classes need to implement `put_cancel_item()` and `get_value()` methods. The reason is because we are inserting the watchdog cancel sentinel and there needs to be a way to compare it with other items. The `__lt__` method was not enough because it depends on the order of comparisson. To make it more robust sub-classes now need to indicate how to insert a watchdogcancel sentinel, following the priority scheme.
