### PR TITLE
fix: preserve UninterruptibleFrames in __reset_process_queue

### DIFF
--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -950,7 +950,8 @@ class FrameProcessor(BaseObject):
         # Process current queue and keep UninterruptibleFrame frames.
         while not self.__process_queue.empty():
             item = self.__process_queue.get_nowait()
-            if isinstance(item, UninterruptibleFrame):
+            frame = item[0]
+            if isinstance(frame, UninterruptibleFrame):
                 new_queue.put_nowait(item)
             self.__process_queue.task_done()
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3478 

#### Problem 
The `__reset_process_queue()` method was checking `isinstance(item, UninterruptibleFrame)` but item is actually a `tuple (frame, direction, callback)` - not the frame itself. This meant the check always returned False, so all queued frames got tossed during interruptions, including the ones that should've been kept.

#### Solution
Extracted frame from the tuple before checking.