### PR TITLE
GroqTTSService: switch to canopylabs/orpheus-v1-english

### DIFF
--- a/changelog/3399.changed.md
+++ b/changelog/3399.changed.md
@@ -1,0 +1,1 @@
+- Updated default model for `GroqTTSService` to `canopylabs/orpheus-v1-english` and voice ID to `autumn`.

--- a/src/pipecat/services/groq/tts.py
+++ b/src/pipecat/services/groq/tts.py
@@ -59,8 +59,8 @@ class GroqTTSService(TTSService):
         api_key: str,
         output_format: str = "wav",
         params: Optional[InputParams] = None,
-        model_name: str = "playai-tts",
-        voice_id: str = "Celeste-PlayAI",
+        model_name: str = "canopylabs/orpheus-v1-english",
+        voice_id: str = "autumn",
         sample_rate: Optional[int] = GROQ_SAMPLE_RATE,
         **kwargs,
     ):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Model `playai-tts` is deprecated see (https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic). Switch to `canopylabs/orpheus-v1-english`.