### PR TITLE
BaseOutputTransport: ensure bot speaking flag is set on time

### DIFF
--- a/changelog/3400.fixed.md
+++ b/changelog/3400.fixed.md
@@ -1,0 +1,1 @@
+- Fixed timing issue in `BaseOutputTransport` where the bot speaking flag was set after awaiting, allowing the event loop to re-enter the method before the guard was set.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This PR makes sure the internal `self._bot_speaking` flag is quickly set before any other task can take control in the asyncio event loop. The `await` calls might cause the event loop to potentially switch tasks.