### PR TITLE
Fix STT model name attribute retrieval in tracing decorator

### DIFF
--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -303,7 +303,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                         add_stt_span_attributes(
                             span=current_span,
                             service_name=service_class_name,
-                            model=getattr(self, "model_name", settings.get("model", "unknown")),
+                            model=getattr(self, "model_name") or settings.get("model", "unknown"),
                             transcript=transcript,
                             is_final=is_final,
                             language=str(language) if language else None,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Changed getattr with default value to use 'or' operator for fallback. This ensures proper model name retrieval when model_name attribute exists but is None or empty.


Since `AIService` put empty string to `_model_name`, `getattr(self, "model_name")` always returns an empty string, doesn't fall back to `settings.get("model", ...)`.

https://github.com/pipecat-ai/pipecat/blob/1c80c739d688c14b7ec8bc9c267e94e5ae1ac5ab/src/pipecat/services/ai_service.py#L44