### PR TITLE
fix: Separate LLMContextAssistantTimestampFrame from OpenAILLMContext…

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -514,9 +514,15 @@ class OpenAILLMContextAssistantTimestampFrame(DataFrame):
             )
 
 
-# A more universal (LLM-agnostic) name for
-# OpenAILLMContextAssistantTimestampFrame, matching LLMContext
-LLMContextAssistantTimestampFrame = OpenAILLMContextAssistantTimestampFrame
+@dataclass
+class LLMContextAssistantTimestampFrame(DataFrame):
+    """Timestamp information for assistant messages in LLM context.
+
+    Parameters:
+        timestamp: Timestamp when the assistant message was created.
+    """
+
+    timestamp: str
 
 
 @dataclass


### PR DESCRIPTION
…AssistantTimestampFrame

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

With the addition of the deprecation warning, using the LLMContext results in:
```
DeprecationWarning: OpenAILLMContextAssistantTimestampFrame is deprecated and will be removed in a future version. Use LLMContextAssistantTimestampFrame with the universal LLMContext and LLMContextAggregatorPair instead. See OpenAILLMContext docstring for migration guide.
```

The root cause is that the `LLMContextAssistantTimestampFrame` is aliased from the `OpenAILLMContextAssistantTimestampFrame`, so the deprecation from `OpenAILLMContextAssistantTimestampFrame` is passed on. Instead, these should be two separate frames without any inheritance. Doing so eliminates the deprecation warning and creates a clear path for removing the old path.