### PR TITLE
fix(smallwebrtc): suppress timeout warnings when tracks are disabled

### DIFF
--- a/changelog/3336.changed.md
+++ b/changelog/3336.changed.md
@@ -1,0 +1,1 @@
+- Updated `read_audio_frame` & `read_video_frame` methods in `SmallWebRTCClient` to check if the track is enabled before logging a warning.

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -304,7 +304,11 @@ class SmallWebRTCClient:
             try:
                 frame = await asyncio.wait_for(video_track.recv(), timeout=2.0)
             except asyncio.TimeoutError:
-                if self._webrtc_connection.is_connected():
+                if (
+                    self._webrtc_connection.is_connected()
+                    and video_track
+                    and video_track.is_enabled()
+                ):
                     logger.warning("Timeout: No video frame received within the specified time.")
                     # self._webrtc_connection.ask_to_renegotiate()
                 frame = None
@@ -354,7 +358,11 @@ class SmallWebRTCClient:
             try:
                 frame = await asyncio.wait_for(self._audio_input_track.recv(), timeout=2.0)
             except asyncio.TimeoutError:
-                if self._webrtc_connection.is_connected():
+                if (
+                    self._webrtc_connection.is_connected()
+                    and self._audio_input_track
+                    and self._audio_input_track.is_enabled()
+                ):
                     logger.warning("Timeout: No audio frame received within the specified time.")
                 frame = None
             except MediaStreamError:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #2755 

Issue : `SmallWebRTCTransport` is logging false-positive timeout warnings as reported by @ripperdoc 

Added a fix where transport now checks if the track is actually enabled before flagging a timeout, ensuring we only warn about genuine network drops rather than intentional silence.


#### Before

<img width="2906" height="1042" alt="image" src="https://github.com/user-attachments/assets/c4b6bcb3-389b-486c-9e9f-37529d656259" />

#### After

<img width="2906" height="456" alt="image" src="https://github.com/user-attachments/assets/d691af6d-150b-4c48-b2a2-233cb94174cc" />

