### PR TITLE
Simplify STT finalize handling

### DIFF
--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -221,13 +221,10 @@ class CartesiaSTTService(WebsocketSTTService):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, VADUserStartedSpeakingFrame):
-            # Reset finalize state for new utterance
-            self.set_finalize_pending(False)
             await self._start_metrics()
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             # Send finalize command to flush the transcription session
             if self._websocket and self._websocket.state is State.OPEN:
-                self.set_finalize_pending(True)
                 await self._websocket.send("finalize")
 
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -551,8 +551,6 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, VADUserStartedSpeakingFrame):
-            # Reset finalize state for new utterance
-            self.set_finalize_pending(False)
             # Start metrics when user starts speaking
             await self._start_metrics()
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
@@ -560,8 +558,6 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
             if self._params.commit_strategy == CommitStrategy.MANUAL:
                 if self._websocket and self._websocket.state is State.OPEN:
                     try:
-                        # Mark that the next committed transcript should be finalized
-                        self.set_finalize_pending(True)
                         commit_message = {
                             "message_type": "input_audio_chunk",
                             "audio_base_64": "",

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -193,11 +193,9 @@ class SarvamSTTService(STTService):
         # Only handle VAD frames when not using Sarvam's VAD signals
         if not self._vad_signals:
             if isinstance(frame, VADUserStartedSpeakingFrame):
-                self.set_finalize_pending(False)
                 await self._start_metrics()
             elif isinstance(frame, VADUserStoppedSpeakingFrame):
                 if self._socket_client:
-                    self.set_finalize_pending(True)
                     await self._socket_client.flush()
 
     async def set_language(self, language: Language):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

### Summary

Simplifies the STT finalization methods used for TTFB measurement. Now, only services with explicit server confirmation of finalization (e.g., Deepgram's from_finalize field) should use `request_finalize()` + `confirm_finalize()`. Services without server confirmation rely on the TTFB timeout fallback.

### Rationale

For services without a finalize confirmation message, using the timeout is:
- Simpler: No need for extra method calls in subclasses
- More robust:  If a service sends multiple transcripts after finalize, the timeout waits for the last one
- Equally accurate: Timeliness of TTFB reporting is less important than correctness
