### PR TITLE
fix: AudioBufferProcessor has_audio returns based on user or bot audi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in `AudioBufferProcessor` where a recording is not created
+  when a bot speaks and user input is blocked.
+
 - Fixed a `FastAPIWebsocketTransport` and `SmallWebRTCTransport` issue where
   `on_client_disconnected` would be triggered when the bot ends the
   conversation. That is, `on_client_disconnected` should only be triggered when

--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -137,12 +137,12 @@ class AudioBufferProcessor(FrameProcessor):
         return self._num_channels
 
     def has_audio(self) -> bool:
-        """Check if both user and bot audio buffers contain data.
+        """Check if either user or bot audio buffers contain data.
 
         Returns:
-            True if both buffers contain audio data.
+            True if either buffer contains audio data.
         """
-        return self._buffer_has_audio(self._user_audio_buffer) and self._buffer_has_audio(
+        return self._buffer_has_audio(self._user_audio_buffer) or self._buffer_has_audio(
             self._bot_audio_buffer
         )
 


### PR DESCRIPTION
…o existing

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This was causing no recording to be generated when the STTMuteFilter was enabled using `MUTE_UNTIL_FIRST_BOT_COMPLETE` strategy, the bot speaks first, and the session ends before the user speaks.

Instead, a recording should be produced with either user or bot audio.

For turn audio, it will only produce a recording if there is existing audio.