### PR TITLE
wait until endframe fully through pipeline before audiobuffer and turn_tracking

### DIFF
--- a/src/pipecat/observers/turn_tracking_observer.py
+++ b/src/pipecat/observers/turn_tracking_observer.py
@@ -23,6 +23,7 @@ from pipecat.frames.frames import (
     StartFrame,
     UserStartedSpeakingFrame,
 )
+from pipecat.pipeline.pipeline import Pipeline
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 
 
@@ -100,7 +101,9 @@ class TurnTrackingObserver(BaseObserver):
         # We only want to end the turn if the bot was previously speaking
         elif isinstance(data.frame, BotStoppedSpeakingFrame) and self._is_bot_speaking:
             await self._handle_bot_stopped_speaking(data)
-        elif isinstance(data.frame, (EndFrame, CancelFrame)):
+        elif isinstance(data.frame, CancelFrame):
+            await self._handle_pipeline_end(data)
+        elif isinstance(data.frame, EndFrame) and isinstance(data.src, Pipeline):
             await self._handle_pipeline_end(data)
 
     def _schedule_turn_end(self, data: FramePushed):

--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -27,6 +27,7 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
+from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 
@@ -197,7 +198,9 @@ class AudioBufferProcessor(FrameProcessor):
         if self._recording:
             await self._process_recording(frame)
 
-        if isinstance(frame, (CancelFrame, EndFrame)):
+        if isinstance(frame, CancelFrame):
+            await self.stop_recording()
+        elif isinstance(data.frame, EndFrame) and isinstance(data.src, Pipeline):
             await self.stop_recording()
 
         await self.push_frame(frame, direction)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

in `turn_tracking_observer` and `audio_buffer_processor`, as soon as an `EndFrame` is seen, the turn is ended / the recording stops.  
`EndFrame` usually indicates a graceful shutdown, so there could still be other frames in the pipeline.  this could result in a turn not fully being captured or a recording missing the final turn segment of audio.
I think we can solve this by checking the source of the `EndFrame` and if it is the Pipeline, we can be sure all other frames have been processed.  (Source because we push EndFrames upstream).
wdyt @aconchillo @filipi87 ?
