### PR TITLE
Add whisker_setup.py setup file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/api/api
 
 # uv
 .python-version
+
+# Pipecat
+whisker_setup.py


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

I wanted to make pipecat-ai-whisker a dev dependency of pipecat-ai, but this would create a circular dependency :/

Instead, we'll have to just install pip install pipecat-ai-whisker.

This commit adds whisker_setup.py to .gitignore. I'm open to other names.