### PR TITLE
Adding include_language_detection param to Elevenlabs Realtime STT

### DIFF
--- a/changelog/3216.changed.md
+++ b/changelog/3216.changed.md
@@ -1,0 +1,7 @@
+- Updated `ElevenLabsRealtimeSTTService` to accept the `include_language_detection` parameter to detect language.
+  ```python
+    stt = ElevenLabsRealtimeSTTService(
+        api_key=os.getenv("ELEVENLABS_API_KEY"),
+        include_language_detection=True
+    )
+  ```

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -417,6 +417,7 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
                 Only used when commit_strategy is VAD. None uses ElevenLabs default.
             include_timestamps: Whether to include word-level timestamps in transcripts.
             enable_logging: Whether to enable logging on ElevenLabs' side.
+            include_language_detection: Whether to include language detection in transcripts.
         """
 
         language_code: Optional[str] = None
@@ -642,7 +643,9 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
                 params.append(f"enable_logging={str(self._params.enable_logging).lower()}")
 
             if self._params.include_language_detection:
-                params.append(f"include_language_detection={str(self._params.include_language_detection).lower()}")
+                params.append(
+                    f"include_language_detection={str(self._params.include_language_detection).lower()}"
+                )
 
             # Add VAD parameters if using VAD commit strategy and values are specified
             if self._params.commit_strategy == CommitStrategy.VAD:


### PR DESCRIPTION
Adding a param to the config while connecting to the session

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
Currently, the ElevenLabsRealtimeSTTService doesn't allow us to pass `include_language_detection`, which can be used to get the language code in the response of the Scribe ve realtime model. After discussing with the Elevenlabs team that this is the parameter name that can be passed to get the language code, I'm creating this PR 