### PR TITLE
TextFrame: add skip_tts field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for switching between audio+text to text-only modes within the
+  same pipeline. This is done by pushing
+  `LLMConfigureOutputFrame(skip_tts=True)` to enter text-only mode, and
+  disabling it to return to audio+text. The LLM will still generate tokens and
+  add them to the context, but they will not be sent to TTS.
+
 - Added `skip_tts` field to `TextFrame`. This lets a text frame bypass TTS while
   still being included in the LLM context. Useful for cases like structured text
   that isn’t meant to be spoken but should still contribute to context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `skip_tts` field to `TextFrame`. This lets a text frame bypass TTS while
+  still being included in the LLM context. Useful for cases like structured text
+  that isn’t meant to be spoken but should still contribute to context.
+
 - Added a `cancel_timeout_secs` argument to `PipelineTask` which defines how
   long the pipeline has to complete cancellation. When `PipelineTask.cancel()`
   is called, a `CancelFrame` is pushed through the pipeline and must reach the

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1351,14 +1351,22 @@ class LLMFullResponseStartFrame(ControlFrame):
     more TextFrames and a final LLMFullResponseEndFrame.
     """
 
-    pass
+    skip_tts: bool = field(init=False)
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.skip_tts = False
 
 
 @dataclass
 class LLMFullResponseEndFrame(ControlFrame):
     """Frame indicating the end of an LLM response."""
 
-    pass
+    skip_tts: bool = field(init=False)
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.skip_tts = False
 
 
 @dataclass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -305,6 +305,11 @@ class TextFrame(DataFrame):
     """
 
     text: str
+    skip_tts: bool = field(init=False)
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.skip_tts = False
 
     def __str__(self):
         pts = format_pts(self.pts)

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -608,6 +608,21 @@ class LLMEnablePromptCachingFrame(DataFrame):
 
 
 @dataclass
+class LLMConfigureOutputFrame(DataFrame):
+    """Frame to configure LLM output.
+
+    This frame is used to configure how the LLM produces output. For example, it
+    can tell the LLM to generate tokens that should be added to the context but
+    not spoken by the TTS service (if one is present in the pipeline).
+
+    Parameters:
+        skip_tts: Whether LLM tokens should skip the TTS service (if any).
+    """
+
+    skip_tts: bool
+
+
+@dataclass
 class TTSSpeakFrame(DataFrame):
     """Frame containing text that should be spoken by TTS.
 

--- a/src/pipecat/processors/aggregators/dtmf_aggregator.py
+++ b/src/pipecat/processors/aggregators/dtmf_aggregator.py
@@ -103,7 +103,7 @@ class DTMFAggregator(FrameProcessor):
         digit_value = frame.button.value
         self._aggregation += digit_value
 
-        # For first digit, schedule interruption in separate task
+        # For first digit, schedule interruption.
         if is_first_digit:
             await self.push_frame(BotInterruptionFrame(), FrameDirection.UPSTREAM)
 

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -14,7 +14,6 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
-    List,
     Mapping,
     Optional,
     Protocol,
@@ -38,6 +37,8 @@ from pipecat.frames.frames import (
     FunctionCallResultProperties,
     FunctionCallsStartedFrame,
     LLMConfigureOutputFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
     LLMTextFrame,
     StartFrame,
     StartInterruptionFrame,
@@ -285,7 +286,7 @@ class LLMService(AIService):
             frame: The frame to push.
             direction: The direction of frame pushing.
         """
-        if isinstance(frame, LLMTextFrame):
+        if isinstance(frame, (LLMTextFrame, LLMFullResponseStartFrame, LLMFullResponseEndFrame)):
             frame.skip_tts = self._skip_tts
 
         await super().push_frame(frame, direction)

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -296,7 +296,9 @@ class TTSService(AIService):
         """
         await super().process_frame(frame, direction)
 
-        if (
+        if isinstance(frame, TextFrame) and frame.skip_tts:
+            await self.push_frame(frame, direction)
+        elif (
             isinstance(frame, TextFrame)
             and not isinstance(frame, InterimTranscriptionFrame)
             and not isinstance(frame, TranscriptionFrame)

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -296,7 +296,10 @@ class TTSService(AIService):
         """
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, TextFrame) and frame.skip_tts:
+        if (
+            isinstance(frame, (TextFrame, LLMFullResponseStartFrame, LLMFullResponseEndFrame))
+            and frame.skip_tts
+        ):
             await self.push_frame(frame, direction)
         elif (
             isinstance(frame, TextFrame)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR adds `skip_tts` field to `TextFrame`. This lets a text frame bypass TTS while still being included in the LLM context. Useful for cases like structured text that isn’t meant to be spoken but should still contribute to context.

It also adds support for switching between text-only and audio-only modes within the same pipeline. This is done by pushing `LLMConfigureOutputFrame(skip_tts=True)`. The LLM will still generate tokens and add them to the context, but they will not be sent to TTS.
