### PR TITLE
PipelineTask: wait for StartFrame to reach end of pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `PipelineTask` now waits for `StartFrame` to reach the end of the pipeline
+  before pushing any other frames.
+
 - Updated `CartesiaTTSService` and `CartesiaHttpTTSService` to align with
   Cartesia's changes for the `speed` parameter. It now takes only an enum of
   `slow`, `normal`, or `fast`.
@@ -99,6 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `SarvamHttpTTSService`.
 
 ### Fixed
+
+- Fixed an RTVI issue that was causing frames to be pushed before pipeline was
+  properly initialized.
 
 - Fixed some `get_messages_for_logging()` that were returning a JSON string
   instead of a list.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

When using RTVI we were getting this error on startup:

```
RTVIProcessor#0 Trying to process TransportMessageUrgentFrame#0(message: {'label': 'rtvi-ai', 'type': 'metrics', 'data': {'ttfb': [{'processor': 'DeepgramSTTService#0', 'value': 0.0}, {'processor': 'OpenAILLMService#0', 'value': 0.0}, {'processor': 'CartesiaTTSService#0', 'value': 0.0}], 'processing': [{'processor': 'DeepgramSTTService#0', 'value': 0.0}, {'processor': 'OpenAILLMService#0', 'value': 0.0}, {'processor': 'CartesiaTTSService#0', 'value': 0.0}]}}) but StartFrame not received yet   
```

The problem is that observers listen for `on_push_frame` and this might get called before `StartFrame` reaches the RTVI processor.

The reason is that in PipelineTask we were doing:

```
queue_frame(StartFrame())
queue_frame(MetricsFrame())
```

`queue_frame(MetricsFrame())` will generate an `on_push_frame` before `StartFrame` actually gets to the `RTVIProcessor` causing the error mentioned above.

So, we now wait for `StartFrame` to reach the end of the pipeline before doing anything else. This means that you are not able to speed up things anymore. That is, before it was possible to send something along `StartFrame` so processors that have already started are already processing things (even if the processors down below are not started yet). But I believe it makes things more reliable and predictable. Plus, I don't think anyone was using this trick.
