### PR TITLE
feat: add API key validation for services

### DIFF
--- a/API_KEY_VALIDATION_GUIDE.md
+++ b/API_KEY_VALIDATION_GUIDE.md
@@ -1,0 +1,249 @@
+# API Key Validation Implementation Guide
+
+This guide explains how to implement API key validation for Pipecat services to address issue #941.
+
+## Overview
+
+The API key validation feature raises exceptions early when API keys are missing or blank, improving developer experience by catching configuration errors during service initialization rather than at runtime.
+
+## Implementation
+
+### 1. Utility Function
+
+The validation logic is centralized in `src/pipecat/utils/api_key_validator.py`:
+
+```python
+from pipecat.utils.api_key_validator import validate_api_key, APIKeyError
+```
+
+### 2. Function Signature
+
+```python
+validate_api_key(
+    api_key: Optional[str],
+    service_name: str,
+    allow_none: bool = False,
+    env_var_name: Optional[str] = None,
+) -> None
+```
+
+**Parameters:**
+- `api_key`: The API key to validate
+- `service_name`: Name of the service (used in error messages)
+- `allow_none`: If True, allows None values (for services that support environment variables)
+- `env_var_name`: Optional environment variable name to suggest in error message
+
+### 3. Adding Validation to Services
+
+#### Step 1: Import the validator
+
+Add to the service file imports:
+
+```python
+from pipecat.utils.api_key_validator import validate_api_key
+```
+
+#### Step 2: Add validation in `__init__`
+
+Add the validation call right after `super().__init__()`:
+
+**For services that REQUIRE an API key explicitly:**
+
+```python
+def __init__(self, *, api_key: str, **kwargs):
+    super().__init__(**kwargs)
+
+    # Validate API key (required)
+    validate_api_key(api_key, "ServiceName", allow_none=False, env_var_name="SERVICE_API_KEY")
+
+    # Rest of initialization...
+```
+
+**For services that allow environment variable fallback:**
+
+```python
+def __init__(self, *, api_key=None, **kwargs):
+    super().__init__(**kwargs)
+
+    # Validate API key (allow None since SDK uses env var)
+    validate_api_key(api_key, "ServiceName", allow_none=True, env_var_name="SERVICE_API_KEY")
+
+    # Rest of initialization...
+```
+
+## Examples
+
+### Example 1: OpenAI (allows None for env var)
+
+**File:** `src/pipecat/services/openai/base_llm.py`
+
+```python
+from pipecat.utils.api_key_validator import validate_api_key
+
+class BaseOpenAILLMService(LLMService):
+    def __init__(self, *, model: str, api_key=None, **kwargs):
+        super().__init__(**kwargs)
+
+        # Allow None since OpenAI SDK uses OPENAI_API_KEY env var
+        validate_api_key(api_key, "OpenAI", allow_none=True, env_var_name="OPENAI_API_KEY")
+
+        # ... rest of initialization
+```
+
+### Example 2: Anthropic (requires explicit API key)
+
+**File:** `src/pipecat/services/anthropic/llm.py`
+
+```python
+from pipecat.utils.api_key_validator import validate_api_key
+
+class AnthropicLLMService(LLMService):
+    def __init__(self, *, api_key: str, **kwargs):
+        super().__init__(**kwargs)
+
+        # Required for Anthropic
+        validate_api_key(api_key, "Anthropic", allow_none=False, env_var_name="ANTHROPIC_API_KEY")
+
+        # ... rest of initialization
+```
+
+### Example 3: Deepgram STT (requires explicit API key)
+
+**File:** `src/pipecat/services/deepgram/stt.py`
+
+```python
+from pipecat.utils.api_key_validator import validate_api_key
+
+class DeepgramSTTService(STTService):
+    def __init__(self, *, api_key: str, **kwargs):
+        super().__init__(**kwargs)
+
+        # Required for Deepgram
+        validate_api_key(api_key, "Deepgram", allow_none=False, env_var_name="DEEPGRAM_API_KEY")
+
+        # ... rest of initialization
+```
+
+## Error Messages
+
+### When API key is None (and not allowed):
+
+```
+APIKeyError: API key for Anthropic is missing or empty. Set the ANTHROPIC_API_KEY
+environment variable or pass it explicitly. Please provide a valid API key to use this service.
+```
+
+### When API key is blank/whitespace:
+
+```
+APIKeyError: API key for OpenAI is missing or empty. Set the OPENAI_API_KEY
+environment variable or pass it explicitly. Please provide a valid API key to use this service.
+```
+
+## Testing
+
+### Unit Tests
+
+Test the validation function directly:
+
+```python
+from pipecat.utils.api_key_validator import APIKeyError, validate_api_key
+
+def test_valid_api_key():
+    validate_api_key("sk-test-key", "TestService")  # Should pass
+
+def test_none_api_key():
+    with pytest.raises(APIKeyError):
+        validate_api_key(None, "TestService", allow_none=False)
+
+def test_empty_api_key():
+    with pytest.raises(APIKeyError):
+        validate_api_key("", "TestService")
+```
+
+### Integration Tests
+
+Test services with invalid keys:
+
+```python
+from pipecat.services.openai import OpenAILLMService
+
+def test_openai_with_blank_key():
+    with pytest.raises(APIKeyError):
+        OpenAILLMService(api_key="", model="gpt-4.1")
+```
+
+## Services Already Updated
+
+- ✅ **OpenAI** (LLM) - `src/pipecat/services/openai/base_llm.py`
+- ✅ **Anthropic** (LLM) - `src/pipecat/services/anthropic/llm.py`
+- ✅ **Deepgram** (STT) - `src/pipecat/services/deepgram/stt.py`
+
+## Services To Update
+
+The validation should be added to all services that require API keys:
+
+### LLM Services
+- [ ] AWS (Bedrock)
+- [ ] Azure
+- [ ] Cerebras
+- [ ] DeepSeek
+- [ ] Fireworks
+- [ ] Gemini
+- [ ] Grok
+- [ ] Groq
+- [ ] Mistral
+- [ ] Perplexity
+- [ ] Together AI
+- [ ] etc.
+
+### TTS Services
+- [ ] ElevenLabs
+- [ ] Cartesia
+- [ ] Fish
+- [ ] LMNT
+- [ ] PlayHT
+- [ ] Rime
+- [ ] etc.
+
+### STT Services
+- [ ] AssemblyAI
+- [ ] Gladia
+- [ ] Soniox
+- [ ] etc.
+
+### Other Services
+- [ ] HeyGen
+- [ ] Tavus
+- [ ] Simli
+- [ ] etc.
+
+## Rollout Strategy
+
+1. **Phase 1** (Completed): Core implementation
+   - Create utility function
+   - Update 3 example services (OpenAI, Anthropic, Deepgram)
+   - Add comprehensive tests
+
+2. **Phase 2**: Update high-traffic services
+   - Update most commonly used LLM services
+   - Update popular TTS/STT services
+
+3. **Phase 3**: Complete rollout
+   - Update all remaining services
+   - Add validation to new services going forward
+
+## Benefits
+
+1. **Better Developer Experience**: Errors caught immediately during initialization
+2. **Clearer Error Messages**: Helpful messages with environment variable suggestions
+3. **Consistent Behavior**: All services validate API keys the same way
+4. **Easier Debugging**: No need to wait for API calls to fail
+5. **Documentation**: Error messages guide users to fix configuration
+
+## Notes
+
+- Services that use environment variables should set `allow_none=True`
+- Services that require explicit API keys should set `allow_none=False`
+- Always provide the `env_var_name` parameter for better error messages
+- The validator checks for both `None` and empty/whitespace-only strings

--- a/changelog/941.added.md
+++ b/changelog/941.added.md
@@ -1,0 +1,1 @@
+- Added API key validation during service initialization to catch missing or blank API keys early with helpful error messages. This improves developer experience by preventing confusing runtime errors when API keys are misconfigured.

--- a/examples/api_key_validation_demo.py
+++ b/examples/api_key_validation_demo.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""
+API Key Validation Demo
+
+This script demonstrates the API key validation feature that was added to improve
+developer experience by catching missing or empty API keys early during service
+initialization.
+
+Run this script to see how different scenarios are handled:
+    python examples/api_key_validation_demo.py
+"""
+
+from pipecat.utils.api_key_validator import APIKeyError
+
+
+def demo_valid_key():
+    """Example 1: Service initialized with a valid API key - works correctly."""
+    print("\n" + "=" * 60)
+    print("Example 1: Valid API Key")
+    print("=" * 60)
+
+    try:
+        from pipecat.services.openai import OpenAILLMService
+
+        # This works - valid API key provided
+        service = OpenAILLMService(api_key="sk-test-key-123", model="gpt-4.1")
+        print("✅ SUCCESS: Service created with valid API key")
+        print(f"   Service: {service.__class__.__name__}")
+        print(f"   Model: {service.model_name}")
+    except APIKeyError as e:
+        print(f"❌ ERROR: {e}")
+
+
+def demo_none_key_not_allowed():
+    """Example 2: Service that requires API key, None provided - raises error."""
+    print("\n" + "=" * 60)
+    print("Example 2: None API Key (not allowed)")
+    print("=" * 60)
+
+    try:
+        # Anthropic requires explicit API key
+        from pipecat.services.anthropic import AnthropicLLMService
+
+        # This will fail - None is not allowed for Anthropic
+        service = AnthropicLLMService(api_key=None, model="claude-sonnet-4-5-20250929")
+        print("✅ SUCCESS: Service created")
+    except APIKeyError as e:
+        print(f"❌ EXPECTED ERROR: {e}")
+        print("   This error helps catch configuration issues early!")
+    except Exception as e:
+        print(f"   (Skipped - anthropic package not installed: {type(e).__name__})")
+
+
+def demo_empty_key():
+    """Example 3: Service initialized with empty string - raises error."""
+    print("\n" + "=" * 60)
+    print("Example 3: Empty String API Key")
+    print("=" * 60)
+
+    try:
+        from pipecat.services.openai import OpenAILLMService
+
+        # This will fail - empty string is not valid
+        service = OpenAILLMService(api_key="", model="gpt-4.1")
+        print("✅ SUCCESS: Service created")
+    except APIKeyError as e:
+        print(f"❌ EXPECTED ERROR: {e}")
+        print("   Even blank strings are caught!")
+
+
+def demo_whitespace_key():
+    """Example 4: Service initialized with whitespace-only string - raises error."""
+    print("\n" + "=" * 60)
+    print("Example 4: Whitespace-Only API Key")
+    print("=" * 60)
+
+    try:
+        from pipecat.services.openai import OpenAILLMService
+
+        # This will fail - whitespace-only is not valid
+        service = OpenAILLMService(api_key="   ", model="gpt-4.1")
+        print("✅ SUCCESS: Service created")
+    except APIKeyError as e:
+        print(f"❌ EXPECTED ERROR: {e}")
+        print("   Whitespace-only strings are also caught!")
+
+
+def demo_none_key_allowed():
+    """Example 5: Service that allows None (uses env var) - works correctly."""
+    print("\n" + "=" * 60)
+    print("Example 5: None API Key (allowed for env var fallback)")
+    print("=" * 60)
+
+    try:
+        from pipecat.services.openai import OpenAILLMService
+
+        # This works - OpenAI SDK can use OPENAI_API_KEY environment variable
+        # Note: This will only work if OPENAI_API_KEY env var is set
+        print("   OpenAI allows None since it can use OPENAI_API_KEY env var")
+        print("   (This would work if OPENAI_API_KEY is set in environment)")
+    except APIKeyError as e:
+        print(f"❌ ERROR: {e}")
+
+
+def main():
+    """Run all demonstration examples."""
+    print("\n" + "=" * 60)
+    print("API Key Validation Demonstration")
+    print("=" * 60)
+    print("\nThis demo shows how API key validation improves developer experience")
+    print("by catching configuration errors early during service initialization.")
+
+    # Run all examples
+    demo_valid_key()
+    demo_none_key_not_allowed()
+    demo_empty_key()
+    demo_whitespace_key()
+    demo_none_key_allowed()
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+    print("""
+Key Benefits:
+1. ✅ Errors caught immediately during initialization
+2. ✅ Clear, helpful error messages with environment variable hints
+3. ✅ Prevents confusing runtime errors later
+4. ✅ Consistent validation across all services
+5. ✅ Better developer experience overall
+
+Implementation:
+- Add validation to __init__ method of each service
+- Use validate_api_key() from pipecat.utils.api_key_validator
+- Set allow_none=True for services that support env vars
+- Set allow_none=False for services that require explicit keys
+- Always provide env_var_name for helpful error messages
+
+See API_KEY_VALIDATION_GUIDE.md for full implementation details.
+    """)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -59,6 +59,7 @@ from pipecat.processors.aggregators.openai_llm_context import (
 )
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
+from pipecat.utils.api_key_validator import validate_api_key
 from pipecat.utils.tracing.service_decorators import traced_llm
 
 try:
@@ -203,6 +204,10 @@ class AnthropicLLMService(LLMService):
             **kwargs: Additional arguments passed to parent LLMService.
         """
         super().__init__(**kwargs)
+
+        # Validate API key (required for Anthropic)
+        validate_api_key(api_key, "Anthropic", allow_none=False, env_var_name="ANTHROPIC_API_KEY")
+
         params = params or AnthropicLLMService.InputParams()
         self._client = client or AsyncAnthropic(
             api_key=api_key

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -25,6 +25,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.stt_service import STTService
 from pipecat.transcriptions.language import Language
+from pipecat.utils.api_key_validator import validate_api_key
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
 
@@ -88,6 +89,9 @@ class DeepgramSTTService(STTService):
         """
         sample_rate = sample_rate or (live_options.sample_rate if live_options else None)
         super().__init__(sample_rate=sample_rate, **kwargs)
+
+        # Validate API key (required for Deepgram)
+        validate_api_key(api_key, "Deepgram", allow_none=False, env_var_name="DEEPGRAM_API_KEY")
 
         if url:
             import warnings

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -41,6 +41,7 @@ from pipecat.processors.aggregators.openai_llm_context import (
 )
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
+from pipecat.utils.api_key_validator import validate_api_key
 from pipecat.utils.tracing.service_decorators import traced_llm
 
 
@@ -116,6 +117,9 @@ class BaseOpenAILLMService(LLMService):
             **kwargs: Additional arguments passed to the parent LLMService.
         """
         super().__init__(**kwargs)
+
+        # Validate API key (allow None since OpenAI SDK uses OPENAI_API_KEY env var)
+        validate_api_key(api_key, "OpenAI", allow_none=True, env_var_name="OPENAI_API_KEY")
 
         params = params or BaseOpenAILLMService.InputParams()
 

--- a/src/pipecat/utils/api_key_validator.py
+++ b/src/pipecat/utils/api_key_validator.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""API key validation utilities for AI services."""
+
+from typing import Optional
+
+
+class APIKeyError(ValueError):
+    """Exception raised when an API key is missing or invalid."""
+
+    pass
+
+
+def validate_api_key(
+    api_key: Optional[str],
+    service_name: str,
+    allow_none: bool = False,
+    env_var_name: Optional[str] = None,
+) -> None:
+    """Validate that an API key is not None or blank.
+
+    This function raises an exception if the API key is missing or empty,
+    improving developer experience by catching configuration errors early.
+
+    Args:
+        api_key: The API key to validate.
+        service_name: Name of the service (e.g., "OpenAI", "Anthropic").
+        allow_none: If True, allows None values (for services that use environment variables).
+        env_var_name: Optional name of the environment variable to suggest in error message.
+
+    Raises:
+        APIKeyError: If the API key is None or blank (unless allow_none is True).
+
+    Example:
+        >>> validate_api_key(api_key, "OpenAI", env_var_name="OPENAI_API_KEY")
+        >>> # Raises APIKeyError if api_key is None or empty
+    """
+    # Allow None if the service supports environment variable fallback
+    if allow_none and api_key is None:
+        return
+
+    # Check for None or empty/whitespace-only strings
+    if api_key is None or (isinstance(api_key, str) and not api_key.strip()):
+        env_hint = f" Set the {env_var_name} environment variable or pass it explicitly." if env_var_name else ""
+        raise APIKeyError(
+            f"API key for {service_name} is missing or empty.{env_hint} "
+            f"Please provide a valid API key to use this service."
+        )

--- a/tests/test_api_key_validation.py
+++ b/tests/test_api_key_validation.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for API key validation."""
+
+import pytest
+
+from pipecat.utils.api_key_validator import APIKeyError, validate_api_key
+
+
+class TestAPIKeyValidation:
+    """Test cases for API key validation functionality."""
+
+    def test_valid_api_key(self):
+        """Test that a valid API key passes validation."""
+        # Should not raise an exception
+        validate_api_key("sk-test-key-123", "TestService")
+
+    def test_none_api_key_not_allowed(self):
+        """Test that None API key raises error when not allowed."""
+        with pytest.raises(APIKeyError) as exc_info:
+            validate_api_key(None, "TestService", allow_none=False)
+
+        assert "API key for TestService is missing or empty" in str(exc_info.value)
+
+    def test_none_api_key_allowed(self):
+        """Test that None API key is allowed when explicitly permitted."""
+        # Should not raise an exception
+        validate_api_key(None, "TestService", allow_none=True)
+
+    def test_empty_string_api_key(self):
+        """Test that empty string API key raises error."""
+        with pytest.raises(APIKeyError) as exc_info:
+            validate_api_key("", "TestService")
+
+        assert "API key for TestService is missing or empty" in str(exc_info.value)
+
+    def test_whitespace_only_api_key(self):
+        """Test that whitespace-only API key raises error."""
+        with pytest.raises(APIKeyError) as exc_info:
+            validate_api_key("   ", "TestService")
+
+        assert "API key for TestService is missing or empty" in str(exc_info.value)
+
+    def test_error_message_with_env_var(self):
+        """Test that error message includes environment variable hint."""
+        with pytest.raises(APIKeyError) as exc_info:
+            validate_api_key(None, "TestService", env_var_name="TEST_API_KEY")
+
+        error_msg = str(exc_info.value)
+        assert "TEST_API_KEY" in error_msg
+        assert "environment variable" in error_msg
+
+    def test_error_message_without_env_var(self):
+        """Test that error message works without environment variable hint."""
+        with pytest.raises(APIKeyError) as exc_info:
+            validate_api_key("", "TestService")
+
+        error_msg = str(exc_info.value)
+        assert "TestService" in error_msg
+        assert "Please provide a valid API key" in error_msg
+
+
+class TestServiceIntegration:
+    """Test integration with actual services."""
+
+    def test_openai_with_blank_key(self):
+        """Test that OpenAI service rejects blank API key."""
+        from pipecat.services.openai import OpenAILLMService
+
+        # Blank string should raise error even with allow_none=True
+        with pytest.raises(APIKeyError) as exc_info:
+            OpenAILLMService(api_key="", model="gpt-4.1")
+
+        assert "OpenAI" in str(exc_info.value)
+
+    def test_anthropic_with_none_key(self):
+        """Test that Anthropic service rejects None API key."""
+        pytest.importorskip("anthropic")
+        from pipecat.services.anthropic import AnthropicLLMService
+
+        with pytest.raises(APIKeyError) as exc_info:
+            AnthropicLLMService(api_key=None, model="claude-sonnet-4-5-20250929")
+
+        assert "Anthropic" in str(exc_info.value)
+
+    def test_anthropic_with_blank_key(self):
+        """Test that Anthropic service rejects blank API key."""
+        pytest.importorskip("anthropic")
+        from pipecat.services.anthropic import AnthropicLLMService
+
+        with pytest.raises(APIKeyError) as exc_info:
+            AnthropicLLMService(api_key="   ", model="claude-sonnet-4-5-20250929")
+
+        assert "Anthropic" in str(exc_info.value)
+
+    def test_deepgram_with_none_key(self):
+        """Test that Deepgram service rejects None API key."""
+        pytest.importorskip("deepgram")
+        from pipecat.services.deepgram import DeepgramSTTService
+
+        with pytest.raises(APIKeyError) as exc_info:
+            DeepgramSTTService(api_key=None)
+
+        assert "Deepgram" in str(exc_info.value)


### PR DESCRIPTION
- Add validate_api_key() utility function with APIKeyError exception
- Validate API keys in OpenAI, Anthropic, and Deepgram services
- Raise clear errors when keys are missing or blank
- Include comprehensive tests and documentation
- Add implementation guide for applying to other services

This improves developer experience by catching configuration errors early during service initialization with helpful error messages that include environment variable hints.

Fixes #941

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.