### PR TITLE
Remove async_mode parameter from Mem0 storage

### DIFF
--- a/src/pipecat/services/mem0/memory.py
+++ b/src/pipecat/services/mem0/memory.py
@@ -121,7 +121,6 @@ class Mem0MemoryService(FrameProcessor):
         try:
             logger.debug(f"Storing {len(messages)} messages in Mem0")
             params = {
-                "async_mode": True,
                 "messages": messages,
                 "metadata": {"platform": "pipecat"},
                 "output_format": "v1.1",


### PR DESCRIPTION
# pipecat version
0.0.98

# Service Name
Mem0

# Service or model version
No response

# Issue Description
When using the Mem0 memory service, there's an issue when calling it with a local configuration; an error occurs related to a keyword argument.

Additionally, the "async_mode": True parameter appears unnecessary in the "memory" code.

Reproduction steps:

Add `Mem0MemoryService` with a local configuration. You'll see the error; it only appears when using a local configuration.

# Expected Behavior
Message storage should not be blocked, as when using a cloud configuration.

# Actual Behavior
Message storage is blocked.

# Error Logs

```bash
pipecat.services.mem0.memory:_store_messages:138 - Error storing messages in Mem0: Memory.add() got an unexpected keyword argument 'async_mode'
```