### PR TITLE
PipelineRunner/PipelineTask: fix asyncio task cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue that would cause `PipelineRunner` and `PipelineTask` to not
+  handle external asyncio task cancellation properly.
+
 - Added `SpeechmaticsSTTService` exception handling on connection and sending.
 
 - Replaced `asyncio.wait_for()` for `wait_for2.wait_for()` for Python <

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can get started with Pipecat running on your local machine, then move your a
 ### Prerequisites
 
 **Minimum Python Version:** 3.10
-**Recommended Python Version:** 3.11-3.12
+**Recommended Python Version:** 3.12
 
 ### Setup Steps
 

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -370,11 +370,9 @@ class PipelineTask(BasePipelineTask):
             # We have already cleaned up the pipeline inside the task.
             cleanup_pipeline = False
         except asyncio.CancelledError:
-            # We are awaiting on the push task and it might be cancelled
-            # (e.g. Ctrl-C). This means we will get a CancelledError here as
-            # well, because you get a CancelledError in every place you are
-            # awaiting a task.
-            pass
+            # Raise exception back to the pipeline runner so it can cancel this
+            # task properly.
+            raise
         finally:
             await self._cancel_tasks()
             await self._cleanup(cleanup_pipeline)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -298,8 +298,11 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
         identity = IdentityFilter()
         pipeline = Pipeline([identity])
         task = PipelineTask(pipeline, idle_timeout_secs=0.2)
-        await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
-        assert True
+        try:
+            await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
+            assert False
+        except asyncio.CancelledError:
+            assert True
 
     async def test_no_idle_task(self):
         identity = IdentityFilter()
@@ -326,8 +329,11 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
             ),
             idle_timeout_secs=0.3,
         )
-        await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
-        assert True
+        try:
+            await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
+            assert False
+        except asyncio.CancelledError:
+            assert True
 
     async def test_idle_task_event_handler_no_frames(self):
         identity = IdentityFilter()
@@ -342,8 +348,11 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
             idle_timeout = True
             await task.cancel()
 
-        await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
-        assert idle_timeout
+        try:
+            await task.run(PipelineTaskParams(loop=asyncio.get_event_loop()))
+            assert False
+        except asyncio.CancelledError:
+            assert idle_timeout
 
     async def test_idle_task_event_handler_quiet_user(self):
         identity = IdentityFilter()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR fixed an issue where PipelineRunner and PipelineTask don't handle asyncio task cancellation. We need to raise the exception from `PipelineTask` and handle it in `PipelineRunner`. This way, we can properly cancel the pipeline task.

This fixes an issue we had in release evals where if the eval takes a long time we cancel the asyncio task. This was causing all sort of problems and not allowing the following evals to execute correctly.