### PR TITLE
UserTurnController: reset user turn start strategies when turn triggered

### DIFF
--- a/changelog/3455.fixed.md
+++ b/changelog/3455.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where user turn start strategies were not being reset after a user turn started, causing incorrect strategy behavior.

--- a/src/pipecat/turns/user_turn_controller.py
+++ b/src/pipecat/turns/user_turn_controller.py
@@ -251,6 +251,10 @@ class UserTurnController(BaseObject):
         self._user_turn = True
         self._user_turn_stop_timeout_event.set()
 
+        # Reset all user turn start strategies to start fresh.
+        for s in self._user_turn_strategies.start or []:
+            await s.reset()
+
         await self._call_event_handler("on_user_turn_started", strategy, params)
 
     async def _trigger_user_turn_stop(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

When moving the logic to `UserTurnController` we removed resetting the start strategies by mistake. They should be reset if a turn is triggered.