### PR TITLE
Log Daily participant and meeting session IDs upon successful join in…

### DIFF
--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -759,7 +759,11 @@ class DailyTransportClient(EventHandler):
             # Increment leave counter if we successfully joined.
             self._leave_counter += 1
 
-            logger.info(f"Joined {self._room_url}")
+            participant_id = data.get("participants", {}).get("local", {}).get("id")
+            meeting_id = data.get("meetingSession", {}).get("id")
+            logger.info(
+                f"Joined {self._room_url}. Participant ID: {participant_id}, Meeting ID: {meeting_id}"
+            )
 
             await self._callbacks.on_joined(data)
 


### PR DESCRIPTION
… Daily Transport

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Logs Daily participant and meeting IDs upon join, if available. Looking over the latest contributor guidelines, I'm not sure if this warrants a changelog entry – I'm thinking no..?

Tested in a staging pipecat cloud deployment and it looks as expected