### PR TITLE
Add Keepalive Function to Inworld TTS

### DIFF
--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -10,9 +10,10 @@ Contains two TTS services:
 - InworldTTSService: WebSocket-based TTS service.
 - InworldHttpTTSService: HTTP-based TTS service.
 
-Inworld’s text-to-speech (TTS) models offer ultra-realistic, context-aware speech synthesis and precise voice cloning capabilities, enabling developers to build natural and engaging experiences with human-like speech quality at an accessible price point.
+Inworld's text-to-speech (TTS) models offer ultra-realistic, context-aware speech synthesis and precise voice cloning capabilities, enabling developers to build natural and engaging experiences with human-like speech quality at an accessible price point.
 """
 
+import asyncio
 import base64
 import json
 import uuid
@@ -23,6 +24,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 try:
+    import websockets
     from websockets.asyncio.client import connect as websocket_connect
     from websockets.protocol import State
 except ModuleNotFoundError as e:
@@ -479,6 +481,7 @@ class InworldTTSService(AudioContextWordTTSService):
         }
 
         self._receive_task = None
+        self._keepalive_task = None
         self._context_id = None
         self._started = False
 
@@ -608,6 +611,8 @@ class InworldTTSService(AudioContextWordTTSService):
         await self._connect_websocket()
         if self._websocket and not self._receive_task:
             self._receive_task = self.create_task(self._receive_task_handler(self._report_error))
+        if self._websocket and not self._keepalive_task:
+            self._keepalive_task = self.create_task(self._keepalive_task_handler())
 
     async def _disconnect(self):
         """Disconnect from the Inworld WebSocket TTS service.
@@ -618,6 +623,10 @@ class InworldTTSService(AudioContextWordTTSService):
         if self._receive_task:
             await self.cancel_task(self._receive_task)
             self._receive_task = None
+
+        if self._keepalive_task:
+            await self.cancel_task(self._keepalive_task)
+            self._keepalive_task = None
 
         await self._disconnect_websocket()
 
@@ -756,6 +765,24 @@ class InworldTTSService(AudioContextWordTTSService):
                 if ctx_id and self.audio_context_available(ctx_id):
                     await self.remove_audio_context(ctx_id)
                 await self.add_word_timestamps([("TTSStoppedFrame", 0), ("Reset", 0)])
+
+    async def _keepalive_task_handler(self):
+        """Send periodic keepalive messages to maintain WebSocket connection."""
+        KEEPALIVE_SLEEP = 60
+        while True:
+            await asyncio.sleep(KEEPALIVE_SLEEP)
+            try:
+                if self._websocket and self._websocket.state is State.OPEN:
+                    if self._context_id:
+                        keepalive_message = {"send_text": {"text": ""}, "contextId": self._context_id}
+                        logger.trace(f"Sending keepalive for context {self._context_id}")
+                    else:
+                        keepalive_message = {"send_text": {"text": ""}}
+                        logger.trace("Sending keepalive without context")
+                    await self._websocket.send(json.dumps(keepalive_message))
+            except websockets.ConnectionClosed as e:
+                logger.warning(f"{self} keepalive error: {e}")
+                break
 
     async def _send_context(self, context_id: str):
         """Send a context to the Inworld WebSocket TTS service.


### PR DESCRIPTION
Continuing from the Inworld TTS service improvements in #3288, adding a keepalive function to prevent the timeout issues noted in #3269.

This follows similar patterns from other providers like Elevenlabs.

Note that Inworld will return an error when there's no context (eg. when the keepalive runs during a user interruption), but this doesn't affect functionality.