### PR TITLE
fix timeout handling in AWSBedrockLLMService

### DIFF
--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -880,7 +880,7 @@ class AWSBedrockLLMService(LLMService):
         if self._retry_on_timeout:
             try:
                 response = await asyncio.wait_for(
-                    await client.converse_stream(**request_params), timeout=self._retry_timeout_secs
+                    client.converse_stream(**request_params), timeout=self._retry_timeout_secs
                 )
                 return response
             except (ReadTimeoutError, asyncio.TimeoutError) as e:


### PR DESCRIPTION
# Fix double await in AWSBedrockLLMService._create_converse_stream

## Problem

Fixes issue https://github.com/pipecat-ai/pipecat/issues/2558.

When using `retry_timeout_secs` and `retry_on_timeout` parameters with `AWSBedrockLLMService`, the following error occurs:
````
TypeError: object dict can't be used in 'await' expression
````

The error is caused by a double `await` on line 883 in `pipecat/services/aws/llm.py`:

```python
response = await asyncio.wait_for(
    await client.converse_stream(**request_params), timeout=self._retry_timeout_secs
)
```

## Root Cause

The issue occurs because:

1. `client.converse_stream(**request_params)` returns a coroutine
2. The inner `await client.converse_stream(**request_params)` resolves this coroutine to a dictionary response
3. `asyncio.wait_for()` then tries to await this dictionary, which is not awaitable
4. This results in the TypeError: "object dict can't be used in 'await' expression"

## Solution

Remove the inner `await` and pass the coroutine directly to `asyncio.wait_for()`:

```python
response = await asyncio.wait_for(
    client.converse_stream(**request_params), timeout=self._retry_timeout_secs
)
```

This allows `asyncio.wait_for()` to properly handle the timeout on the coroutine execution.

## Testing

- ✅ Verified the fix resolves the TypeError when using retry parameters
- ✅ Confirmed timeout functionality works as expected
- ✅ Retry logic executes properly on timeout
- ✅ Normal operation (without timeout) remains unaffected

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Fully maintained
- **Performance**: No impact on performance, only fixes broken functionality

This fix enables users to properly utilize the timeout and retry functionality in AWS Bedrock LLM service without encountering runtime errors.