### PR TITLE
limit openai version up to 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pyloudnorm~=0.1.1",
     "resampy~=0.4.3",
     "soxr~=0.5.0",
-    "openai>=1.74.0,<=1.99.1",
+    "openai>=1.74.0,<2.0.0",
     # Pinning numba to resolve package dependencies
     "numba==0.61.2",
     "wait_for2>=0.4.1; python_version<'3.12'",

--- a/uv.lock
+++ b/uv.lock
@@ -4502,7 +4502,7 @@ requires-dist = [
     { name = "nvidia-riva-client", marker = "extra == 'riva'", specifier = "~=2.21.1" },
     { name = "onnxruntime", marker = "extra == 'local-smart-turn-v3'", specifier = ">=1.20.1,<2" },
     { name = "onnxruntime", marker = "extra == 'silero'", specifier = ">=1.20.1,<2" },
-    { name = "openai", specifier = ">=1.74.0,<=1.99.1" },
+    { name = "openai", specifier = ">=1.74.0,<2.0.0" },
     { name = "opencv-python", marker = "extra == 'webrtc'", specifier = "~=4.11.0.86" },
     { name = "openpipe", marker = "extra == 'openpipe'", specifier = "~=4.50.0" },
     { name = "opentelemetry-api", marker = "extra == 'tracing'", specifier = ">=1.33.0" },


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

there are many packages that get blocked to upgrade because of this version lock.
ie: agents-sdk, litellm, and probably more.