### PR TITLE
MinWordsUserTurnStartStrategy: don't aggregate transcriptions

### DIFF
--- a/changelog/3462.fixed.md
+++ b/changelog/3462.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `MinWordsUserTurnStartStrategy` to not aggregate transcriptions, preventing incorrect turn starts when words are spoken with pauses between them.

--- a/tests/test_user_turn_controller.py
+++ b/tests/test_user_turn_controller.py
@@ -84,7 +84,7 @@ class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(should_start, 0)
 
         await controller.process_frame(
-            TranscriptionFrame(text=" two three!", user_id="cat", timestamp="")
+            TranscriptionFrame(text="One two three!", user_id="cat", timestamp="")
         )
         self.assertEqual(should_start, 1)
 
@@ -92,13 +92,11 @@ class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(USER_TURN_STOP_TIMEOUT + 0.1)
 
         await controller.process_frame(BotStartedSpeakingFrame())
-        await controller.process_frame(
-            TranscriptionFrame(text="Hello", user_id="cat", timestamp="")
-        )
+        await controller.process_frame(TranscriptionFrame(text="Hi!", user_id="cat", timestamp=""))
         self.assertEqual(should_start, 1)
 
         await controller.process_frame(
-            TranscriptionFrame(text=" there friend!", user_id="cat", timestamp="")
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
         )
         self.assertEqual(should_start, 2)
 

--- a/tests/test_user_turn_start_strategy.py
+++ b/tests/test_user_turn_start_strategy.py
@@ -38,7 +38,7 @@ class TestMinWordsInterruptionStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(should_start)
 
         await strategy.process_frame(
-            TranscriptionFrame(text=" there!", user_id="cat", timestamp="")
+            TranscriptionFrame(text="Hello there!", user_id="cat", timestamp="")
         )
         self.assertTrue(should_start)
 
@@ -54,6 +54,26 @@ class TestMinWordsInterruptionStrategy(unittest.IsolatedAsyncioTestCase):
             TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
         )
         self.assertTrue(should_start)
+
+    async def test_bot_speaking_singlw_words(self):
+        strategy = MinWordsUserTurnStartStrategy(min_words=3)
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_started")
+        async def on_user_turn_started(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(TranscriptionFrame(text="One", user_id="cat", timestamp=""))
+        self.assertFalse(should_start)
+
+        await strategy.process_frame(TranscriptionFrame(text="Two", user_id="cat", timestamp=""))
+        self.assertFalse(should_start)
+
+        await strategy.process_frame(TranscriptionFrame(text="Three", user_id="cat", timestamp=""))
+        self.assertFalse(should_start)
 
     async def test_bot_speaking_interim_transcriptions(self):
         strategy = MinWordsUserTurnStartStrategy(min_words=2)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

If we aggregate transcriptions we will get incorrect interruptions. For example, if we have a strategy with min_words=3 and we say "One" and pause, then "Two" and pause and then "Three", this would trigger the start of the turn when it shouldn't. We should only look at the incoming transcription text and don't aggregate it with the previous.

