### PR TITLE
Fix: Ensure EndFrame propagates through AIService before stop()

### DIFF
--- a/src/pipecat/services/ai_service.py
+++ b/src/pipecat/services/ai_service.py
@@ -152,6 +152,9 @@ class AIService(FrameProcessor):
         elif isinstance(frame, CancelFrame):
             await self.cancel(frame)
         elif isinstance(frame, EndFrame):
+            # Push EndFrame before stop(), because stop() may wait on tasks to
+            # finish and downstream processors need to receive the EndFrame.
+            await self.push_frame(frame, direction)
             await self.stop(frame)
 
     async def process_generator(self, generator: AsyncGenerator[Frame | None, None]):


### PR DESCRIPTION
This PR fixes a critical bug where EndFrame would trigger the stop() method in AIService but never be pushed downstream to subsequent processors, causing pipelines to hang during graceful shutdown.

## The Problem

Investigation of production logs revealed:
- EndFrame successfully reached ElevenLabsTTSService
- But there was NO log showing the frame being pushed FROM ElevenLabsTTSService to the next processor
- The pipeline hung, waiting indefinitely for the EndFrame that never arrived

AIService.process_frame() handled EndFrame by calling stop() without first pushing the frame downstream.

## The Fix

Ensures EndFrame is pushed downstream BEFORE calling stop(), following the pattern used by RTVIProcessor.

This guarantees:
1. Downstream processors receive the EndFrame for proper cleanup
2. The stop() method can then safely perform service-specific cleanup
3. The ordering prevents race conditions during shutdown

## Impact

- Fixes pipeline hangs during graceful shutdown
- Affects all AI services inheriting from AIService
- Critical for production stability