### PR TITLE
Introduce an affordance to `LLMService` for generating a summary of a…

### DIFF
--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -733,6 +733,58 @@ class GoogleLLMService(LLMService):
     def _create_client(self, api_key: str, http_options: Optional[HttpOptions] = None):
         self._client = genai.Client(api_key=api_key, http_options=http_options)
 
+    async def generate_summary(
+        self, summary_prompt: str, context: LLMContext | OpenAILLMContext
+    ) -> Optional[str]:
+        """Generate a conversation summary from the given LLM context.
+
+        Args:
+            summary_prompt: The prompt to use to guide generating the summary.
+            context: The LLM context containing conversation history.
+
+        Returns:
+            The generated summary, or None if generation failed.
+        """
+        try:
+            if isinstance(context, LLMContext):
+                # Not sure if it's strictly necessary to adapt messages here
+                # since they'll just be a string in the prompt, but erring on
+                # the side of putting them in the format the LLM would expect
+                # if consuming them directly (i.e. assuming greater LLM
+                # familiarity with its own format).
+                adapter = self.get_llm_adapter()
+                params: GeminiLLMInvocationParams = adapter.get_llm_invocation_params(context)
+                messages = params["messages"]
+            else:
+                messages = context.messages
+
+            # Format conversation history as user message
+            contents = [
+                Content(role="user", parts=[Part(text=f"Conversation history: {messages}")])
+            ]
+
+            # Use summary_prompt as system instruction
+            generation_config = GenerateContentConfig(system_instruction=summary_prompt)
+
+            # Use the new google-genai client's async method
+            response = await self._client.aio.models.generate_content(
+                model=self._model_name,
+                contents=contents,
+                config=generation_config,
+            )
+
+            # Extract text from response
+            if response.candidates and response.candidates[0].content:
+                for part in response.candidates[0].content.parts:
+                    if part.text:
+                        return part.text
+
+            return None
+
+        except Exception as e:
+            logger.error(f"Google summary generation failed: {e}", exc_info=True)
+            return None
+
     def needs_mcp_alternate_schema(self) -> bool:
         """Check if this LLM service requires alternate MCP schema.
 

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -14,6 +14,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    List,
     Mapping,
     Optional,
     Protocol,
@@ -189,6 +190,20 @@ class LLMService(AIService):
             The adapter instance used for LLM communication.
         """
         return self._adapter
+
+    async def generate_summary(
+        self, summary_prompt: str, context: LLMContext | OpenAILLMContext
+    ) -> Optional[str]:
+        """Generate a conversation summary from the given LLM context.
+
+        Args:
+            summary_prompt: The prompt to use to guide generating the summary.
+            context: The LLM context containing conversation history.
+
+        Returns:
+            The generated summary, or None if generation failed.
+        """
+        raise NotImplementedError(f"generate_summary() not supported by {self.__class__.__name__}")
 
     def create_context_aggregator(
         self,

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -245,6 +245,54 @@ class BaseOpenAILLMService(LLMService):
         params.update(self._settings["extra"])
         return params
 
+    async def generate_summary(
+        self, summary_prompt: str, context: LLMContext | OpenAILLMContext
+    ) -> Optional[str]:
+        """Generate a conversation summary from the given LLM context.
+
+        Args:
+            summary_prompt: The prompt to use to guide generating the summary.
+            context: The LLM context containing conversation history.
+
+        Returns:
+            The generated summary, or None if generation failed.
+        """
+        try:
+            if isinstance(context, LLMContext):
+                # Not sure if it's strictly necessary to adapt messages here
+                # since they'll just be a string in the prompt, but erring on
+                # the side of putting them in the format the LLM would expect
+                # if consuming them directly (i.e. assuming greater LLM
+                # familiarity with its own format).
+                adapter = self.get_llm_adapter()
+                params: OpenAILLMInvocationParams = adapter.get_llm_invocation_params(context)
+                messages = params["messages"]
+            else:
+                messages = context.messages
+            prompt_messages = [
+                {
+                    "role": "system",
+                    "content": summary_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": f"Conversation history: {messages}",
+                },
+            ]
+
+            # LLM completion
+            response = await self._client.chat.completions.create(
+                model=self.model_name,
+                messages=prompt_messages,
+                stream=False,
+            )
+
+            return response.choices[0].message.content
+
+        except Exception as e:
+            logger.error(f"OpenAI summary generation failed: {e}", exc_info=True)
+            return None
+
     async def _stream_chat_completions_specific_context(
         self, context: OpenAILLMContext
     ) -> AsyncStream[ChatCompletionChunk]:


### PR DESCRIPTION
… conversation directly (i.e. without going through the pipeline).

This abstraction will allow us to update Pipecat Flows to avoid reaching into LLM service internals to generate summaries.

In addition to being a helpful refactor to remove a fragile part of Pipecat Flows (which, it turns out, [had already broken without us noticing!](https://github.com/pipecat-ai/pipecat/pull/2477#discussion_r2289114976)), this change helps set the stage for supporting the upcoming `LLMSwitcher`, where the “active” LLM will only be determined at runtime—today, Pipecat Flows needs to know ahead of time what type of LLM it’s working with, to load an LLM-specific “adapter” that does the work of generating summaries, among other things.

**NOTE: this PR isn't open against `main`. It's dependent on https://github.com/pipecat-ai/pipecat/pull/2440**

**The Pipecat Flows branch I'm testing this against is https://github.com/pipecat-ai/pipecat-flows/pull/174. I'll leave that PR in Draft until all the Pipecat changes have landed that will allow it to properly support runtime LLM switching**