### PR TITLE
refactor(user_mute): remove unnecessary _bot_speaking assignment in _handle_bot_stopped_speaking

### DIFF
--- a/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
@@ -51,6 +51,5 @@ class MuteUntilFirstBotCompleteUserMuteStrategy(BaseUserMuteStrategy):
         return not self._first_speech_handled
 
     async def _handle_bot_stopped_speaking(self, frame: BotStoppedSpeakingFrame):
-        self._bot_speaking = False
         if not self._first_speech_handled:
             self._first_speech_handled = True


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

The `_bot_speaking` flag does not need to be set in this method, so the redundant assignment has been removed.