### PR TITLE
Allow WebsocketClientTransport to send custom headers

### DIFF
--- a/changelog/3461.added.md
+++ b/changelog/3461.added.md
@@ -1,0 +1,1 @@
+- Added the `additional_headers` param to `WebsocketClientParams`, allowing `WebsocketClientTransport` to send custom headers on connect, for cases such as authentication.

--- a/src/pipecat/transports/websocket/client.py
+++ b/src/pipecat/transports/websocket/client.py
@@ -20,7 +20,6 @@ from typing import Awaitable, Callable, Optional
 import websockets
 from loguru import logger
 from pydantic.main import BaseModel
-from websockets import HeadersLike
 from websockets.asyncio.client import connect as websocket_connect
 
 from pipecat.frames.frames import (


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The `additional_headers` param has been added to allow `WebsocketClientTransport` to send custom headers, for things like authentication.