### PR TITLE
Fix DailyParams Import

### DIFF
--- a/examples/quickstart/bot.py
+++ b/examples/quickstart/bot.py
@@ -44,7 +44,7 @@ from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.services.daily import DailyParams
 
 logger.info("✅ All components loaded successfully!")
 


### PR DESCRIPTION
The quickstart project doesn't run:

```
➜  pipecat git:(main) ✗ uv run bot.py
2025-09-04 11:41:05.219 | INFO     | pipecat:<module>:14 - ᓚᘏᗢ Pipecat 0.0.82 (Python 3.12.6 (main, Sep  6 2024, 19:03:47) [Clang 15.0.0 (clang-1500.3.9.4)]) ᓚᘏᗢ
🚀 Starting Pipecat bot...
⏳ Loading models and imports (20 seconds first run only)

2025-09-04 11:41:05.983 | INFO     | __main__:<module>:31 - Loading Silero VAD model...
2025-09-04 11:41:06.024 | INFO     | __main__:<module>:34 - ✅ Silero VAD model loaded
2025-09-04 11:41:06.024 | INFO     | __main__:<module>:35 - Loading pipeline components...
Traceback (most recent call last):
  File "/Users/anton/local/repos/voiceai/apps/pipecat/bot.py", line 47, in <module>
    from pipecat.transports.daily.transport import DailyParams
ModuleNotFoundError: No module named 'pipecat.transports.daily'
```

This commit is to blame: https://github.com/pipecat-ai/pipecat-quickstart/commit/11a5131c610a2d7fb9e65230f62c87d59acdaef0

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.