### PR TITLE
DailyTransport sip_call_transfer now automatically receives session_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `DailyTransport.sip_call_transfer()` to automatically use the session
+  ID from the `on_dialin_connected` event, when not explicitly provided. Now
+  supports cold transfers (from incoming dial-in calls) by automatically
+  tracking session IDs from connection events.
+
 - Fixed a memory leak in `SmallWebRTCTransport`. In `aiortc`, when you receive
   a `MediaStreamTrack` (audio or video), frames are produced asynchronously. If
   the code never consumes these frames, they are queued in memory, causing a


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Before, you had to handle the session_id and pass it to the sip_call_transfer method. Now, the session_id is automatically provided, allowing developers to just do the following:

```python
transfer_params = {"toEndPoint": operator_number}
await transport.sip_call_transfer(transfer_params)
```

The developer can still pass in the session_id to override.

I think this is an improvement we want to make.