### PR TITLE
Add ttfb tracking for Ultravox

### DIFF
--- a/changelog/XXX.added.md
+++ b/changelog/XXX.added.md
@@ -1,0 +1,1 @@
+- Added an approximation of TTFB for Ultravox.


### PR DESCRIPTION
Adds (approximate) ttfb tracking for Ultravox, following the Gemini Live approach.

The measurement is from client detection of ended user speech (based on VAD) to the first audio frames received on the client in response or the first agent text transcript received for text responses.

This number will be artificially high in two cases:
1. Tool calls - If an agent turn begins with a tool call, the first response bytes will be delayed by the generation of the full tool call plus the tool's execution and response. (This matches the Gemini Live behavior AFAICT.)
2. Endpointing mismatches - Ultravox uses a transformer-based endpointing detection model to decide when a user has stopped speaking. If VAD thinks the user is done and that model disagrees, the TTFB timer will start increasing well before Ultravox responds. (But this will usually end up being an "interruption" anyway.)