### PR TITLE
Remove proxy warning for telephony bots

### DIFF
--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -788,10 +788,6 @@ def main():
         logger.error("For ESP32, you need to specify `--host IP` so we can do SDP munging.")
         return
 
-    if args.transport in TELEPHONY_TRANSPORTS and not args.proxy:
-        logger.error(f"For telephony transports, you need to specify `--proxy PROXY`.")
-        return
-
     # Log level
     logger.remove()
     logger.add(sys.stderr, level="TRACE" if args.verbose else "DEBUG")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

A proxy isn't required to start a bot. There's a `/ws` route that passes the websocket through to the bot, which mimics Pipecat Cloud's behavior. I'm making updates to our examples to eliminate the need of a server, which involves using the `/ws` route to forward the websocket messages to the bot.

Let's remove this to restore this capability.