### PR TITLE
Add `messages` property to `LLMContext` for usage parity with `OpenAI…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   # or
   context: OpenAILLMContext
 
-  # Reading messages from context
-  messages = context.messages
-
   ## AFTER:
 
   # Context aggregator type
@@ -54,9 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   # Context type
   context: LLMContext
-
-  # Reading messages from context
-  messages = context.get_messages()
   ```
 
 - Added support for `bulbul:v3` model in `SarvamTTSService` and

--- a/src/pipecat/processors/aggregators/llm_context.py
+++ b/src/pipecat/processors/aggregators/llm_context.py
@@ -106,6 +106,19 @@ class LLMContext:
         self._tools: ToolsSchema | NotGiven = LLMContext._normalize_and_validate_tools(tools)
         self._tool_choice: LLMContextToolChoice | NotGiven = tool_choice
 
+    @property
+    def messages(self) -> List[LLMContextMessage]:
+        """Get the current messages list.
+
+        NOTE: This is equivalent to calling `get_messages()` with no filter. If
+        you want to filter out LLM-specific messages that don't pertain to your
+        LLM, use `get_messages()` directly.
+
+        Returns:
+            List of conversation messages.
+        """
+        return self.get_messages()
+
     def get_messages(self, llm_specific_filter: Optional[str] = None) -> List[LLMContextMessage]:
         """Get the current messages list.
 
@@ -113,7 +126,8 @@ class LLMContext:
             llm_specific_filter: Optional filter to return LLM-specific
                 messages for the given LLM, in addition to the standard
                 messages. If messages end up being filtered, an error will be
-                logged.
+                logged; this is intended to catch accidental use of
+                incompatible LLM-specific messages.
 
         Returns:
             List of conversation messages.

--- a/src/pipecat/services/aws/nova_sonic/context.py
+++ b/src/pipecat/services/aws/nova_sonic/context.py
@@ -27,9 +27,6 @@ including conversation history management and role-specific message processing.
     context: AWSNovaSonicLLMContext
     # or
     context: OpenAILLMContext
-
-    # Reading messages from context
-    messages = context.messages
     ```
 
     AFTER:
@@ -43,9 +40,6 @@ including conversation history management and role-specific message processing.
 
     # Context type
     context: LLMContext
-
-    # Reading messages from context
-    messages = context.get_messages()
     ```
 """
 
@@ -70,8 +64,6 @@ with warnings.catch_warnings():
         "context: AWSNovaSonicLLMContext\n"
         "# or\n"
         "context: OpenAILLMContext\n\n"
-        "# Reading messages from context\n"
-        "messages = context.messages\n"
         "```\n\n"
         "AFTER:\n"
         "```\n"
@@ -82,8 +74,6 @@ with warnings.catch_warnings():
         "frame: LLMContextFrame\n\n"
         "# Context type\n"
         "context: LLMContext\n\n"
-        "# Reading messages from context\n"
-        "messages = context.messages\n"
         "```",
         DeprecationWarning,
         stacklevel=2,


### PR DESCRIPTION
…LLMContext`.

This wasn't really an issue before, when folks were *knowingly* migrating from `OpenAILLMContext` to `LLMContext`. But in the latest AWS Nova Sonic change, we're swapping it out from under folks, so this kind of compatibility is more important.

For context, the reason we *didn't* offer the `messages` property earlier was to aid in the development of `LLMContext`—we wanted to draw attention to all the places where messages were being read from context, so we could find the places where we might need to pass an argument to the read.