### PR TITLE
Remove development runner requirement for proxy

### DIFF
--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -794,10 +794,6 @@ def main():
         logger.error("For ESP32, you need to specify `--host IP` so we can do SDP munging.")
         return
 
-    if args.transport in TELEPHONY_TRANSPORTS and not args.proxy:
-        logger.error(f"For telephony transports, you need to specify `--proxy PROXY`.")
-        return
-
     # Log level
     logger.remove()
     logger.add(sys.stderr, level="TRACE" if args.verbose else "DEBUG")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Currently, an error is thrown when using a telephony provider and a proxy URL isn't provided to the runner.

The proxy is needed when handling the webhook from the telephony provider. There are cases where the proxy isn't needed; In those cases, the websocket connection is made directly to the runner's `/ws` endpoint and then passed to the bot.

We recommend this direct connection to `/ws` for Twilio dial-in, for example.