### PR TITLE
add missing import asyncio

### DIFF
--- a/src/pipecat/processors/metrics/sentry.py
+++ b/src/pipecat/processors/metrics/sentry.py
@@ -6,6 +6,8 @@
 
 """Sentry integration for frame processor metrics."""
 
+import asyncio
+
 from loguru import logger
 
 from pipecat.utils.asyncio.task_manager import BaseTaskManager


### PR DESCRIPTION
Adds missing `import asyncio` to `sentry.py` which is causing apps to crash. See issue.

https://github.com/pipecat-ai/pipecat/issues/2519