### PR TITLE
Include pts in video and audio frames in SmallWebRTCClient

### DIFF
--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -332,6 +332,7 @@ class SmallWebRTCClient:
                 format="RGB",
             )
             image_frame.transport_source = video_source
+            image_frame.pts = frame.pts
 
             del frame  # free original VideoFrame
             del image_bytes  # reference kept in image_frame
@@ -379,6 +380,7 @@ class SmallWebRTCClient:
                         sample_rate=resampled_frame.sample_rate,
                         num_channels=self._audio_in_channels,
                     )
+                    audio_frame.pts = frame.pts
                     del pcm_bytes  # reference kept in audio_frame
 
                     yield audio_frame
@@ -393,6 +395,7 @@ class SmallWebRTCClient:
                     sample_rate=frame.sample_rate,
                     num_channels=self._audio_in_channels,
                 )
+                audio_frame.pts = frame.pts
                 del pcm_bytes  # reference kept in audio_frame
 
                 yield audio_frame


### PR DESCRIPTION
The incoming video and audio frames didn't have their `pts` property set by the SmallWebRTCClient. This PR sets them.