### PR TITLE
BaseTextFilter: only require subclasses to implement filter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ElevenLabsRealtimeSTTService` which implements the Realtime STT
   service from ElevenLabs.
 
+- Added ai-coustics integrated VAD (`AICVADAnalyzer`) with `AICFilter` factory and
+  example wiring; leverages the enhancement model for robust detection with no
+  ONNX dependency or added processing complexity.
+
 ### Changed
+
+- `BaseTextFilter` only require subclasses to implement the `filter()` method.
 
 - Extracted the logic for retrying connections, and create a new `send_with_retry`
   method inside `WebSocketService`.
@@ -64,12 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `keyterm` or `tag` containing a space.
 
 - Prevented `HeyGenVideoService` from automatically disconnecting after 5 minutes.
-
-### Added
-
-- Added ai-coustics integrated VAD (`AICVADAnalyzer`) with `AICFilter` factory and
-  example wiring; leverages the enhancement model for robust detection with no
-  ONNX dependency or added processing complexity.
 
 ## [0.0.94] - 2025-11-10
 

--- a/src/pipecat/utils/text/base_text_filter.py
+++ b/src/pipecat/utils/text/base_text_filter.py
@@ -26,7 +26,6 @@ class BaseTextFilter(ABC):
     behavior, settings management, and interruption handling logic.
     """
 
-    @abstractmethod
     async def update_settings(self, settings: Mapping[str, Any]):
         """Update the filter's configuration settings.
 
@@ -53,7 +52,6 @@ class BaseTextFilter(ABC):
         """
         pass
 
-    @abstractmethod
     async def handle_interruption(self):
         """Handle interruption events in the processing pipeline.
 
@@ -62,7 +60,6 @@ class BaseTextFilter(ABC):
         """
         pass
 
-    @abstractmethod
     async def reset_interruption(self):
         """Reset the filter state after an interruption has been handled.
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This is to simplify subclasses. Sometimes they don't need to handle any settings update or interruptions, all they are is a simple one time filter.