### PR TITLE
Add filters to MCP Client

### DIFF
--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -47,7 +47,7 @@ class MCPClient(BaseObject):
         self,
         server_params: ServerParameters,
         tools_filter: Optional[List[str]] = None,
-        tools_output_filters: Dict[str, Callable[[Any], Any]] | None = None,
+        tools_output_filters: Optional[Dict[str, Callable[[Any], Any]]] = None,
         **kwargs,
     ):
         """Initialize the MCP client with server parameters.


### PR DESCRIPTION
This PR enhances the MCPClient by introducing two new optional configuration mechanisms:
- tools_filter – allows registering only a selected subset of tools.
- tools_output_filters – allows post-processing tool outputs through user-provided filter functions.

These features improve security, customization, and output handling when integrating external MCP tools with LLMs.

✨ Key Changes

1. Added tools_filter support
- A new optional argument tools_filter: List[str] | None is added to the constructor.
- During tool registration (_list_tools_helper), tools not included in this list are skipped.
- This enables restricting tool usage to an explicitly whitelisted set.

2. Added tools_output_filters
- A new optional argument tools_output_filters: Dict[str, Callable[[Any], Any]] | None.
- After a tool returns its output, the client now:
  - Checks whether that tool has a configured filter function.
  - Applies the filter to the tool’s raw response.

This is especially useful for:
- Sanitizing output
- Normalizing different tool response formats
- Extracting specific fields from large payloads

✅ Benefits
- Better control over which tools an LLM is allowed to call.
- More robust output handling, reducing the need for downstream parsing logic.
- Backward compatible: if no filters are provided, behavior remains unchanged.

📌 Notes
- No breaking changes were introduced.
- Default behavior remains unchanged when both new arguments are None.