### PR TITLE
Fix numba pin wording in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2199,7 +2199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compatibility issues with other packages. Now you can use the PlayHT HTTP
   service with other services, like GoogleLLMService.
 
-- Updated `pyproject.toml` to once again pin `numba` to `>=0.61.2` in order to
+- Updated `pyproject.toml` to once again pin `numba` to `==0.61.2` in order to
   resolve package versioning issues.
 
 - Updated the `STTMuteFilter` to include `VADUserStartedSpeakingFrame` and


### PR DESCRIPTION
Correct changelog entry of of [0.0.80] - 2025-08-13 to reflect that numba was pinned to ==0.61.2 (not >=0.61.2), to avoid confusion about the intended version. Can otherwise lead users (and agents) to believe later versions of numba are supported when they are not. Current pyproject.toml is correct; only the changelog is in error.