### PR TITLE
Improve TTSService handling of long LLM token outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `maybe_capture_participant_screen()` for `SmallWebRTCTransport` in the runner
   utils.
 
+- Improved `SimpleTextAggregator` and `TTSService` to properly handle buffered
+  sentences at the end of LLM responses. Previously, when an LLM response ended,
+  any complete sentences remaining in the aggregator's buffer would be sent to
+  TTS as one large chunk. Now these sentences are flushed individually, providing
+  better interruption points. Added `flush_next_sentence()` method to
+  `SimpleTextAggregator` to extract buffered sentences without adding new text.
+
 - Added Hindi support for Rime TTS services.
 
 - Updated `GeminiTTSService` to use Google Cloud Text-to-Speech streaming API

--- a/tests/test_simple_text_aggregator.py
+++ b/tests/test_simple_text_aggregator.py
@@ -19,11 +19,39 @@ class TestSimpleTextAggregator(unittest.IsolatedAsyncioTestCase):
         await self.aggregator.reset()
         assert self.aggregator.text == ""
 
-    async def test_simple_sentence(self):
-        assert await self.aggregator.aggregate("Hello ") == None
-        assert await self.aggregator.aggregate("Pipecat!") == "Hello Pipecat!"
+    async def test_word_by_word(self):
+        """Test word-by-word token aggregation (e.g., OpenAI)."""
+        assert await self.aggregator.aggregate("Hello") == None
+        assert await self.aggregator.aggregate("!") == "Hello!"
+        assert await self.aggregator.aggregate(" I") == None
+        assert await self.aggregator.aggregate(" am") == None
+        assert await self.aggregator.aggregate(" Doug.") == " I am Doug."
         assert self.aggregator.text == ""
 
-    async def test_multiple_sentences(self):
-        assert await self.aggregator.aggregate("Hello Pipecat! How are ") == "Hello Pipecat!"
-        assert await self.aggregator.aggregate("you?") == " How are you?"
+    async def test_chunks_with_partial_sentences(self):
+        """Test chunks with partial sentences."""
+        assert await self.aggregator.aggregate("Hey!") == "Hey!"
+        assert await self.aggregator.aggregate(" Nice to meet you! So") == " Nice to meet you!"
+        assert self.aggregator.text == " So"
+        assert await self.aggregator.aggregate(" what") == None
+        assert await self.aggregator.aggregate("'d you like?") == " So what'd you like?"
+
+    async def test_multi_sentence_chunk(self):
+        """Test chunks with multiple complete sentences."""
+        result = await self.aggregator.aggregate("Hello! I am Doug. Nice to meet you!")
+        assert result == "Hello!"
+        # Drain remaining sentences
+        assert await self.aggregator.flush_next_sentence() == " I am Doug."
+        assert await self.aggregator.flush_next_sentence() == " Nice to meet you!"
+        assert await self.aggregator.flush_next_sentence() == None
+        assert self.aggregator.text == ""
+
+    async def test_flush_next_sentence_with_incomplete(self):
+        """Test flush_next_sentence with incomplete sentence in buffer."""
+        assert await self.aggregator.aggregate("Hello! I am") == "Hello!"
+        assert await self.aggregator.flush_next_sentence() == None
+        assert self.aggregator.text == " I am"
+
+    async def test_flush_next_sentence_empty_buffer(self):
+        """Test flush_next_sentence with empty buffer."""
+        assert await self.aggregator.flush_next_sentence() == None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The motivation for this change was discovering that Google Gemini outputs long chunks, sometimes containing multiple sentences. The `SimpleTextAggregator` extracts only the first sentence and buffers the remainder of the text. When the `LLMFullResponseEndFrame` is received, all remaining buffered text was being pushed to TTS as one large chunk. This results in potentially many sentences being sent to TTS at once.

The issue is that interruptions capture the last complete sentence; for long outputs with many buffered sentences, it was possible to have many sentences missed during interruption, which could cause the bot to repeat itself or continue speaking after being interrupted.

This PR adds a `flush_next_sentence()` method to the `SimpleTextAggregator` which is used when the `LLMFullResponseEndFrame` is received. Instead of sending all remaining text as one chunk, the buffered sentences are now flushed individually, providing better interruption points throughout the response.

**DON'T MERGE YET. WAIT UNTIL https://github.com/pipecat-ai/pipecat/pull/2899 LANDS.**