### PR TITLE
add logged frame

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --group dev --extra anthropic --extra aws --extra google --extra langchain
+          uv sync --group dev --extra anthropic --extra aws --extra google --extra langchain --extra daily
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --group dev --extra anthropic --extra aws --extra google --extra langchain
+          uv sync --group dev --extra anthropic --extra aws --extra google --extra langchain --extra daily
 
       - name: Test with pytest
         run: |

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -567,8 +567,17 @@ class DailyTransportClient(EventHandler):
         Returns:
             error: An error description or None.
         """
+        # Wait for join to complete with timeout
+        # If already joined, this returns immediately
         if not self._joined:
-            return "Unable to send messages before joining."
+            try:
+                await asyncio.wait_for(self._joined_event.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                return "Join operation timed out, unable to send message."
+
+        # Double-check we're still joined (could have been cleared if left during wait)
+        if not self._joined:
+            return "Transport disconnected while waiting to send message."
 
         participant_id = None
         if isinstance(
@@ -770,6 +779,8 @@ class DailyTransportClient(EventHandler):
             logger.error(error_msg)
             await self._callbacks.on_error(error_msg)
             self._joining = False
+            # Ensure any waiting callers are notified of failure
+            self._joined_event.set()  # Allows send attempts to fail immediately instead of hanging
 
     async def _join(self):
         """Execute the actual room join operation."""
@@ -1050,8 +1061,16 @@ class DailyTransportClient(EventHandler):
         Returns:
             error: An error description or None.
         """
+        # Wait for join to complete with timeout
         if not self._joined:
-            return "Can't send message if not joined"
+            try:
+                await asyncio.wait_for(self._joined_event.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                return "Join operation timed out, unable to send message."
+
+        # Double-check we're still joined
+        if not self._joined:
+            return "Transport disconnected while waiting to send message."
 
         future = self._get_event_loop().create_future()
         self._client.send_prebuilt_chat_message(

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -1960,7 +1960,7 @@ class DailyOutputTransport(BaseOutputTransport):
         """
         error = await self._client.send_message(frame)
         if error:
-            logger.error(f"Unable to send message: {error}")
+            logger.error(f"Unable to send message: {error}", extra={"frame": frame})
 
     async def register_video_destination(self, destination: str):
         """Register a video output destination.

--- a/tests/test_daily_transport_service.py
+++ b/tests/test_daily_transport_service.py
@@ -4,7 +4,152 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
+    """Tests for the race condition fix in DailyTransport.send_message()"""
+
+    async def test_send_message_waits_for_join(self):
+        """Test that send_message() waits for join to complete instead of rejecting immediately."""
+        from pipecat.frames.frames import OutputTransportMessageFrame
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        # Create a mock transport object with just the attributes we need
+        transport = MagicMock(spec=DailyTransportClient)
+        transport._joined = False
+        transport._joined_event = asyncio.Event()
+        transport._client = MagicMock()
+
+        # Mock the send_app_message to succeed via completion callback
+        def mock_send(msg, pid, completion):
+            completion(None)
+
+        transport._client.send_app_message = mock_send
+        transport._get_event_loop = MagicMock(return_value=asyncio.get_event_loop())
+
+        # Set up the joined event to fire after a short delay
+        async def set_joined_after_delay():
+            await asyncio.sleep(0.05)
+            transport._joined = True
+            transport._joined_event.set()
+
+        # Bind the real send_message method to our mock
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        send_message = DailyTransportClient.send_message
+
+        # Schedule the event setter
+        task = asyncio.create_task(set_joined_after_delay())
+
+        # Call the real send_message with our mock object
+        frame = OutputTransportMessageFrame(message="test message")
+        result = await send_message(transport, frame)
+
+        await task
+
+        # Should succeed (no error)
+        self.assertIsNone(result)
+
+    async def test_send_message_timeout_if_join_slow(self):
+        """Test that send_message() times out if join takes longer than 10 seconds."""
+        from pipecat.frames.frames import OutputTransportMessageFrame
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        # Create a mock transport that never joins
+        transport = MagicMock(spec=DailyTransportClient)
+        transport._joined = False
+        transport._joined_event = asyncio.Event()  # Event that never gets set
+        transport._client = MagicMock()
+        transport._get_event_loop = MagicMock(return_value=asyncio.get_event_loop())
+
+        # Bind the real send_message method
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        send_message = DailyTransportClient.send_message
+
+        frame = OutputTransportMessageFrame(message="test message")
+
+        # Call send_message - it should timeout after ~10 seconds
+        # For testing, we'll wrap it with a shorter timeout to fail fast
+        start = asyncio.get_event_loop().time()
+        result = await asyncio.wait_for(send_message(transport, frame), timeout=11.0)
+        elapsed = asyncio.get_event_loop().time() - start
+
+        # Should fail with timeout error (took at least 10 seconds)
+        self.assertGreaterEqual(elapsed, 9.5)
+        self.assertIn("timed out", result.lower() if result else "")
+
+    async def test_send_message_already_joined(self):
+        """Test that send_message() returns immediately if already joined."""
+        from pipecat.frames.frames import OutputTransportMessageFrame
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        # Create a mock transport that's already joined
+        transport = MagicMock(spec=DailyTransportClient)
+        transport._joined = True
+        transport._joined_event = asyncio.Event()
+        transport._joined_event.set()
+        transport._client = MagicMock()
+        transport._get_event_loop = MagicMock(return_value=asyncio.get_event_loop())
+
+        # Mock the send_app_message to succeed
+        def mock_send(msg, pid, completion):
+            completion(None)
+
+        transport._client.send_app_message = mock_send
+
+        # Bind the real send_message method
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        send_message = DailyTransportClient.send_message
+
+        frame = OutputTransportMessageFrame(message="test message")
+
+        start_time = asyncio.get_event_loop().time()
+        result = await send_message(transport, frame)
+        elapsed = asyncio.get_event_loop().time() - start_time
+
+        # Should succeed immediately
+        self.assertIsNone(result)
+        # Should not take significant time
+        self.assertLess(elapsed, 0.1)
+
+    async def test_send_message_disconnects_during_wait(self):
+        """Test that send_message() handles disconnect during wait."""
+        from pipecat.frames.frames import OutputTransportMessageFrame
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        transport = MagicMock(spec=DailyTransportClient)
+        transport._joined = False
+        transport._joined_event = asyncio.Event()
+        transport._client = MagicMock()
+        transport._get_event_loop = MagicMock(return_value=asyncio.get_event_loop())
+
+        # Simulate transport being left while waiting
+        async def clear_joined_during_wait():
+            await asyncio.sleep(0.05)
+            transport._joined = False
+            transport._joined_event.set()
+
+        # Bind the real method
+        from pipecat.transports.daily.transport import DailyTransportClient
+
+        send_message = DailyTransportClient.send_message
+
+        frame = OutputTransportMessageFrame(message="test message")
+
+        # Schedule disconnect
+        task = asyncio.create_task(clear_joined_during_wait())
+
+        result = await send_message(transport, frame)
+
+        await task
+
+        # Should fail because transport disconnected
+        self.assertIn("disconnected", result.lower() if result else "")
 
 
 class TestDailyTransport(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_daily_transport_service.py
+++ b/tests/test_daily_transport_service.py
@@ -6,7 +6,10 @@
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
+
+from pipecat.frames.frames import OutputTransportMessageFrame
+from pipecat.transports.daily.transport import DailyTransportClient
 
 
 class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
@@ -14,8 +17,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_message_waits_for_join(self):
         """Test that send_message() waits for join to complete instead of rejecting immediately."""
-        from pipecat.frames.frames import OutputTransportMessageFrame
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         # Create a mock transport object with just the attributes we need
         transport = MagicMock(spec=DailyTransportClient)
@@ -36,9 +37,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
             transport._joined = True
             transport._joined_event.set()
 
-        # Bind the real send_message method to our mock
-        from pipecat.transports.daily.transport import DailyTransportClient
-
         send_message = DailyTransportClient.send_message
 
         # Schedule the event setter
@@ -55,8 +53,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_message_timeout_if_join_slow(self):
         """Test that send_message() times out if join takes longer than 10 seconds."""
-        from pipecat.frames.frames import OutputTransportMessageFrame
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         # Create a mock transport that never joins
         transport = MagicMock(spec=DailyTransportClient)
@@ -66,7 +62,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
         transport._get_event_loop = MagicMock(return_value=asyncio.get_event_loop())
 
         # Bind the real send_message method
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         send_message = DailyTransportClient.send_message
 
@@ -84,8 +79,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_message_already_joined(self):
         """Test that send_message() returns immediately if already joined."""
-        from pipecat.frames.frames import OutputTransportMessageFrame
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         # Create a mock transport that's already joined
         transport = MagicMock(spec=DailyTransportClient)
@@ -102,7 +95,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
         transport._client.send_app_message = mock_send
 
         # Bind the real send_message method
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         send_message = DailyTransportClient.send_message
 
@@ -119,8 +111,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_message_disconnects_during_wait(self):
         """Test that send_message() handles disconnect during wait."""
-        from pipecat.frames.frames import OutputTransportMessageFrame
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         transport = MagicMock(spec=DailyTransportClient)
         transport._joined = False
@@ -135,7 +125,6 @@ class TestDailyTransportRaceCondition(unittest.IsolatedAsyncioTestCase):
             transport._joined_event.set()
 
         # Bind the real method
-        from pipecat.transports.daily.transport import DailyTransportClient
 
         send_message = DailyTransportClient.send_message
 


### PR DESCRIPTION
## Summary

This PR addresses two critical issues in the Pipecat DailyTransport:

### 1. **Original Issue**: Logged Frame on Failed (Initial commit)
When frames fail to send, we now log which specific frame failed, making debugging easier.

### 2. **New Fix**: Race Condition in `DailyTransport.send_message()`
The transport had a race condition where `send_message()` and `send_prebuilt_chat_message()` would immediately reject messages if the join operation hadn't completed yet, causing production failures under load.

## Changes Made

### Core Fixes (src/pipecat/transports/daily/transport.py)

1. **Updated `send_message()` method (lines 559-592)**
   - Added wait with 10-second timeout for `_joined_event` instead of immediate rejection
   - Returns descriptive timeout error if join takes too long
   - Includes safety check after wait to ensure transport is still connected

2. **Updated `send_prebuilt_chat_message()` method (lines 1050-1077)**
   - Applied the same wait-with-timeout pattern as `send_message()`
   - Prevents race condition during concurrent join operations

3. **Fixed `join()` error path (lines 777-783)**
   - Sets `_joined_event` even on join failure
   - Prevents infinite hangs for callers waiting on the event

### Test Coverage (tests/test_daily_transport_service.py)

Added comprehensive unit tests:
- `test_send_message_waits_for_join`: Verifies messages wait for join to complete
- `test_send_message_already_joined`: Confirms immediate send when already joined
- `test_send_message_disconnects_during_wait`: Tests error handling on disconnect
- `test_send_message_timeout_if_join_slow`: Validates timeout behavior (10s test)

All tests pass successfully.

## How It Works

**Before**: Messages were rejected immediately if not joined
```
Pipeline starts → send_message() called → Error: "Unable to send messages before joining"
```

**After**: Messages wait for join to complete with timeout
```
Pipeline starts → send_message() called → Wait for _joined_event (up to 10s) → Send succeeds
```

## Edge Cases Handled

| Scenario | Behavior |
|----------|----------|
| Already joined | Returns immediately (no wait) |
| Join in progress | Waits up to 10 seconds |
| Join fails | Timeout + descriptive error |
| Transport leaves during wait | Caught by post-wait check |

## Impact

- ✅ Eliminates race condition errors in production
- ✅ Graceful handling of slow joins
- ✅ Prevents infinite hangs on join failures
- ✅ No API changes - fully backward compatible
- ✅ Minimal performance impact (async wait logic)

## Commits

1. f9aa0682 - `fix: resolve race condition in DailyTransport.send_message()`
2. 4dbf645a - `test: add tests for DailyTransport race condition fix`