### PR TITLE
fix: remove stt_sagemaker import from deepgram/__init__.py

### DIFF
--- a/src/pipecat/services/deepgram/__init__.py
+++ b/src/pipecat/services/deepgram/__init__.py
@@ -10,7 +10,6 @@ from pipecat.services import DeprecatedModuleProxy
 
 from .flux import *
 from .stt import *
-from .stt_sagemaker import *
 from .tts import *
 
 sys.modules[__name__] = DeprecatedModuleProxy(globals(), "deepgram", "deepgram.[stt,tts]")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This resolves an import error when using Deepgram with the `sagemaker` extra installed.

It's suboptimal because our DeprecatedModuleProxy issues a deprecation warning for it. But, this will be short lived as we'll remove the DeprecatedModuleProxy in the 1.0.0 release. I'd rather have this module configuration and a deprecation for the next few weeks vs a different module structure to avoid the deprecation warning...