### PR TITLE
PipelineTask: fix task cancellation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CartesiaSTTService` now inherits from `WebsocketSTTService`.
 
-- Package upgrades:
+# Package upgrades:
   - `openai` upgraded to support up to 2.x.x.
   - `openpipe` upgraded to support up to 5.x.x.
 
 ### Fixed
+
+- Fixed multiple pipeline task cancellation issues. `asyncio.CancelledError` is
+  now handled properly in `PipelineTask` making it possible to cancel an asyncio
+  task that it's executing a `PipelineRunner` cleanly. Also,
+  `PipelineTask.cancel()` does not block anymore waiting for the `CancelFrame`
+  to reach the end of the pipeline (going back to the behavior in < 0.0.83).
 
 - Fixed an issue in `ElevenLabsTTSService` and `ElevenLabsHttpTTSService` where
   the Flash models would split words, resulting in a space being inserted

--- a/src/pipecat/pipeline/runner.py
+++ b/src/pipecat/pipeline/runner.py
@@ -70,11 +70,15 @@ class PipelineRunner(BaseObject):
         """
         logger.debug(f"Runner {self} started running {task}")
         self._tasks[task.name] = task
-        params = PipelineTaskParams(loop=self._loop)
+
+        # PipelineTask handles asyncio.CancelledError to shutdown the pipeline
+        # properly and re-raises it in case there's more cleanup to do.
         try:
+            params = PipelineTaskParams(loop=self._loop)
             await task.run(params)
         except asyncio.CancelledError:
-            await self._cancel()
+            pass
+
         del self._tasks[task.name]
 
         # Cleanup base object.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR fixes a couple of issues:

#### PipelineTask asyncio.CancelledError proper handling

The main issue was that `PipelineTask` was awaiting for a task (`_process_push_queue`). The way `asyncio` task cancellation works is that everything in the `await` chain gets cancelled: if it's a function the function gets cancelled, if it's a task, the task gets cancelled. This was complicating the logic and was error prone.

So, in this PR we simplify the logic and instead of waiting for a task (or a future) we just wait for an event. This way we can keep all the `PipelineTask` running and cancel them when needed.

The release evals which were leaving things in a messy state in case there was a timeout for example, now work very well.

#### PipelineTask.cancel() doesn't block anymore

We go back to Pipecat < 0.0.83 behavior where `PipelineTask.cancel()` was not blocking. Because of the simplified logic we can now do this.
