### PR TITLE
fix: clean up how UserIdleProcessor handles return False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a self-cancellation deadlock in `UserIdleProcessor` when returning
+  `False` from an idle callback. The task now terminates naturally instead of
+  attempting to cancel itself.
+
 - Fixed an issue in `AudioBufferProcessor` where a recording is not created
   when a bot speaks and user input is blocked.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Surfaced in Discord:
https://discord.com/channels/1239284677165056021/1417456786377543680/1417456786377543680

The comment is correct, but didn't really have an impact because `return False` should only be called when ending the Pipeline and cleanup() was ensuring tasks were cancelled correctly. Nonetheless, this change aligns with how things are done elsewhere.