### PR TITLE
Fix Gemini Live session resumption. The problem was that we weren't p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `GeminiLiveLLMService` session resumption after a connection timeout.
+
 - `GeminiLiveLLMService` now properly supports context-provided system
-  instruction and tools
+  instruction and tools.
 
 ## [0.0.92] - 2025-10-31 🎃 "The Haunted Edition" 👻
 


### PR DESCRIPTION
…roperly ignoring send errors during reconnection.

(These are "expected" errors that occur for messages that were being sent when the disconnection occurred)