### PR TITLE
Reset the FrameProcessor process_event when resuming processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- It is now possible to register synchronous event handlers. By default, all
+  event handlers are executed in a separate task. However, in some cases we want
+  to guarantee order of execution, for example, executing something before
+  disconnecting a transport.
+
+  ```python
+  self._register_event_handler("on_event_name", sync=True)
+  ```
+
 - Added support for global location in `GoogleVertexLLMService`. The service now
   supports both regional locations (e.g., "us-east4") and the "global" location
   for Vertex AI endpoints. When using "global" location, the service will use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `on_before_disconnect` synchronous event to `DailyTransport`.
+
 - It is now possible to register synchronous event handlers. By default, all
   event handlers are executed in a separate task. However, in some cases we want
   to guarantee order of execution, for example, executing something before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `on_before_disconnect` synchronous event to `DailyTransport`.
+- Added `on_before_disconnect` synchronous event to `DailyTransport` and
+  `LiveKitTransport`.
 
 - It is now possible to register synchronous event handlers. By default, all
   event handlers are executed in a separate task. However, in some cases we want

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where multiple handlers for an event would not run in parallel.
+
 - Fixed `DailyTransport.sip_call_transfer()` to automatically use the session
   ID from the `on_dialin_connected` event, when not explicitly provided. Now
   supports cold transfers (from incoming dial-in calls) by automatically

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -568,11 +568,17 @@ class FrameProcessor(BaseObject):
         """Pause processing of queued frames."""
         logger.trace(f"{self}: pausing frame processing")
         self.__should_block_frames = True
+        # We should also unset the process event here, in case it was set immediately after an interruption
+        if self.__process_event:
+            self.__process_event.clear()
 
     async def pause_processing_system_frames(self):
         """Pause processing of queued system frames."""
         logger.trace(f"{self}: pausing system frame processing")
         self.__should_block_system_frames = True
+        # We should also unset the input event here, in case it was set immediately after an interruption
+        if self.__input_event:
+            self.__input_event.clear()
 
     async def resume_processing_frames(self):
         """Resume processing of queued frames."""

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -106,15 +106,6 @@ class DailyInputTransportMessageUrgentFrame(InputTransportMessageUrgentFrame):
 
     participant_id: Optional[str] = None
 
-@dataclass
-class DailyUpdateRemoteParticipantsFrame(DataFrame):
-    """Frame to update remote participants in Daily calls.
-
-    Parameters:
-        remote_participants: See https://reference-python.daily.co/api_reference.html#daily.CallClient.update_remote_participants.
-    """
-
-    remote_participants: Optional[Any] = None
 
 @dataclass
 class DailyUpdateRemoteParticipantsFrame(ControlFrame):
@@ -1811,7 +1802,7 @@ class DailyOutputTransport(BaseOutputTransport):
         await super().cancel(frame)
         # Leave the room.
         await self._client.leave()
-    
+
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process outgoing frames, including transport messages.
 

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -41,6 +41,7 @@ from pipecat.frames.frames import (
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
+    DataFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transcriptions.language import Language
@@ -104,6 +105,15 @@ class DailyInputTransportMessageUrgentFrame(InputTransportMessageUrgentFrame):
 
     participant_id: Optional[str] = None
 
+@dataclass
+class DailyUpdateRemoteParticipantsFrame(DataFrame):
+    """Frame to update remote participants in Daily calls.
+
+    Parameters:
+        remote_participants: See https://reference-python.daily.co/api_reference.html#daily.CallClient.update_remote_participants.
+    """
+
+    remote_participants: Optional[Any] = None
 
 class WebRTCVADAnalyzer(VADAnalyzer):
     """Voice Activity Detection analyzer using WebRTC.
@@ -1784,6 +1794,19 @@ class DailyOutputTransport(BaseOutputTransport):
         await super().cancel(frame)
         # Leave the room.
         await self._client.leave()
+    
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process outgoing frames, including transport messages.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame flow in the pipeline.
+        """
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, DailyUpdateRemoteParticipantsFrame):
+            logger.debug(f"Got a DailyUpdateRemoteParticipantsFrame: {frame}")
+            await self._client.update_remote_participants(frame.remote_participants)
 
     async def send_message(self, frame: TransportMessageFrame | TransportMessageUrgentFrame):
         """Send a transport message to participants.

--- a/src/pipecat/utils/base_object.py
+++ b/src/pipecat/utils/base_object.py
@@ -14,11 +14,31 @@ and async cleanup for all Pipecat components.
 import asyncio
 import inspect
 from abc import ABC
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
 from pipecat.utils.utils import obj_count, obj_id
+
+
+@dataclass
+class EventHandler:
+    """Data class to store event handlers information.
+
+    This data class stores the event name, a list of handlers to run for this
+    event, and whether these handlers will be executed in a task.
+
+    Attributes:
+        name (str): The name of the event handler.
+        handlers (List[Any]): A list of functions to be called when this event is triggered.
+        is_sync (bool): Indicates whether the functions are executed in a task.
+
+    """
+
+    name: str
+    handlers: List[Any]
+    is_sync: bool
 
 
 class BaseObject(ABC):
@@ -41,7 +61,7 @@ class BaseObject(ABC):
         self._name = name or f"{self.__class__.__name__}#{obj_count(self)}"
 
         # Registered event handlers.
-        self._event_handlers: dict = {}
+        self._event_handlers: Dict[str, EventHandler] = {}
 
         # Set of tasks being executed. When a task finishes running it gets
         # automatically removed from the set. When we cleanup we wait for all
@@ -103,18 +123,21 @@ class BaseObject(ABC):
                 Can be sync or async.
         """
         if event_name in self._event_handlers:
-            self._event_handlers[event_name].append(handler)
+            self._event_handlers[event_name].handlers.append(handler)
         else:
             logger.warning(f"Event handler {event_name} not registered")
 
-    def _register_event_handler(self, event_name: str):
+    def _register_event_handler(self, event_name: str, sync: bool = False):
         """Register an event handler type.
 
         Args:
             event_name: The name of the event type to register.
+            sync: Whether this event handler will be executed in a task.
         """
         if event_name not in self._event_handlers:
-            self._event_handlers[event_name] = []
+            self._event_handlers[event_name] = EventHandler(
+                name=event_name, handlers=[], is_sync=sync
+            )
         else:
             logger.warning(f"Event handler {event_name} not registered")
 
@@ -126,36 +149,40 @@ class BaseObject(ABC):
             *args: Positional arguments to pass to event handlers.
             **kwargs: Keyword arguments to pass to event handlers.
         """
-        # If we haven't registered an event handler, we don't need to do
-        # anything.
-        if not self._event_handlers.get(event_name):
+        if event_name not in self._event_handlers:
             return
 
-        # Create the task.
-        task = asyncio.create_task(self._run_task(event_name, *args, **kwargs))
+        event_handler = self._event_handlers[event_name]
 
-        # Add it to our list of event tasks.
-        self._event_tasks.add((event_name, task))
+        if event_handler.is_sync:
+            # Just run the handler.
+            await self._run_handler(event_handler, *args, **kwargs)
+        else:
+            # Create the task.
+            task = asyncio.create_task(self._run_handler(event_handler, *args, **kwargs))
 
-        # Remove the task from the event tasks list when the task completes.
-        task.add_done_callback(self._event_task_finished)
+            # Add it to our list of event tasks.
+            self._event_tasks.add((event_name, task))
 
-    async def _run_task(self, event_name: str, *args, **kwargs):
+            # Remove the task from the event tasks list when the task completes.
+            task.add_done_callback(self._event_task_finished)
+
+    async def _run_handler(self, event_handler: EventHandler, *args, **kwargs):
         """Execute all handlers for an event.
 
         Args:
-            event_name: The name of the event being handled.
+            event_handler: The event handler to run.
             *args: Positional arguments to pass to handlers.
             **kwargs: Keyword arguments to pass to handlers.
         """
         try:
-            for handler in self._event_handlers[event_name]:
+            for handler in event_handler.handlers:
                 if inspect.iscoroutinefunction(handler):
                     await handler(self, *args, **kwargs)
                 else:
                     handler(self, *args, **kwargs)
         except Exception as e:
-            logger.exception(f"Exception in event handler {event_name}: {e}")
+            logger.exception(f"Exception in event handler {event_handler.name}: {e}")
 
     def _event_task_finished(self, task: asyncio.Task):
         """Clean up completed event handler tasks.


### PR DESCRIPTION
FrameProcessors that pause frame processing (like async TTS) wait on a `__process_event` when they are paused. If a TTS processor is in the middle of generating audio (and therefore paused), its `__process_frame_task_handler` is waiting on that `__process_event`. When the output transport detects the bot has finished speaking, it pushes a `BotStoppedSpeakingFrame` system frame back up the pipeline. The TTS processor then fires the`__process_event`, and the process frame task handler continues.

If the TTS processor gets an `InterruptionFrame` while it's generating speech, the process frame task handler is canceled, and the process event is recreated. But the output transport will also process the interruption and push a `BotStoppedSpeakingFrame` back up the pipeline... which will cause the TTS processor to fire the process event.

But since the previous process frame task handler (that was waiting on the old process event) was canceled, there's nothing waiting on that event. Instead, the new process frame task handler is sitting at `self.__process_queue.get()`, waiting for the next frame to process.

If the next frame is a `TTSSpeakFrame` or something else that expects to start generating speech and pause the TTS processor, it will set `self.__should_block_frames`, which will cause the process frame task handler to reach the `await self.__process_event.wait()`. But because that event was already fired _after the task reset_, this wait returns immediately. This causes frame processing to continue immediately, instead of waiting for 1) TTS generation to complete, 2) a `BotStoppedSpeakingFrame` to get pushed back upstream, and 3) the event to get fired and resume processing.

I know that this fixes the problem for my specific use case of pushing things after an interruption and TTSSpeakFrame, but I haven't been able to adequately test other conditions where this may cause unexpected behavior.