### PR TITLE
Fix: OutputGate SystemFrame condition for EndFrame

### DIFF
--- a/examples/foundational/22b-natural-conversation-proposal.py
+++ b/examples/foundational/22b-natural-conversation-proposal.py
@@ -145,7 +145,7 @@ class OutputGate(FrameProcessor):
         await super().process_frame(frame, direction)
 
         # We must not block system frames.
-        if isinstance(frame, SystemFrame):
+        if isinstance(frame, (SystemFrame, EndFrame)):
             if isinstance(frame, StartFrame):
                 await self._start()
             if isinstance(frame, (EndFrame, CancelFrame)):

--- a/examples/foundational/22c-natural-conversation-mixed-llms.py
+++ b/examples/foundational/22c-natural-conversation-mixed-llms.py
@@ -348,7 +348,7 @@ class OutputGate(FrameProcessor):
         await super().process_frame(frame, direction)
 
         # We must not block system frames.
-        if isinstance(frame, SystemFrame):
+        if isinstance(frame, (SystemFrame, EndFrame)):
             if isinstance(frame, StartFrame):
                 await self._start()
             if isinstance(frame, (EndFrame, CancelFrame)):

--- a/examples/foundational/22d-natural-conversation-gemini-audio.py
+++ b/examples/foundational/22d-natural-conversation-gemini-audio.py
@@ -568,7 +568,7 @@ class OutputGate(FrameProcessor):
         await super().process_frame(frame, direction)
 
         # We must not block system frames.
-        if isinstance(frame, SystemFrame):
+        if isinstance(frame, (SystemFrame, EndFrame)):
             if isinstance(frame, StartFrame):
                 await self._start()
             if isinstance(frame, (EndFrame, CancelFrame)):


### PR DESCRIPTION
The `OutputGate` in the example will cause `EndFrame` never go through properly.

`EndFrame` is a `ControlFrame`, so `if isinstance(frame, SystemFrame)` will never let `EndFrame` to pass in.