### PR TITLE
Add `user_bot_latency_seconds` to OpenTelemetry turn spans

### DIFF
--- a/changelog/3355.added.md
+++ b/changelog/3355.added.md
@@ -1,0 +1,1 @@
+- Added `UserBotLatencyObserver` for tracking user-to-bot response latency. When tracing is enabled, latency measurements are automatically recorded as `turn.user_bot_latency_seconds` attributes on OpenTelemetry turn spans.

--- a/changelog/3355.deprecated.md
+++ b/changelog/3355.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated `UserBotLatencyLogObserver`. Use `UserBotLatencyObserver` directly with its `on_latency_measured` event handler instead.

--- a/examples/foundational/29-turn-tracking-observer.py
+++ b/examples/foundational/29-turn-tracking-observer.py
@@ -15,6 +15,7 @@ from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import LLMRunFrame
 from pipecat.observers.loggers.user_bot_latency_log_observer import UserBotLatencyLogObserver
+from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -96,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
+    # Create latency tracking observers
+    latency_tracker = UserBotLatencyObserver()
+    latency_log_observer = UserBotLatencyLogObserver(latency_tracker)
+
     task = PipelineTask(
         pipeline,
         params=PipelineParams(
@@ -103,7 +108,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             enable_usage_metrics=True,
         ),
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
-        observers=[UserBotLatencyLogObserver()],
+        observers=[latency_tracker, latency_log_observer],
     )
 
     turn_observer = task.turn_tracking_observer

--- a/examples/foundational/29-turn-tracking-observer.py
+++ b/examples/foundational/29-turn-tracking-observer.py
@@ -14,7 +14,6 @@ from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnal
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import LLMRunFrame
-from pipecat.observers.loggers.user_bot_latency_log_observer import UserBotLatencyLogObserver
 from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
@@ -97,9 +96,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
-    # Create latency tracking observers
-    latency_tracker = UserBotLatencyObserver()
-    latency_log_observer = UserBotLatencyLogObserver(latency_tracker)
+    # Create latency tracking observer
+    latency_observer = UserBotLatencyObserver()
 
     task = PipelineTask(
         pipeline,
@@ -108,8 +106,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             enable_usage_metrics=True,
         ),
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
-        observers=[latency_tracker, latency_log_observer],
+        observers=[latency_observer],
     )
+
+    # Log latency measurements using the event handler
+    @latency_observer.event_handler("on_latency_measured")
+    async def on_latency_measured(observer, latency_seconds):
+        logger.info(f"⏱️ User-to-bot latency: {latency_seconds:.3f}s")
 
     turn_observer = task.turn_tracking_observer
     if turn_observer:

--- a/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
+++ b/src/pipecat/observers/loggers/user_bot_latency_log_observer.py
@@ -6,67 +6,63 @@
 
 """Observer for measuring user-to-bot response latency."""
 
-import time
 from statistics import mean
 
 from loguru import logger
 
 from pipecat.frames.frames import (
-    BotStartedSpeakingFrame,
     CancelFrame,
     EndFrame,
-    VADUserStartedSpeakingFrame,
-    VADUserStoppedSpeakingFrame,
 )
 from pipecat.observers.base_observer import BaseObserver, FramePushed
-from pipecat.processors.frame_processor import FrameDirection
+from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 
 
 class UserBotLatencyLogObserver(BaseObserver):
-    """Observer that measures time between user stopping speech and bot starting speech.
+    """Observer that logs user-to-bot response latency.
 
-    This helps measure how quickly the AI services respond by tracking
-    conversation turn timing and logging latency metrics.
+    Uses UserBotLatencyObserver to track latency measurements and provides
+    logging and statistics. Logs individual latencies and a summary with
+    average, min, and max values when the pipeline ends.
     """
 
-    def __init__(self):
-        """Initialize the latency observer.
+    def __init__(self, latency_tracker: UserBotLatencyObserver, **kwargs):
+        """Initialize the latency log observer.
 
-        Sets up tracking for processed frames and user speech timing
-        to calculate response latencies.
+        Args:
+            latency_tracker: The latency tracking observer to monitor.
+            **kwargs: Additional arguments passed to parent class.
         """
-        super().__init__()
-        self._user_bot_latency_processed_frames = set()
-        self._user_stopped_time = 0
+        super().__init__(**kwargs)
+        self._latency_tracker = latency_tracker
         self._latencies = []
 
+        if latency_tracker:
+
+            @latency_tracker.event_handler("on_latency_measured")
+            async def on_latency_measured(tracker, latency_seconds):
+                await self._handle_latency_measured(latency_seconds)
+
     async def on_push_frame(self, data: FramePushed):
-        """Process frames to track speech timing and calculate latency.
+        """Process frames to handle pipeline end events.
 
         Args:
             data: Frame push event containing the frame and direction information.
         """
-        # Only process downstream frames
-        if data.direction != FrameDirection.DOWNSTREAM:
-            return
-
-        # Skip already processed frames
-        if data.frame.id in self._user_bot_latency_processed_frames:
-            return
-
-        self._user_bot_latency_processed_frames.add(data.frame.id)
-
-        if isinstance(data.frame, VADUserStartedSpeakingFrame):
-            self._user_stopped_time = 0
-        elif isinstance(data.frame, VADUserStoppedSpeakingFrame):
-            self._user_stopped_time = time.time()
-        elif isinstance(data.frame, (EndFrame, CancelFrame)):
+        if isinstance(data.frame, (EndFrame, CancelFrame)):
             self._log_summary()
-        elif isinstance(data.frame, BotStartedSpeakingFrame) and self._user_stopped_time:
-            latency = time.time() - self._user_stopped_time
-            self._user_stopped_time = 0
-            self._latencies.append(latency)
-            self._log_latency(latency)
+
+    async def _handle_latency_measured(self, latency_seconds: float):
+        """Handle latency measurement events.
+
+        Called when the latency tracker measures user-to-bot latency.
+        Stores the latency and logs it.
+
+        Args:
+            latency_seconds: The measured latency in seconds.
+        """
+        self._latencies.append(latency_seconds)
+        self._log_latency(latency_seconds)
 
     def _log_summary(self):
         if not self._latencies:

--- a/src/pipecat/observers/user_bot_latency_observer.py
+++ b/src/pipecat/observers/user_bot_latency_observer.py
@@ -1,0 +1,81 @@
+"""Observer for tracking user-to-bot response latency.
+
+This module provides an observer that monitors the time between when a user
+stops speaking and when the bot starts speaking, emitting events when latency
+is measured.
+"""
+
+import time
+from typing import Optional, Set
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.processors.frame_processor import FrameDirection
+
+
+class UserBotLatencyObserver(BaseObserver):
+    """Observer that tracks user-to-bot response latency.
+
+    Measures the time between when a user stops speaking (VADUserStoppedSpeakingFrame)
+    and when the bot starts speaking (BotStartedSpeakingFrame). Emits events when
+    latency is measured, allowing consumers to log, trace, or otherwise process
+    the latency data.
+
+    This observer follows the composition pattern used by TurnTrackingObserver,
+    acting as a reusable component for latency measurement.
+
+    Events:
+        on_latency_measured(observer, latency_seconds): Emitted when user-to-bot
+            latency is calculated. Includes the latency value in seconds as a float.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize the user-bot latency observer.
+
+        Sets up tracking for processed frames and user speech timing
+        to calculate response latencies.
+
+        Args:
+            **kwargs: Additional arguments passed to parent class.
+        """
+        super().__init__(**kwargs)
+        self._user_stopped_time: Optional[float] = None
+        self._processed_frames: Set[str] = set()
+
+        self._register_event_handler("on_latency_measured")
+
+    async def on_push_frame(self, data: FramePushed):
+        """Process frames to track speech timing and calculate latency.
+
+        Tracks VAD events and bot speaking events to measure the time between
+        user stopping speech and bot starting speech.
+
+        Args:
+            data: Frame push event containing the frame and direction information.
+        """
+        # Only process downstream frames
+        if data.direction != FrameDirection.DOWNSTREAM:
+            return
+
+        # Skip already processed frames
+        if data.frame.id in self._processed_frames:
+            return
+
+        self._processed_frames.add(data.frame.id)
+
+        # Track VAD and bot speaking events for latency
+        if isinstance(data.frame, VADUserStartedSpeakingFrame):
+            # Reset when user starts speaking
+            self._user_stopped_time = None
+        elif isinstance(data.frame, VADUserStoppedSpeakingFrame):
+            # Record timestamp when user stops speaking
+            self._user_stopped_time = time.time()
+        elif isinstance(data.frame, BotStartedSpeakingFrame) and self._user_stopped_time:
+            # Calculate and emit latency
+            latency = time.time() - self._user_stopped_time
+            self._user_stopped_time = None
+            await self._call_event_handler("on_latency_measured", latency)

--- a/src/pipecat/utils/tracing/turn_trace_observer.py
+++ b/src/pipecat/utils/tracing/turn_trace_observer.py
@@ -18,6 +18,7 @@ from loguru import logger
 from pipecat.frames.frames import StartFrame
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
+from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 from pipecat.utils.tracing.conversation_context_provider import ConversationContextProvider
 from pipecat.utils.tracing.setup import is_tracing_available
 from pipecat.utils.tracing.turn_context_provider import TurnContextProvider
@@ -45,6 +46,7 @@ class TurnTraceObserver(BaseObserver):
     def __init__(
         self,
         turn_tracker: TurnTrackingObserver,
+        latency_tracker: UserBotLatencyObserver,
         conversation_id: Optional[str] = None,
         additional_span_attributes: Optional[dict] = None,
         **kwargs,
@@ -53,12 +55,14 @@ class TurnTraceObserver(BaseObserver):
 
         Args:
             turn_tracker: The turn tracking observer to monitor.
+            latency_tracker: The latency tracking observer for user-bot latency.
             conversation_id: Optional conversation ID for grouping turns.
             additional_span_attributes: Additional attributes to add to spans.
             **kwargs: Additional arguments passed to parent class.
         """
         super().__init__(**kwargs)
         self._turn_tracker = turn_tracker
+        self._latency_tracker = latency_tracker
         self._current_span: Optional["Span"] = None
         self._current_turn_number: int = 0
         self._trace_context_map: Dict[int, "SpanContext"] = {}
@@ -69,15 +73,32 @@ class TurnTraceObserver(BaseObserver):
         self._conversation_id = conversation_id
         self._additional_span_attributes = additional_span_attributes or {}
 
-        if turn_tracker:
+        @turn_tracker.event_handler("on_turn_started")
+        async def on_turn_started(tracker, turn_number):
+            await self._handle_turn_started(turn_number)
 
-            @turn_tracker.event_handler("on_turn_started")
-            async def on_turn_started(tracker, turn_number):
-                await self._handle_turn_started(turn_number)
+        @turn_tracker.event_handler("on_turn_ended")
+        async def on_turn_ended(tracker, turn_number, duration, was_interrupted):
+            await self._handle_turn_ended(turn_number, duration, was_interrupted)
 
-            @turn_tracker.event_handler("on_turn_ended")
-            async def on_turn_ended(tracker, turn_number, duration, was_interrupted):
-                await self._handle_turn_ended(turn_number, duration, was_interrupted)
+        @latency_tracker.event_handler("on_latency_measured")
+        async def on_latency_measured(tracker, latency_seconds):
+            await self._handle_latency_measured(latency_seconds)
+
+    async def _handle_latency_measured(self, latency_seconds: float):
+        """Handle latency measurement events.
+
+        Called when the latency tracker measures user-to-bot latency.
+        Adds the latency as an attribute to the current turn span.
+
+        Args:
+            latency_seconds: The measured latency in seconds.
+        """
+        if self._current_span and is_tracing_available():
+            self._current_span.set_attribute("turn.user_bot_latency_seconds", latency_seconds)
+            logger.debug(
+                f"Turn {self._current_turn_number} user-bot latency: {latency_seconds:.3f}s"
+            )
 
     async def on_push_frame(self, data: FramePushed):
         """Process a frame without modifying it.

--- a/tests/test_user_bot_latency_observer.py
+++ b/tests/test_user_bot_latency_observer.py
@@ -1,0 +1,137 @@
+import unittest
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
+from pipecat.processors.filters.identity_filter import IdentityFilter
+from pipecat.tests.utils import run_test
+
+
+class TestUserBotLatencyObserver(unittest.IsolatedAsyncioTestCase):
+    """Tests for UserBotLatencyObserver."""
+
+    async def test_normal_latency_measurement(self):
+        """Test basic latency measurement from user stop to bot start."""
+        # Create observer
+        observer = UserBotLatencyObserver()
+
+        # Create identity filter (passes all frames through)
+        processor = IdentityFilter()
+
+        # Capture latency events
+        latencies = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        # Define frame sequence
+        frames_to_send = [
+            VADUserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            VADUserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+        ]
+
+        # Run test
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[observer],
+        )
+
+        # Verify latency was measured
+        self.assertEqual(len(latencies), 1)
+        self.assertGreater(latencies[0], 0)
+        self.assertLess(latencies[0], 1.0)  # Should be very quick
+
+    async def test_multiple_latency_measurements(self):
+        """Test that multiple user-bot exchanges produce separate latency events."""
+        # Create observer
+        observer = UserBotLatencyObserver()
+
+        # Create identity filter
+        processor = IdentityFilter()
+
+        # Capture latency events
+        latencies = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        # Define frame sequence with two complete cycles
+        frames_to_send = [
+            # First cycle
+            VADUserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+            # Second cycle
+            VADUserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            VADUserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+            VADUserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+        ]
+
+        # Run test
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[observer],
+        )
+
+        # Verify two separate latencies were measured
+        self.assertEqual(len(latencies), 2)
+        self.assertGreater(latencies[0], 0)
+        self.assertGreater(latencies[1], 0)
+
+    async def test_no_measurement_without_user_stop(self):
+        """Test that latency is not measured if bot starts without user stopping first."""
+        # Create observer
+        observer = UserBotLatencyObserver()
+
+        # Create identity filter
+        processor = IdentityFilter()
+
+        # Capture latency events
+        latencies = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        # Define frame sequence - bot starts without user stop
+        frames_to_send = [
+            BotStartedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            BotStartedSpeakingFrame,
+        ]
+
+        # Run test
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[observer],
+        )
+
+        # Verify no latency was measured
+        self.assertEqual(len(latencies), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is intended to provide more insights into potential problems during a conversation by adding a `user_bot_latency_seconds` attribute to OpenTelemetry turn spans.

I created `UserBotLatencyObserver` to abstract the actual latency tracking so it can be reused by the existing `UserBotLatencyLogObserver` and included directly in `TurnTraceObserver`, following the same pattern as `TurnTrackingObserver`.

Below is a screenshot showing the `user_bot_latency_seconds` being rendered in [Finchvox](https://github.com/itsderek23/finchvox/):

<img width="1437" height="683" alt="image" src="https://github.com/user-attachments/assets/75faae3e-5f52-4e93-a8fc-d72005be8dfd" />

Here is the raw span as well:

```json
{
  "trace_id": "hKgttwU0ynjgpQw6q0OgeA==",
  "span_id": "+0pOdMKLd3k=",
  "parent_span_id": "pbym7ya48ko=",
  "name": "turn",
  "kind": "SPAN_KIND_INTERNAL",
  "start_time_unix_nano": "1767551104418988000",
  "end_time_unix_nano": "1767551126286140000",
  "attributes": [
    {
      "key": "turn.number",
      "value": {
        "int_value": "3"
      }
    },
    {
      "key": "turn.type",
      "value": {
        "string_value": "conversation"
      }
    },
    {
      "key": "conversation.id",
      "value": {
        "string_value": "212b72b0-91a8-47d4-b2cb-cd4c32304d92"
      }
    },
    {
      "key": "turn.user_bot_latency_seconds",
      "value": {
        "double_value": 4.258035898208618
      }
    },
    {
      "key": "turn.duration_seconds",
      "value": {
        "double_value": 21.867765208
      }
    },
    {
      "key": "turn.was_interrupted",
      "value": {
        "bool_value": true
      }
    }
  ],
  "status": {},
  "flags": 256,
  "trace_id_hex": "84a82db70534ca78e0a50c3aab43a078",
  "span_id_hex": "fb4a4e74c28b7779",
  "parent_span_id_hex": "a5bca6ef26b8f24a",
  "resource": {
    "attributes": [
      {
        "key": "telemetry.sdk.language",
        "value": {
          "string_value": "python"
        }
      },
      {
        "key": "telemetry.sdk.name",
        "value": {
          "string_value": "opentelemetry"
        }
      },
      {
        "key": "telemetry.sdk.version",
        "value": {
          "string_value": "1.39.1"
        }
      },
      {
        "key": "service.name",
        "value": {
          "string_value": "switch-voices"
        }
      },
      {
        "key": "service.instance.id",
        "value": {
          "string_value": "unknown"
        }
      },
      {
        "key": "deployment.environment",
        "value": {
          "string_value": "development"
        }
      }
    ]
  },
  "instrumentation_scope": {
    "name": "pipecat.turn"
  }
}
```
