### PR TITLE
fix `Preserving Reasoning Blocks` of OpenRouter

### DIFF
--- a/src/pipecat/processors/aggregators/openai_llm_context.py
+++ b/src/pipecat/processors/aggregators/openai_llm_context.py
@@ -115,6 +115,7 @@ class OpenAILLMContext:
         self._tool_choice: ChatCompletionToolChoiceOptionParam | NotGiven = tool_choice
         self._tools: List[ChatCompletionToolParam] | NotGiven | ToolsSchema = tools
         self._llm_adapter: Optional[BaseLLMAdapter] = None
+        self._reasoning_details_by_tool_call_id: Dict[str, List[Any]] = {}
 
     def get_llm_adapter(self) -> Optional[BaseLLMAdapter]:
         """Get the current LLM adapter.
@@ -208,6 +209,16 @@ class OpenAILLMContext:
             List of all messages in the conversation history.
         """
         return self._messages
+
+    def set_reasoning_details(self, tool_call_id: str, details: List[Any]):
+        if details:
+            self._reasoning_details_by_tool_call_id[tool_call_id] = details
+
+    def get_reasoning_details(self, tool_call_id: str) -> Optional[List[Any]]:
+        return self._reasoning_details_by_tool_call_id.get(tool_call_id)
+
+    def clear_reasoning_details(self, tool_call_id: str):
+        self._reasoning_details_by_tool_call_id.pop(tool_call_id, None)
 
     def get_messages_json(self) -> str:
         """Get messages as a formatted JSON string.

--- a/src/pipecat/services/openrouter/llm.py
+++ b/src/pipecat/services/openrouter/llm.py
@@ -45,6 +45,7 @@ class OpenRouterLLMService(OpenAILLMService):
             api_key=api_key,
             base_url=base_url,
             model=model,
+            include_reasoning_details=True,
             **kwargs,
         )
 


### PR DESCRIPTION
https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#preserving-reasoning-blocks

This pull request introduces support for tracking and managing "reasoning details" associated with tool calls in the OpenAI LLM context and service classes. The changes add mechanisms to store, propagate, and clear reasoning details throughout the tool call lifecycle, with optional inclusion in model messages. This enhances traceability and debugging for function/tool calls in LLM-driven workflows.

### Reasoning details tracking and propagation

* Added a `reasoning_details_by_tool_call_id` dictionary and related methods (`set_reasoning_details`, `get_reasoning_details`, `clear_reasoning_details`) to `OpenAILLMContext` for storing and managing reasoning details per tool call. [[1]](diffhunk://#diff-59a94d63283f1fd2a2b85586387e9e5b269a0df6217442200d59b73562650f8eR118) [[2]](diffhunk://#diff-59a94d63283f1fd2a2b85586387e9e5b269a0df6217442200d59b73562650f8eR213-R222)
* Updated `BaseOpenAILLMService` to extract reasoning details from streaming deltas, associate them with tool calls, and optionally include them in outgoing messages based on the new `include_reasoning_details` parameter. [[1]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R103) [[2]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R139) [[3]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9L306-R316) [[4]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R362-R363) [[5]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R406-R408) [[6]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R426-R430) [[7]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R457) [[8]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R474-R478) [[9]](diffhunk://#diff-b2e8682de13adbf0ed9b7ad0927a4b59be150f1322129165cf130d199e4125d9R520-R529)

### API and constructor changes

* Added the `include_reasoning_details` option to the constructors of `BaseOpenAILLMService`, `OpenAILLMService`, and `OpenRouterLLMService` to control whether reasoning details are included in tool call messages. [[1]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eR77) [[2]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eL86-R92) [[3]](diffhunk://#diff-02e8226721a1c42d4f148964176fd677c723005e899e2c20a63ec0217b880ce9R48)

### Message construction and cleanup

* Modified message construction in `handle_function_call_in_progress` to include reasoning details when present, and ensured reasoning details are cleared after function call completion, cancellation, or user image frame handling. [[1]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eL164-R181) [[2]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eR206) [[3]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eR219) [[4]](diffhunk://#diff-f54541f9fbecce628d53b6d28db442d4b58504e605401119aeb4612f1f48458eR250)

### Miscellaneous

* Added a deep copy of messages in `_stream_chat_completions_specific_context` to avoid mutation issues and ensure reasoning details are properly excluded or included.
* Imported `copy` module for deep copying messages.