### PR TITLE
fix: correct GoogleLLMService token counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ reason")`.
 - `GeminiLiveLLMService` now properly supports context-provided system
   instruction and tools.
 
+- Fixed `GoogleLLMService` token counting to avoid double-counting tokens when
+  Gemini sends usage metadata across multiple streaming chunks.
+
 ### Removed
 
 - Removed `needs_mcp_alternate_schema()` from `LLMService`. The mechanism that


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Gemini can return multiple response chunks, each with an estimate of the final token count. We only want the final token count in the final message, so we just set the value and don't accumulate. For example:
```
response chunk: sdk_http_response=HttpResponse(
  headers=<dict len=11>
) candidates=[Candidate(
  content=Content(
    parts=[
      Part(
        text="You're welcome"
      ),
    ],
    role='model'
  ),
  index=0
)] create_time=None model_version='gemini-2.5-flash' prompt_feedback=None response_id='irUMafy0Je-9qtsPlNOm6AM' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=4,
  prompt_token_count=576,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=576
    ),
  ],
  total_token_count=580
) automatic_function_calling_history=None parsed=None
response chunk: sdk_http_response=HttpResponse(
  headers=<dict len=11>
) candidates=[Candidate(
  content=Content(
    parts=[
      Part(
        text='.'
      ),
    ],
    role='model'
  ),
  finish_reason=<FinishReason.STOP: 'STOP'>,
  index=0
)] create_time=None model_version='gemini-2.5-flash' prompt_feedback=None response_id='irUMafy0Je-9qtsPlNOm6AM' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=5,
  prompt_token_count=576,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=576
    ),
  ],
  total_token_count=581
) automatic_function_calling_history=None parsed=None
```