### PR TITLE
Update linting scripts to use ruff version installed by uv

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,20 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
           version: "latest"
-      
+
       - name: Set up Python
-        run: uv python install 3.10
-      
+        run: uv python install 3.12
+
       - name: Install development dependencies
         run: uv sync --group dev
-      
+
       - name: Build project
         run: uv build
-      
+
       - name: Install project in editable mode
         run: uv pip install --editable .

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -22,22 +22,22 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
           version: "latest"
-      
+
       - name: Set up Python
-        run: uv python install 3.10
-      
+        run: uv python install 3.12
+
       - name: Install development dependencies
         run: uv sync --group dev
-      
+
       - name: Ruff formatter
         id: ruff-format
         run: uv run ruff format --diff
-      
+
       - name: Ruff linter (all rules)
         id: ruff-check
         run: uv run ruff check

--- a/scripts/fix-ruff.sh
+++ b/scripts/fix-ruff.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 echo "Running ruff format..."
-ruff format "$PROJECT_ROOT"
+uv run ruff format "$PROJECT_ROOT"
 echo "Running ruff check..."
-ruff check --fix "$PROJECT_ROOT"
+uv run ruff check --fix "$PROJECT_ROOT"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -12,14 +12,14 @@ cd "$(dirname "$0")/.."
 
 # Format check
 echo "📝 Checking code formatting..."
-if ! NO_COLOR=1 ruff format --diff --check; then
-    echo -e "${RED}❌ Code formatting issues found. Run 'ruff format' to fix.${NC}"
+if ! NO_COLOR=1 uv run ruff format --diff --check; then
+    echo -e "${RED}❌ Code formatting issues found. Run 'uv run ruff format' to fix.${NC}"
     exit 1
 fi
 
 # Lint check
 echo "🔍 Running linter..."
-if ! ruff check; then
+if ! uv run ruff check; then
     echo -e "${RED}❌ Linting issues found.${NC}"
     exit 1
 fi


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I stumbled on an issue where my local ruff check was passing but CI was not. The root cause is that my system version of ruff was different than what uv installs. The solution is to make the fix-ruff and pre-commit scripts use the uv installed ruff version. This will ensure linting works uniformly for everyone.

Also, some housekeeping on our github workflows; now they all use Python 3.12.

No changelog needed since these changes are unrelated to source.