### PR TITLE
fix: openai image generator now initiates URLImageRawFrame with correct order of arguments

### DIFF
--- a/src/pipecat/services/openai/image.py
+++ b/src/pipecat/services/openai/image.py
@@ -84,5 +84,10 @@ class OpenAIImageGenService(ImageGenService):
         async with self._aiohttp_session.get(image_url) as response:
             image_stream = io.BytesIO(await response.content.read())
             image = Image.open(image_stream)
-            frame = URLImageRawFrame(image_url, image.tobytes(), image.size, image.format)
+            frame = URLImageRawFrame(
+                image=image.tobytes(),
+                size=image.size,
+                format=image.format,
+                url=image_url,
+            )
             yield frame


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The OpenAI image generator was initiating `URLImageRawFrame` with the wrong order of arguments, `image_url` should be last argument if it is initiating it with positional arguments (inherited dataclasses, list their properties after the inherited class in the `__init__` function.)

I made it use keyword arguments to be safer.

If we have a typechecking task using pyright for example in the CI/CD, it should help to prevent similar issues.