### PR TITLE
Ignore None value for 'completion_tokens' or similar for Gemini

### DIFF
--- a/src/pipecat/services/google/llm_openai.py
+++ b/src/pipecat/services/google/llm_openai.py
@@ -94,9 +94,9 @@ class GoogleLLMOpenAIBetaService(OpenAILLMService):
         async for chunk in chunk_stream:
             if chunk.usage:
                 tokens = LLMTokenUsage(
-                    prompt_tokens=chunk.usage.prompt_tokens,
-                    completion_tokens=chunk.usage.completion_tokens,
-                    total_tokens=chunk.usage.total_tokens,
+                    prompt_tokens=chunk.usage.prompt_tokens or 0,
+                    completion_tokens=chunk.usage.completion_tokens or 0,
+                    total_tokens=chunk.usage.total_tokens or 0,
                 )
                 await self.start_llm_usage_metrics(tokens)
 


### PR DESCRIPTION
Similar fix as https://github.com/pipecat-ai/pipecat/commit/144ea36c81e0698163493e945a33d5b5b4ebd406 but for regular Gemini instead of Gemini Live ; problem reported by multiple users in https://github.com/pipecat-ai/pipecat/issues/2207