### PR TITLE
feat(task): add additive filter methods for frame monitoring

### DIFF
--- a/changelog/3510.added.2.md
+++ b/changelog/3510.added.2.md
@@ -1,0 +1,1 @@
+- Added `add_reached_upstream_filter()` and `add_reached_downstream_filter()` methods to `PipelineTask` for appending frame types.

--- a/changelog/3510.added.md
+++ b/changelog/3510.added.md
@@ -1,0 +1,1 @@
+- Added `reached_upstream_types` and `reached_downstream_types` read-only properties to `PipelineTask` for inspecting current frame filters.

--- a/changelog/3510.changed.3.md
+++ b/changelog/3510.changed.3.md
@@ -1,0 +1,1 @@
+- Changed frame filter storage from tuples to sets in `PipelineTask`.

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -427,6 +427,24 @@ class PipelineTask(BasePipelineTask):
             raise Exception(f"{self} RTVI is not enabled.")
         return self._rtvi
 
+    @property
+    def reached_upstream_types(self) -> Tuple[Type[Frame], ...]:
+        """Get the currently configured upstream frame type filters.
+
+        Returns:
+            Tuple of frame types that trigger the on_frame_reached_upstream event.
+        """
+        return self._reached_upstream_types
+
+    @property
+    def reached_downstream_types(self) -> Tuple[Type[Frame], ...]:
+        """Get the currently configured downstream frame type filters.
+
+        Returns:
+            Tuple of frame types that trigger the on_frame_reached_downstream event.
+        """
+        return self._reached_downstream_types
+
     def event_handler(self, event_name: str):
         """Decorator for registering event handlers.
 
@@ -479,6 +497,30 @@ class PipelineTask(BasePipelineTask):
             types: Tuple of frame types to monitor for downstream events.
         """
         self._reached_downstream_types = types
+
+    def add_reached_upstream_filter(self, types: Tuple[Type[Frame], ...]):
+        """Add frame types to trigger the on_frame_reached_upstream event.
+
+        Args:
+            types: Tuple of frame types to add to upstream monitoring.
+        """
+        if not types:
+            return
+        current = set(self._reached_upstream_types)
+        current.update(types)
+        self._reached_upstream_types = tuple(current)
+
+    def add_reached_downstream_filter(self, types: Tuple[Type[Frame], ...]):
+        """Add frame types to trigger the on_frame_reached_downstream event.
+
+        Args:
+            types: Tuple of frame types to add to downstream monitoring.
+        """
+        if not types:
+            return
+        current = set(self._reached_downstream_types)
+        current.update(types)
+        self._reached_downstream_types = tuple(current)
 
     def has_finished(self) -> bool:
         """Check if the pipeline task has finished execution.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

### Problem

There's no public API to **read** or **append to** the frame monitoring filters - user can only replace them via `set_reached_downstream_filter()`.

This limits : when multiple components (e.g., Pipecat Flows & user code) need to monitor different frame types, they must either:
- Access private `_reached_downstream_types` directly (fragile)
- Risk overwriting filters set by other components

### Solution

Added public APIs for reading and appending:
- `reached_upstream_types` / `reached_downstream_types` - read-only properties  
- `add_reached_upstream_filter()` / `add_reached_downstream_filter()` - append without replacing

Closes #3507