### PR TITLE
AWSNovaSonicLLMService: pre-load audio cue in the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pipecat.frames.frames.KeypadEntry` is deprecated and has been moved to
   `pipecat.audio.dtmf.types.KeypadEntry`.
 
+## Deprecated
+
+- `pipecat.frames.frames.KeypadEntry` is deprecated use
+  `pipecat.audio.dtmf.types.KeypadEntry` instead.
+
 ## Removed
 
 - `DailyTransport.write_dtmf()` has been removed in favor of the generic
@@ -54,10 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove deprecated `DailyTransport.send_dtmf()`.
 
-## Deprecated
+## Performance
 
-- `pipecat.frames.frames.KeypadEntry` is deprecated use
-  `pipecat.audio.dtmf.types.KeypadEntry` instead.
+- Pre-load `AWSNovaSonicLLMService` audio cue file in the constructor to avoid
+  loading files in real-time.
 
 ## [0.0.82] - 2025-08-28
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

For the DTMF support we just added we load DTMF wav files. I remembered we were doing that for AWS Nova Sonic so I followed the same approach. I was going to use `aiofiles` to load the audio cue but then realized we could just pre-load it in the constructor. This will make the constructor a bit slower but it will avoid loading reading from files in real-time.