### PR TITLE
user-bot-latency log observer internal var change

### DIFF
--- a/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
+++ b/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
@@ -36,7 +36,7 @@ class UserBotLatencyLogObserver(BaseObserver):
         to calculate response latencies.
         """
         super().__init__()
-        self._processed_frames = set()
+        self._user_bot_latency_processed_frames = set()
         self._user_stopped_time = 0
         self._latencies = []
 
@@ -51,10 +51,10 @@ class UserBotLatencyLogObserver(BaseObserver):
             return
 
         # Skip already processed frames
-        if data.frame.id in self._processed_frames:
+        if data.frame.id in self._user_bot_latency_processed_frames:
             return
 
-        self._processed_frames.add(data.frame.id)
+        self._user_bot_latency_processed_frames.add(data.frame.id)
 
         if isinstance(data.frame, VADUserStartedSpeakingFrame):
             self._user_stopped_time = 0


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I am creating a custom observer that inherits from multiple observers like so:
```
class MyCustomObserver(TurnTrackingObserver, UserBotLatencyLogObserver):
```
Both [`TurnTrackingObserver`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/observers/turn_tracking_observer.py#L66) and [`UserBotLatencyLogObserver`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/observers/loggers/user_bot_latency_log_observer.py#L39) use an internal `self._processed_frames` variable. The TurnTrackingObserver's `self._processed_frames` clobbers the UserBotLatencyLogObserver's version. We should scope the variable name to avoid such collisions.