### PR TITLE
Clean up use of pipecat version

### DIFF
--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -17,7 +17,7 @@ from urllib.parse import urlencode
 
 from loguru import logger
 
-from pipecat import __version__ as pipecat_version
+from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -254,7 +254,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             ws_url = self._build_ws_url()
             headers = {
                 "Authorization": self._api_key,
-                "User-Agent": f"AssemblyAI/1.0 (integration=Pipecat/{pipecat_version})",
+                "User-Agent": f"AssemblyAI/1.0 (integration=Pipecat/{pipecat_version()})",
             }
             self._websocket = await websocket_connect(
                 ws_url,

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncGenerator, Dict, Literal, Optional
 import aiohttp
 from loguru import logger
 
-from pipecat import __version__ as pipecat_version
+from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -299,7 +299,7 @@ class GladiaSTTService(WebsocketSTTService):
 
         # Add custom_metadata if provided
         settings["custom_metadata"] = dict(self._params.custom_metadata or {})
-        settings["custom_metadata"]["pipecat"] = pipecat_version
+        settings["custom_metadata"]["pipecat"] = pipecat_version()
 
         # Add endpointing parameters if provided
         if self._params.endpointing is not None:

--- a/src/pipecat/services/hume/tts.py
+++ b/src/pipecat/services/hume/tts.py
@@ -12,7 +12,7 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel
 
-from pipecat import __version__
+from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -43,7 +43,7 @@ HUME_SAMPLE_RATE = 48_000  # Hume TTS streams at 48 kHz
 # Tracking headers for Hume API requests
 DEFAULT_HEADERS = {
     "X-Hume-Client-Name": "pipecat",
-    "X-Hume-Client-Version": __version__,
+    "X-Hume-Client-Version": pipecat_version(),
 }
 
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Use the `pipecat_version()` function instead of `__version__`.