### PR TITLE
fix: change FrameProcessorResumeFrame to SystemFrame to fix deadlock

### DIFF
--- a/changelog/3448.fixed.md
+++ b/changelog/3448.fixed.md
@@ -1,0 +1,1 @@
+- Fixed deadlock caused by `FrameProcessorResumeFrame` waiting in the process queue by changing it to a `SystemFrame`.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1106,6 +1106,11 @@ class FrameProcessorResumeUrgentFrame(SystemFrame):
     if it was previously paused as fast as possible. After resuming frame
     processing all queued frames will be processed in the order received.
 
+    Note:
+        This frame is now equivalent to FrameProcessorResumeFrame, which was
+        changed to a SystemFrame to fix a bug where resume frames would get
+        stuck in the blocked processing queue.
+
     Parameters:
         processor: The frame processor to resume.
     """
@@ -1832,12 +1837,19 @@ class FrameProcessorPauseFrame(ControlFrame):
 
 
 @dataclass
-class FrameProcessorResumeFrame(ControlFrame):
+class FrameProcessorResumeFrame(SystemFrame):
     """Frame to resume frame processing for a specific processor.
 
     This frame is used to resume frame processing for the given processor if
     it was previously paused. After resuming frame processing all queued frames
     will be processed in the order received.
+
+    This is a SystemFrame to ensure it bypasses the blocked processing queue
+    when the processor is paused. Otherwise, the resume frame would get queued
+    and never processed.
+
+    Note:
+        This frame is now equivalent to FrameProcessorResumeUrgentFrame.
 
     Parameters:
         processor: The frame processor to resume.


### PR DESCRIPTION
## Summary
- [x] Changed `FrameProcessorResumeFrame` from `ControlFrame` to `SystemFrame`.
- [x] Updated docstrings for both `FrameProcessorResumeFrame` and `FrameProcessorResumeUrgentFrame`.

## Problem
`FrameProcessorResumeFrame` was a `ControlFrame`, which meant it got queued in the processing queue. When a processor was paused, the queue was blocked waiting on an event, so the resume frame would never be processed - causing a deadlock.

The workaround was to use `FrameProcessorResumeUrgentFrame` (a `SystemFrame`), which bypasses the queue.

## Solution
Changed `FrameProcessorResumeFrame` to inherit from `SystemFrame` so it bypasses the blocked queue and is processed immediately. This makes it equivalent to `FrameProcessorResumeUrgentFrame`.

## Reasoning

**Internal vs External usage pattern:**
- Internal code (TTS service, ParallelPipeline, Neuphonic) calls `resume_processing_frames()` directly on `self` - this works fine.
- `FrameProcessorResumeFrame` is for external control via `task.queue_frames()` - this is where the bug occurs.

**Low risk change:**
- No usages of `FrameProcessorResumeFrame()` or `FrameProcessorPauseFrame()` found in the codebase or examples.
- These frames are defined but unused in practice - internal code uses direct method calls.
- The symmetric design (both as ControlFrame) was likely theoretical but didn't account for the blocked queue edge case.

**Why SystemFrame is correct:**
- A resume frame IS a system-level operation that should be processed immediately.
- Uses the type system rather than adding special-case handling in the processing loop.
- `FrameProcessorResumeUrgentFrame` remains available for backwards compatibility.

Fixes #3114