### PR TITLE
Fix: Reset _closing flag on WebSocket reconnection

### DIFF
--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -105,6 +105,8 @@ class FastAPIWebsocketClient:
             _: The start frame (unused).
         """
         self._leave_counter += 1
+        # Reset closing flag when setting up a new connection
+        self._closing = False
 
     def receive(self) -> typing.AsyncIterator[bytes | str]:
         """Get an async iterator for receiving WebSocket messages.


### PR DESCRIPTION
## Problem

The `on_client_disconnected` event handler stops firing after the first call in long-running containers:

- **First call**: `on_client_disconnected` fires normally ✅
- **Keep container/app alive** (no reset/clean)
- **Subsequent calls**: Event never fires ❌

### Error logs observed:
```
2025-10-01 02:14:41 | ERROR    | pipecat.transports.websocket.fastapi:send:130 - <pipecat.transports.websocket.fastapi.FastAPIWebsocketClient object at 0x320a53710> exception sending data: WebSocketDisconnect (), application_state: WebSocketState.DISCONNECTED
2025-10-01 02:14:41 | WARNING  | pipecat.transports.websocket.fastapi:send:139 - Closing already disconnected websocket!
2025-10-01 02:14:41 | ERROR    | pipecat.transports.websocket.fastapi:_receive_messages:296 - FastAPIWebsocketInputTransport#0 exception receiving data: RuntimeError (WebSocket is not connected. Need to call "accept" first.)
```

## Root Cause

The `FastAPIWebsocketClient` instance is reused across multiple connections in long-running containers. The `_closing` flag is set to `True` on the first disconnect but never reset when a new connection is established. This causes the check `if not self._client.is_closing:` in `_receive_messages()` to fail on subsequent disconnects, preventing the `on_client_disconnected` callback from firing.

## Solution

Reset the `_closing` flag to `False` in the `setup()` method, which is called when each new connection starts. This ensures that each new connection begins with a clean state.

## Changes
- Added `self._closing = False` in `FastAPIWebsocketClient.setup()` method

## Testing
This fix ensures that in long-running containers:
- Each new WebSocket connection starts fresh
- The `on_client_disconnected` event fires reliably on every disconnect
- No regression in normal connection/disconnection behavior