### PR TITLE
Reset the FrameProcessor process_event when resuming processing

### DIFF
--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -568,11 +568,15 @@ class FrameProcessor(BaseObject):
         """Pause processing of queued frames."""
         logger.trace(f"{self}: pausing frame processing")
         self.__should_block_frames = True
+        if self.__process_event:
+            self.__process_event.clear()
 
     async def pause_processing_system_frames(self):
         """Pause processing of queued system frames."""
         logger.trace(f"{self}: pausing system frame processing")
         self.__should_block_system_frames = True
+        if self.__input_event:
+            self.__input_event.clear()
 
     async def resume_processing_frames(self):
         """Resume processing of queued frames."""


### PR DESCRIPTION
FrameProcessors that pause frame processing (like async TTS) wait on a `__process_event` when they are paused. If a TTS processor is in the middle of generating audio (and therefore paused), its `__process_frame_task_handler` is waiting on that `__process_event`. When the output transport detects the bot has finished speaking, it pushes a `BotStoppedSpeakingFrame` system frame back up the pipeline. The TTS processor then fires the`__process_event`, and the process frame task handler continues.

If the TTS processor gets an `InterruptionFrame` while it's generating speech, the process frame task handler is canceled, and the process event is recreated. But the output transport will also process the interruption and push a `BotStoppedSpeakingFrame` back up the pipeline... which will cause the TTS processor to fire the process event.

But since the previous process frame task handler (that was waiting on the old process event) was canceled, there's nothing waiting on that event. Instead, the new process frame task handler is sitting at `self.__process_queue.get()`, waiting for the next frame to process.

If the next frame is a `TTSSpeakFrame` or something else that expects to start generating speech and pause the TTS processor, it will set `self.__should_block_frames`, which will cause the process frame task handler to reach the `await self.__process_event.wait()`. But because that event was already fired _after the task reset_, this wait returns immediately. This causes frame processing to continue immediately, instead of waiting for 1) TTS generation to complete, 2) a `BotStoppedSpeakingFrame` to get pushed back upstream, and 3) the event to get fired and resume processing.

I know that this fixes the problem for my specific use case of pushing things after an interruption and TTSSpeakFrame, but I haven't been able to adequately test other conditions where this may cause unexpected behavior.