### PR TITLE
Deprecate KrispFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Not released yet
+## [Unreleased]
+
+### Deprecated
+
+- The KrispFilter is deprecated and will be removed in a future version. Use
+  the KrispVivaFilter instead.
 
 ### Removed
 

--- a/src/pipecat/audio/filters/krisp_filter.py
+++ b/src/pipecat/audio/filters/krisp_filter.py
@@ -61,6 +61,10 @@ class KrispFilter(BaseAudioFilter):
     Provides real-time noise reduction for audio streams using Krisp's
     proprietary noise suppression algorithms. Requires a Krisp model file
     for operation.
+
+    .. deprecated:: 0.0.94
+        The KrispFilter is deprecated and will be removed in a future version.
+        Use KrispVivaFilter instead.
     """
 
     def __init__(
@@ -78,6 +82,17 @@ class KrispFilter(BaseAudioFilter):
             ValueError: If model_path is not provided and KRISP_MODEL_PATH is not set.
         """
         super().__init__()
+
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "KrispFilter is deprecated and will be removed in a future version. "
+                "Use KrispVivaFilter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Set model path, checking environment if not specified
         self._model_path = model_path or os.getenv("KRISP_MODEL_PATH")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Now that `KrispVivaFilter` is available (and available on Pipecat Cloud), it's time to deprecate `KrispFilter`.