### PR TITLE
adds support to Azure STT for creating InterimTranscriptFrames 

### DIFF
--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -140,6 +140,7 @@ class AzureSTTService(STTService):
         self._speech_recognizer = SpeechRecognizer(
             speech_config=self._speech_config, audio_config=audio_config
         )
+        self._speech_recognizer.recognizing.connect(self._on_handle_recognizing)
         self._speech_recognizer.recognized.connect(self._on_handle_recognized)
         self._speech_recognizer.start_continuous_recognition_async()
 
@@ -195,5 +196,17 @@ class AzureSTTService(STTService):
             )
             asyncio.run_coroutine_threadsafe(
                 self._handle_transcription(event.result.text, True, language), self.get_event_loop()
+            )
+            asyncio.run_coroutine_threadsafe(self.push_frame(frame), self.get_event_loop())
+
+    def _on_handle_recognizing(self, event):
+        if event.result.reason == ResultReason.RecognizingSpeech and len(event.result.text) > 0:
+            language = getattr(event.result, "language", None) or self._settings.get("language")
+            frame = InterimTranscriptionFrame(
+                event.result.text,
+                self._user_id,
+                time_now_iso8601(),
+                language,
+                result=event,
             )
             asyncio.run_coroutine_threadsafe(self.push_frame(frame), self.get_event_loop())


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I was having trouble getting speech to come through my pipeline in realtime, it would only come through after the recording was finished.  After a lot of debugging, I realized there are two hooks for getting transcripts from Azure, one called `recognized` which fires at the completion of the stt process, and another called `recognizing` which fires after a chunk of the recording has been recognized.  

This PR just adds a hook, and follows the coding patterns presented in the `_on_handle_recognized` handler.  