### PR TITLE
Fix an issue in ElevenLabsHttpTTSService where the last word is not e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue in `ElevenLabsTTSService` and `ElevenLabsHttpTTSService` where
+  the Flash models would split words, resulting in a space being inserted
+  between words.
+
 - Fixed an issue where audio filters' `stop()` would not be called when using
   `CancelFrame`.
 

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -1070,6 +1070,14 @@ class ElevenLabsHttpTTSService(WordTTSService):
                         logger.error(f"Error processing response: {e}", exc_info=True)
                         continue
 
+                # After processing all chunks, emit any remaining partial word
+                # since this is the end of the utterance
+                if self._partial_word:
+                    final_word_time = [(self._partial_word, self._partial_word_start_time)]
+                    await self.add_word_timestamps(final_word_time)
+                    self._partial_word = ""
+                    self._partial_word_start_time = 0.0
+
                 # After processing all chunks, add the total utterance duration
                 # to the cumulative time to ensure next utterance starts after this one
                 if utterance_duration > 0:


### PR DESCRIPTION
…mitted

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

There's an inconsistency between ElevenLabs' Websocket and HTTP APIs:

Websocket API outputs alignment data ending in a trailing space:
```
{'chars': [..., 't', 'o', 'd', 'a', 'y', '?', ' '], ...}
```

HTTP API lacks the trailing space:
```
{'characters': [..., 't', 'o', 'd', 'a', 'y', '?'], ...}
```

The fix in #2840 handles partial words due to the behavior of the Flash models, where words can be split across alignment data chunks. This algorithm looks for trailing spaces as a sign of complete words, which works great for the Websocket API. The HTTP API needs special handling, so after processing all chunks, we need to emit any remaining partials, which will always be the case due to the missing space.

We're already hacking around the weird behavior in ElevenLabs' Flash models, so this is just another hack to work around another inconsistency in the API.

Note: I reported this inconsistency to ElevenLabs. If they resolve this difference, we can remove this workaround. For now, we need it.