### PR TITLE
DailyTransport: update start_dialout/start_recording return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `DailyTransport` triggers `on_error` event if transcription can't be started
+  or stopped.
+
 - `DailyTransport` updates: `start_dialout()` now returns two values:
   `session_id` and `error`. `start_recording()` now returns two values:
   `stream_id` and `error`.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -2479,7 +2479,11 @@ class DailyTransport(BaseTransport):
     async def _on_joined(self, data):
         """Handle room joined events."""
         if self._params.transcription_enabled:
-            await self.start_transcription(self._params.transcription_settings)
+            # We report an error because we are starting transcription
+            # internally and if it fails we need to know.
+            error = await self.start_transcription(self._params.transcription_settings)
+            if error:
+                await self._on_error(f"Unable to start transcription: {error}")
         await self._call_event_handler("on_joined", data)
 
     async def _on_left(self):
@@ -2489,7 +2493,11 @@ class DailyTransport(BaseTransport):
     async def _on_before_leave(self):
         """Handle before leave room events."""
         if self._params.transcription_enabled:
-            await self.stop_transcription()
+            # We report an error because we are stopping transcription
+            # internally and if it fails we need to know.
+            error = await self.stop_transcription()
+            if error:
+                await self._on_error(f"Unable to stop transcription: {error}")
         await self._call_event_handler("on_before_leave")
 
     async def _on_error(self, error):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

A few updates:
- The main one are the return values of `start_dialout` and `start_recording`, which are now `(session_id, error)` or `(recording_id, error)`.
- Also, we move error logging to the transport instead of the client as much as possible.
- We now check for errors and log them in every `daily-python` function called.