### PR TITLE
Improve TTFB of Deepgram TTS

### DIFF
--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -10,8 +10,10 @@ This module provides integration with Deepgram's text-to-speech API
 for generating speech from text using various voice models.
 """
 
+import asyncio
 from typing import AsyncGenerator, Optional
 
+import aiohttp
 from loguru import logger
 
 from pipecat.frames.frames import (
@@ -25,7 +27,7 @@ from pipecat.services.tts_service import TTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
 
 try:
-    from deepgram import DeepgramClient, DeepgramClientOptions, SpeakOptions
+    from deepgram import DeepgramClient, DeepgramClientOptions
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error("In order to use Deepgram, you need to `pip install pipecat-ai[deepgram]`.")
@@ -62,11 +64,15 @@ class DeepgramTTSService(TTSService):
         """
         super().__init__(sample_rate=sample_rate, **kwargs)
 
+        self._api_key = api_key
         self._settings = {
             "encoding": encoding,
         }
         self.set_voice(voice)
 
+        # Keep the base URL for potential custom endpoints
+        self._base_url = base_url if base_url else "https://api.beta.deepgram.com"
+        
         client_options = DeepgramClientOptions(url=base_url)
         self._deepgram_client = DeepgramClient(api_key, config=client_options)
 
@@ -90,27 +96,45 @@ class DeepgramTTSService(TTSService):
         """
         logger.debug(f"{self}: Generating TTS [{text}]")
 
-        options = SpeakOptions(
-            model=self._voice_id,
-            encoding=self._settings["encoding"],
-            sample_rate=self.sample_rate,
-            container="none",
-        )
+        # Build URL with parameters
+        url = f"{self._base_url}/v1/speak"
+        
+        headers = {
+            "Authorization": f"Token {self._api_key}",
+            "Content-Type": "application/json"
+        }
+
+        params = {
+            "model": self._voice_id,
+            "encoding": self._settings["encoding"],
+            "sample_rate": self.sample_rate,
+            "container": "none"
+        }
+        
+        payload = {
+            "text": text,
+        }
 
         try:
             await self.start_ttfb_metrics()
 
-            response = await self._deepgram_client.speak.asyncrest.v("1").stream_raw(
-                {"text": text}, options
-            )
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=payload, params=params) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        raise Exception(f"HTTP {response.status}: {error_text}")
 
-            await self.start_tts_usage_metrics(text)
-            yield TTSStartedFrame()
+                    await self.start_tts_usage_metrics(text)
+                    yield TTSStartedFrame()
 
-            async for data in response.aiter_bytes():
-                await self.stop_ttfb_metrics()
-                if data:
-                    yield TTSAudioRawFrame(audio=data, sample_rate=self.sample_rate, num_channels=1)
+                    first_chunk = True
+                    async for chunk in response.content.iter_chunked(1024):
+                        if first_chunk:
+                            await self.stop_ttfb_metrics()
+                            first_chunk = False
+                        
+                        if chunk:
+                            yield TTSAudioRawFrame(audio=chunk, sample_rate=self.sample_rate, num_channels=1)
 
             yield TTSStoppedFrame()
 


### PR DESCRIPTION
### Issue
Deepgram's Python SDK produces slow TTS outputs with ~2.1s average TTFB.

### Solution
Switch to direct HTTP POST requests, reducing average TTFB to ~0.8s (more than 2x faster).