### PR TITLE
PipelineRunner: use signal.signal() on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `PipelineRunner` issue on Windows where setting up SIGINT and SIGTERM
+  was raising an exception.
+
 - Fixed an issue where multiple handlers for an event would not run in parallel.
 
 - Fixed `DailyTransport.sip_call_transfer()` to automatically use the session

--- a/src/pipecat/pipeline/runner.py
+++ b/src/pipecat/pipeline/runner.py
@@ -106,13 +106,21 @@ class PipelineRunner(BaseObject):
 
     def _setup_sigint(self):
         """Set up signal handlers for graceful shutdown."""
-        loop = asyncio.get_running_loop()
-        loop.add_signal_handler(signal.SIGINT, lambda *args: self._sig_handler())
+        try:
+            loop = asyncio.get_running_loop()
+            loop.add_signal_handler(signal.SIGINT, lambda *args: self._sig_handler())
+        except NotImplementedError:
+            # Windows fallback
+            signal.signal(signal.SIGINT, lambda s, f: self._sig_handler())
 
     def _setup_sigterm(self):
         """Set up signal handlers for graceful shutdown."""
-        loop = asyncio.get_running_loop()
-        loop.add_signal_handler(signal.SIGTERM, lambda *args: self._sig_handler())
+        try:
+            loop = asyncio.get_running_loop()
+            loop.add_signal_handler(signal.SIGTERM, lambda *args: self._sig_handler())
+        except NotImplementedError:
+            # Windows fallback
+            signal.signal(signal.SIGTERM, lambda s, f: self._sig_handler())
 
     def _sig_handler(self):
         """Handle interrupt signals by cancelling all tasks."""


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`asyncio`'s event loop `add_signal_handler()` is not implemented on Windows. Instead we need to use `signal.signal()`.