### PR TITLE
fix: replace `Tuple` type with `TypeAlias` for server params in MCP client

### DIFF
--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -7,7 +7,7 @@
 """MCP (Model Context Protocol) client for integrating external tools with LLMs."""
 
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, TypeAlias
 
 from loguru import logger
 
@@ -28,6 +28,7 @@ except ModuleNotFoundError as e:
     logger.error("In order to use an MCP client, you need to `pip install pipecat-ai[mcp]`.")
     raise Exception(f"Missing module: {e}")
 
+ServerParameters: TypeAlias = StdioServerParameters | SseServerParameters | StreamableHttpParameters
 
 class MCPClient(BaseObject):
     """Client for Model Context Protocol (MCP) servers.
@@ -42,7 +43,7 @@ class MCPClient(BaseObject):
 
     def __init__(
         self,
-        server_params: Tuple[StdioServerParameters, SseServerParameters, StreamableHttpParameters],
+        server_params: ServerParameters,
         **kwargs,
     ):
         """Initialize the MCP client with server parameters.

--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -30,6 +30,7 @@ except ModuleNotFoundError as e:
 
 ServerParameters: TypeAlias = StdioServerParameters | SseServerParameters | StreamableHttpParameters
 
+
 class MCPClient(BaseObject):
     """Client for Model Context Protocol (MCP) servers.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Currently the MCP client is expected a `Tuple` type as `server_params`. This is wrong since the code, expects one server with a `Type` that is either `StdioServerParameters`, `SseServerParameters` or `StreamableHttpParameters`.

This will lead to Type check issues as `__init__` would expected a `Tuple` as input with all three server param types present. 

Current code:
```
    def __init__(
        self,
        server_params: Tuple[StdioServerParameters, SseServerParameters, StreamableHttpParameters],
        **kwargs,
    ):
        """Initialize the MCP client with server parameters.

        Args:
            server_params: Server connection parameters (stdio or SSE).
            **kwargs: Additional arguments passed to the parent BaseObject.
        """
        super().__init__(**kwargs)
        self._server_params = server_params
        self._session = ClientSession
        self._needs_alternate_schema = False

        if isinstance(server_params, StdioServerParameters):
            self._client = stdio_client
            self._register_tools = self._stdio_register_tools
        elif isinstance(server_params, SseServerParameters):
            self._client = sse_client
            self._register_tools = self._sse_register_tools
        elif isinstance(server_params, StreamableHttpParameters):
            self._client = streamablehttp_client
            self._register_tools = self._streamable_http_register_tools
        else:
            raise TypeError(
                f"{self} invalid argument type: `server_params` must be either StdioServerParameters, SseServerParameters, or StreamableHttpParameters."
            )
```

I am changing this to use the following TypeAlias instead:

`ServerParameters: TypeAlias = StdioServerParameters | SseServerParameters | StreamableHttpParameters`

I also suggest adding Typechecking stage to your build pipeline to prevent these types of issues in releases. For example, if you run type checking on this example, it would fail:

https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/39-mcp-stdio.py
