### PR TITLE
PipelineTask: handle BotInterruptionFrame in PipelineTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `pipeline.tests.utils.run_test()` now allows passing `PipelineParams` instead
+  of individual parameters.
+
 - Updated `daily-python` to 0.19.8.
 
 - `PipelineTask` now waits for `StartFrame` to reach the end of the pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `BotInterruptionFrame` frame handling has been moved from `BaseInputTransport`
+  to `PipelineTask`. This allows any type of pipeline to handle
+  `BotInterruptionFrame` without the need of an input transport.
+
 - `pipeline.tests.utils.run_test()` now allows passing `PipelineParams` instead
   of individual parameters.
 

--- a/src/pipecat/tests/utils.py
+++ b/src/pipecat/tests/utils.py
@@ -8,7 +8,7 @@
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Awaitable, Callable, List, Optional, Sequence, Tuple
 
 from pipecat.frames.frames import (
     EndFrame,
@@ -128,7 +128,7 @@ async def run_test(
     expected_up_frames: Optional[Sequence[type]] = None,
     ignore_start: bool = True,
     observers: Optional[List[BaseObserver]] = None,
-    start_metadata: Optional[Dict[str, Any]] = None,
+    pipeline_params: Optional[PipelineParams] = None,
     send_end_frame: bool = True,
 ) -> Tuple[Sequence[Frame], Sequence[Frame]]:
     """Run a test pipeline with the specified processor and validate frame flow.
@@ -144,7 +144,7 @@ async def run_test(
         expected_up_frames: Expected frame types flowing upstream (optional).
         ignore_start: Whether to ignore StartFrames in frame validation.
         observers: Optional list of observers to attach to the pipeline.
-        start_metadata: Optional metadata to include with the StartFrame.
+        pipeline_params: Pipeline parameters.
         send_end_frame: Whether to send an EndFrame at the end of the test.
 
     Returns:
@@ -154,7 +154,6 @@ async def run_test(
         AssertionError: If the received frames don't match the expected frame types.
     """
     observers = observers or []
-    start_metadata = start_metadata or {}
 
     received_up = asyncio.Queue()
     received_down = asyncio.Queue()
@@ -173,7 +172,7 @@ async def run_test(
 
     task = PipelineTask(
         pipeline,
-        params=PipelineParams(start_metadata=start_metadata),
+        params=pipeline_params,
         observers=observers,
         cancel_on_idle_timeout=False,
     )

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -22,7 +22,6 @@ from pipecat.audio.turn.base_turn_analyzer import (
 )
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADState
 from pipecat.frames.frames import (
-    BotInterruptionFrame,
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     CancelFrame,
@@ -289,8 +288,6 @@ class BaseInputTransport(FrameProcessor):
         elif isinstance(frame, CancelFrame):
             await self.cancel(frame)
             await self.push_frame(frame, direction)
-        elif isinstance(frame, BotInterruptionFrame):
-            await self._handle_bot_interruption(frame)
         elif isinstance(frame, BotStartedSpeakingFrame):
             await self._handle_bot_started_speaking(frame)
             await self.push_frame(frame, direction)
@@ -334,13 +331,6 @@ class BaseInputTransport(FrameProcessor):
     #
     # Handle interruptions
     #
-
-    async def _handle_bot_interruption(self, frame: BotInterruptionFrame):
-        """Handle bot interruption frames."""
-        logger.debug("Bot interruption")
-        if self.interruptions_allowed:
-            await self._start_interruption()
-            await self.push_frame(StartInterruptionFrame())
 
     async def _handle_user_interruption(self, frame: Frame):
         """Handle user interruption events based on speaking state."""

--- a/tests/test_dtmf_aggregator.py
+++ b/tests/test_dtmf_aggregator.py
@@ -12,6 +12,7 @@ from pipecat.frames.frames import (
     KeypadEntry,
     TranscriptionFrame,
 )
+from pipecat.pipeline.task import PipelineParams
 from pipecat.processors.aggregators.dtmf_aggregator import DTMFAggregator
 from pipecat.tests.utils import SleepFrame, run_test
 
@@ -69,6 +70,8 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
             aggregator,
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
+            # TODO(aleix): we should handle StartInterruptionFrame
+            pipeline_params=PipelineParams(allow_interruptions=False),
         )
 
         # Find the TranscriptionFrames
@@ -105,6 +108,8 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
             aggregator,
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
+            # TODO(aleix): we should handle StartInterruptionFrame
+            pipeline_params=PipelineParams(allow_interruptions=False),
         )
 
         transcription_frames = [
@@ -134,6 +139,8 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
             aggregator,
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
+            # TODO(aleix): we should handle StartInterruptionFrame
+            pipeline_params=PipelineParams(allow_interruptions=False),
             send_end_frame=False,  # We're sending one in the test to test EndFrame logic
         )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -65,7 +65,7 @@ class TestPipeline(unittest.IsolatedAsyncioTestCase):
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
             ignore_start=False,
-            start_metadata={"foo": "bar"},
+            pipeline_params=PipelineParams(start_metadata={"foo": "bar"}),
         )
         assert "foo" in received_down[-1].metadata
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This allows having processors before the input transport or even not having an input transport.

A couple of questions:
1. what if a pipeline doesn’t have an input transport?
2. what if a pipeline has something before the input transport? do we want that to be cancelled as well?

Before:
1. pushing BotInterruptionFrame has no effect
2. it would not be cancelled

Now:
1. pushing BotInterruptionFrame keeps working
2. it would be cancelled

It feels that “Now” is more correct? Also, if you place processors before the input you still have the option to ignore `StartInterruptionFrame`. With the current approach, `StartInterruptionFrame` was being swallowed by the input transport.
