### PR TITLE
update imports to avoid deprecated module

### DIFF
--- a/examples/foundational/41a-text-only-webrtc.py
+++ b/examples/foundational/41a-text-only-webrtc.py
@@ -29,8 +29,7 @@ from pipecat.processors.frameworks.rtvi import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
-from pipecat.services.openai import OpenAIContextAggregatorPair
-from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.openai.llm import OpenAIContextAggregatorPair, OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 
 load_dotenv(override=True)

--- a/examples/foundational/41b-text-and-audio-webrtc.py
+++ b/examples/foundational/41b-text-and-audio-webrtc.py
@@ -32,8 +32,7 @@ from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
-from pipecat.services.openai import OpenAIContextAggregatorPair
-from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.openai.llm import OpenAIContextAggregatorPair, OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 
 load_dotenv(override=True)


### PR DESCRIPTION
This PR fixes the deprecated import warning for the following examples
- examples/foundational/41a-text-only-webrtc.py
- examples/foundational/41b-text-and-audio-webrtc.py

This updates the imports to the recommended format i.e
`from pipecat.services.openai` -> `from pipecat.services.openai.llm`