### PR TITLE
Refactoring AudioBufferProcessor to fix audio track synchronization.

### DIFF
--- a/changelog/3541.fixed.md
+++ b/changelog/3541.fixed.md
@@ -1,0 +1,1 @@
+- Fixed how audio tracks are synchronized inside the `AudioBufferProcessor` to fix timing issues where silence and audio were misaligned between user and bot buffers.


### PR DESCRIPTION
We were trying to use `time.time()` to compute how much silence to insert. But for some reason, this was not reliable enough, and the audio was appended at the wrong position relative to the other track.

So, in this PR we are simplifying the logic of how we are keeping both tracks in sync. We are now using buffer positions as the source of truth.
- When we add audio to one buffer, we are immediately ensuring the other buffer is at the same position (by padding with silence if needed).
- When user audio arrives, we first pad the bot buffer with silence up to where the user buffer currently is.
- When bot audio arrives, we first pad the user buffer with silence up to where the bot buffer currently is.

This way, audio is always added at the correct synchronized position.

I have tested it with `Daily`, `SmallWebRTC`, and `FastApiWebsocket`. Using all these transports, it feels like it is working as expected.