### PR TITLE
Only set last_frame_time when handling OutputAudioRawFrame

### DIFF
--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -642,7 +642,7 @@ class BaseOutputTransport(FrameProcessor):
                         self._transport.reset_watchdog()
                         if isinstance(frame, OutputAudioRawFrame):
                             frame.audio = await self._mixer.mix(frame.audio)
-                        last_frame_time = time.time()
+                            last_frame_time = time.time()
                         yield frame
                     except asyncio.QueueEmpty:
                         self._transport.reset_watchdog()


### PR DESCRIPTION
We don't want to set `last_frame_time` on other frames like `HeartBeatFrame`, `LLMGeneratedTextFrame`, `InterruptionFrames` so that we can calculate `diff_time` and compare it against `vad_stop_secs` properly

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.