### PR TITLE
Mb/retry completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the ability to retry executing a chat completion after a timeout period
+  for `OpenAILLMService` and its subclasses, `AnthropicLLMService`, and
+  `AWSBedrockLLMService`. The LLM services accept new args:
+  `retry_timeout_secs` and `retry_on_timeout`. This feature is disabled by
+  default.
+
 ## [0.0.80] - 2025-08-13
 
 ### Added
@@ -12,11 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `GeminiTTSService` which uses Google Gemini to generate TTS output. The
   Gemini model can be prompted to insert styled speech to control the TTS
   output.
-
-- For `OpenAILLMService` and its subclasses, added the ability to retry
-  executing a chat completion after a timeout period. The new args are
-  `retry_timeout_secs` and `retry_on_timeout`. This feature is disabled by
-  default.
 
 - Added Exotel support to Pipecat's development runner. You can now connect
   using the runner with `uv run bot.py -t exotel` and an ngrok connection to

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -191,7 +191,7 @@ class AnthropicLLMService(LLMService):
                 return response
             except (APITimeoutError, asyncio.TimeoutError):
                 # Retry, this time without a timeout so we get a response
-                logger.info(f"{self}: Retrying message creation due to timeout")
+                logger.debug(f"{self}: Retrying message creation due to timeout")
                 response = await api_call(**params)
                 return response
         else:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I previously added this retry logic to OpenAILLMService and its subclasses ([PR](https://github.com/pipecat-ai/pipecat/pull/2387)). This adds similar support to `AnthropicLLMService` and `AWSBedrockLLMService`.

The remaining service is `GoogleLLMService`. In looking at its client, the response from the request returns immediately with a stream. Given that, the same approach will not work. If we want to add this feature to `GoogleLLMService`, then we'll have to do something more complex.