### PR TITLE
fix: preserve asyncio.Task return value in create_task

### DIFF
--- a/src/pipecat/utils/asyncio/task_manager.py
+++ b/src/pipecat/utils/asyncio/task_manager.py
@@ -157,7 +157,7 @@ class TaskManager(BaseTaskManager):
 
         async def run_coroutine():
             try:
-                await coroutine
+                return await coroutine
             except asyncio.CancelledError:
                 logger.trace(f"{name}: task cancelled")
                 # Re-raise the exception to ensure the task is cancelled.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
Fixes #2874 

Issue: `TaskManager` wraps coroutine but awaits it without returning the result. As a result, tasks created via create_task (including those in `FrameProcessor`) always resolve to None when awaited, breaking the expected asyncio.Task behavior.

Fix: Return the result of the awaited coroutine from the run_coroutine wrapper.