### PR TITLE
smartturn: rename on_vad_start_secs_updated to update_vad_start_secs

### DIFF
--- a/src/pipecat/audio/turn/base_turn_analyzer.py
+++ b/src/pipecat/audio/turn/base_turn_analyzer.py
@@ -116,8 +116,8 @@ class BaseTurnAnalyzer(ABC):
         """
         pass
 
-    def on_vad_start_secs_updated(self, vad_start_secs: float):
-        """Invoked when the VAD start trigger time is updated.
+    def update_vad_start_secs(self, vad_start_secs: float):
+        """Update the VAD start trigger time.
 
         The turn analyzer may choose to change its buffer size depending
         on this value.

--- a/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/base_smart_turn.py
@@ -162,7 +162,7 @@ class BaseSmartTurn(BaseTurnAnalyzer):
         logger.debug(f"End of Turn result: {state}")
         return state, result
 
-    def on_vad_start_secs_updated(self, vad_start_secs: float):
+    def update_vad_start_secs(self, vad_start_secs: float):
         """Store the new vad_start_secs value."""
         self._vad_start_secs = vad_start_secs
 

--- a/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
@@ -114,7 +114,7 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
         audio collected during that confirmation window, so we let the analyzer know
         when this value has changed.
         """
-        self._turn_analyzer.on_vad_start_secs_updated(frame.vad_params.start_secs)
+        self._turn_analyzer.update_vad_start_secs(frame.vad_params.start_secs)
 
     async def _handle_input_audio(self, frame: InputAudioRawFrame):
         """Handle input audio to check if the turn is completed."""


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Renaming `on_vad_start_secs_updated` to `update_vad_start_secs`. This is to avoid confusion since we usually use `on_*` for actual events. Also, you could just call  `update_vad_start_secs` manually without needing a frame.