### PR TITLE
Gladia - add missing config parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sending it through the transport. This makes sending DTMF generic across all
   output transports.
 
+- Added new config parameters to `GladiaSTTService`. 
+  - PreProcessingConfig > `audio_enhancer` to enhance audio quality.
+  - CustomVocabularyItem > `pronunciations` and `language` to specify special pronunciations and in which language it will be pronounced.
+
 ## Changed
 
 - `pipecat.frames.frames.KeypadEntry` is deprecated and has been moved to

--- a/src/pipecat/services/gladia/config.py
+++ b/src/pipecat/services/gladia/config.py
@@ -29,10 +29,12 @@ class PreProcessingConfig(BaseModel):
     """Configuration for audio pre-processing options.
 
     Parameters:
+        audio_enhancer: Apply pre-processing to the audio stream to enhance quality
         speech_threshold: Sensitivity for speech detection (0-1)
     """
 
-    speech_threshold: Optional[float] = None
+    audio_enhancer: Optional[bool] = None
+    speech_threshold: Optional[float] = 0.7
 
 
 class CustomVocabularyItem(BaseModel):
@@ -41,10 +43,14 @@ class CustomVocabularyItem(BaseModel):
     Parameters:
         value: The vocabulary word or phrase
         intensity: The bias intensity for this vocabulary item (0-1)
+        pronunciations: The pronunciations used in the transcription.
+        language: Specify the language in which it will be pronounced when sound comparison occurs. Default to transcription language.
     """
 
     value: str
     intensity: float
+    pronunciations: Optional[List[str]] = None
+    language: Optional[str] = None
 
 
 class CustomVocabularyConfig(BaseModel):
@@ -149,6 +155,7 @@ class GladiaInputParams(BaseModel):
     Parameters:
         encoding: Audio encoding format
         bit_depth: Audio bit depth
+        sample_rate: Audio sample rate
         channels: Number of audio channels
         custom_metadata: Additional metadata to include with requests
         endpointing: Silence duration in seconds to mark end of speech
@@ -167,10 +174,11 @@ class GladiaInputParams(BaseModel):
 
     encoding: Optional[str] = "wav/pcm"
     bit_depth: Optional[int] = 16
+    sample_rate: Optional[int] = 16000
     channels: Optional[int] = 1
     custom_metadata: Optional[Dict[str, Any]] = None
     endpointing: Optional[float] = None
-    maximum_duration_without_endpointing: Optional[int] = 10
+    maximum_duration_without_endpointing: Optional[int] = 5
     language: Optional[Language] = None  # Deprecated
     language_config: Optional[LanguageConfig] = None
     pre_processing: Optional[PreProcessingConfig] = None

--- a/src/pipecat/services/gladia/config.py
+++ b/src/pipecat/services/gladia/config.py
@@ -34,7 +34,7 @@ class PreProcessingConfig(BaseModel):
     """
 
     audio_enhancer: Optional[bool] = None
-    speech_threshold: Optional[float] = 0.7
+    speech_threshold: Optional[float] = None
 
 
 class CustomVocabularyItem(BaseModel):
@@ -155,7 +155,6 @@ class GladiaInputParams(BaseModel):
     Parameters:
         encoding: Audio encoding format
         bit_depth: Audio bit depth
-        sample_rate: Audio sample rate
         channels: Number of audio channels
         custom_metadata: Additional metadata to include with requests
         endpointing: Silence duration in seconds to mark end of speech

--- a/src/pipecat/services/gladia/config.py
+++ b/src/pipecat/services/gladia/config.py
@@ -174,7 +174,6 @@ class GladiaInputParams(BaseModel):
 
     encoding: Optional[str] = "wav/pcm"
     bit_depth: Optional[int] = 16
-    sample_rate: Optional[int] = 16000
     channels: Optional[int] = 1
     custom_metadata: Optional[Dict[str, Any]] = None
     endpointing: Optional[float] = None

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -304,10 +304,7 @@ class GladiaSTTService(STTService):
         }
 
         # Add custom_metadata if provided
-        if self._params.custom_metadata:
-            settings["custom_metadata"] = self._params.custom_metadata
-        else:
-            settings["custom_metadata"] = {}
+        settings["custom_metadata"] = dict(self._params.custom_metadata or {})
         settings["custom_metadata"]["pipecat"] = pipecat_version
 
         # Add endpointing parameters if provided

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncGenerator, Dict, Literal, Optional
 import aiohttp
 from loguru import logger
 
+from pipecat import __version__ as pipecat_version
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -305,6 +306,9 @@ class GladiaSTTService(STTService):
         # Add custom_metadata if provided
         if self._params.custom_metadata:
             settings["custom_metadata"] = self._params.custom_metadata
+        else:
+            settings["custom_metadata"] = {}
+        settings["custom_metadata"]["pipecat"] = pipecat_version
 
         # Add endpointing parameters if provided
         if self._params.endpointing is not None:
@@ -430,6 +434,7 @@ class GladiaSTTService(STTService):
                     response = await self._setup_gladia(settings)
                     self._session_url = response["url"]
                     self._reconnection_attempts = 0
+                    logger.info(f"Session URL : {self._session_url}")
 
                 # Connect with automatic reconnection
                 async with websocket_connect(self._session_url) as websocket:


### PR DESCRIPTION
Adding some missing parameters, and pass pipecat version to Gladia so we can trace pipecat transcriptions more easily.