### PR TITLE
fix(asyncai): force flush WS TTS to eliminate stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed AsyncAI WS TTS startup latency by sending `force=true`
+
 - Fixed an issue with the `BaseWhisperSTTService` where the language was
   specified as an enum and not a string.
 

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -335,7 +335,7 @@ class AsyncAITTSService(InterruptibleTTSService):
                 yield TTSStartedFrame()
                 self._started = True
 
-            msg = self._build_msg(text=text)
+            msg = self._build_msg(text=text, force=True)
 
             try:
                 await self._get_websocket().send(msg)


### PR DESCRIPTION
fix(asyncai): reduce WS TTS startup latency by sending `force=true`.