### PR TITLE
fix: make SmallWebRTCConnection pc_id globally unique

### DIFF
--- a/src/pipecat/transports/smallwebrtc/connection.py
+++ b/src/pipecat/transports/smallwebrtc/connection.py
@@ -14,6 +14,7 @@ for real-time communication applications.
 import asyncio
 import json
 import time
+import uuid
 from typing import Any, List, Literal, Optional, Union
 
 from loguru import logger
@@ -278,7 +279,7 @@ class SmallWebRTCConnection(BaseObject):
 
         self._answer: Optional[RTCSessionDescription] = None
         self._pc = RTCPeerConnection(rtc_config)
-        self._pc_id = self.name
+        self._pc_id = f"{self.name}-{uuid.uuid4().hex}"
         self._setup_listeners()
         self._data_channel = None
         self._renegotiation_in_progress = False


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3485 

### Problem
The `pc_id` was previously derived from `self.name` (e.g., `SmallWebRTCConnection#1`), which uses a process-local counter. In multi-process deployments behind a load balancer, different processes generate identical `pc_id` values, causing connection conflicts during client reconnection.

### Solution
Append a full UUIDv4 hex suffix to `pc_id` to guarantee global uniqueness:
- **Before:** `SmallWebRTCConnection#1`
- **After:** `SmallWebRTCConnection#1-550e8400e29b41d4a716446655440000`

Preserves a human-readable class name for debugging, while eliminating collision risks at scale.