### PR TITLE
use VADUserStarted/StoppedSpeakingFrame s in user_bot_latency_log_observer.py

### DIFF
--- a/changelog/3206.changed.md
+++ b/changelog/3206.changed.md
@@ -1,0 +1,3 @@
+- `UserBotLatencyLogObserver` now uses `VADUserStartedSpeakingFrame` and 
+`VADUserStoppedSpeakingFrame` to determine latency from user stopped speaking
+to bot started speaking.

--- a/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
+++ b/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
@@ -15,8 +15,8 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     CancelFrame,
     EndFrame,
-    UserStartedSpeakingFrame,
-    UserStoppedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
 )
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.processors.frame_processor import FrameDirection
@@ -56,9 +56,9 @@ class UserBotLatencyLogObserver(BaseObserver):
 
         self._processed_frames.add(data.frame.id)
 
-        if isinstance(data.frame, UserStartedSpeakingFrame):
+        if isinstance(data.frame, VADUserStartedSpeakingFrame):
             self._user_stopped_time = 0
-        elif isinstance(data.frame, UserStoppedSpeakingFrame):
+        elif isinstance(data.frame, VADUserStoppedSpeakingFrame):
             self._user_stopped_time = time.time()
         elif isinstance(data.frame, (EndFrame, CancelFrame)):
             self._log_summary()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Use `VADUserStartedSpeakingFrame` instead of `UserStartedSpeakingFrame` and `VADUserStoppedSpeakingFrame` instead of `UserStoppedSpeakingFrame` in ` user_bot_latency_log_observer.py` as it is a more accurate representation of the latency between user and bot.