### PR TITLE
fix:  deepgram tts sample rate issue

### DIFF
--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -94,7 +94,7 @@ class DeepgramTTSService(TTSService):
         options = SpeakOptions(
             model=self._voice_id,
             encoding=self._settings["encoding"],
-            sample_rate=self.sample_rate,
+            sample_rate=self._init_sample_rate or self.sample_rate or None,
             container="none",
         )
 
@@ -188,7 +188,7 @@ class DeepgramHttpTTSService(TTSService):
         params = {
             "model": self._voice_id,
             "encoding": self._settings["encoding"],
-            "sample_rate": self.sample_rate,
+            "sample_rate": self._init_sample_rate or self.sample_rate or None,
             "container": "none",
         }
 


### PR DESCRIPTION
## **PipeCat Fix Summary**

### **Root Cause Discovered:**
PipeCat's `DeepgramTTSService` was passing `sample_rate=0` to the Deepgram API, causing an `INVALID_QUERY_PARAMETER` error. The API returned 193-byte JSON error messages instead of audio.

### **Why This Happened:**
- PipeCat's parent class `TTSService` initializes `self._sample_rate = 0`
- `DeepgramTTSService.run_tts()` used `sample_rate=self.sample_rate` (which was 0)
- The v4.7 SDK's `SpeakOptions` dataclass included fields with value `0` in the API request
- Deepgram API requires sample_rate to be `> 0` or omitted entirely

### **The Fix:**
Changed line 97 and 191 in `/pipecat/src/pipecat/services/deepgram/tts.py`:
```python
# Before:
sample_rate=self.sample_rate  # Always 0

# After:
sample_rate=self._init_sample_rate or self.sample_rate or None  # Use passed value or omit
```

### **Result:**
- ✅ API accepts requests (returns real audio, not errors)
- ✅ Respects user-provided `sample_rate` when specified
- ✅ Omits parameter when not specified (API uses default)
- ✅ Fixes both `DeepgramTTSService` and `DeepgramHttpTTSService`

### **Why Customer Reported as "Performance Issue":**

A Deepgram customer who also uses Pipecat reported "slower TTS performance" when comparing direct HTTP vs. PipeCat with the SDK. However, this wasn't a performance issue—**PipeCat was returning API errors instead of audio**. The perceived "performance difference" was likely due to error handling, retries, or the application failing silently. The customer may not have been aware they were getting errors rather than actual audio output.
