### PR TITLE
Fix Cartesia STT dynamic updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed 
+
+- Fixed an issue in `CartesiaSTTService` where dynamic language
+  updates were failing.
+
 ## [0.0.96] - 2025-11-26 🦃 "Happy Thanksgiving!" 🦃
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 
 
-- Fixed an issue in `CartesiaSTTService` where dynamic language
-  updates were failing.
+- Fixed an issue in `CartesiaSTTService` where dynamic language updates were failing.
 
 ## [0.0.96] - 2025-11-26 🦃 "Happy Thanksgiving!" 🦃
 

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -172,7 +172,7 @@ class CartesiaSTTService(WebsocketSTTService):
                 }
             )
 
-        self._settings = merged_options
+        self._settings = merged_options.to_dict()
         self.set_model_name(merged_options.model)
         self._api_key = api_key
         self._base_url = base_url or "api.cartesia.ai"
@@ -269,7 +269,7 @@ class CartesiaSTTService(WebsocketSTTService):
                 return
             logger.debug("Connecting to Cartesia STT")
 
-            params = self._settings.to_dict()
+            params = self._settings
             ws_url = f"wss://{self._base_url}/stt/websocket?{urllib.parse.urlencode(params)}"
             headers = {"Cartesia-Version": "2025-04-16", "X-API-Key": self._api_key}
 
@@ -363,3 +363,14 @@ class CartesiaSTTService(WebsocketSTTService):
                         language,
                     )
                 )
+
+    async def set_language(self, language: Language):
+        """Set the transcription language.
+
+        Args:
+            language: The language to use for speech-to-text transcription.
+        """
+        logger.debug(f"Switching STT language to: [{language}]")
+        # Reconnect with new settings
+        await self._disconnect()
+        await self._connect()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

**Problem:**
Dynamic settings updates via `STTUpdateSettingsFrame` were failing for the Cartesia STT service.

The service was storing the `CartesiaLiveOptions` object in `_settings`, but the base `STTService` class expects `_settings` to be a dictionary. This caused an error (`argument of type 'CartesiaLiveOptions' is not iterable`) during settings updates.

Additionally, the `set_language()` method was unimplemented. Even if `_settings` had been correct, the service would not have reconnected with the new language settings upon update.

**Solution:**
1. Initialized `_settings` as a dictionary using `.to_dict()` on the options object.
2. Implemented `set_language()` to handle reconnection when the language changes.
    - Note: I intentionally omitted the explicit update of `_settings["language"]` in this method. The base `STTService._update_settings()` already performs this update (at `self._settings[key] = value`) before calling `set_language()`.
3. Updated `_connect_websocket()` to use the dictionary format of `_settings` for compatibility.

**Testing:**
- Verified that `STTUpdateSettingsFrame` now successfully updates language settings.
- Confirmed that language changes trigger a proper reconnection with the new settings.