### PR TITLE
Add PR link to the changelog line item

### DIFF
--- a/changelog/_template.md.j2
+++ b/changelog/_template.md.j2
@@ -4,7 +4,7 @@
 ### {{ definitions[category]['name'] }}
 
 {% for text, values in sections[section][category].items() %}
-{{ text }}
+{{ text }} ({{ values|join(', ') }})
 
 {% endfor %}
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ directory = "changelog"
 start_string = "<!-- towncrier release notes start -->\n"
 template = "changelog/_template.md.j2"
 title_format = "## [{version}] - {project_date}"
+issue_format = "[#{issue}](https://github.com/pipecat-ai/pipecat/pull/{issue})"
 underlines = ["", "", ""]
 wrap = true
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Previously, you could use a tool like GitLens to see the corresponding PR, but now that changelog fragments are batch processed, that traceability is lost. Given that, I think we want to include the PR link for each changelog entry.

They will be formatted like this:
```
- Added pipecat library version info to the `about` field in the `bot-ready`
  RTVI message ([#3248](https://github.com/pipecat-ai/pipecat/pull/3248))
```

E.g.
- Added pipecat library version info to the `about` field in the `bot-ready`
  RTVI message ([#3248](https://github.com/pipecat-ai/pipecat/pull/3248))