### PR TITLE
fix: treat language as first-class STT setting

### DIFF
--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -152,6 +152,8 @@ class STTService(AIService):
                 self._settings[key] = value
                 if key == "language":
                     await self.set_language(value)
+            elif key == "language":
+                await self.set_language(value)
             elif key == "model":
                 self.set_model_name(value)
             else:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #2617 

Issue : `STTUpdateSettingsFrame` failed to update language for stt services that don't store "language" key in their settings.
Eg : 
Some services, like Google STT, do not use a singular "language" key. Instead, they use keys like "language_codes" to support advanced features like multi-language recognition or primary/alternative language lists. Because "language" was missing from the internal dict, the base class rejected the update with `Warning : Unknown setting for STT service: language.`

Fix :  Updated `stt_service.py` to treat "language" as a first-class property.


### Testing 
example : 
<img width="1225" height="672" alt="image" src="https://github.com/user-attachments/assets/92d60661-bccd-4376-a7f2-9a4bc19a09d9" />


before : 
<img width="1840" height="466" alt="image" src="https://github.com/user-attachments/assets/7c067c0d-1e9f-42b7-b0c0-7c4e1e89002e" />


after : 
<img width="1849" height="377" alt="image" src="https://github.com/user-attachments/assets/a068357d-7725-4a5f-92a1-bcf354534e95" />

<img width="1845" height="430" alt="image" src="https://github.com/user-attachments/assets/c9def27d-1283-46ee-8843-1faf13ffe8d4" />
