### PR TITLE
Fix: Handle both camelCase and snake_case for request_data field in SmallWebRTC requests

### DIFF
--- a/changelog/3544.fixed.md
+++ b/changelog/3544.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SmallWebRTCRequest` to accept both camelCase (`requestData`) and snake_case (`request_data`) for cross-platform compatibility between JavaScript and Python clients.

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -327,10 +327,10 @@ def _setup_webrtc_routes(
                 if request.method == HTTPMethod.POST.value:
                     request_data = await request.json()
                     webrtc_request = SmallWebRTCRequest.model_validate(request_data)
-                    
+
                     if webrtc_request.request_data is None:
                         webrtc_request.request_data = active_session
-                    
+
                     return await offer(webrtc_request, background_tasks)
                 elif request.method == HTTPMethod.PATCH.value:
                     patch_request = SmallWebRTCPatchRequest(

--- a/src/pipecat/transports/smallwebrtc/request_handler.py
+++ b/src/pipecat/transports/smallwebrtc/request_handler.py
@@ -13,10 +13,11 @@ import asyncio
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, List, Optional
-from pydantic import BaseModel, Field
+
 from aiortc.sdp import candidate_from_sdp
 from fastapi import HTTPException
 from loguru import logger
+from pydantic import BaseModel, Field
 
 from pipecat.transports.smallwebrtc.connection import IceServer, SmallWebRTCConnection
 
@@ -40,6 +41,12 @@ class SmallWebRTCRequest(BaseModel):
     request_data: Optional[Any] = Field(None, alias="requestData")
 
     class Config:
+        """Pydantic configuration for the model.
+
+        `populate_by_name` allows population of fields by their Python
+        attribute names as well as any aliases (e.g. camelCase).
+        """
+
         populate_by_name = True
 
     @classmethod


### PR DESCRIPTION
The Pipecat /api/offer endpoint fails to receive custom configuration data sent from JavaScript clients due to a field name mismatch between JavaScript's camelCase convention (requestData) and Python's snake_case convention (request_data). This PR converts SmallWebRTCRequest from a @dataclass to a Pydantic BaseModel with field aliasing to accept both naming conventions.

Changes
- Converted SmallWebRTCRequest from @dataclass to Pydantic BaseModel in src/pipecat/transports/smallwebrtc/request_handler.py
- Added alias="requestData" to the request_data field to support camelCase from JavaScript clients
- Added Config class with populate_by_name = True to maintain backwards compatibility with existing Python code using request_data
- Updated from_dict() classmethod to use Pydantic's model_validate() for consistent field aliasing behavior 

Backwards Compatibility
- Function signatures remain unchanged
- Existing Python code using request_data continues to work
- Existing code using from_dict() continues to work
- Already includes Pydantic as a dependency (no new dependencies)