### PR TITLE
Enabling observer to measure user to bot latency in the heygen example.

### DIFF
--- a/examples/foundational/43a-heygen-video-service.py
+++ b/examples/foundational/43a-heygen-video-service.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.observers.loggers.user_bot_latency_log_observer import UserBotLatencyLogObserver
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -94,7 +95,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
                 enable_metrics=True,
                 enable_usage_metrics=True,
             ),
-            idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+            observers=[UserBotLatencyLogObserver()],
         )
 
         @transport.event_handler("on_client_connected")


### PR DESCRIPTION
Enabling observer to measure user to bot latency in the heygen example.