### PR TITLE
AudioBufferProcessor properly computes silence based on audio frame duration

### DIFF
--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -218,7 +218,8 @@ class AudioBufferProcessor(FrameProcessor):
             resampled = await self._resample_input_audio(frame)
             self._user_audio_buffer.extend(resampled)
             # Save time of frame so we can compute silence.
-            self._last_user_frame_at = time.time()
+            frame_time = frame.num_frames / frame.sample_rate
+            self._last_user_frame_at = time.time() + frame_time
         elif self._recording and isinstance(frame, OutputAudioRawFrame):
             # Add silence if we need to.
             silence = self._compute_silence(self._last_bot_frame_at)
@@ -227,7 +228,8 @@ class AudioBufferProcessor(FrameProcessor):
             resampled = await self._resample_output_audio(frame)
             self._bot_audio_buffer.extend(resampled)
             # Save time of frame so we can compute silence.
-            self._last_bot_frame_at = time.time()
+            frame_time = frame.num_frames / frame.sample_rate
+            self._last_bot_frame_at = time.time() + frame_time
 
         if self._buffer_size > 0 and (
             len(self._user_audio_buffer) >= self._buffer_size


### PR DESCRIPTION
## Issues
- Merged audio from the `AudioBufferProcessor` wasn't correctly aligning the samples from the input and output, causing the timing of the conversation to be off.

## Updates
- Now when the `AudioBufferProcessor` calculates the "silence" based on the time since the previous user or bot frame, it correctly incorporates the duration of the audio frame itself.  This allows the computed silence to be shortened appropriately before appending to the audio buffer.
- Before, the computed silence was from the *start* of the previous frame to the start of the current frame, but now it calculates based on the *end* of the previous frame to the start of the current frame.
