### PR TITLE
Fixed race condition in OpenAIRealtimeBetaLLMService

### DIFF
--- a/changelog/3567.fixed.md
+++ b/changelog/3567.fixed.md
@@ -1,0 +1,1 @@
+- Fixed race condition in `OpenAIRealtimeBetaLLMService` that could cause an error when truncating the conversation.

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -525,6 +525,14 @@ class OpenAIRealtimeBetaLLMService(LLMService):
         # note: ttfb is faster by 1/2 RTT than ttfb as measured for other services, since we're getting
         # this event from the server
         await self.stop_ttfb_metrics()
+
+        if self._current_audio_response and self._current_audio_response.item_id != evt.item_id:
+            logger.warning(
+                f"Received a new audio delta for an already completed audio response before receiving the BotStoppedSpeakingFrame."
+            )
+            logger.debug("Forcing previous audio response to None")
+            self._current_audio_response = None
+
         if not self._current_audio_response:
             self._current_audio_response = CurrentAudioResponse(
                 item_id=evt.item_id,


### PR DESCRIPTION
Fixed race condition in `OpenAIRealtimeBetaLLMService` that could cause an error when truncating the conversation.