### PR TITLE
Add ellipsis character to sentence ending punctuation list

### DIFF
--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -47,6 +47,7 @@ SENTENCE_ENDING_PUNCTUATION: FrozenSet[str] = frozenset(
         "!",
         "?",
         ";",
+        "…",
         # East Asian punctuation (Chinese (Traditional & Simplified), Japanese, Korean)
         "。",  # Ideographic full stop
         "？",  # Full-width question mark


### PR DESCRIPTION
Our LLM sometimes generates the ellipsis character `…` ([U+2026](https://www.compart.com/en/unicode/U+2026)) in text. This is currently not detected as sentence-ending punctuation, which causes `PatternPairAggregator` to buffer text longer than necessary.

This PR adds `…` to the list of sentence-ending punctuation.