### PR TITLE
frames: remove StopInterruptionFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
+- Remove `StopInterruptionFrame`. This was a legacy frame that was not being
+  used really anywhere and it didn't provide any useful meaning. It was only
+  pushed after `UserStoppedSpeakingFrame`, so developers can just use
+  `UserStoppedSpeakingFrame`.
+
 - `DailyTransport.write_dtmf()` has been removed in favor of the generic
   `BaseOutputTransport.write_dtmf()`.
 

--- a/examples/foundational/07c-interruptible-deepgram-vad.py
+++ b/examples/foundational/07c-interruptible-deepgram-vad.py
@@ -12,9 +12,8 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from pipecat.frames.frames import (
-    BotInterruptionFrame,
     LLMRunFrame,
-    StopInterruptionFrame,
+    StartInterruptionFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
@@ -98,11 +97,11 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     @stt.event_handler("on_speech_started")
     async def on_speech_started(stt, *args, **kwargs):
-        await task.queue_frames([BotInterruptionFrame(), UserStartedSpeakingFrame()])
+        await task.queue_frames([StartInterruptionFrame(), UserStartedSpeakingFrame()])
 
     @stt.event_handler("on_utterance_end")
     async def on_utterance_end(stt, *args, **kwargs):
-        await task.queue_frames([StopInterruptionFrame(), UserStoppedSpeakingFrame()])
+        await task.queue_frames([UserStoppedSpeakingFrame()])
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -21,7 +21,6 @@ from pipecat.frames.frames import (
     LLMRunFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     SystemFrame,
     TextFrame,
     TranscriptionFrame,
@@ -234,7 +233,6 @@ class TurnDetectionLLM(Pipeline):
             return (
                 isinstance(frame, OpenAILLMContextFrame)
                 or isinstance(frame, StartInterruptionFrame)
-                or isinstance(frame, StopInterruptionFrame)
                 or isinstance(frame, FunctionCallInProgressFrame)
                 or isinstance(frame, FunctionCallResultFrame)
             )

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -21,7 +21,6 @@ from pipecat.frames.frames import (
     LLMRunFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     SystemFrame,
     TextFrame,
     TranscriptionFrame,
@@ -428,7 +427,6 @@ class TurnDetectionLLM(Pipeline):
             return (
                 isinstance(frame, OpenAILLMContextFrame)
                 or isinstance(frame, StartInterruptionFrame)
-                or isinstance(frame, StopInterruptionFrame)
                 or isinstance(frame, FunctionCallInProgressFrame)
                 or isinstance(frame, FunctionCallResultFrame)
             )

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -870,19 +870,6 @@ class StartInterruptionFrame(SystemFrame):
 
 
 @dataclass
-class StopInterruptionFrame(SystemFrame):
-    """Frame indicating user stopped speaking (interruption ended).
-
-    Emitted by the BaseInputTransport to indicate that a user has stopped
-    speaking (i.e. no more interruptions). This is similar to
-    UserStoppedSpeakingFrame except that it should be pushed concurrently
-    with other frames (so the order is not guaranteed).
-    """
-
-    pass
-
-
-@dataclass
 class UserStartedSpeakingFrame(SystemFrame):
     """Frame indicating user has started speaking.
 

--- a/src/pipecat/processors/filters/stt_mute_filter.py
+++ b/src/pipecat/processors/filters/stt_mute_filter.py
@@ -27,7 +27,6 @@ from pipecat.frames.frames import (
     InterimTranscriptionFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     STTMuteFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
@@ -206,7 +205,6 @@ class STTMuteFilter(FrameProcessor):
             frame,
             (
                 StartInterruptionFrame,
-                StopInterruptionFrame,
                 VADUserStartedSpeakingFrame,
                 VADUserStoppedSpeakingFrame,
                 UserStartedSpeakingFrame,

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -30,7 +30,6 @@ from pipecat.frames.frames import (
     FrameProcessorResumeUrgentFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     SystemFrame,
 )
 from pipecat.metrics.metrics import LLMTokenUsage, MetricsData
@@ -587,8 +586,6 @@ class FrameProcessor(BaseObject):
         elif isinstance(frame, StartInterruptionFrame):
             await self._start_interruption()
             await self.stop_all_metrics()
-        elif isinstance(frame, StopInterruptionFrame):
-            self._should_report_ttfb = True
         elif isinstance(frame, CancelFrame):
             await self.__cancel(frame)
         elif isinstance(frame, (FrameProcessorPauseFrame, FrameProcessorPauseUrgentFrame)):

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -32,7 +32,6 @@ from pipecat.frames.frames import (
     LLMUpdateSettingsFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     TranscriptionFrame,
     TTSAudioRawFrame,
     TTSStartedFrame,
@@ -653,7 +652,6 @@ class OpenAIRealtimeBetaLLMService(LLMService):
         await self.start_ttfb_metrics()
         await self.start_processing_metrics()
         await self._stop_interruption()
-        await self.push_frame(StopInterruptionFrame())
         await self.push_frame(UserStoppedSpeakingFrame())
 
     async def _maybe_handle_evt_retrieve_conversation_item_error(self, evt: events.ErrorEvent):

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -38,7 +38,6 @@ from pipecat.frames.frames import (
     StartFrame,
     StartInterruptionFrame,
     StopFrame,
-    StopInterruptionFrame,
     SystemFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
@@ -374,7 +373,6 @@ class BaseInputTransport(FrameProcessor):
             await self.push_frame(frame)
             if self.interruptions_allowed:
                 await self._stop_interruption()
-                await self.push_frame(StopInterruptionFrame())
 
     #
     # Handle bot speaking state

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -39,7 +39,6 @@ from pipecat.frames.frames import (
     SpriteFrame,
     StartFrame,
     StartInterruptionFrame,
-    StopInterruptionFrame,
     SystemFrame,
     TransportMessageFrame,
     TransportMessageUrgentFrame,
@@ -273,7 +272,7 @@ class BaseOutputTransport(FrameProcessor):
         elif isinstance(frame, CancelFrame):
             await self.cancel(frame)
             await self.push_frame(frame, direction)
-        elif isinstance(frame, (StartInterruptionFrame, StopInterruptionFrame)):
+        elif isinstance(frame, StartInterruptionFrame):
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
         elif isinstance(frame, TransportMessageUrgentFrame):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR removes `StopInterruptionFrame`. This was a legacy frame that was not being used really anywhere and it didn't provide any useful meaning. It was only pushed after `UserStoppedSpeakingFrame`, so developers can just use `UserStoppedSpeakingFrame`.

I don't think it make sense to deprecate it.
