### PR TITLE
Lazy-load NLTK to avoid import-time downloads

### DIFF
--- a/changelog/3382.fixed.md
+++ b/changelog/3382.fixed.md
@@ -1,0 +1,1 @@
+- Fixed NLTK import-time downloads causing failures in read-only container filesystems by lazy-loading the tokenizer data.

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -17,33 +17,24 @@ Dependencies:
     Source: https://www.nltk.org/api/nltk.tokenize.punkt.html
 """
 
+import functools
 import re
 from dataclasses import dataclass
 from typing import FrozenSet, List, Optional, Sequence, Tuple
 
 from loguru import logger
 
-# Lazy-loaded NLTK components
-_nltk_initialized = False
-_sent_tokenize = None
 
-
-def _ensure_nltk_initialized():
-    """Lazily initialize NLTK and download required data.
+@functools.lru_cache(maxsize=1)
+def _get_sent_tokenize():
+    """Lazily initialize NLTK and return the sent_tokenize function.
 
     This function is called on-demand when sentence tokenization is needed,
     avoiding import-time downloads that can fail in containerized environments
     where the filesystem may be read-only.
     """
-    global _nltk_initialized, _sent_tokenize
-
-    if _nltk_initialized:
-        return
-
     import nltk
     from nltk.tokenize import sent_tokenize
-
-    _sent_tokenize = sent_tokenize
 
     # Ensure punkt_tab tokenizer data is available
     try:
@@ -61,7 +52,7 @@ def _ensure_nltk_initialized():
                 "See https://www.nltk.org/data.html for more information."
             )
 
-    _nltk_initialized = True
+    return sent_tokenize
 
 
 SENTENCE_ENDING_PUNCTUATION: FrozenSet[str] = frozenset(
@@ -158,16 +149,14 @@ def match_endofsentence(text: str) -> int:
     Returns:
         The position of the end of the sentence if found, otherwise 0.
     """
-    # Lazily initialize NLTK on first use
-    _ensure_nltk_initialized()
-
     text = text.rstrip()
 
     if not text:
         return 0
 
     # Use NLTK's sentence tokenizer to find sentence boundaries
-    sentences = _sent_tokenize(text)
+    sent_tokenize = _get_sent_tokenize()
+    sentences = sent_tokenize(text)
 
     if not sentences:
         return 0

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -21,25 +21,48 @@ import re
 from dataclasses import dataclass
 from typing import FrozenSet, List, Optional, Sequence, Tuple
 
-import nltk
 from loguru import logger
-from nltk.tokenize import sent_tokenize
 
-# Ensure punkt_tab tokenizer data is available
-try:
-    nltk.data.find("tokenizers/punkt_tab")
-except LookupError:
+# Lazy-loaded NLTK components
+_nltk_initialized = False
+_sent_tokenize = None
+
+
+def _ensure_nltk_initialized():
+    """Lazily initialize NLTK and download required data.
+
+    This function is called on-demand when sentence tokenization is needed,
+    avoiding import-time downloads that can fail in containerized environments
+    where the filesystem may be read-only.
+    """
+    global _nltk_initialized, _sent_tokenize
+
+    if _nltk_initialized:
+        return
+
+    import nltk
+    from nltk.tokenize import sent_tokenize
+
+    _sent_tokenize = sent_tokenize
+
+    # Ensure punkt_tab tokenizer data is available
     try:
-        nltk.download("punkt_tab", quiet=True)
-    except (OSError, PermissionError) as e:
-        logger.error(
-            f"Failed to download NLTK 'punkt_tab' tokenizer data: {e}. "
-            "This data is required for sentence tokenization features. "
-            "The download failed due to filesystem permissions. "
-            "To resolve: pre-install the data in a location with appropriate read permissions, "
-            "or set the NLTK_DATA environment variable to point to a writable directory. "
-            "See https://www.nltk.org/data.html for more information."
-        )
+        nltk.data.find("tokenizers/punkt_tab")
+    except LookupError:
+        try:
+            nltk.download("punkt_tab", quiet=True)
+        except (OSError, PermissionError) as e:
+            logger.error(
+                f"Failed to download NLTK 'punkt_tab' tokenizer data: {e}. "
+                "This data is required for sentence tokenization features. "
+                "The download failed due to filesystem permissions. "
+                "To resolve: pre-install the data in a location with appropriate read permissions, "
+                "or set the NLTK_DATA environment variable to point to a writable directory. "
+                "See https://www.nltk.org/data.html for more information."
+            )
+
+    _nltk_initialized = True
+
 
 SENTENCE_ENDING_PUNCTUATION: FrozenSet[str] = frozenset(
     {
@@ -135,13 +158,16 @@ def match_endofsentence(text: str) -> int:
     Returns:
         The position of the end of the sentence if found, otherwise 0.
     """
+    # Lazily initialize NLTK on first use
+    _ensure_nltk_initialized()
+
     text = text.rstrip()
 
     if not text:
         return 0
 
     # Use NLTK's sentence tokenizer to find sentence boundaries
-    sentences = sent_tokenize(text)
+    sentences = _sent_tokenize(text)
 
     if not sentences:
         return 0


### PR DESCRIPTION
## Summary

This PR defers NLTK initialization until `match_endofsentence()` is actually called, rather than at module import time.

## Problem

Currently, `pipecat/utils/string.py` imports NLTK and attempts to download `punkt_tab` data at module import time (lines 24-42). This causes issues in containerized environments where:

- The home directory may not exist or be writable (e.g., non-root users in Docker)
- Network access may be restricted during startup
- Users may not need sentence tokenization features at all (e.g., when using smart TTS services like ElevenLabs that handle buffering internally)

While PR #2786 made the error non-fatal, users still see error logs even when they don't use sentence aggregation features.

## Solution

Move NLTK import and initialization into a lazy-loading function that's called on first use of `match_endofsentence()`. This follows the same pattern as PR #2692 which lazy-loaded WebRTC components.

**Before:**
```python
import nltk
from nltk.tokenize import sent_tokenize

# Downloads at import time - fails in read-only containers
try:
    nltk.data.find("tokenizers/punkt_tab")
except LookupError:
    nltk.download("punkt_tab", quiet=True)
```

**After:**
```python
_nltk_initialized = False
_sent_tokenize = None

def _ensure_nltk_initialized():
    global _nltk_initialized, _sent_tokenize
    if _nltk_initialized:
        return
    import nltk
    from nltk.tokenize import sent_tokenize
    _sent_tokenize = sent_tokenize
    # ... download logic ...
    _nltk_initialized = True

def match_endofsentence(text: str) -> int:
    _ensure_nltk_initialized()  # Only loads when actually needed
    # ...
```

## Benefits

- Users who don't use `SentenceAggregator` or `match_endofsentence()` won't see NLTK-related errors
- Faster import time for users who don't need sentence tokenization
- Better compatibility with read-only container filesystems
- Existing error handling preserved for users who do use the feature

## Testing

- Verified that importing `pipecat.utils.string` no longer triggers NLTK download
- Verified that `match_endofsentence()` still works correctly when called
- Existing tests in `test_utils_string.py` should continue to pass