### PR TITLE
Add trailing space to DeepgramTTSService text generation

### DIFF
--- a/changelog/3345.fixed.md
+++ b/changelog/3345.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue with DeepgramTTSService where the model would output "Dot" instead of a period in some circumstances.

--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -287,7 +287,9 @@ class DeepgramTTSService(WebsocketTTSService):
         Yields:
             Frame: Audio frames containing the synthesized speech, plus start/stop frames.
         """
-        logger.debug(f"{self}: Generating TTS [{text}]")
+        # Append trailing space to prevent TTS from vocalizing trailing periods as "dot"
+        text_with_trailing_space = text + " "
+        logger.debug(f"{self}: Generating TTS [{text_with_trailing_space}]")
 
         try:
             # Reconnect if the websocket is closed
@@ -295,14 +297,14 @@ class DeepgramTTSService(WebsocketTTSService):
                 await self._connect()
 
             await self.start_ttfb_metrics()
-            await self.start_tts_usage_metrics(text)
+            await self.start_tts_usage_metrics(text_with_trailing_space)
 
             yield TTSStartedFrame()
 
             # Send text message to Deepgram
             # Note: We don't send Flush here - that should only be sent when the
             # LLM finishes a complete response via flush_audio()
-            speak_msg = {"type": "Speak", "text": text}
+            speak_msg = {"type": "Speak", "text": text_with_trailing_space}
             await self._get_websocket().send(json.dumps(speak_msg))
 
             # The audio frames will be handled in _receive_messages


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In some cases, `DeepgramTTSService` outputs a "Dot" when a period occurs. For example, this is reproducible when a sentence ends in a number and `.` (e.g. The secret code is 1234.)

Deepgram expects spaces to be preserved, but Pipecat strips them in the aggregation logic. This fix is targeted to the DeepgramTTSService class to add a trailing space. DeepgramTTSService is a TTSService class, so no word-timestamp alignment data exists. That means this added space is only for audio generation and is not added to the context.

Fixes #3242 