### PR TITLE
feat: implement LLMMessagesAppendFrame for OpenAI Realtime services

### DIFF
--- a/changelog/messages-append-openai-realtime.added.md
+++ b/changelog/messages-append-openai-realtime.added.md
@@ -1,0 +1,1 @@
+- Added `LLMMessagesAppendFrame` support for `OpenAIRealtimeLLMService` and `OpenAIRealtimeBetaLLMService`, enabling programmatic message injection and bot response triggering.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -448,8 +448,56 @@ class OpenAIRealtimeLLMService(LLMService):
             # Send results for newly-completed function calls, if any.
             await self._process_completed_function_calls(send_new_results=True)
 
-    async def _handle_messages_append(self, frame):
-        logger.error("!!! NEED TO IMPLEMENT MESSAGES APPEND")
+    async def _handle_messages_append(self, frame: LLMMessagesAppendFrame):
+        """Handle appending messages to the conversation and optionally triggering a response.
+
+        Converts messages from the frame to OpenAI Realtime conversation items and sends
+        them to the API. If `frame.run_llm` is True, triggers a response generation.
+
+        Args:
+            frame: Frame containing messages to append and whether to trigger LLM response.
+        """
+        for message in frame.messages:
+            role = message.get("role")
+            content = message.get("content")
+
+            # Convert content to string if it's a list
+            if isinstance(content, list):
+                # Handle content list format (e.g., [{"type": "text", "text": "..."}])
+                text_parts = []
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = " ".join(text_parts)
+
+            # Determine content type based on role
+            # User messages use "input_text", assistant/system messages use "text"
+            if role == "user":
+                content_type = "input_text"
+            else:
+                content_type = "text"
+
+            # Create conversation item
+            item = events.ConversationItem(
+                type="message",
+                role=role,
+                content=[events.ItemContent(type=content_type, text=content)],
+            )
+
+            # Send the conversation item
+            await self.send_client_event(events.ConversationItemCreateEvent(item=item))
+
+        # Trigger response if requested
+        if frame.run_llm:
+            await self.send_client_event(
+                events.ResponseCreateEvent(
+                    response=events.ResponseProperties(
+                        output_modalities=self._get_enabled_modalities()
+                    )
+                )
+            )
 
     #
     # websocket communication


### PR DESCRIPTION
Implement the _handle_messages_append method for OpenAIRealtimeLLMService and OpenAIRealtimeBetaLLMService to support programmatic message injection and bot response triggering.

This enables use cases like:
- Making the bot speak first by injecting a prompt message
- Adding context messages to the conversation programmatically
- Triggering responses without audio input

The implementation:
- Converts messages from LLMMessagesAppendFrame to ConversationItem objects
- Uses "input_text" content type for user messages, "text" for others
- Sends each message via ConversationItemCreateEvent
- Triggers ResponseCreateEvent if frame.run_llm is True