### PR TITLE
CartesiaTTSService: reconnect on Cartesia's timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a `CartesiaTTSService` issue that was causing the application to hang
+  after Cartesia's 5 minutes timed out.
+
 ## [0.0.81] - 2025-08-25
 
 ### Added

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -386,7 +386,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
         await self._websocket.send(msg)
         self._context_id = None
 
-    async def _receive_messages(self):
+    async def _process_messages(self):
         async for message in self._get_websocket():
             msg = json.loads(message)
             if not msg or not self.audio_context_available(msg["context_id"]):
@@ -418,6 +418,14 @@ class CartesiaTTSService(AudioContextWordTTSService):
                 self._context_id = None
             else:
                 logger.error(f"{self} error, unknown message type: {msg}")
+
+    async def _receive_messages(self):
+        while True:
+            await self._process_messages()
+            # Cartesia times out after 5 minutes of innactivity (no keepalive
+            # mechanism is available). So, we try to reconnect.
+            logger.debug(f"{self} Cartesia connection was disconnected (timeout?), reconnecting")
+            await self._connect_websocket()
 
     @traced_tts
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Cartesia doesn't support keep alive messages so it will just disconnect after 5 minutes. We cancel this use case by simply reconnecting. Note that this is not made generic because we don't know how the other `_receive_messages()` implementations might behave. So, this needs to be done per service.