### PR TITLE
feat: handle server_content.interrupted for faster interruptions

### DIFF
--- a/changelog/3429.added.md
+++ b/changelog/3429.added.md
@@ -1,0 +1,1 @@
+- Added handling for `server_content.interrupted` signal in Gemini Live services for faster interruption response.

--- a/changelog/3429.added.md
+++ b/changelog/3429.added.md
@@ -1,1 +1,1 @@
-- Added handling for `server_content.interrupted` signal in Gemini Live services for faster interruption response.
+- Added handling for `server_content.interrupted` signal in the Gemini Live service for faster interruption response in the case where there isn't already turn tracking in the pipeline, e.g. local VAD + context aggregators. When there is already turn tracking in the pipeline, the additional interruption does no harm.

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1198,7 +1198,11 @@ class GeminiLiveLLMService(LLMService):
                         # Reset failure counter if connection has been stable
                         self._check_and_reset_failure_counter()
 
-                        if message.server_content and message.server_content.model_turn:
+                        if message.server_content and message.server_content.interrupted:
+                            logger.debug("Gemini VAD: interrupted signal received")
+                            await self.broadcast_frame(UserStartedSpeakingFrame())
+                            await self.push_interruption_task_frame_and_wait()
+                        elif message.server_content and message.server_content.model_turn:
                             await self._handle_msg_model_turn(message)
                         elif (
                             message.server_content

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1199,8 +1199,17 @@ class GeminiLiveLLMService(LLMService):
                         self._check_and_reset_failure_counter()
 
                         if message.server_content and message.server_content.interrupted:
+                            # NOTE: while the service triggers interruptions in
+                            # the specific case of barge-ins, it does *not*
+                            # emit UserStarted/StoppedSpeakingFrames, as the
+                            # Gemini Live API does not give us broadly reliable
+                            # signals to base those off of. Pipelines that
+                            # require turn tracking (like those using context
+                            # aggregators) still need an independent way to
+                            # track turns, such as local Silero VAD in
+                            # combination with the context aggregator default
+                            # turn strategies.
                             logger.debug("Gemini VAD: interrupted signal received")
-                            await self.broadcast_frame(UserStartedSpeakingFrame())
                             await self.push_interruption_task_frame_and_wait()
                         elif message.server_content and message.server_content.model_turn:
                             await self._handle_msg_model_turn(message)


### PR DESCRIPTION
## Summary
- [x] Handle `server_content.interrupted` signal in GeminiLiveLLMService message loop.
- [x] Provides ~700-1100ms faster interruptions when not using local VAD.

## Problem
When using GeminiLiveLLMService without local VAD (Silero), interruptions were delayed because the service waited for `input_transcription`. Gemini sends `server_content.interrupted` instantly when its VAD detects speech.

## Approach
Added inline handling in the message loop - no new methods or config flags.

**Alternatives considered:**
- Add config flag (`use_native_vad_interruptions`) - rejected per YAGNI, no one has asked for it
- Create separate handler method - rejected, 3 lines of code doesn't warrant abstraction

**Why this is safe:** `_handle_interruption()` is idempotent, so duplicate signals (from both local VAD and Gemini) are harmless.

Fixes #3381