### PR TITLE
Catch `asyncio.CancelledError` exception on `WebsocketService._receive_task_handler`

### DIFF
--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -83,6 +83,9 @@ class WebsocketService(ABC):
             try:
                 await self._receive_messages()
                 retry_count = 0  # Reset counter on successful message receive
+            except asyncio.CancelledError:
+                logger.debug(f"{self} receive task cancelled")
+                break
             except ConnectionClosedOK as e:
                 # Normal closure, don't retry
                 logger.debug(f"{self} connection closed normally: {e}")


### PR DESCRIPTION
## Description

This PR updates the `WebsocketService._receive_task_handler` method to catch the `asyncio.CancelledError` exception and break the receive messages loop in that case. This is required as some services such as `ElevenLabsTTSService` create a task for this method and then cancel it in its `_disconnect` method. As the code did not specifically catch `asyncio.CancelledError`, it was getting into the reconnect logic, not properly shutting down.