### PR TITLE
feat(google): add image_url support for Gemini adapter

### DIFF
--- a/changelog/3573.added.md
+++ b/changelog/3573.added.md
@@ -1,0 +1,1 @@
+- Added `image_url` support for Gemini adapter, enabling external URLs via `Part.from_uri()`.

--- a/src/pipecat/adapters/services/gemini_adapter.py
+++ b/src/pipecat/adapters/services/gemini_adapter.py
@@ -415,7 +415,7 @@ class GeminiLLMAdapter(BaseLLMAdapter[GeminiLLMInvocationParams]):
                     )
                 elif c["type"] == "image_url":
                     url = c["image_url"]["url"]
-                    logger.warning(f"Unsupported 'image_url': {url}")
+                    parts.append(Part.from_uri(file_uri=url))
                 elif c["type"] == "input_audio":
                     input_audio = c["input_audio"]
                     audio_bytes = base64.b64decode(input_audio["data"])


### PR DESCRIPTION
## Summary

- Enable external URLs for images in Gemini API using `Part.from_uri()`
- Previously `image_url` content type was logged as unsupported, but Google now allows external URLs for file input

Tested with Gemini from Vertex AI.

Reference: https://ai.google.dev/gemini-api/docs/file-input-methods