### PR TITLE
DailyTransport: Remove duplicate on_joined, on_left events

### DIFF
--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -1948,8 +1948,6 @@ class DailyTransport(BaseTransport):
         # Register supported handlers. The user will only be able to register
         # these handlers.
         self._register_event_handler("on_active_speaker_changed")
-        self._register_event_handler("on_joined")
-        self._register_event_handler("on_left")
         self._register_event_handler("on_error")
         self._register_event_handler("on_app_message")
         self._register_event_handler("on_call_state_updated")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

These events were duplicated in `__init__`, causing the following warning:
```
2025-09-21 09:16:01.726 | WARNING  | pipecat.utils.base_object:_register_event_handler:142 - Event handler on_joined not registered
2025-09-21 09:16:01.726 | WARNING  | pipecat.utils.base_object:_register_event_handler:142 - Event handler on_left not registered
```

I'm leaving the version of event marked as deprecated.