### PR TITLE
Update GeminiLiveLLMService to push thought frames, update 26a for new transcript events

### DIFF
--- a/changelog/3431.changed.md
+++ b/changelog/3431.changed.md
@@ -1,0 +1,1 @@
+- Updated `GeminiLiveLLMService` to push `LLMThoughtStartFrame`, `LLMThoughtTextFrame`, and `LLMThoughtEndFrame` when the model returns thought content.

--- a/examples/foundational/26a-gemini-live-transcription.py
+++ b/examples/foundational/26a-gemini-live-transcription.py
@@ -12,13 +12,16 @@ from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
-from pipecat.frames.frames import LLMRunFrame, TranscriptionMessage
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
-from pipecat.processors.transcript_processor import TranscriptProcessor
+from pipecat.processors.aggregators.llm_response_universal import (
+    AssistantTurnStoppedMessage,
+    LLMContextAggregatorPair,
+    UserTurnStoppedMessage,
+)
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
@@ -93,17 +96,16 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     )
     context_aggregator = LLMContextAggregatorPair(context)
 
-    transcript = TranscriptProcessor()
+    user_aggregator = context_aggregator.user()
+    assistant_aggregator = context_aggregator.assistant()
 
     pipeline = Pipeline(
         [
             transport.input(),
-            context_aggregator.user(),
-            transcript.user(),
+            user_aggregator,
             llm,
             transport.output(),
-            transcript.assistant(),
-            context_aggregator.assistant(),
+            assistant_aggregator,
         ]
     )
 
@@ -127,14 +129,17 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info(f"Client disconnected")
         await task.cancel()
 
-    # Register event handler for transcript updates
-    @transcript.event_handler("on_transcript_update")
-    async def on_transcript_update(processor, frame):
-        for msg in frame.messages:
-            if isinstance(msg, TranscriptionMessage):
-                timestamp = f"[{msg.timestamp}] " if msg.timestamp else ""
-                line = f"{timestamp}{msg.role}: {msg.content}"
-                logger.info(f"Transcript: {line}")
+    @user_aggregator.event_handler("on_user_turn_stopped")
+    async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
+        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
+        line = f"{timestamp}user: {message.content}"
+        logger.info(f"Transcript: {line}")
+
+    @assistant_aggregator.event_handler("on_assistant_turn_stopped")
+    async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
+        line = f"{timestamp}assistant: {message.content}"
+        logger.info(f"Transcript: {line}")
 
     runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
 

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1464,7 +1464,7 @@ class GeminiLiveLLMService(LLMService):
                 # so bracket each thought in start/end frames
                 await self.push_frame(LLMThoughtStartFrame())
                 await self.push_frame(LLMThoughtTextFrame(text))
-                await self.push_frame(LLMThoughtEndFrame(signature=part.thought_signature))
+                await self.push_frame(LLMThoughtEndFrame())
             else:
                 # Regular text response
                 self._bot_text_buffer += text


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In porting the realtime LLM examples to use the new transcription events from the context aggregators, I found that the transcript showed both the thinking and spoken data. This means that the context includes that data as well, which is not desired.

This update handles the `part.thought` content and pushes `LLMThoughtStartFrame`, `LLMThoughtTextFrame`, and `LLMThoughtEndFrame`.

Also, 26a is updated to use the new transcription events.

Notes:

- The new Gemini Live models only have an audio+text mode; no text only mode. This means that you'll get these frames by default, unless the thinking budget is set to 0.
  - LLMFullResponseStartFrame
  - TTSTextFrame
  - LLMFullResponseEndFrame
  - LLMThoughtStartFrame
  - LLMThoughtTextFrame
  - LLMThoughtEndFrame

- If the thinking budget is set to 0, you'll get these frames, which matches the previous behavior:
  - LLMFullResponseStartFrame
  - TTSTextFrame
  - LLMFullResponseEndFrame