### PR TITLE
Update so that TTSSpeakFrame can be configured to append_to_context

### DIFF
--- a/changelog/3465.changed.md
+++ b/changelog/3465.changed.md
@@ -1,0 +1,1 @@
+- Added a parameter called `append_to_context` to the `TTSSpeakFrame`, which controls whether or not the `TTSSpeakFrame` should be added to the context. By default this value is False.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -341,6 +341,11 @@ class TextFrame(DataFrame):
 
     Parameters:
         text: The text content.
+        skip_tts: Whether this text should be skipped by the TTS service.
+        includes_inter_frame_spaces: Whether any necessary inter-frame (leading/trailing) spaces are already
+            included in the text.
+        append_to_context: Whether this text should be appended to the LLM context.
+            Defaults to True.
     """
 
     text: str
@@ -918,9 +923,12 @@ class TTSSpeakFrame(DataFrame):
 
     Parameters:
         text: The text to be spoken.
+        append_to_context: Whether this text should be appended to the LLM context.
+            Defaults to False.
     """
 
     text: str
+    append_to_context: bool = False
 
 
 @dataclass

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -49,6 +49,7 @@ from pipecat.frames.frames import (
     StartFrame,
     TextFrame,
     TranscriptionFrame,
+    TranslationFrame,
     UserImageRawFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
@@ -639,7 +640,6 @@ class LLMAssistantAggregator(LLMContextAggregator):
                     DeprecationWarning,
                 )
 
-        self._started = 0
         self._function_calls_in_progress: Dict[str, Optional[FunctionCallInProgressFrame]] = {}
         self._function_calls_image_results: Dict[str, UserImageRawFrame] = {}
         self._context_updated_tasks: Set[asyncio.Task] = set()
@@ -758,7 +758,6 @@ class LLMAssistantAggregator(LLMContextAggregator):
 
     async def _handle_interruptions(self, frame: InterruptionFrame):
         await self._trigger_assistant_turn_stopped()
-        self._started = 0
         await self.reset()
 
     async def _handle_function_calls_started(self, frame: FunctionCallsStartedFrame):
@@ -904,15 +903,17 @@ class LLMAssistantAggregator(LLMContextAggregator):
             )
 
     async def _handle_llm_start(self, _: LLMFullResponseStartFrame):
-        self._started += 1
         await self._trigger_assistant_turn_started()
 
     async def _handle_llm_end(self, _: LLMFullResponseEndFrame):
-        self._started -= 1
         await self._trigger_assistant_turn_stopped()
 
     async def _handle_text(self, frame: TextFrame):
-        if not self._started or not frame.append_to_context:
+        # Skip TextFrame types not intended to build the assistant context
+        if isinstance(frame, (TranscriptionFrame, TranslationFrame, InterimTranscriptionFrame)):
+            return
+
+        if not frame.append_to_context:
             return
 
         # Make sure we really have text (spaces count, too!)
@@ -926,18 +927,12 @@ class LLMAssistantAggregator(LLMContextAggregator):
         )
 
     async def _handle_thought_start(self, frame: LLMThoughtStartFrame):
-        if not self._started:
-            return
-
         await self._reset_thought_aggregation()
         self._thought_append_to_context = frame.append_to_context
         self._thought_llm = frame.llm
         self._thought_start_time = time_now_iso8601()
 
     async def _handle_thought_text(self, frame: LLMThoughtTextFrame):
-        if not self._started:
-            return
-
         # Make sure we really have text (spaces count, too!)
         if len(frame.text) == 0:
             return
@@ -949,9 +944,6 @@ class LLMAssistantAggregator(LLMContextAggregator):
         )
 
     async def _handle_thought_end(self, frame: LLMThoughtEndFrame):
-        if not self._started:
-            return
-
         thought = concatenate_aggregated_text(self._thought_aggregation)
 
         if self._thought_append_to_context:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Whether `TTSSpeakFrame` text should be added to the LLM context has been debated. Previously, text was only added to context if it occurred between `LLMFullResponseStartFrame` and `LLMFullResponseEndFrame`, which was limiting and non-obvious.

This change adds an `append_to_context` parameter to `TTSSpeakFrame` (defaults to `False`), giving developers explicit control over whether the spoken text should be added to the LLM context.

**Implementation details:**

- **`TTSSpeakFrame`**: Added `append_to_context: bool = False` parameter

- **`TTSService`**: Modified `_push_tts_frames()` to accept and pass through the `append_to_context` parameter. When `append_to_context` is explicitly set, it's applied to the generated `TTSTextFrame`s; otherwise, the `TTSTextFrame` uses its default (`True`).

- **`WordTTSService`**: This required a slightly awkward workaround. `WordTTSService` classes (like `CartesiaTTSService`) collect word/timestamp tuples asynchronously and emit `TTSTextFrame`s via a task handler (`_words_task_handler`). To propagate the `append_to_context` setting:
  - Override `_push_tts_frames()` to capture the `append_to_context` value into `self._current_append_to_context`
  - The task handler applies this stored value to each word's `TTSTextFrame`
  - **Future consideration**: In a future refactor, merging `TTSService` and `WordTTSService` into a single class hierarchy would make this more natural.

- **`LLMAssistantAggregator`**: Simplified `_handle_text()` to rely solely on the `append_to_context` parameter:
  - Removed the `self._started` check (which required text to be between `LLMFullResponseStartFrame` and `LLMFullResponseEndFrame`)
  - Now any `TextFrame` with `append_to_context=True` will be aggregated and added to context
  - This allows `TTSSpeakFrame`-generated text to be added to context regardless of LLM response boundaries
  - **Note**: This is a simplification that makes the aggregator more flexible - text frames now control their own context inclusion via the `append_to_context` flag

Addresses https://github.com/pipecat-ai/pipecat/issues/3459.