### PR TITLE
Bugfix/aws nova sonic interruption propagation

### DIFF
--- a/src/pipecat/services/aws_nova_sonic/aws.py
+++ b/src/pipecat/services/aws_nova_sonic/aws.py
@@ -931,7 +931,7 @@ class AWSNovaSonicLLMService(LLMService):
 
         if content.role == Role.ASSISTANT:
             if content.type == ContentType.TEXT:
-                # Ignore non-final text, and the "interrupted" message (which isn't meaningful text)
+                # Ignore non-final text, but do process the "interrupted" message
                 if content.text_stage == TextStage.FINAL:
                     if stop_reason != "INTERRUPTED":
                         if self._assistant_is_responding:


### PR DESCRIPTION
Nova Sonic can detect and handle interruptions natively, known as barge-in support and is much more realiable that VADs.  However, the current pipecat implementation for Nova Sonic ignores the interrupt event emitted by nova sonic. 

This PR is to correctly process the interrupt event from the Nova sonic by creating and propagating a StartInterruptionFrame. It has been well tested and works well.

Here is a reference for the Nova sonic's barge-in support: 
https://github.com/aws-samples/amazon-nova-samples/blob/main/speech-to-speech/sample-codes/console-python/nova_sonic.py

Speech to speech models like Nova Sonic are seeing a lot of traction, and I myself have helped multiple customers with this patch. So kindly review and merge this PR at the earliest. 

Thank you !