### PR TITLE
examples(foundational): add missing transport.output() to 49c

### DIFF
--- a/examples/foundational/49c-thinking-functions-anthropic.py
+++ b/examples/foundational/49c-thinking-functions-anthropic.py
@@ -127,6 +127,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             user_aggregator,  # User responses
             llm,  # LLM
             tts,  # TTS
+            transport.output(),  # Transport bot output
             assistant_aggregator,  # Assistant spoken responses
         ]
     )


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Add missing `transport.output()` that was removed by mistake in #3385 .