### PR TITLE
DeepgramSTTService pushes user started/stopped speaking and interrupt…

### DIFF
--- a/changelog/xxx.changed.md
+++ b/changelog/xxx.changed.md
@@ -1,0 +1,1 @@
+- Updated `DeepgramSTTService` to push user started/stopped speaking and interruption frames when `vad_enabled` is set to true. This centralizes the frames into the service, removing the need to have your application code handle Deepgram's events and push these frames.

--- a/examples/foundational/07c-interruptible-deepgram-vad.py
+++ b/examples/foundational/07c-interruptible-deepgram-vad.py
@@ -11,12 +11,7 @@ from deepgram import LiveOptions
 from dotenv import load_dotenv
 from loguru import logger
 
-from pipecat.frames.frames import (
-    InterruptionFrame,
-    LLMRunFrame,
-    UserStartedSpeakingFrame,
-    UserStoppedSpeakingFrame,
-)
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -102,14 +97,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
-
-    @stt.event_handler("on_speech_started")
-    async def on_speech_started(stt, *args, **kwargs):
-        await task.queue_frames([UserStartedSpeakingFrame(), InterruptionFrame()])
-
-    @stt.event_handler("on_utterance_end")
-    async def on_utterance_end(stt, *args, **kwargs):
-        await task.queue_frames([UserStoppedSpeakingFrame()])
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -17,6 +17,8 @@ from pipecat.frames.frames import (
     InterimTranscriptionFrame,
     StartFrame,
     TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
@@ -271,9 +273,12 @@ class DeepgramSTTService(STTService):
     async def _on_speech_started(self, *args, **kwargs):
         await self.start_metrics()
         await self._call_event_handler("on_speech_started", *args, **kwargs)
+        await self.broadcast_frame(UserStartedSpeakingFrame)
+        await self.push_interruption_task_frame_and_wait()
 
     async def _on_utterance_end(self, *args, **kwargs):
         await self._call_event_handler("on_utterance_end", *args, **kwargs)
+        await self.broadcast_frame(UserStoppedSpeakingFrame)
 
     @traced_stt
     async def _handle_transcription(


### PR DESCRIPTION
…ion frames

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This aligns DeepgramSTTService with other services. For anyone using  DeepgramSTTService with `vad_enabled=True`, this could mean extra frames are pushed. But, I can't think of a way around it. It's better to align the service to Pipecat's norms. This makes it easier to work with.