### PR TITLE
Fix Pylance reportOptionalMemberAccess in _handle_function_call_cancel

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -1024,10 +1024,8 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
         logger.debug(
             f"{self} FunctionCallCancelFrame: [{frame.function_name}:{frame.tool_call_id}]"
         )
-        if frame.tool_call_id not in self._function_calls_in_progress:
-            return
-
-        if self._function_calls_in_progress[frame.tool_call_id].cancel_on_interruption:
+        function_call = self._function_calls_in_progress.get(frame.tool_call_id)
+        if function_call and function_call.cancel_on_interruption:
             await self.handle_function_call_cancel(frame)
             del self._function_calls_in_progress[frame.tool_call_id]
 

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -858,10 +858,8 @@ class LLMAssistantAggregator(LLMContextAggregator):
         logger.debug(
             f"{self} FunctionCallCancelFrame: [{frame.function_name}:{frame.tool_call_id}]"
         )
-        if frame.tool_call_id not in self._function_calls_in_progress:
-            return
-
-        if self._function_calls_in_progress[frame.tool_call_id].cancel_on_interruption:
+        function_call = self._function_calls_in_progress.get(frame.tool_call_id)
+        if function_call and function_call.cancel_on_interruption:
             # Update context with the function call cancellation
             self._update_function_call_result(frame.function_name, frame.tool_call_id, "CANCELLED")
             del self._function_calls_in_progress[frame.tool_call_id]


### PR DESCRIPTION
## Summary
Fix Pylance type error in `_handle_function_call_cancel` method of `LLMAssistantContextAggregator`.

## Changes
Extract the dictionary value into a local variable and check for `None` before accessing `cancel_on_interruption` attribute. This is needed because `_function_calls_in_progress` is typed as `Dict[str, Optional[FunctionCallInProgressFrame]]`, so values can be `None`.

## Before
```python
if self._function_calls_in_progress[frame.tool_call_id].cancel_on_interruption:
```

## After
```python
function_call = self._function_calls_in_progress[frame.tool_call_id]
if function_call and function_call.cancel_on_interruption:
```