### PR TITLE
feat(cartesia): make pause_frame_processing configurable in CartesiaTTSService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `pause_frame_processing` parameter to `CartesiaTTSService` to allow
+  disabling frame processing pausing during TTS generation.
+
 - Added `wait_for_all` argument to the base `LLMService`. When enabled, this
   ensures all function calls complete before returning results to the LLM (i.e.,
   before running a new inference with those results).

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -234,6 +234,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
         params: Optional[InputParams] = None,
         text_aggregator: Optional[BaseTextAggregator] = None,
         aggregate_sentences: Optional[bool] = True,
+        pause_frame_processing: Optional[bool] = True,
         **kwargs,
     ):
         """Initialize the Cartesia TTS service.
@@ -254,6 +255,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
                     Use an LLMTextProcessor before the TTSService for custom text aggregation.
 
             aggregate_sentences: Whether to aggregate sentences within the TTSService.
+            pause_frame_processing: Whether to pause processing frames while receiving audio.
             **kwargs: Additional arguments passed to the parent service.
         """
         # Aggregating sentences still gives cleaner-sounding results and fewer
@@ -269,7 +271,7 @@ class CartesiaTTSService(AudioContextWordTTSService):
         super().__init__(
             aggregate_sentences=aggregate_sentences,
             push_text_frames=False,
-            pause_frame_processing=True,
+            pause_frame_processing=pause_frame_processing,
             sample_rate=sample_rate,
             text_aggregator=text_aggregator,
             **kwargs,


### PR DESCRIPTION
## Summary

Add `pause_frame_processing` parameter to `CartesiaTTSService` constructor to allow users to disable frame processing pausing during TTS generation.

## Motivation

This is useful for use cases where:
- Text aggregation is disabled (`aggregate_sentences=False`)
- Users want to send text directly to the TTS service without pausing incoming frame processing
- More control over frame flow is needed for custom pipelines

## Changes

- Added `pause_frame_processing` parameter to `CartesiaTTSService.__init__()` with default value `True` (preserving existing behavior)
- Updated docstring to document the new parameter
- Passes the parameter through to the parent `AudioContextWordTTSService` class

## Usage

```python
tts = CartesiaTTSService(
    api_key=os.getenv("CARTESIA_API_KEY"),
    voice_id="your_voice_id",
    aggregate_sentences=False,
    pause_frame_processing=False,  # New parameter
)
```