### PR TITLE
Update Simli to align with Pipecat constructor norms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `daily-python` to 0.21.0.
 
+- `SimliVideoService` now accepts `api_key` and `face_id` parameters directly,
+  with optional `params` for `max_session_length` and `max_idle_time`
+  configuration, aligning with other Pipecat service patterns.
+
 - Updated the default model to `sonic-3` for `CartesiaTTSService` and
   `CartesiaHttpTTSService`.
 
@@ -19,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgraded `aws_sdk_bedrock_runtime` to v0.1.1 to resolve potential CPU issues
   when running `AWSNovaSonicLLMService`.
+
+### Deprecated
+
+- `SimliVideoService` `simli_config` parameter is deprecated. Use `api_key` and
+  `face_id` parameters instead.
 
 ### Removed
 

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -9,7 +9,6 @@ import os
 
 from dotenv import load_dotenv
 from loguru import logger
-from simli import SimliConfig
 
 from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
 from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
@@ -66,11 +65,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     tts = CartesiaTTSService(
         api_key=os.getenv("CARTESIA_API_KEY"),
-        voice_id="a167e0f3-df7e-4d52-a9c3-f949145efdab",
+        voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",
     )
 
     simli_ai = SimliVideoService(
-        SimliConfig(os.getenv("SIMLI_API_KEY"), os.getenv("SIMLI_FACE_ID")),
+        api_key=os.getenv("SIMLI_API_KEY"),
+        face_id="cace3ef7-a4c4-425d-a8cf-a5358eb0c427",
     )
 
     llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o-mini")

--- a/src/pipecat/services/simli/video.py
+++ b/src/pipecat/services/simli/video.py
@@ -7,9 +7,12 @@
 """Simli video service for real-time avatar generation."""
 
 import asyncio
+import warnings
+from typing import Optional
 
 import numpy as np
 from loguru import logger
+from pydantic import BaseModel
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -41,30 +44,103 @@ class SimliVideoService(FrameProcessor):
     audio resampling, video frame processing, and connection management.
     """
 
+    class InputParams(BaseModel):
+        """Input parameters for Simli video configuration.
+
+        Parameters:
+            max_session_length: Absolute maximum session duration in seconds.
+                Avatar will disconnect after this time even if it's speaking.
+            max_idle_time: Maximum duration in seconds the avatar is not speaking
+                before the avatar disconnects.
+        """
+
+        max_session_length: Optional[int] = None
+        max_idle_time: Optional[int] = None
+
     def __init__(
         self,
-        simli_config: SimliConfig,
+        *,
+        api_key: Optional[str] = None,
+        face_id: Optional[str] = None,
+        simli_config: Optional[SimliConfig] = None,
         use_turn_server: bool = False,
         latency_interval: int = 0,
         simli_url: str = "https://api.simli.ai",
         is_trinity_avatar: bool = False,
+        params: Optional[InputParams] = None,
+        **kwargs,
     ):
         """Initialize the Simli video service.
 
         Args:
+            api_key: Simli API key for authentication.
+            face_id: Simli Face ID. For Trinity avatars, specify "faceId/emotionId"
+                to use a different emotion than the default.
             simli_config: Configuration object for Simli client settings.
-            use_turn_server: Whether to use TURN server for connection. Defaults to False.
-            latency_interval: Latency interval setting for sending health checks to check the latency to Simli Servers. Defaults to 0.
-            simli_url: URL of the simli servers. Can be changed for custom deployments of enterprise users.
-            is_trinity_avatar: boolean to tell simli client that this is a Trinity avatar which reduces latency when using Trinity.
+                Use api_key and face_id instead.
 
+                .. deprecated:: 0.0.92
+                    The 'simli_config' parameter is deprecated and will be removed in a future version.
+                    Please use 'api_key' and 'face_id' parameters instead.
+
+            use_turn_server: Whether to use TURN server for connection. Defaults to False.
+            latency_interval: Latency interval setting for sending health checks to check
+                the latency to Simli Servers. Defaults to 0.
+            simli_url: URL of the simli servers. Can be changed for custom deployments
+                of enterprise users.
+            is_trinity_avatar: Boolean to tell simli client that this is a Trinity avatar
+                which reduces latency when using Trinity.
+            params: Additional input parameters for session configuration.
+            **kwargs: Additional arguments passed to the parent FrameProcessor.
         """
-        super().__init__()
+        super().__init__(**kwargs)
+
+        params = params or SimliVideoService.InputParams()
+
+        # Handle deprecated simli_config parameter
+        if simli_config is not None:
+            if api_key is not None or face_id is not None:
+                raise ValueError(
+                    "Cannot specify both simli_config and api_key/face_id. "
+                    "Please use api_key and face_id (simli_config is deprecated)."
+                )
+
+            warnings.warn(
+                "The 'simli_config' parameter is deprecated and will be removed in a future version. "
+                "Please use 'api_key' and 'face_id' parameters instead, with optional 'params' for "
+                "max_session_length and max_idle_time configuration.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+            # Use the provided simli_config
+            config = simli_config
+        else:
+            # Validate new parameters
+            if api_key is None:
+                raise ValueError("api_key is required")
+            if face_id is None:
+                raise ValueError("face_id is required")
+
+            # Build SimliConfig from new parameters
+            # Only pass optional parameters if explicitly provided to use SimliConfig defaults
+            config_kwargs = {
+                "apiKey": api_key,
+                "faceId": face_id,
+            }
+            if params.max_session_length is not None:
+                config_kwargs["maxSessionLength"] = params.max_session_length
+            if params.max_idle_time is not None:
+                config_kwargs["maxIdleTime"] = params.max_idle_time
+
+            config = SimliConfig(**config_kwargs)
+
         self._initialized = False
-        simli_config.maxIdleTime += 5
-        simli_config.maxSessionLength += 5
+        # Add buffer time to session limits
+        config.maxIdleTime += 5
+        config.maxSessionLength += 5
         self._simli_client = SimliClient(
-            simli_config,
+            config,
             use_turn_server,
             latency_interval,
             simliURL=simli_url,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The goal is in this is making `SimliVideoService` better align with other video services. With this, we can more easily add support for it to the CLI.

This also makes InputParams more discoverable as they're now documented in Pipecat docs.