### PR TITLE
Add remote participant updates to DailyTransport

### DIFF
--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 from pipecat.frames.frames import (
     CancelFrame,
+    ControlFrame,
     EndFrame,
     ErrorFrame,
     Frame,
@@ -41,7 +42,6 @@ from pipecat.frames.frames import (
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
-    ControlFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transcriptions.language import Language

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 from pipecat.frames.frames import (
     CancelFrame,
+    ControlFrame,
     EndFrame,
     ErrorFrame,
     Frame,
@@ -41,7 +42,6 @@ from pipecat.frames.frames import (
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
-    DataFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transcriptions.language import Language
@@ -105,8 +105,9 @@ class DailyInputTransportMessageUrgentFrame(InputTransportMessageUrgentFrame):
 
     participant_id: Optional[str] = None
 
+
 @dataclass
-class DailyUpdateRemoteParticipantsFrame(DataFrame):
+class DailyUpdateRemoteParticipantsFrame(ControlFrame):
     """Frame to update remote participants in Daily calls.
 
     Parameters:
@@ -114,6 +115,7 @@ class DailyUpdateRemoteParticipantsFrame(DataFrame):
     """
 
     remote_participants: Optional[Any] = None
+
 
 class WebRTCVADAnalyzer(VADAnalyzer):
     """Voice Activity Detection analyzer using WebRTC.
@@ -1794,7 +1796,7 @@ class DailyOutputTransport(BaseOutputTransport):
         await super().cancel(frame)
         # Leave the room.
         await self._client.leave()
-    
+
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process outgoing frames, including transport messages.
 

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -41,6 +41,7 @@ from pipecat.frames.frames import (
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
+    DataFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transcriptions.language import Language
@@ -104,6 +105,15 @@ class DailyInputTransportMessageUrgentFrame(InputTransportMessageUrgentFrame):
 
     participant_id: Optional[str] = None
 
+@dataclass
+class DailyUpdateRemoteParticipantsFrame(DataFrame):
+    """Frame to update remote participants in Daily calls.
+
+    Parameters:
+        remote_participants: See https://reference-python.daily.co/api_reference.html#daily.CallClient.update_remote_participants.
+    """
+
+    remote_participants: Optional[Any] = None
 
 class WebRTCVADAnalyzer(VADAnalyzer):
     """Voice Activity Detection analyzer using WebRTC.
@@ -1784,6 +1794,19 @@ class DailyOutputTransport(BaseOutputTransport):
         await super().cancel(frame)
         # Leave the room.
         await self._client.leave()
+    
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process outgoing frames, including transport messages.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame flow in the pipeline.
+        """
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, DailyUpdateRemoteParticipantsFrame):
+            logger.debug(f"Got a DailyUpdateRemoteParticipantsFrame: {frame}")
+            await self._client.update_remote_participants(frame.remote_participants)
 
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):
         """Send a transport message to participants.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -25,7 +25,6 @@ from pydantic import BaseModel
 from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 from pipecat.frames.frames import (
     CancelFrame,
-    ControlFrame,
     EndFrame,
     ErrorFrame,
     Frame,
@@ -42,6 +41,7 @@ from pipecat.frames.frames import (
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
+    ControlFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transcriptions.language import Language
@@ -114,7 +114,7 @@ class DailyUpdateRemoteParticipantsFrame(ControlFrame):
         remote_participants: See https://reference-python.daily.co/api_reference.html#daily.CallClient.update_remote_participants.
     """
 
-    remote_participants: Optional[Any] = None
+    remote_participants: Mapping[str, Any] = None
 
 
 class WebRTCVADAnalyzer(VADAnalyzer):
@@ -1807,7 +1807,6 @@ class DailyOutputTransport(BaseOutputTransport):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, DailyUpdateRemoteParticipantsFrame):
-            logger.debug(f"Got a DailyUpdateRemoteParticipantsFrame: {frame}")
             await self._client.update_remote_participants(frame.remote_participants)
 
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):


### PR DESCRIPTION
This PR adds a `DailyUpdateRemoteParticipantsFrame`, which enables use of the [`daily.update_remote_participants` function](https://reference-python.daily.co/api_reference.html#daily.CallClient.update_remote_participants) within a sequence of frames.