### PR TITLE
LLMUserAggregator: also read deprecated allow_interruptions

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -564,7 +564,7 @@ class LLMUserAggregator(LLMContextAggregator):
             # TODO(aleix): This frame should really come from the top of the pipeline.
             await self.broadcast_frame(UserStartedSpeakingFrame)
 
-        if params.enable_interruptions:
+        if params.enable_interruptions and self._allow_interruptions:
             # TODO(aleix): This frame should really come from the top of the pipeline.
             await self.broadcast_frame(InterruptionFrame)
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`PipelineParams.allow_interruptions` is deprecated but we still should use it for backwards compatibility.