### PR TITLE
`ServiceSwitcher` unit tests (ended up being much more than that)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a couple of bugs in `ServiceSwitcher`:
+  - Using multiple `ServiceSwitcher`s in a pipeline would result in an error.
+  - `ServiceSwitcherFrame`s (such as `ManuallySwitchServiceFrame`s) were having
+    an effect too early, essentially "jumping the queue" in terms of pipeline
+    frame ordering.
+
 - Fixed a self-cancellation deadlock in `UserIdleProcessor` when returning
   `False` from an idle callback. The task now terminates naturally instead of
   attempting to cancel itself.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1603,46 +1603,17 @@ class MixerEnableFrame(MixerControlFrame):
 
 
 @dataclass
-class ManuallySwitchServiceBaseFrame:
-    """Base class for frames that request a manual service switch from a ServiceSwitcher.
+class ServiceSwitcherFrame(ControlFrame):
+    """A base class for frames that affect ServiceSwitcher behavior."""
 
-    Must be inherited alongside either ServiceSwitcherFrame or ServiceSwitcherControlFrame.
+    pass
+
+
+@dataclass
+class ManuallySwitchServiceFrame(ServiceSwitcherFrame):
+    """A frame to request a manual switch in the active service in a ServiceSwitcher.
+
+    Handled by ServiceSwitcherStrategyManual to switch the active service.
     """
 
     service: "FrameProcessor"
-
-
-@dataclass
-class ServiceSwitcherFrame(SystemFrame):
-    """A base class for frames that affect ServiceSwitcher behavior immediately."""
-
-    pass
-
-
-@dataclass
-class ManuallySwitchServiceFrame(ServiceSwitcherFrame, ManuallySwitchServiceBaseFrame):
-    """A frame to request an immediate manual switch in the active service in a ServiceSwitcher.
-
-    Handled by ServiceSwitcherStrategyManual to switch the active service.
-    """
-
-    pass
-
-
-@dataclass
-class ServiceSwitcherControlFrame(ControlFrame):
-    """A base class for frames that affect ServiceSwitcher behavior, in order."""
-
-    pass
-
-
-@dataclass
-class ManuallySwitchServiceControlFrame(
-    ServiceSwitcherControlFrame, ManuallySwitchServiceBaseFrame
-):
-    """A frame to request a manual switch in the active service in a ServiceSwitcher, in order.
-
-    Handled by ServiceSwitcherStrategyManual to switch the active service.
-    """
-
-    pass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1603,17 +1603,46 @@ class MixerEnableFrame(MixerControlFrame):
 
 
 @dataclass
-class ServiceSwitcherFrame(ControlFrame):
-    """A base class for frames that control ServiceSwitcher behavior."""
+class ManuallySwitchServiceBaseFrame:
+    """Base class for frames that request a manual service switch from a ServiceSwitcher.
+
+    Must be inherited alongside either ServiceSwitcherFrame or ServiceSwitcherControlFrame.
+    """
+
+    service: "FrameProcessor"
+
+
+@dataclass
+class ServiceSwitcherFrame(SystemFrame):
+    """A base class for frames that affect ServiceSwitcher behavior immediately."""
 
     pass
 
 
 @dataclass
-class ManuallySwitchServiceFrame(ServiceSwitcherFrame):
-    """A frame to request a manual switch in the active service in a ServiceSwitcher.
+class ManuallySwitchServiceFrame(ServiceSwitcherFrame, ManuallySwitchServiceBaseFrame):
+    """A frame to request an immediate manual switch in the active service in a ServiceSwitcher.
 
     Handled by ServiceSwitcherStrategyManual to switch the active service.
     """
 
-    service: "FrameProcessor"
+    pass
+
+
+@dataclass
+class ServiceSwitcherControlFrame(ControlFrame):
+    """A base class for frames that affect ServiceSwitcher behavior, in order."""
+
+    pass
+
+
+@dataclass
+class ManuallySwitchServiceControlFrame(
+    ServiceSwitcherControlFrame, ManuallySwitchServiceBaseFrame
+):
+    """A frame to request a manual switch in the active service in a ServiceSwitcher, in order.
+
+    Handled by ServiceSwitcherStrategyManual to switch the active service.
+    """
+
+    pass

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -102,16 +102,16 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
             """Initialize the service switcher filter with a strategy and direction."""
 
             async def filter(_: Frame) -> bool:
-                return self.wrapped_service == self.active_service
+                return self._wrapped_service == self._active_service
 
             super().__init__(filter, direction)
-            self.wrapped_service = wrapped_service
-            self.active_service = active_service
+            self._wrapped_service = wrapped_service
+            self._active_service = active_service
 
         async def process_frame(self, frame, direction):
             """Process a frame through the filter, handling special internal filter-updating frames."""
             if isinstance(frame, ServiceSwitcher.ServiceSwitcherFilterFrame):
-                self.active_service = frame.active_service
+                self._active_service = frame.active_service
                 # Two ServiceSwitcherFilters "sandwich" a service. Push the
                 # frame only to update the other side of the sandwich, but
                 # otherwise don't let it leave the sandwich.

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -112,6 +112,11 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
             """Process a frame through the filter, handling special internal filter-updating frames."""
             if isinstance(frame, ServiceSwitcher.ServiceSwitcherFilterFrame):
                 self.active_service = frame.active_service
+                # Two ServiceSwitcherFilters "sandwich" a service. Push the
+                # frame only to update the other side of the sandwich, but
+                # otherwise don't let it leave the sandwich.
+                if direction == self._direction:
+                    await self.push_frame(frame, direction)
                 return
 
             await super().process_frame(frame, direction)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -169,6 +169,11 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
             service_switcher_filter_frame = ServiceSwitcher.ServiceSwitcherFilterFrame(
                 active_service=self.strategy.active_service
             )
-            # Hack: we need access ParallelPipeline internals here to queue the frame in each of the pipelines
+            # Hack: we need access ParallelPipeline internals here to queue the
+            # frame in each of the pipelines.
+            # Why not just call super().process_frame(service_switcher_filter_frame, direction),
+            # you ask? Because that would also send this internal-only frame
+            # down the "main" pipeline instead of only down the individual
+            # branches of the parallel pipeline, which we want to avoid.
             for p in self._pipelines:
                 await p.queue_frame(service_switcher_filter_frame, direction)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -6,9 +6,15 @@
 
 """Service switcher for switching between different services at runtime, with different switching strategies."""
 
+from dataclasses import dataclass
 from typing import Any, Generic, List, Optional, Type, TypeVar
 
-from pipecat.frames.frames import Frame, ManuallySwitchServiceFrame, ServiceSwitcherFrame
+from pipecat.frames.frames import (
+    ControlFrame,
+    Frame,
+    ManuallySwitchServiceFrame,
+    ServiceSwitcherFrame,
+)
 from pipecat.pipeline.parallel_pipeline import ParallelPipeline
 from pipecat.processors.filters.function_filter import FunctionFilter
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -21,19 +27,6 @@ class ServiceSwitcherStrategy:
         """Initialize the service switcher strategy with a list of services."""
         self.services = services
         self.active_service: Optional[FrameProcessor] = None
-
-    def is_active(self, service: FrameProcessor) -> bool:
-        """Determine if the given service is the currently active one.
-
-        This method should be overridden by subclasses to implement specific logic.
-
-        Args:
-            service: The service to check.
-
-        Returns:
-            True if the given service is the active one, False otherwise.
-        """
-        raise NotImplementedError("Subclasses must implement this method.")
 
     def handle_frame(self, frame: ServiceSwitcherFrame, direction: FrameDirection):
         """Handle a frame that controls service switching.
@@ -59,17 +52,6 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
         """Initialize the manual service switcher strategy with a list of services."""
         super().__init__(services)
         self.active_service = services[0] if services else None
-
-    def is_active(self, service: FrameProcessor) -> bool:
-        """Check if the given service is the currently active one.
-
-        Args:
-            service: The service to check.
-
-        Returns:
-            True if the given service is the active one, False otherwise.
-        """
-        return service == self.active_service
 
     def handle_frame(self, frame: ServiceSwitcherFrame, direction: FrameDirection):
         """Handle a frame that controls service switching.
@@ -108,6 +90,38 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         self.services = services
         self.strategy = strategy
 
+    class ServiceSwitcherFilter(FunctionFilter):
+        """An internal filter that allows frames to pass through to the wrapped service only if it's the active service."""
+
+        def __init__(
+            self,
+            wrapped_service: FrameProcessor,
+            active_service: FrameProcessor,
+            direction: FrameDirection,
+        ):
+            """Initialize the service switcher filter with a strategy and direction."""
+
+            async def filter(_: Frame) -> bool:
+                return self.wrapped_service == self.active_service
+
+            super().__init__(filter, direction)
+            self.wrapped_service = wrapped_service
+            self.active_service = active_service
+
+        async def process_frame(self, frame, direction):
+            """Process a frame through the filter, handling special internal filter-updating frames."""
+            if isinstance(frame, ServiceSwitcher.ServiceSwitcherFilterFrame):
+                self.active_service = frame.active_service
+                return
+
+            await super().process_frame(frame, direction)
+
+    @dataclass
+    class ServiceSwitcherFilterFrame(ControlFrame):
+        """An internal frame used by ServiceSwitcher to filter frames based on active service."""
+
+        active_service: FrameProcessor
+
     @staticmethod
     def _make_pipeline_definitions(
         services: List[FrameProcessor], strategy: ServiceSwitcherStrategy
@@ -121,14 +135,18 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
     def _make_pipeline_definition(
         service: FrameProcessor, strategy: ServiceSwitcherStrategy
     ) -> Any:
-        async def filter(frame) -> bool:
-            _ = frame
-            return strategy.is_active(service)
-
         return [
-            FunctionFilter(filter, direction=FrameDirection.DOWNSTREAM),
+            ServiceSwitcher.ServiceSwitcherFilter(
+                wrapped_service=service,
+                active_service=strategy.active_service,
+                direction=FrameDirection.DOWNSTREAM,
+            ),
             service,
-            FunctionFilter(filter, direction=FrameDirection.UPSTREAM),
+            ServiceSwitcher.ServiceSwitcherFilter(
+                wrapped_service=service,
+                active_service=strategy.active_service,
+                direction=FrameDirection.UPSTREAM,
+            ),
         ]
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
@@ -142,3 +160,10 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
 
         if isinstance(frame, ServiceSwitcherFrame):
             self.strategy.handle_frame(frame, direction)
+            service_switcher_filter_frame = ServiceSwitcher.ServiceSwitcherFilterFrame(
+                active_service=self.strategy.active_service
+            )
+            # Queue frame that updates filters with new active service
+            # (Hack: we need access ParallelPipeline internals here to queue the frame in each of the pipelines)
+            for p in self._pipelines:
+                await p.queue_frame(service_switcher_filter_frame, direction)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -61,20 +61,21 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
             direction: The direction of the frame (upstream or downstream).
         """
         if isinstance(frame, ManuallySwitchServiceFrame):
-            self._set_active(frame.service)
+            self._set_active_if_available(frame.service)
         else:
             raise ValueError(f"Unsupported frame type: {type(frame)}")
 
-    def _set_active(self, service: FrameProcessor):
-        """Set the active service to the given one.
+    def _set_active_if_available(self, service: FrameProcessor):
+        """Set the active service to the given one, if it is in the list of available services.
+
+        If it's not in the list, the request is ignored, as it may have been
+        intended for another ServiceSwitcher in the pipeline.
 
         Args:
             service: The service to set as active.
         """
         if service in self.services:
             self.active_service = service
-        else:
-            raise ValueError(f"Service {service} is not in the list of available services.")
 
 
 StrategyType = TypeVar("StrategyType", bound=ServiceSwitcherStrategy)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -12,8 +12,10 @@ from typing import Any, Generic, List, Optional, Type, TypeVar
 from pipecat.frames.frames import (
     ControlFrame,
     Frame,
-    ManuallySwitchServiceFrame,
+    ManuallySwitchServiceBaseFrame,
+    ServiceSwitcherControlFrame,
     ServiceSwitcherFrame,
+    SystemFrame,
 )
 from pipecat.pipeline.parallel_pipeline import ParallelPipeline
 from pipecat.processors.filters.function_filter import FunctionFilter
@@ -28,7 +30,9 @@ class ServiceSwitcherStrategy:
         self.services = services
         self.active_service: Optional[FrameProcessor] = None
 
-    def handle_frame(self, frame: ServiceSwitcherFrame, direction: FrameDirection):
+    def handle_frame(
+        self, frame: ServiceSwitcherFrame | ServiceSwitcherControlFrame, direction: FrameDirection
+    ):
         """Handle a frame that controls service switching.
 
         This method can be overridden by subclasses to implement specific logic
@@ -53,14 +57,16 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
         super().__init__(services)
         self.active_service = services[0] if services else None
 
-    def handle_frame(self, frame: ServiceSwitcherFrame, direction: FrameDirection):
+    def handle_frame(
+        self, frame: ServiceSwitcherFrame | ServiceSwitcherControlFrame, direction: FrameDirection
+    ):
         """Handle a frame that controls service switching.
 
         Args:
             frame: The frame to handle.
             direction: The direction of the frame (upstream or downstream).
         """
-        if isinstance(frame, ManuallySwitchServiceFrame):
+        if isinstance(frame, ManuallySwitchServiceBaseFrame):
             self._set_active(frame.service)
         else:
             raise ValueError(f"Unsupported frame type: {type(frame)}")
@@ -110,7 +116,7 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
 
         async def process_frame(self, frame, direction):
             """Process a frame through the filter, handling special internal filter-updating frames."""
-            if isinstance(frame, ServiceSwitcher.ServiceSwitcherFilterFrame):
+            if isinstance(frame, ServiceSwitcher.ServiceSwitcherFilterBaseFrame):
                 self.active_service = frame.active_service
                 # Two ServiceSwitcherFilters "sandwich" a service. Push the
                 # frame only to update the other side of the sandwich, but
@@ -122,10 +128,22 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
             await super().process_frame(frame, direction)
 
     @dataclass
-    class ServiceSwitcherFilterFrame(ControlFrame):
-        """An internal frame used by ServiceSwitcher to filter frames based on active service."""
+    class ServiceSwitcherFilterBaseFrame:
+        """Base class for internal frames used by ServiceSwitcher to filter frames based on active service."""
 
         active_service: FrameProcessor
+
+    @dataclass
+    class ServiceSwitcherFilterFrame(SystemFrame, ServiceSwitcherFilterBaseFrame):
+        """An internal frame used by ServiceSwitcher to filter frames based on active service."""
+
+        pass
+
+    @dataclass
+    class ServiceSwitcherFilterControlFrame(ControlFrame, ServiceSwitcherFilterBaseFrame):
+        """An internal control frame used by ServiceSwitcher to filter frames based on active service."""
+
+        pass
 
     @staticmethod
     def _make_pipeline_definitions(
@@ -163,11 +181,18 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         """
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, ServiceSwitcherFrame):
+        if isinstance(frame, (ServiceSwitcherFrame, ServiceSwitcherControlFrame)):
             self.strategy.handle_frame(frame, direction)
-            service_switcher_filter_frame = ServiceSwitcher.ServiceSwitcherFilterFrame(
-                active_service=self.strategy.active_service
-            )
+            if isinstance(frame, ServiceSwitcherFrame):
+                # Apply immediate update (system frame)
+                service_switcher_filter_frame = ServiceSwitcher.ServiceSwitcherFilterFrame(
+                    active_service=self.strategy.active_service
+                )
+            else:
+                # Apply in-order update (control frame)
+                service_switcher_filter_frame = ServiceSwitcher.ServiceSwitcherFilterControlFrame(
+                    active_service=self.strategy.active_service
+                )
             # Queue frame that updates filters with new active service
             # (Hack: we need access ParallelPipeline internals here to queue the frame in each of the pipelines)
             for p in self._pipelines:

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -100,19 +100,6 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(strategy.active_service, self.service2)
         self.assertEqual(strategy.active_service, self.service3)
 
-    def test_handle_frame_invalid_service(self):
-        """Test that switching to an invalid service raises an error."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
-        invalid_service = MockFrameProcessor("invalid")
-
-        switch_frame = ManuallySwitchServiceFrame(service=invalid_service)
-
-        with self.assertRaises(ValueError) as context:
-            strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-
-        self.assertIn("Service", str(context.exception))
-        self.assertIn("is not in the list of available services", str(context.exception))
-
     def test_handle_frame_unsupported_frame_type(self):
         """Test that unsupported frame types raise an error."""
         strategy = ServiceSwitcherStrategyManual(self.services)

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -9,7 +9,12 @@
 import asyncio
 import unittest
 
-from pipecat.frames.frames import Frame, ManuallySwitchServiceFrame, TextFrame
+from pipecat.frames.frames import (
+    Frame,
+    ManuallySwitchServiceControlFrame,
+    ManuallySwitchServiceFrame,
+    TextFrame,
+)
 from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategyManual
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.tests.utils import run_test
@@ -72,7 +77,7 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strategy.services, [])
         self.assertIsNone(strategy.active_service)
 
-    def test_handle_frame_manually_switch_service(self):
+    def test_handle_manually_switch_service_frame(self):
         """Test manual service switching with ManuallySwitchServiceFrame."""
         strategy = ServiceSwitcherStrategyManual(self.services)
 
@@ -90,6 +95,30 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
 
         # Switch to service3
         switch_frame = ManuallySwitchServiceFrame(service=self.service3)
+        strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertNotEqual(strategy.active_service, self.service1)
+        self.assertNotEqual(strategy.active_service, self.service2)
+        self.assertEqual(strategy.active_service, self.service3)
+
+    def test_handle_manually_switch_service_control_frame(self):
+        """Test manual service switching with ManuallySwitchServiceControlFrame."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        # Initially service1 should be active
+        self.assertEqual(strategy.active_service, self.service1)
+        self.assertNotEqual(strategy.active_service, self.service2)
+
+        # Switch to service2
+        switch_frame = ManuallySwitchServiceControlFrame(service=self.service2)
+        strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertNotEqual(strategy.active_service, self.service1)
+        self.assertEqual(strategy.active_service, self.service2)
+        self.assertNotEqual(strategy.active_service, self.service3)
+
+        # Switch to service3
+        switch_frame = ManuallySwitchServiceControlFrame(service=self.service3)
         strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
 
         self.assertNotEqual(strategy.active_service, self.service1)
@@ -178,8 +207,8 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         for i, frame in enumerate(text_frames):
             self.assertEqual(frame.text, f"Hello {i + 1}")
 
-    async def test_service_switching(self):
-        """Test that after service switching the new active service receives frames while others don't."""
+    async def test_service_switching_in_order(self):
+        """Test that after service switching using ManuallySwitchServiceControlFrame, the new active service receives frames while others don't."""
         switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
 
         # Reset counters
@@ -191,10 +220,10 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
             switcher,
             frames_to_send=[
                 TextFrame("Frame for service1"),
-                ManuallySwitchServiceFrame(service=self.service2),
+                ManuallySwitchServiceControlFrame(service=self.service2),
                 TextFrame("Frame for service2"),
             ],
-            expected_down_frames=[TextFrame, ManuallySwitchServiceFrame, TextFrame],
+            expected_down_frames=[TextFrame, ManuallySwitchServiceControlFrame, TextFrame],
         )
 
         # Verify service2 received the frame
@@ -213,6 +242,43 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(service3_text_frames), 0)
         self.assertEqual(service1_text_frames[0].text, "Frame for service1")
         self.assertEqual(service2_text_frames[0].text, "Frame for service2")
+
+    async def test_service_switching_immediate(self):
+        """Test that after service switching using ManuallySwitchServiceFrame, the new active service receives frames while others don't."""
+        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+
+        # Reset counters
+        for service in self.services:
+            service.reset_counters()
+
+        # Send a test frame, a switch frame, and another test frame
+        await run_test(
+            switcher,
+            frames_to_send=[
+                # Out of order on purpose - ManuallySwitchServiceFrame should jump the queue
+                TextFrame("Frame 1 for service2"),
+                ManuallySwitchServiceFrame(service=self.service2),
+                TextFrame("Frame 2 for service2"),
+            ],
+            expected_down_frames=[ManuallySwitchServiceFrame, TextFrame, TextFrame],
+        )
+
+        # Verify service2 received the frame
+        service1_text_frames = [
+            f for f in self.service1.processed_frames if isinstance(f, TextFrame)
+        ]
+        service2_text_frames = [
+            f for f in self.service2.processed_frames if isinstance(f, TextFrame)
+        ]
+        service3_text_frames = [
+            f for f in self.service3.processed_frames if isinstance(f, TextFrame)
+        ]
+
+        self.assertEqual(len(service1_text_frames), 0)
+        self.assertEqual(len(service2_text_frames), 2)
+        self.assertEqual(len(service3_text_frames), 0)
+        self.assertEqual(service2_text_frames[0].text, "Frame 1 for service2")
+        self.assertEqual(service2_text_frames[1].text, "Frame 2 for service2")
 
 
 if __name__ == "__main__":

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -214,41 +214,6 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(service1_text_frames[0].text, "Frame for service1")
         self.assertEqual(service2_text_frames[0].text, "Frame for service2")
 
-    async def test_service_switching_functionality(self):
-        """Test that switching between services works correctly."""
-        # This test is simplified to avoid timing issues
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
-
-        # Test that we can programmatically switch services
-        self.assertEqual(switcher.strategy.active_service, self.service1)  # Initially service1
-
-        # Manually switch to service2
-        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
-        switcher.strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-
-        # Verify the switch worked
-        self.assertNotEqual(switcher.strategy.active_service, self.service1)
-        self.assertEqual(switcher.strategy.active_service, self.service2)
-        self.assertNotEqual(switcher.strategy.active_service, self.service3)
-
-        # Switch to service3
-        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
-        switcher.strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-
-        # Verify the switch worked
-        self.assertNotEqual(switcher.strategy.active_service, self.service1)
-        self.assertNotEqual(switcher.strategy.active_service, self.service2)
-        self.assertEqual(switcher.strategy.active_service, self.service3)
-
-    async def test_service_switching_with_empty_services_list(self):
-        """Test behavior with an empty services list."""
-        # ServiceSwitcher should handle empty services gracefully, but ParallelPipeline needs at least one pipeline
-        # So this test verifies that an exception is raised as expected
-        with self.assertRaises(Exception) as context:
-            ServiceSwitcher([], ServiceSwitcherStrategyManual)
-
-        self.assertIn("ParallelPipeline needs at least one argument", str(context.exception))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -1,0 +1,254 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Unit tests for ServiceSwitcher and related components."""
+
+import asyncio
+import unittest
+
+from pipecat.frames.frames import Frame, ManuallySwitchServiceFrame, TextFrame
+from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategyManual
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.tests.utils import run_test
+
+
+class MockFrameProcessor(FrameProcessor):
+    """A test frame processor that tracks which frames it has processed."""
+
+    def __init__(self, test_name: str, **kwargs):
+        """Initialize the test processor with a name.
+
+        Args:
+            test_name: A unique name for this processor instance.
+            **kwargs: Additional arguments passed to the parent FrameProcessor.
+        """
+        super().__init__(name=test_name, **kwargs)
+        self.test_name = test_name
+        self.processed_frames = []
+        self.frame_count = 0
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process an incoming frame and track it.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame flow in the pipeline.
+        """
+        await super().process_frame(frame, direction)
+        self.processed_frames.append(frame)
+        self.frame_count += 1
+        await self.push_frame(frame, direction)
+
+    def reset_counters(self):
+        """Reset the frame tracking counters."""
+        self.processed_frames = []
+        self.frame_count = 0
+
+
+class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
+    """Test cases for ServiceSwitcherStrategyManual."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.service1 = MockFrameProcessor("service1")
+        self.service2 = MockFrameProcessor("service2")
+        self.service3 = MockFrameProcessor("service3")
+        self.services = [self.service1, self.service2, self.service3]
+
+    def test_init_with_services(self):
+        """Test initialization with a list of services."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        self.assertEqual(strategy.services, self.services)
+        self.assertEqual(strategy.active_service, self.service1)  # First service should be active
+
+    def test_init_with_empty_services(self):
+        """Test initialization with an empty list of services."""
+        strategy = ServiceSwitcherStrategyManual([])
+
+        self.assertEqual(strategy.services, [])
+        self.assertIsNone(strategy.active_service)
+
+    def test_handle_frame_manually_switch_service(self):
+        """Test manual service switching with ManuallySwitchServiceFrame."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        # Initially service1 should be active
+        self.assertEqual(strategy.active_service, self.service1)
+        self.assertNotEqual(strategy.active_service, self.service2)
+
+        # Switch to service2
+        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
+        strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertNotEqual(strategy.active_service, self.service1)
+        self.assertEqual(strategy.active_service, self.service2)
+        self.assertNotEqual(strategy.active_service, self.service3)
+
+        # Switch to service3
+        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
+        strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertNotEqual(strategy.active_service, self.service1)
+        self.assertNotEqual(strategy.active_service, self.service2)
+        self.assertEqual(strategy.active_service, self.service3)
+
+    def test_handle_frame_invalid_service(self):
+        """Test that switching to an invalid service raises an error."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+        invalid_service = MockFrameProcessor("invalid")
+
+        switch_frame = ManuallySwitchServiceFrame(service=invalid_service)
+
+        with self.assertRaises(ValueError) as context:
+            strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertIn("Service", str(context.exception))
+        self.assertIn("is not in the list of available services", str(context.exception))
+
+    def test_handle_frame_unsupported_frame_type(self):
+        """Test that unsupported frame types raise an error."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+        unsupported_frame = TextFrame(text="test")  # Not a ServiceSwitcherFrame
+
+        with self.assertRaises(ValueError) as context:
+            strategy.handle_frame(unsupported_frame, FrameDirection.DOWNSTREAM)
+
+        self.assertIn("Unsupported frame type", str(context.exception))
+
+
+class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
+    """Test cases for ServiceSwitcher."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.service1 = MockFrameProcessor("service1")
+        self.service2 = MockFrameProcessor("service2")
+        self.service3 = MockFrameProcessor("service3")
+        self.services = [self.service1, self.service2, self.service3]
+
+    def test_init_with_manual_strategy(self):
+        """Test initialization with manual strategy."""
+        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+
+        self.assertEqual(switcher.services, self.services)
+        self.assertIsInstance(switcher.strategy, ServiceSwitcherStrategyManual)
+        self.assertEqual(switcher.strategy.services, self.services)
+
+    async def test_default_active_service(self):
+        """Test that the initially-active service receives frames while others don't."""
+        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+
+        # Reset counters
+        for service in self.services:
+            service.reset_counters()
+
+        # Send some test frames
+        frames_to_send = [
+            TextFrame(text="Hello 1"),
+            TextFrame(text="Hello 2"),
+            TextFrame(text="Hello 3"),
+        ]
+
+        await run_test(
+            switcher,
+            frames_to_send=frames_to_send,
+            expected_down_frames=[TextFrame, TextFrame, TextFrame],
+        )
+
+        # Only service1 should have processed the text frames
+        # Note: The service also receives StartFrame and EndFrame, so count those too
+        text_frames = [f for f in self.service1.processed_frames if isinstance(f, TextFrame)]
+        self.assertEqual(len(text_frames), 3)
+
+        # Check that other services don't receive text frames (they might get StartFrame/EndFrame)
+        service2_text_frames = [
+            f for f in self.service2.processed_frames if isinstance(f, TextFrame)
+        ]
+        service3_text_frames = [
+            f for f in self.service3.processed_frames if isinstance(f, TextFrame)
+        ]
+        self.assertEqual(len(service2_text_frames), 0)
+        self.assertEqual(len(service3_text_frames), 0)
+
+        # Verify the actual text frames processed
+        for i, frame in enumerate(text_frames):
+            self.assertEqual(frame.text, f"Hello {i + 1}")
+
+    async def test_service_switching(self):
+        """Test that after service switching the new active service receives frames while others don't."""
+        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+
+        # Reset counters
+        for service in self.services:
+            service.reset_counters()
+
+        # Send a test frame, a switch frame, and another test frame
+        await run_test(
+            switcher,
+            frames_to_send=[
+                TextFrame("Frame for service1"),
+                ManuallySwitchServiceFrame(service=self.service2),
+                TextFrame("Frame for service2"),
+            ],
+            expected_down_frames=[TextFrame, ManuallySwitchServiceFrame, TextFrame],
+        )
+
+        # Verify service2 received the frame
+        service1_text_frames = [
+            f for f in self.service1.processed_frames if isinstance(f, TextFrame)
+        ]
+        service2_text_frames = [
+            f for f in self.service2.processed_frames if isinstance(f, TextFrame)
+        ]
+        service3_text_frames = [
+            f for f in self.service3.processed_frames if isinstance(f, TextFrame)
+        ]
+
+        self.assertEqual(len(service1_text_frames), 1)
+        self.assertEqual(len(service2_text_frames), 1)
+        self.assertEqual(len(service3_text_frames), 0)
+        self.assertEqual(service1_text_frames[0].text, "Frame for service1")
+        self.assertEqual(service2_text_frames[0].text, "Frame for service2")
+
+    async def test_service_switching_functionality(self):
+        """Test that switching between services works correctly."""
+        # This test is simplified to avoid timing issues
+        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+
+        # Test that we can programmatically switch services
+        self.assertEqual(switcher.strategy.active_service, self.service1)  # Initially service1
+
+        # Manually switch to service2
+        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
+        switcher.strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        # Verify the switch worked
+        self.assertNotEqual(switcher.strategy.active_service, self.service1)
+        self.assertEqual(switcher.strategy.active_service, self.service2)
+        self.assertNotEqual(switcher.strategy.active_service, self.service3)
+
+        # Switch to service3
+        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
+        switcher.strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+
+        # Verify the switch worked
+        self.assertNotEqual(switcher.strategy.active_service, self.service1)
+        self.assertNotEqual(switcher.strategy.active_service, self.service2)
+        self.assertEqual(switcher.strategy.active_service, self.service3)
+
+    async def test_service_switching_with_empty_services_list(self):
+        """Test behavior with an empty services list."""
+        # ServiceSwitcher should handle empty services gracefully, but ParallelPipeline needs at least one pipeline
+        # So this test verifies that an exception is raised as expected
+        with self.assertRaises(Exception) as context:
+            ServiceSwitcher([], ServiceSwitcherStrategyManual)
+
+        self.assertIn("ParallelPipeline needs at least one argument", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
And fix an issue caught by those tests! See [commit message](https://github.com/pipecat-ai/pipecat/pull/2646/commits/a2ad71d02958caf58cfe3ba131349cee6536e8fd) for description. TL;DR: `ServiceSwitcherFrame`s were updated to be properly processed in order.

UPDATE: actually, [_another fix_](https://github.com/pipecat-ai/pipecat/pull/2646/commits/71015bc6a79ec8fc3ac6485e1ff94f69a7da0eeb): we probably generally _don't_ want `ServiceSwitcherFrame`s to be processed in order. They should probably be `SystemFrame`s.

ANOTHER UPDATE: scratch that—we're back to processing the frames in order, as `ControlFrame`s.