### PR TITLE
Deprecate support for vad_events in DeepgramSTTService

### DIFF
--- a/changelog/3386.deprecated.md
+++ b/changelog/3386.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated support for the `vad_events` `LiveOptions` in `DeepgramSTTService`. Instead, use a local Silero VAD for VAD events. Additionally, deprecated `should_interrupt` which will be removed along with `vad_events` support in a future release.

--- a/scripts/evals/run-release-evals.py
+++ b/scripts/evals/run-release-evals.py
@@ -105,7 +105,6 @@ TESTS_07 = [
     ("07c-interruptible-deepgram.py", EVAL_SIMPLE_MATH),
     ("07c-interruptible-deepgram-flux.py", EVAL_SIMPLE_MATH),
     ("07c-interruptible-deepgram-http.py", EVAL_SIMPLE_MATH),
-    ("07c-interruptible-deepgram-vad.py", EVAL_SIMPLE_MATH),
     ("07d-interruptible-elevenlabs.py", EVAL_SIMPLE_MATH),
     ("07d-interruptible-elevenlabs-http.py", EVAL_SIMPLE_MATH),
     ("07f-interruptible-azure.py", EVAL_SIMPLE_MATH),

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -48,8 +48,7 @@ class DeepgramSTTService(STTService):
     """Deepgram speech-to-text service.
 
     Provides real-time speech recognition using Deepgram's WebSocket API.
-    Supports configurable models, languages, VAD events, and various audio
-    processing options.
+    Supports configurable models, languages, and various audio processing options.
     """
 
     def __init__(
@@ -78,7 +77,14 @@ class DeepgramSTTService(STTService):
             live_options: Deepgram LiveOptions for detailed configuration.
             addons: Additional Deepgram features to enable.
             should_interrupt: Determine whether the bot should be interrupted when Deepgram VAD events are enabled and the system detects that the user is speaking.
+
+                .. deprecated:: 0.0.99
+                    This parameter will be removed along with `vad_events` support.
+
             **kwargs: Additional arguments passed to the parent STTService.
+
+        Note:
+            The `vad_events` option in LiveOptions is deprecated as of version 0.0.99 and will be removed in a future version. Please use the Silero VAD instead.
         """
         sample_rate = sample_rate or (live_options.sample_rate if live_options else None)
         super().__init__(sample_rate=sample_rate, **kwargs)
@@ -122,6 +128,18 @@ class DeepgramSTTService(STTService):
         self._settings = merged_options
         self._addons = addons
         self._should_interrupt = should_interrupt
+
+        if merged_options.get("vad_events"):
+            import warnings
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "The 'vad_events' parameter is deprecated and will be removed in a future version. "
+                    "Please use the Silero VAD instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
         self._client = DeepgramClient(
             api_key,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The Deepgram team recommends using either a local VAD, like Silero, or Flux over the server-side vad_events. Due to performance issues, we're deprecated support.

@filipi87 this includes also deprecating the newly added `support_interruptions` feature. I don't love this sequence, but it works given the changes in 0.0.99. Any other ideas?

I'm also removing the 07c VAD variant from the release evals.