### PR TITLE
Revert pydantic 2.12 extra type annotation

### DIFF
--- a/src/pipecat/services/openai/realtime/events.py
+++ b/src/pipecat/services/openai/realtime/events.py
@@ -1003,7 +1003,6 @@ class TokenDetails(BaseModel):
     """
 
     model_config = ConfigDict(extra="allow")
-    __pydantic_extra__: dict[str, Any]
 
     cached_tokens: Optional[int] = 0
     text_tokens: Optional[int] = 0

--- a/src/pipecat/services/openai_realtime_beta/events.py
+++ b/src/pipecat/services/openai_realtime_beta/events.py
@@ -878,7 +878,6 @@ class TokenDetails(BaseModel):
     """
 
     model_config = ConfigDict(extra="allow")
-    __pydantic_extra__: dict[str, Any]
 
     cached_tokens: Optional[int] = 0
     text_tokens: Optional[int] = 0

--- a/src/pipecat/transports/daily/utils.py
+++ b/src/pipecat/transports/daily/utils.py
@@ -102,9 +102,6 @@ class DailyRoomProperties(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    # Pydantic v2.12+ requires explicit annotation for extra fields
-    __pydantic_extra__: dict[str, Any]
-
     exp: Optional[float] = None
     enable_chat: bool = False
     enable_prejoin_ui: bool = False


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This annotation isn't necessary, so reverting.

Note: there's some type of issue between sphinx / autodoc / pydantic which doesn't yet understand or like the pydantic 2.12 extra. This means two docs pages aren't being generated:

- runner/daily
- daily/utils

I think this is OK for now. We'll have to revisit in the future.