### PR TITLE
Add language options in AWS Transcribe STT Service

### DIFF
--- a/src/pipecat/services/aws/__init__.py
+++ b/src/pipecat/services/aws/__init__.py
@@ -8,6 +8,7 @@ import sys
 
 from pipecat.services import DeprecatedModuleProxy
 
+from .config import *
 from .llm import *
 from .nova_sonic import *
 from .stt import *

--- a/src/pipecat/services/aws/config.py
+++ b/src/pipecat/services/aws/config.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2024–2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Configuration for the AWS Transcribe STT service."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from pipecat.transcriptions.language import Language
+
+
+class AWSInputParams(BaseModel):
+    """Configuration parameters for the AWS Transcribe STT service.
+
+    Parameters:
+        sample_rate: Audio sample rate in Hz. Must be 8000 or 16000. Defaults to 16000.
+        language_code: Language for transcription. Cannot be used with identify_multiple_languages.
+        language_options: List of languages for multi-language identification. Required when identify_multiple_languages is True.
+        identify_multiple_languages: Enable multiple language identification. Defaults to False.
+        identify_language: Enable language identification. Defaults to False.
+        preferred_language: Preferred language from language_options to speed up identification.
+        enable_partial_results_stabilization: Enable stabilization of partial results. Defaults to True.
+        partial_results_stability: Stability level: "low" (faster, less stable) or "high" (slower, more stable). Defaults to "low".
+        media_encoding: Audio encoding format. Defaults to "linear16".
+        number_of_channels: Number of audio channels. Defaults to 1.
+        show_speaker_label: Enable speaker identification in transcription results. Defaults to False.
+        enable_channel_identification: Enable channel identification for multi-channel audio. Defaults to False.
+        vocabulary_name: Name of custom vocabulary to use for improved transcription accuracy.
+        vocabulary_filter_name: Name of vocabulary filter to apply for content filtering.
+
+    Note:
+        For real-time conversations, use partial_results_stability="low" for faster responses.
+        Multi-language identification may have higher latency than single language mode.
+    """
+
+    sample_rate: int = 16000
+    language_code: Optional[Language] = None
+    language_options: Optional[List[Language]] = None
+    identify_multiple_languages: bool = False
+    identify_language: bool = False
+    preferred_language: Optional[Language] = None
+    enable_partial_results_stabilization: bool = True
+    partial_results_stability: str = "high"
+    media_encoding: str = "linear16"
+    number_of_channels: int = 1
+    show_speaker_label: bool = False
+    enable_channel_identification: bool = False
+    vocabulary_name: Optional[str] = None
+    vocabulary_filter_name: Optional[str] = None

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -7,7 +7,14 @@
 """AWS Transcribe Speech-to-Text service implementation.
 
 This module provides a WebSocket-based connection to AWS Transcribe for real-time
-speech-to-text transcription with support for multiple languages and audio formats.
+speech-to-text transcription with support for single and multiple language identification.
+
+Features:
+
+- Single language mode: Transcribe audio in a specific language
+- Multi-language mode: Automatically identify and transcribe from multiple languages
+- Real-time language detection with confidence scores
+- Support for various audio formats and sample rates
 """
 
 import asyncio
@@ -15,7 +22,8 @@ import json
 import os
 import random
 import string
-from typing import AsyncGenerator, Optional
+import warnings
+from typing import AsyncGenerator, List, Optional
 
 from loguru import logger
 
@@ -28,7 +36,12 @@ from pipecat.frames.frames import (
     StartFrame,
     TranscriptionFrame,
 )
-from pipecat.services.aws.utils import build_event_message, decode_event, get_presigned_url
+from pipecat.services.aws.config import AWSInputParams
+from pipecat.services.aws.utils import (
+    build_event_message,
+    decode_event,
+    get_presigned_url,
+)
 from pipecat.services.stt_service import STTService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
@@ -44,12 +57,133 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
+def language_to_aws_language(language: Language) -> Optional[str]:
+    """Convert a Language enum to ElevenLabs language code.
+
+    Source:
+        https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html
+
+    Args:
+        language: The Language enum value to convert.
+
+    Returns:
+        The corresponding ElevenLabs language code, or None if not supported.
+    """
+    BASE_LANGUAGES = {
+        Language.AF: "af-ZA",
+        Language.AF_ZA: "af-ZA",
+        Language.AR: "ar-SA",
+        Language.AR_AE: "ar-AE",
+        Language.AR_SA: "ar-SA",
+        Language.EU: "eu-ES",
+        Language.EU_ES: "eu-ES",
+        Language.CA: "ca-ES",
+        Language.CA_ES: "ca-ES",
+        Language.ZH: "zh-CN",
+        Language.ZH_CN: "zh-CN",
+        Language.ZH_TW: "zh-TW",
+        Language.ZH_HK: "zh-HK",
+        Language.YUE: "zh-HK",
+        Language.HR: "hr-HR",
+        Language.HR_HR: "hr-HR",
+        Language.CS: "cs-CZ",
+        Language.CS_CZ: "cs-CZ",
+        Language.DA: "da-DK",
+        Language.DA_DK: "da-DK",
+        Language.NL: "nl-NL",
+        Language.NL_NL: "nl-NL",
+        Language.EN: "en-US",
+        Language.EN_AU: "en-AU",
+        Language.EN_GB: "en-GB",
+        Language.EN_IN: "en-IN",
+        Language.EN_IE: "en-IE",
+        Language.EN_NZ: "en-NZ",
+        Language.EN_ZA: "en-ZA",
+        Language.EN_US: "en-US",
+        Language.FA: "fa-IR",
+        Language.FA_IR: "fa-IR",
+        Language.FI: "fi-FI",
+        Language.FI_FI: "fi-FI",
+        Language.FR: "fr-FR",
+        Language.FR_FR: "fr-FR",
+        Language.FR_CA: "fr-CA",
+        Language.GL: "gl-ES",
+        Language.GL_ES: "gl-ES",
+        Language.KA: "ka-GE",
+        Language.KA_GE: "ka-GE",
+        Language.DE: "de-DE",
+        Language.DE_DE: "de-DE",
+        Language.DE_CH: "de-CH",
+        Language.EL: "el-GR",
+        Language.EL_GR: "el-GR",
+        Language.HE: "he-IL",
+        Language.HE_IL: "he-IL",
+        Language.HI: "hi-IN",
+        Language.HI_IN: "hi-IN",
+        Language.ID: "id-ID",
+        Language.ID_ID: "id-ID",
+        Language.IT: "it-IT",
+        Language.IT_IT: "it-IT",
+        Language.JA: "ja-JP",
+        Language.JA_JP: "ja-JP",
+        Language.KO: "ko-KR",
+        Language.KO_KR: "ko-KR",
+        Language.LV: "lv-LV",
+        Language.LV_LV: "lv-LV",
+        Language.MS: "ms-MY",
+        Language.MS_MY: "ms-MY",
+        Language.NB: "no-NO",
+        Language.NB_NO: "no-NO",
+        Language.NO: "no-NO",
+        Language.PL: "pl-PL",
+        Language.PL_PL: "pl-PL",
+        Language.PT: "pt-PT",
+        Language.PT_PT: "pt-PT",
+        Language.PT_BR: "pt-BR",
+        Language.RO: "ro-RO",
+        Language.RO_RO: "ro-RO",
+        Language.RU: "ru-RU",
+        Language.RU_RU: "ru-RU",
+        Language.SR: "sr-RS",
+        Language.SR_RS: "sr-RS",
+        Language.SK: "sk-SK",
+        Language.SK_SK: "sk-SK",
+        Language.SO: "so-SO",
+        Language.SO_SO: "so-SO",
+        Language.ES: "es-ES",
+        Language.ES_ES: "es-ES",
+        Language.ES_US: "es-US",
+        Language.SV: "sv-SE",
+        Language.SV_SE: "sv-SE",
+        Language.TL: "tl-PH",
+        Language.FIL: "tl-PH",
+        Language.FIL_PH: "tl-PH",
+        Language.TH: "th-TH",
+        Language.TH_TH: "th-TH",
+        Language.UK: "uk-UA",
+        Language.UK_UA: "uk-UA",
+        Language.VI: "vi-VN",
+        Language.VI_VN: "vi-VN",
+        Language.ZU: "zu-ZA",
+        Language.ZU_ZA: "zu-ZA",
+    }
+
+    result = BASE_LANGUAGES.get(language)
+
+    if not result:
+        lang_str = str(language.value)
+        base_code = lang_str.split("-")[0].lower()
+        result = base_code if base_code in BASE_LANGUAGES.values() else None
+
+    return result
+
+
 class AWSTranscribeSTTService(STTService):
     """AWS Transcribe Speech-to-Text service using WebSocket streaming.
 
     Provides real-time speech transcription using AWS Transcribe's streaming API.
-    Supports multiple languages, configurable sample rates, and both interim and
-    final transcription results.
+    Supports single and multi-language identification, configurable sample rates,
+    and both interim and final transcription results.
     """
 
     def __init__(
@@ -61,6 +195,7 @@ class AWSTranscribeSTTService(STTService):
         region: Optional[str] = "us-east-1",
         sample_rate: int = 16000,
         language: Language = Language.EN,
+        params: Optional[AWSInputParams] = None,
         **kwargs,
     ):
         """Initialize the AWS Transcribe STT service.
@@ -71,26 +206,56 @@ class AWSTranscribeSTTService(STTService):
             aws_session_token: AWS session token for temporary credentials. If None, uses AWS_SESSION_TOKEN environment variable.
             region: AWS region for the service. Defaults to "us-east-1".
             sample_rate: Audio sample rate in Hz. Must be 8000 or 16000. Defaults to 16000.
+
+                .. deprecated:: 0.0.86
+                    The 'sample_rate' parameter is deprecated and will be removed in a future version.
+                    Use 'params' instead.
+
             language: Language for transcription. Defaults to English.
+
+                .. deprecated:: 0.0.86
+                    The 'language' parameter is deprecated and will be removed in a future version.
+                    Use 'params' instead.
+
+            params: Additional configuration parameters for AWS Transcribe service.
             **kwargs: Additional arguments passed to parent STTService class.
         """
         super().__init__(**kwargs)
 
-        self._settings = {
-            "sample_rate": sample_rate,
-            "language": language,
-            "media_encoding": "linear16",  # AWS expects raw PCM
-            "number_of_channels": 1,
-            "show_speaker_label": False,
-            "enable_channel_identification": False,
-        }
+        # Initialize params with defaults or use provided params
+        self._params = params or AWSInputParams()
+
+        if sample_rate:
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "The 'sample_rate' parameter is deprecated and will be removed in a future version. Use 'params' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            if not self._params.sample_rate:
+                self._params.sample_rate = sample_rate
+
+        if language:
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "The 'language' parameter is deprecated and will be removed in a future version. Use 'params' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            if not self._params.language_code:
+                self._params.language_code = language_to_aws_language(language)
 
         # Validate sample rate - AWS Transcribe only supports 8000 Hz or 16000 Hz
-        if sample_rate not in [8000, 16000]:
+        if self._params.sample_rate not in [8000, 16000]:
             logger.warning(
-                f"AWS Transcribe only supports 8000 Hz or 16000 Hz sample rates. Converting from {sample_rate} Hz to 16000 Hz."
+                f"AWS Transcribe only supports 8000 Hz or 16000 Hz sample rates. Converting from {self._params.sample_rate} Hz to 16000 Hz."
             )
-            self._settings["sample_rate"] = 16000
+            self._params.sample_rate = 16000
+
+        # Convert media encoding to AWS format
+        self._params.media_encoding = self.get_service_encoding(self._params.media_encoding)
 
         self._credentials = {
             "aws_access_key_id": aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID"),
@@ -140,7 +305,9 @@ class AWSTranscribeSTTService(STTService):
                     return
                 logger.warning("WebSocket connection not established after connect")
             except Exception as e:
-                logger.error(f"Failed to connect (attempt {retry_count + 1}/{max_retries}): {e}")
+                logger.error(
+                    f"{self} Failed to connect (attempt {retry_count + 1}/{max_retries}): {e}"
+                )
                 retry_count += 1
                 if retry_count < max_retries:
                     await asyncio.sleep(1)  # Wait before retrying
@@ -226,16 +393,49 @@ class AWSTranscribeSTTService(STTService):
                 if self._ws_client:
                     await self._disconnect()
 
-                language_code = self.language_to_service_language(
-                    Language(self._settings["language"])
-                )
-                if not language_code:
-                    raise ValueError(f"Unsupported language: {self._settings['language']}")
+                language_code = None
+                language_options = None
+                preferred_language = None
+
+                if self._params.identify_multiple_languages or self._params.identify_language:
+                    language_options = []
+                    for lang in self._params.language_options:
+                        aws_lang = self.language_to_service_language(Language(lang))
+                        if aws_lang:
+                            language_options.append(aws_lang)
+                        else:
+                            logger.warning(f"Unsupported language in language_options: {lang}.")
+
+                    if not language_options or len(language_options) < 2:
+                        raise ValueError(
+                            "At least 2 valid languages required for language_options."
+                        )
+
+                    if self._params.preferred_language:
+                        preferred_language = self.language_to_service_language(
+                            Language(self._params.preferred_language)
+                        )
+                        if preferred_language not in language_options:
+                            raise ValueError(
+                                f"Preferred language {preferred_language}is not in language_options."
+                            )
+                else:
+                    if self._params.language_code:
+                        language_code = self.language_to_service_language(
+                            Language(self._params.language_code)
+                        )
+                        if not language_code:
+                            raise ValueError(f"Unsupported language: {self._params.language_code}.")
+                    else:
+                        raise ValueError(
+                            "Must specify language_code when identify_multiple_languages and identify_language are not used"
+                        )
 
                 # Generate random websocket key
                 websocket_key = "".join(
                     random.choices(
-                        string.ascii_uppercase + string.ascii_lowercase + string.digits, k=20
+                        string.ascii_uppercase + string.ascii_lowercase + string.digits,
+                        k=20,
                     )
                 )
 
@@ -247,7 +447,7 @@ class AWSTranscribeSTTService(STTService):
                     "Connection": "keep-alive",
                 }
 
-                # Get presigned URL
+                # Get presigned URL with appropriate language parameters
                 presigned_url = get_presigned_url(
                     region=self._credentials["region"],
                     credentials={
@@ -255,16 +455,10 @@ class AWSTranscribeSTTService(STTService):
                         "secret_key": self._credentials["aws_secret_access_key"],
                         "session_token": self._credentials["aws_session_token"],
                     },
+                    params=self._params,
                     language_code=language_code,
-                    media_encoding=self.get_service_encoding(
-                        self._settings["media_encoding"]
-                    ),  # Convert to AWS format
-                    sample_rate=self._settings["sample_rate"],
-                    number_of_channels=self._settings["number_of_channels"],
-                    enable_partial_results_stabilization=True,
-                    partial_results_stability="high",
-                    show_speaker_label=self._settings["show_speaker_label"],
-                    enable_channel_identification=self._settings["enable_channel_identification"],
+                    language_options=language_options,
+                    preferred_language=preferred_language,
                 )
 
                 logger.debug(f"{self} Connecting to WebSocket with URL: {presigned_url[:100]}...")
@@ -314,163 +508,20 @@ class AWSTranscribeSTTService(STTService):
     def language_to_service_language(self, language: Language) -> str | None:
         """Convert internal language enum to AWS Transcribe language code.
 
-        Source:
-        https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html
-        All language codes that support streaming are included.
-
         Args:
             language: Internal language enumeration value.
 
         Returns:
             AWS Transcribe compatible language code, or None if unsupported.
         """
-        language_map = {
-            # Afrikaans
-            Language.AF: "af-ZA",
-            Language.AF_ZA: "af-ZA",
-            # Arabic
-            Language.AR: "ar-SA",  # Default to Modern Standard Arabic
-            Language.AR_AE: "ar-AE",  # Gulf Arabic
-            Language.AR_SA: "ar-SA",  # Modern Standard Arabic
-            # Basque
-            Language.EU: "eu-ES",
-            Language.EU_ES: "eu-ES",
-            # Catalan
-            Language.CA: "ca-ES",
-            Language.CA_ES: "ca-ES",
-            # Chinese
-            Language.ZH: "zh-CN",  # Default to Simplified
-            Language.ZH_CN: "zh-CN",  # Simplified
-            Language.ZH_TW: "zh-TW",  # Traditional
-            Language.ZH_HK: "zh-HK",  # Cantonese (also yue-HK)
-            Language.YUE: "zh-HK",  # Cantonese fallback
-            # Croatian
-            Language.HR: "hr-HR",
-            Language.HR_HR: "hr-HR",
-            # Czech
-            Language.CS: "cs-CZ",
-            Language.CS_CZ: "cs-CZ",
-            # Danish
-            Language.DA: "da-DK",
-            Language.DA_DK: "da-DK",
-            # Dutch
-            Language.NL: "nl-NL",
-            Language.NL_NL: "nl-NL",
-            # English
-            Language.EN: "en-US",  # Default to US
-            Language.EN_AU: "en-AU",  # Australian
-            Language.EN_GB: "en-GB",  # British
-            Language.EN_IN: "en-IN",  # Indian
-            Language.EN_IE: "en-IE",  # Irish
-            Language.EN_NZ: "en-NZ",  # New Zealand
-            # Note: Scottish (en-AB) and Welsh (en-WL) don't have direct Language enum matches
-            Language.EN_ZA: "en-ZA",  # South African
-            Language.EN_US: "en-US",  # US
-            # Persian/Farsi
-            Language.FA: "fa-IR",
-            Language.FA_IR: "fa-IR",
-            # Finnish
-            Language.FI: "fi-FI",
-            Language.FI_FI: "fi-FI",
-            # French
-            Language.FR: "fr-FR",  # Default to France
-            Language.FR_FR: "fr-FR",
-            Language.FR_CA: "fr-CA",  # Canadian
-            # Galician
-            Language.GL: "gl-ES",
-            Language.GL_ES: "gl-ES",
-            # Georgian
-            Language.KA: "ka-GE",
-            Language.KA_GE: "ka-GE",
-            # German
-            Language.DE: "de-DE",  # Default to Germany
-            Language.DE_DE: "de-DE",
-            Language.DE_CH: "de-CH",  # Swiss
-            # Greek
-            Language.EL: "el-GR",
-            Language.EL_GR: "el-GR",
-            # Hebrew
-            Language.HE: "he-IL",
-            Language.HE_IL: "he-IL",
-            # Hindi
-            Language.HI: "hi-IN",
-            Language.HI_IN: "hi-IN",
-            # Indonesian
-            Language.ID: "id-ID",
-            Language.ID_ID: "id-ID",
-            # Italian
-            Language.IT: "it-IT",
-            Language.IT_IT: "it-IT",
-            # Japanese
-            Language.JA: "ja-JP",
-            Language.JA_JP: "ja-JP",
-            # Korean
-            Language.KO: "ko-KR",
-            Language.KO_KR: "ko-KR",
-            # Latvian
-            Language.LV: "lv-LV",
-            Language.LV_LV: "lv-LV",
-            # Malay
-            Language.MS: "ms-MY",
-            Language.MS_MY: "ms-MY",
-            # Norwegian
-            Language.NB: "no-NO",  # Norwegian Bokmål
-            Language.NB_NO: "no-NO",
-            Language.NO: "no-NO",
-            # Polish
-            Language.PL: "pl-PL",
-            Language.PL_PL: "pl-PL",
-            # Portuguese
-            Language.PT: "pt-PT",  # Default to Portugal
-            Language.PT_PT: "pt-PT",
-            Language.PT_BR: "pt-BR",  # Brazilian
-            # Romanian
-            Language.RO: "ro-RO",
-            Language.RO_RO: "ro-RO",
-            # Russian
-            Language.RU: "ru-RU",
-            Language.RU_RU: "ru-RU",
-            # Serbian
-            Language.SR: "sr-RS",
-            Language.SR_RS: "sr-RS",
-            # Slovak
-            Language.SK: "sk-SK",
-            Language.SK_SK: "sk-SK",
-            # Somali
-            Language.SO: "so-SO",
-            Language.SO_SO: "so-SO",
-            # Spanish
-            Language.ES: "es-ES",  # Default to Spain
-            Language.ES_ES: "es-ES",
-            Language.ES_US: "es-US",  # US Spanish
-            # Swedish
-            Language.SV: "sv-SE",
-            Language.SV_SE: "sv-SE",
-            # Tagalog/Filipino
-            Language.TL: "tl-PH",
-            Language.FIL: "tl-PH",  # Filipino maps to Tagalog
-            Language.FIL_PH: "tl-PH",
-            # Thai
-            Language.TH: "th-TH",
-            Language.TH_TH: "th-TH",
-            # Ukrainian
-            Language.UK: "uk-UA",
-            Language.UK_UA: "uk-UA",
-            # Vietnamese
-            Language.VI: "vi-VN",
-            Language.VI_VN: "vi-VN",
-            # Zulu
-            Language.ZU: "zu-ZA",
-            Language.ZU_ZA: "zu-ZA",
-        }
-
-        return language_map.get(language)
+        return language_to_aws_language(language)
 
     @traced_stt
     async def _handle_transcription(
         self, transcript: str, is_final: bool, language: Optional[str] = None
     ):
-        pass
+        await self.stop_ttfb_metrics()
+        await self.stop_processing_metrics()
 
     async def _receive_loop(self):
         """Background task to receive and process messages from AWS Transcribe."""
@@ -484,56 +535,65 @@ class AWSTranscribeSTTService(STTService):
 
                 headers, payload = decode_event(response)
 
-                if headers.get(":message-type") == "event":
+                message_type = headers.get(":message-type")
+
+                if message_type == "event":
                     # Process transcription results
                     results = payload.get("Transcript", {}).get("Results", [])
-                    if results:
+                    if len(results) > 0:
                         result = results[0]
                         alternatives = result.get("Alternatives", [])
                         if alternatives:
                             transcript = alternatives[0].get("Transcript", "")
+                            detected_language = result.get(
+                                "LanguageCode", "en-US"
+                            )  # defaults to english
                             is_final = not result.get("IsPartial", True)
 
                             if transcript:
-                                await self.stop_ttfb_metrics()
                                 if is_final:
                                     await self.push_frame(
                                         TranscriptionFrame(
                                             transcript,
                                             self._user_id,
                                             time_now_iso8601(),
-                                            self._settings["language"],
+                                            detected_language,
                                             result=result,
                                         )
                                     )
                                     await self._handle_transcription(
                                         transcript,
                                         is_final,
-                                        self._settings["language"],
+                                        detected_language,
                                     )
-                                    await self.stop_processing_metrics()
                                 else:
                                     await self.push_frame(
                                         InterimTranscriptionFrame(
                                             transcript,
                                             self._user_id,
                                             time_now_iso8601(),
-                                            self._settings["language"],
+                                            detected_language,
                                             result=result,
                                         )
                                     )
-                elif headers.get(":message-type") == "exception":
+
+                elif message_type == "exception":
                     error_msg = payload.get("Message", "Unknown error")
                     logger.error(f"{self} Exception from AWS: {error_msg}")
                     await self.push_frame(
                         ErrorFrame(f"AWS Transcribe error: {error_msg}", fatal=False)
                     )
                 else:
-                    logger.debug(f"{self} Other message type received: {headers}")
+                    logger.debug(f"{self} Other message type received: {message_type}")
+                    logger.debug(f"{self} Headers: {headers}")
                     logger.debug(f"{self} Payload: {payload}")
+
             except websockets.exceptions.ConnectionClosed as e:
-                logger.error(f"{self} WebSocket connection closed in receive loop: {e}")
+                logger.error(
+                    f"{self} WebSocket connection closed in receive loop with code {e.code}: {e.reason}"
+                )
                 break
             except Exception as e:
                 logger.error(f"{self} Unexpected error in receive loop: {e}")
+                # Consider whether to break or continue based on error type
                 break


### PR DESCRIPTION
Changes
- Add `language_options`, `identify_language`, and `identify_multiple_languages`
- Update query params when creating signed_url
- Use `LanguageCode` as argument when creating `TranscriptionFrame` and `InterimTranscriptionFrame`

Ref #2847 