### PR TITLE
fix: update default Cerebras model to GPT-OSS-120B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `RimeTTSService`'s flush_audio message to conform with Rime's official API.
 
+- - Updated the default model for `CerebrasLLMService` to GPT-OSS-120B.
+
 ### Removed
 
 - Remove `StopInterruptionFrame`. This was a legacy frame that was not being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `RimeTTSService`'s flush_audio message to conform with Rime's official API.
 
-- - Updated the default model for `CerebrasLLMService` to GPT-OSS-120B.
+- Updated the default model for `CerebrasLLMService` to GPT-OSS-120B.
 
 ### Removed
 

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -67,7 +67,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
     )
 
-    llm = CerebrasLLMService(api_key=os.getenv("CEREBRAS_API_KEY"), model="llama-3.3-70b")
+    llm = CerebrasLLMService(api_key=os.getenv("CEREBRAS_API_KEY"), model="gpt-oss-120b")
     # You can also register a function_name of None to get all functions
     # sent to the same callback with an additional function_name parameter.
     llm.register_function("get_current_weather", fetch_weather_from_api)

--- a/examples/foundational/14k-function-calling-cerebras.py
+++ b/examples/foundational/14k-function-calling-cerebras.py
@@ -67,7 +67,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
     )
 
-    llm = CerebrasLLMService(api_key=os.getenv("CEREBRAS_API_KEY"), model="gpt-oss-120b")
+    llm = CerebrasLLMService(api_key=os.getenv("CEREBRAS_API_KEY"))
     # You can also register a function_name of None to get all functions
     # sent to the same callback with an additional function_name parameter.
     llm.register_function("get_current_weather", fetch_weather_from_api)

--- a/src/pipecat/services/cerebras/llm.py
+++ b/src/pipecat/services/cerebras/llm.py
@@ -26,7 +26,7 @@ class CerebrasLLMService(OpenAILLMService):
         *,
         api_key: str,
         base_url: str = "https://api.cerebras.ai/v1",
-        model: str = "qwen-3-32b",
+        model: str = "gpt-oss-120b",
         **kwargs,
     ):
         """Initialize the Cerebras LLM service.
@@ -34,7 +34,7 @@ class CerebrasLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Cerebras's API.
             base_url: The base URL for Cerebras API. Defaults to "https://api.cerebras.ai/v1".
-            model: The model identifier to use. Defaults to "qwen-3-32b".
+            model: The model identifier to use. Defaults to "gpt-oss-120b".
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         super().__init__(api_key=api_key, base_url=base_url, model=model, **kwargs)

--- a/src/pipecat/services/cerebras/llm.py
+++ b/src/pipecat/services/cerebras/llm.py
@@ -26,7 +26,7 @@ class CerebrasLLMService(OpenAILLMService):
         *,
         api_key: str,
         base_url: str = "https://api.cerebras.ai/v1",
-        model: str = "llama-3.3-70b",
+        model: str = "qwen-3-32b",
         **kwargs,
     ):
         """Initialize the Cerebras LLM service.
@@ -34,7 +34,7 @@ class CerebrasLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Cerebras's API.
             base_url: The base URL for Cerebras API. Defaults to "https://api.cerebras.ai/v1".
-            model: The model identifier to use. Defaults to "llama-3.3-70b".
+            model: The model identifier to use. Defaults to "qwen-3-32b".
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         super().__init__(api_key=api_key, base_url=base_url, model=model, **kwargs)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`llama-3.3-70b` is sometimes prone to looping on tool calls. This PR updates the default for Cerebras inference to `gpt-oss-120b`, which is supported in production in Cerebras' inference API and exhibits stronger performance on tool calling.