### PR TITLE
Add TalkDesk serializer

### DIFF
--- a/src/pipecat/runner/utils.py
+++ b/src/pipecat/runner/utils.py
@@ -49,6 +49,17 @@ def _detect_transport_type_from_message(message_data: dict) -> str:
     """Attempt to auto-detect transport type from WebSocket message structure."""
     logger.trace("=== Auto-Detection Analysis ===")
 
+    # Talkdesk detection (must be before Twilio as both have streamSid/callSid)
+    # Talkdesk has interaction_id in customParameters which is Talkdesk-specific
+    if (
+        message_data.get("event") == "start"
+        and "start" in message_data
+        and "streamSid" in message_data.get("start", {})
+        and "interaction_id" in message_data.get("start", {}).get("customParameters", {})
+    ):
+        logger.trace("Auto-detected: TALKDESK")
+        return "talkdesk"
+
     # Twilio detection
     if (
         message_data.get("event") == "start"
@@ -135,6 +146,16 @@ async def parse_telephony_websocket(websocket: WebSocket):
                 "to": str,
             }
 
+        - Talkdesk::
+
+            {
+                "stream_id": str,
+                "interaction_id": str,
+                "account_id": str,
+                "correlation_id": str,
+                "custom_parameters": dict,
+            }
+
     Example usage::
 
         transport_type, call_data = await parse_telephony_websocket(websocket)
@@ -180,7 +201,18 @@ async def parse_telephony_websocket(websocket: WebSocket):
             logger.warning("Could not auto-detect transport type")
 
         # Extract provider-specific data
-        if transport_type == "twilio":
+        if transport_type == "talkdesk":
+            start_data = call_data_raw.get("start", {})
+            custom_params = start_data.get("customParameters", {})
+            call_data = {
+                "stream_id": start_data.get("streamSid"),
+                "interaction_id": custom_params.get("interaction_id"),
+                "account_id": custom_params.get("account_id"),
+                "correlation_id": custom_params.get("correlation_id"),
+                "custom_parameters": custom_params,
+            }
+
+        elif transport_type == "twilio":
             start_data = call_data_raw.get("start", {})
             body_data = start_data.get("customParameters", {})
             call_data = {
@@ -411,7 +443,7 @@ async def _create_telephony_transport(
     Args:
         websocket: FastAPI WebSocket connection from telephony provider
         params: FastAPIWebsocketParams (required)
-        transport_type: Pre-detected provider type ("twilio", "telnyx", "plivo")
+        transport_type: Pre-detected provider type ("twilio", "telnyx", "plivo", "exotel", "talkdesk")
         call_data: Pre-parsed call data dict with provider-specific fields
 
     Returns:
@@ -465,10 +497,16 @@ async def _create_telephony_transport(
             stream_sid=call_data["stream_id"],
             call_sid=call_data["call_id"],
         )
+    elif transport_type == "talkdesk":
+        from pipecat.serializers.talkdesk import TalkdeskFrameSerializer
+
+        params.serializer = TalkdeskFrameSerializer(
+            stream_sid=call_data["stream_id"],
+        )
     else:
         raise ValueError(
             f"Unsupported telephony provider: {transport_type}. "
-            f"Supported providers: twilio, telnyx, plivo, exotel"
+            f"Supported providers: twilio, telnyx, plivo, exotel, talkdesk"
         )
 
     return FastAPIWebsocketTransport(websocket=websocket, params=params)
@@ -485,7 +523,7 @@ async def create_transport(
     Args:
         runner_args: Arguments from the runner.
         transport_params: Dict mapping transport names to parameter factory functions.
-            Keys should be: "daily", "webrtc", "twilio", "telnyx", "plivo", "exotel"
+            Keys should be: "daily", "webrtc", "twilio", "telnyx", "plivo", "exotel", "talkdesk"
             Values should be functions that return transport parameters when called.
 
     Returns:
@@ -527,6 +565,12 @@ async def create_transport(
                 # add_wav_header and serializer will be set automatically
             ),
             "exotel": lambda: FastAPIWebsocketParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                vad_analyzer=SileroVADAnalyzer(),
+                # add_wav_header and serializer will be set automatically
+            ),
+            "talkdesk": lambda: FastAPIWebsocketParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
                 vad_analyzer=SileroVADAnalyzer(),

--- a/src/pipecat/serializers/talkdesk.py
+++ b/src/pipecat/serializers/talkdesk.py
@@ -55,11 +55,11 @@ class TalkdeskControlFrame(ControlFrame, UninterruptibleFrame):
     delivered to Talkdesk.
 
     Parameters:
-        action: The control action to perform (hangup or escalate).
-        ring_group: Optional ring group for escalation (defaults to "agents").
+        action: The control action to perform (hangup, error, or escalate).
+        ring_group: Optional ring group for escalation.
     """
 
-    action: TalkdeskControlAction = TalkdeskControlAction.HANGUP
+    action: TalkdeskControlAction
     ring_group: Optional[str] = None
 
 

--- a/src/pipecat/serializers/talkdesk.py
+++ b/src/pipecat/serializers/talkdesk.py
@@ -1,0 +1,220 @@
+#
+# Copyright (c) 2024–2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Talkdesk Media Streams WebSocket protocol serializer for Pipecat."""
+
+import base64
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from loguru import logger
+from pydantic import BaseModel
+
+from pipecat.audio.dtmf.types import KeypadEntry
+from pipecat.audio.utils import create_stream_resampler, pcm_to_ulaw, ulaw_to_pcm
+from pipecat.frames.frames import (
+    AudioRawFrame,
+    ControlFrame,
+    Frame,
+    InputAudioRawFrame,
+    InputDTMFFrame,
+    InterruptionFrame,
+    OutputTransportMessageFrame,
+    OutputTransportMessageUrgentFrame,
+    StartFrame,
+    UninterruptibleFrame,
+)
+from pipecat.serializers.base_serializer import FrameSerializer, FrameSerializerType
+
+
+class TalkdeskControlAction(Enum):
+    """Control actions for Talkdesk call management.
+
+    Parameters:
+        HANGUP: End the call normally.
+        ERROR: End the call due to an error.
+        ESCALATE: Transfer the call to a human agent.
+    """
+
+    HANGUP = "ok"
+    ERROR = "error"
+    ESCALATE = "escalate"
+
+
+@dataclass
+class TalkdeskControlFrame(ControlFrame, UninterruptibleFrame):
+    """Control frame for Talkdesk-specific call management.
+
+    Used to signal call termination or escalation to a human agent.
+    This is an uninterruptible frame to ensure the stop message is always
+    delivered to Talkdesk.
+
+    Parameters:
+        action: The control action to perform (hangup or escalate).
+        ring_group: Optional ring group for escalation (defaults to "agents").
+    """
+
+    action: TalkdeskControlAction = TalkdeskControlAction.HANGUP
+    ring_group: Optional[str] = None
+
+
+class TalkdeskFrameSerializer(FrameSerializer):
+    """Serializer for Talkdesk Media Streams WebSocket protocol.
+
+    This serializer handles converting between Pipecat frames and Talkdesk's WebSocket
+    media streams protocol. It supports audio conversion, DTMF events, and call control
+    (hangup/escalation).
+    """
+
+    class InputParams(BaseModel):
+        """Configuration parameters for TalkdeskFrameSerializer.
+
+        Parameters:
+            talkdesk_sample_rate: Sample rate used by Talkdesk, defaults to 8000 Hz.
+            sample_rate: Optional override for pipeline input sample rate.
+        """
+
+        talkdesk_sample_rate: int = 8000
+        sample_rate: Optional[int] = None
+
+    def __init__(
+        self,
+        stream_sid: str,
+        params: Optional[InputParams] = None,
+    ):
+        """Initialize the TalkdeskFrameSerializer.
+
+        Args:
+            stream_sid: The Talkdesk Media Stream SID.
+            params: Configuration parameters.
+        """
+        self._params = params or TalkdeskFrameSerializer.InputParams()
+        self._stream_sid = stream_sid
+        self._talkdesk_sample_rate = self._params.talkdesk_sample_rate
+        self._sample_rate = 0  # Pipeline input rate
+
+        self._input_resampler = create_stream_resampler()
+        self._output_resampler = create_stream_resampler()
+        self._stop_sent = False
+
+    @property
+    def type(self) -> FrameSerializerType:
+        """Gets the serializer type.
+
+        Returns:
+            The serializer type, either TEXT or BINARY.
+        """
+        return FrameSerializerType.TEXT
+
+    async def setup(self, frame: StartFrame):
+        """Sets up the serializer with pipeline configuration.
+
+        Args:
+            frame: The StartFrame containing pipeline configuration.
+        """
+        self._sample_rate = self._params.sample_rate or frame.audio_in_sample_rate
+
+    async def serialize(self, frame: Frame) -> str | bytes | None:
+        """Serializes a Pipecat frame to Talkdesk WebSocket format.
+
+        Handles conversion of various frame types to Talkdesk WebSocket messages.
+
+        Args:
+            frame: The Pipecat frame to serialize.
+
+        Returns:
+            Serialized data as string or bytes, or None if the frame isn't handled.
+        """
+        if isinstance(frame, TalkdeskControlFrame):
+            if self._stop_sent:
+                return None
+            self._stop_sent = True
+
+            logger.info(f"Sending stop event to Talkdesk with command {frame.action.value}")
+
+            return json.dumps(
+                {
+                    "event": "stop",
+                    "streamSid": self._stream_sid,
+                    "stop": {"command": frame.action.value, "ringGroup": frame.ring_group},
+                }
+            )
+        elif isinstance(frame, InterruptionFrame):
+            answer = {"event": "clear", "streamSid": self._stream_sid}
+            return json.dumps(answer)
+        elif isinstance(frame, AudioRawFrame):
+            data = frame.audio
+
+            # Output: Convert PCM at frame's rate to 8kHz μ-law for Talkdesk
+            serialized_data = await pcm_to_ulaw(
+                data, frame.sample_rate, self._talkdesk_sample_rate, self._output_resampler
+            )
+            if serialized_data is None or len(serialized_data) == 0:
+                # Ignoring in case we don't have audio
+                return None
+
+            payload = base64.b64encode(serialized_data).decode("utf-8")
+            answer = {
+                "event": "media",
+                "streamSid": self._stream_sid,
+                "media": {"payload": payload},
+            }
+
+            return json.dumps(answer)
+        elif isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame)):
+            return json.dumps(frame.message)
+
+        # Return None for unhandled frames
+        return None
+
+    async def deserialize(self, data: str | bytes) -> Frame | None:
+        """Deserializes Talkdesk WebSocket data to Pipecat frames.
+
+        Handles conversion of Talkdesk media events to appropriate Pipecat frames.
+
+        Args:
+            data: The raw WebSocket data from Talkdesk.
+
+        Returns:
+            A Pipecat frame corresponding to the Talkdesk event, or None if unhandled.
+        """
+        message = json.loads(data)
+        event = message.get("event")
+
+        if event == "media":
+            payload_base64 = message.get("media", {}).get("payload")
+            payload = base64.b64decode(payload_base64)
+
+            # Input: Convert Talkdesk's 8kHz μ-law to PCM at pipeline input rate
+            deserialized_data = await ulaw_to_pcm(
+                payload, self._talkdesk_sample_rate, self._sample_rate, self._input_resampler
+            )
+            if deserialized_data is None or len(deserialized_data) == 0:
+                # Ignoring in case we don't have audio
+                return None
+
+            audio_frame = InputAudioRawFrame(
+                audio=deserialized_data, num_channels=1, sample_rate=self._sample_rate
+            )
+            return audio_frame
+        elif event == "dtmf":
+            digit = message.get("dtmf", {}).get("digit")
+
+            try:
+                return InputDTMFFrame(KeypadEntry(digit))
+            except ValueError:
+                # Handle case where string doesn't match any enum value
+                return None
+        elif event == "stop":
+            # Talkdesk has closed the stream from their side (caller hung up)
+            logger.debug("Received stop event from Talkdesk")
+            # Mark that stop has occurred to prevent sending duplicate stop
+            self._stop_sent = True
+            return None
+
+        return None


### PR DESCRIPTION
# Add TalkdeskFrameSerializer for Bidirectional Audio Streaming

## Summary

This PR adds full Talkdesk integration for Pipecat, including a new `TalkdeskFrameSerializer` and auto-detection support in the runner utilities.

## Background

Talkdesk provides a standard bidirectional WebSocket communication protocol for real-time audio streaming, enabling voice AI applications to interact with Talkdesk's telephony infrastructure.

**Documentation:** https://support.talkdesk.com/hc/en-us/articles/9484798498587-Conversation-Orchestrator-Streaming-Bidirectional-Audio

## Changes

### 1. New Serializer (`src/pipecat/serializers/talkdesk.py`)

**`TalkdeskFrameSerializer`** - A frame serializer implementing the Talkdesk WebSocket protocol:

| Feature | Description |
|---------|-------------|
| **Audio I/O** | Converts between Pipecat's PCM audio and Talkdesk's 8kHz μ-law format |
| **DTMF** | Deserializes DTMF events to `InputDTMFFrame` |
| **Interruptions** | Serializes `InterruptionFrame` to Talkdesk `clear` events |
| **Call Control** | Handles hangup, error, and escalation via `TalkdeskControlFrame` |

**`TalkdeskControlAction`** (Enum) - Control actions for call management:
- `HANGUP` - End the call normally (`"ok"`)
- `ERROR` - End the call due to an error (`"error"`)
- `ESCALATE` - Transfer to a human agent (`"escalate"`)

**`TalkdeskControlFrame`** (ControlFrame, UninterruptibleFrame) - A control frame for Talkdesk-specific call management. Marked as `UninterruptibleFrame` to ensure stop/escalate messages are always delivered even during user interruptions.

### 2. Runner Integration (`src/pipecat/runner/utils.py`)

- **Auto-detection**: Added Talkdesk detection based on `interaction_id` in `customParameters`
- **Call data extraction**: Extracts `stream_id`, `interaction_id`, `account_id`, `correlation_id`, and `custom_parameters`
- **Transport creation**: Automatically creates `TalkdeskFrameSerializer` when Talkdesk is detected

## Usage Example
```python
import json
from fastapi import WebSocket
from pipecat.serializers.talkdesk import (
    TalkdeskFrameSerializer,
    TalkdeskControlFrame,
    TalkdeskControlAction,
)
from pipecat.transports.websocket.fastapi import (
    FastAPIWebsocketTransport,
    FastAPIWebsocketParams,
)
from pipecat.audio.vad.silero import SileroVADAnalyzer


async def wait_for_talkdesk_start(websocket: WebSocket) -> dict:
    """Wait for Talkdesk start event and return the message."""
    async for raw_message in websocket.iter_text():
        message = json.loads(raw_message)
        if message.get("event") == "start":
            return message
    raise Exception("Connection closed before receiving start event")


def create_talkdesk_serializer(start_message: dict) -> TalkdeskFrameSerializer:
    """Create TalkdeskFrameSerializer from start event data."""
    start_data = start_message.get("start", {})
    media_format = start_data.get("mediaFormat", {})

    return TalkdeskFrameSerializer(
        stream_sid=start_data.get("streamSid"),
        params=TalkdeskFrameSerializer.InputParams(
            talkdesk_sample_rate=media_format.get("sampleRate", 8000),
        ),
    )


def extract_talkdesk_call_data(start_message: dict) -> dict:
    """Extract call metadata from Talkdesk start event."""
    start_data = start_message.get("start", {})
    custom_params = start_data.get("customParameters", {})

    return {
        "stream_sid": start_data.get("streamSid"),
        "call_sid": start_data.get("callSid"),
        "interaction_id": custom_params.get("interaction_id"),
        "account_id": custom_params.get("account_id"),
        "correlation_id": custom_params.get("correlation_id"),
        "caller_id": custom_params.get("caller_id"),
        "call_type": custom_params.get("type"),
    }


@app.websocket("/talkdesk")
async def talkdesk_websocket_handler(websocket: WebSocket):
    await websocket.accept()

    # Wait for start event
    start_message = await wait_for_talkdesk_start(websocket)

    # Extract call data for logging/context
    call_data = extract_talkdesk_call_data(start_message)
    logger.info(f"Talkdesk call started: {call_data['interaction_id']}")

    # Create serializer and transport
    serializer = create_talkdesk_serializer(start_message)
    transport = FastAPIWebsocketTransport(
        websocket=websocket,
        params=FastAPIWebsocketParams(
            audio_in_enabled=True,
            audio_out_enabled=True,
            serializer=serializer,
            vad_analyzer=SileroVADAnalyzer(),
        ),
    )

    # Build and run pipeline
    pipeline = Pipeline([
        transport.input(),
        stt,
        llm,
        tts,
        transport.output(),
    ])

    task = PipelineTask(pipeline)
    await PipelineRunner().run(task)


# Call control examples (from within pipeline processors)
await task.queue_frame(TalkdeskControlFrame(
    action=TalkdeskControlAction.HANGUP,
))

await task.queue_frame(TalkdeskControlFrame(
    action=TalkdeskControlAction.ESCALATE,
    ring_group="agents"
))

await task.queue_frame(TalkdeskControlFrame(
    action=TalkdeskControlAction.ERROR
))
```
## Protocol Alignment

| Direction | Event | Implementation |
|-----------|-------|----------------|
| Partner → Talkdesk | `media` | `AudioRawFrame` serialization |
| Partner → Talkdesk | `clear` | `InterruptionFrame` serialization |
| Partner → Talkdesk | `stop` | `TalkdeskControlFrame` serialization |
| Talkdesk → Partner | `media` | Deserialized to `InputAudioRawFrame` |
| Talkdesk → Partner | `dtmf` | Deserialized to `InputDTMFFrame` |
| Talkdesk → Partner | `stop` | Handled (prevents duplicate stop messages) |

## Testing
Tested against Talkdesk's Conversation Orchestrator in a production environment.