### PR TITLE
Handle missing rawResponse in transcription messages

### DIFF
--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -61,9 +61,7 @@ try:
         VirtualCameraDevice,
         VirtualSpeakerDevice,
     )
-    from daily import (
-        LogLevel as DailyLogLevel,
-    )
+    from daily import LogLevel as DailyLogLevel
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
@@ -2317,7 +2315,7 @@ class DailyTransport(BaseTransport):
         """Handle participant updated events."""
         await self._call_event_handler("on_participant_updated", participant)
 
-    async def _on_transcription_message(self, message):
+    async def _on_transcription_message(self, message: Dict[str, Any]) -> None:
         """Handle transcription message events."""
         await self._call_event_handler("on_transcription_message", message)
 
@@ -2329,9 +2327,10 @@ class DailyTransport(BaseTransport):
 
         text = message["text"]
         timestamp = message["timestamp"]
-        is_final = message["rawResponse"]["is_final"]
+        raw_response = message.get("rawResponse", {})
+        is_final = raw_response.get("is_final", False)
         try:
-            language = message["rawResponse"]["channel"]["alternatives"][0]["languages"][0]
+            language = raw_response["channel"]["alternatives"][0]["languages"][0]
             language = Language(language)
         except KeyError:
             language = None


### PR DESCRIPTION
## Summary

This PR improves the robustness of transcription message handling in the Daily transport by gracefully handling cases where the `rawResponse` field might be missing from transcription messages.

## Changes

- Updated `_on_transcription_message` method to use `message.get("rawResponse", {})` instead of direct dictionary access
- Used `.get("is_final", False)` to safely access the `is_final` field with a sensible default
- Added proper type annotations (`message: Dict[str, Any] -> None`) for better code clarity
- Minor import formatting cleanup

## Motivation

In some edge cases, transcription messages from Daily's API may not include the `rawResponse` field, which would cause a `KeyError` and crash the transcription processing. This change ensures that the code continues to work even when this field is missing, defaulting to treating the message as non-final.

## Testing

This change maintains backward compatibility with existing transcription messages that include the `rawResponse` field while preventing crashes when it's missing. The default behavior (treating messages as non-final when `rawResponse` is missing) is a safe fallback that ensures continued operation.