### PR TITLE
fix to make on_user_turn_stop_timeout work with ExternalUserTurnStrat…

### DIFF
--- a/changelog/3454.fixed.md
+++ b/changelog/3454.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `on_user_turn_stop_timeout` could fire while a user is talking when using `ExternalUserTurnStrategies`.


### PR DESCRIPTION
…egies

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

In testing 07c-interruptible-deepgram-flux.py, if you speak for a long time, you'll see this logged mid output:
```
LLMUserAggregator#0: User stopped speaking (strategy: None)
```

This is the `on_user_turn_stop_timeout` firing. The issue is that the timeout looks for speaking as measured only by VADUserStarted/StoppedSpeakingFrames. This fix adds logic to allow UserStarted/StoppedSpeakingFrames to block the timeout from firing as well.