### PR TITLE
Reduce Tool Result Context Size by Using UTF-8 for JSON Serialization

### DIFF
--- a/changelog/3457.changed.md
+++ b/changelog/3457.changed.md
@@ -1,0 +1,16 @@
+# Reduce Call Tool Result Context Size by Allowing UTF-8 in JSON Serialization
+
+This PR changes tool result serialization to prevent UTF-8 code points from being escaped during serialization. This drastically reduces the context size when returning a response that contains languages other than English.
+
+We have been running a monkey-patched version in production and it helped us improve the agent accuracy and control cost better.
+
+```
+>>> data = { "message": "أهلًا بالعالم" }
+>>> json.dumps(data)
+'{"message": "\\u0623\\u0647\\u0644\\u064b\\u0627 \\u0628\\u0627\\u0644\\u0639\\u0627\\u0644\\u0645"}'
+>>> 
+>>> 
+>>> 
+>>> json.dumps(data, ensure_ascii=False)
+'{"message": "أهلًا بالعالم"}'
+```

--- a/changelog/3457.changed.md
+++ b/changelog/3457.changed.md
@@ -1,16 +1,1 @@
-# Reduce Call Tool Result Context Size by Allowing UTF-8 in JSON Serialization
-
-This PR changes tool result serialization to prevent UTF-8 code points from being escaped during serialization. This drastically reduces the context size when returning a response that contains languages other than English.
-
-We have been running a monkey-patched version in production and it helped us improve the agent accuracy and control cost better.
-
-```
->>> data = { "message": "أهلًا بالعالم" }
->>> json.dumps(data)
-'{"message": "\\u0623\\u0647\\u0644\\u064b\\u0627 \\u0628\\u0627\\u0644\\u0639\\u0627\\u0644\\u0645"}'
->>> 
->>> 
->>> 
->>> json.dumps(data, ensure_ascii=False)
-'{"message": "أهلًا بالعالم"}'
-```
+- Changed tool result JSON serialization to use `ensure_ascii=False`, preserving UTF-8 characters instead of escaping them. This reduces context size and token usage for non-English languages.

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -1246,7 +1246,7 @@ class AnthropicAssistantContextAggregator(LLMAssistantContextAggregator):
             frame: Frame containing function call result.
         """
         if frame.result:
-            result = json.dumps(frame.result)
+            result = json.dumps(frame.result, ensure_ascii=False)
             await self._update_function_call_result(frame.function_name, frame.tool_call_id, result)
         else:
             await self._update_function_call_result(

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -691,7 +691,7 @@ class AWSBedrockAssistantContextAggregator(LLMAssistantContextAggregator):
             frame: The function call result frame to handle.
         """
         if frame.result:
-            result = json.dumps(frame.result)
+            result = json.dumps(frame.result, ensure_ascii=False)
             await self._update_function_call_result(frame.function_name, frame.tool_call_id, result)
         else:
             await self._update_function_call_result(

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -1044,7 +1044,9 @@ class AWSNovaSonicLLMService(LLMService):
                     "toolResult": {
                         "promptName": self._prompt_name,
                         "contentName": content_name,
-                        "content": json.dumps(result) if isinstance(result, dict) else result,
+                        "content": json.dumps(result, ensure_ascii=False)
+                        if isinstance(result, dict)
+                        else result,
                     }
                 }
             }

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -200,7 +200,9 @@ class GoogleAssistantContextAggregator(OpenAIAssistantContextAggregator):
             if message.role == "user":
                 for part in message.parts:
                     if part.function_response and part.function_response.id == tool_call_id:
-                        part.function_response.response = {"value": json.dumps(result)}
+                        part.function_response.response = {
+                            "value": json.dumps(result, ensure_ascii=False)
+                        }
 
 
 @dataclass

--- a/src/pipecat/services/grok/realtime/llm.py
+++ b/src/pipecat/services/grok/realtime/llm.py
@@ -939,7 +939,7 @@ class GrokRealtimeLLMService(LLMService):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=tool_call_id,
-            output=json.dumps(result),
+            output=json.dumps(result, ensure_ascii=False),
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))
 

--- a/src/pipecat/services/openai/llm.py
+++ b/src/pipecat/services/openai/llm.py
@@ -255,7 +255,7 @@ class OpenAIAssistantContextAggregator(LLMAssistantContextAggregator):
             frame: Frame containing the function call result.
         """
         if frame.result:
-            result = json.dumps(frame.result)
+            result = json.dumps(frame.result, ensure_ascii=False)
             await self._update_function_call_result(frame.function_name, frame.tool_call_id, result)
         else:
             await self._update_function_call_result(

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -1128,7 +1128,7 @@ class OpenAIRealtimeLLMService(LLMService):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=tool_call_id,
-            output=json.dumps(result),
+            output=json.dumps(result, ensure_ascii=False),
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))
 

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -441,7 +441,7 @@ class OpenAIRealtimeBetaLLMService(LLMService):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=frame.tool_call_id,
-            output=json.dumps(frame.result),
+            output=json.dumps(frame.result, ensure_ascii=False),
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))
 


### PR DESCRIPTION
This PR changes tool result serialization to prevent UTF-8 code points from being escaped during serialization. This drastically reduces the context size when returning a response that contains languages other than English.

We have been running a monkey-patched version in production and it helped us improve the agent accuracy and control cost better.

<img width="753" height="162" alt="Screenshot 2026-01-15 at 10 08 03 AM" src="https://github.com/user-attachments/assets/5bc410c2-6d69-427d-aee4-72b184d303f8" />
