### PR TITLE
fix: AzureTTSService punctuation spacing

### DIFF
--- a/changelog/3489.fixed.md
+++ b/changelog/3489.fixed.md
@@ -1,1 +1,3 @@
-- Fixed `AzureTTSService` transcript formatting where punctuation appeared with extra spaces (e.g., "Hello !" instead of "Hello!"). Azure sends punctuation as separate word boundaries, which are now merged with preceding words to produce properly formatted transcripts across all languages.
+- Fixed `AzureTTSService` transcript formatting issues:
+  - Punctuation now appears without extra spaces (e.g., "Hello!" instead of "Hello !")
+  - CJK languages (Chinese, Japanese, Korean) no longer have unwanted spaces between characters


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Azure's word boundaries separate punctuation into separate words:
```
word: [Hello]
word: [!]
word: [I'm]
word: [your]
word: [helpful]
word: [assistant]
word: [,]
word: [here]
word: [to]
word: [make]
word: [things]
word: [easier]
word: [and]
word: [more]
word: [engaging]
word: [for]
word: [you]
word: [.]
```

This results in a sentence, like this: `Hello ! I'm your helpful assistant , here to make things easier and more engaging for you .`

Unfortunately, they put the burden on the developer to assemble things correctly. This PR does that clean up. The magic is using `isalnum()`, which uses the Unicode Character Database (UCD) to determine if a character is alphanumeric. This works across all languages. Thanks, Claude! 

UPDATE:
In testing non-English languages, I noticed that Chinese, Japanese, and Korean (CJK) languages have spaces inserted. We had a similar issue with Cartesia. I've made a change similar to the one in CartesiaTTSService.

The upside is that spacing is more correct. The downside, is that chunks are emitted after spaces or punctuation, so the fidelity is a little lower on the word output. I think this is a good compromise since we don't understand those languages as well. We're happy to get help from the community if needs to be improved!