### PR TITLE
FrameSerializer: subclass from BaseObject so we can add events

### DIFF
--- a/changelog/3560.changed.md
+++ b/changelog/3560.changed.md
@@ -1,0 +1,1 @@
+- `FrameSerializer` now subclasses from `BaseObject` to enable event support.

--- a/src/pipecat/serializers/base_serializer.py
+++ b/src/pipecat/serializers/base_serializer.py
@@ -9,9 +9,10 @@
 from abc import ABC, abstractmethod
 
 from pipecat.frames.frames import Frame, StartFrame
+from pipecat.utils.base_object import BaseObject
 
 
-class FrameSerializer(ABC):
+class FrameSerializer(BaseObject):
     """Abstract base class for frame serialization implementations.
 
     Defines the interface for converting frames to/from serialized formats


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Simple change to subclass `FrameSerializer` from `BaseObject`. This allows frame serializer to register and trigger events.
