### PR TITLE
fix: adding missing livekit transport configs

### DIFF
--- a/changelog/3580.fixed.md
+++ b/changelog/3580.fixed.md
@@ -1,0 +1,1 @@
+- Added missing `LiveKitRunnerArguments` and `LiveKitTransport` support in runner utilities to enable LiveKit transport configuration.

--- a/src/pipecat/runner/types.py
+++ b/src/pipecat/runner/types.py
@@ -106,3 +106,18 @@ class SmallWebRTCRunnerArguments(RunnerArguments):
     """
 
     webrtc_connection: Any
+
+
+@dataclass
+class LiveKitRunnerArguments(RunnerArguments):
+    """LiveKit transport session arguments for the runner.
+
+    Parameters:
+        room_name: LiveKit room name to join
+        token: Authentication token for the room
+        body: Additional request data
+    """
+
+    room_name: str
+    url: str
+    token: Optional[str] = None

--- a/src/pipecat/runner/utils.py
+++ b/src/pipecat/runner/utils.py
@@ -39,6 +39,7 @@ from loguru import logger
 
 from pipecat.runner.types import (
     DailyRunnerArguments,
+    LiveKitRunnerArguments,
     SmallWebRTCRunnerArguments,
     WebSocketRunnerArguments,
 )
@@ -567,6 +568,17 @@ async def create_transport(
         # Create telephony transport with pre-parsed data
         return await _create_telephony_transport(
             runner_args.websocket, params, transport_type, call_data
+        )
+    elif isinstance(runner_args, LiveKitRunnerArguments):
+        params = _get_transport_params("livekit", transport_params)
+
+        from pipecat.transports.livekit.transport import LiveKitTransport
+
+        return LiveKitTransport(
+            runner_args.url,
+            runner_args.token,
+            runner_args.room_name,
+            params=params,
         )
 
     else:


### PR DESCRIPTION
This pull request adds support for LiveKit as a new transport option in the runner. 

**LiveKit transport integration:**

* Added a new `LiveKitRunnerArguments` dataclass to represent arguments needed for LiveKit transport sessions, including `room_name`, `url`, and an optional `token`.
* Updated the imports in `src/pipecat/runner/utils.py` to include `LiveKitRunnerArguments`.
* Extended the `create_transport` function to recognize `LiveKitRunnerArguments` and instantiate a `LiveKitTransport` with the appropriate parameters.

Note- We are a voice agent company and while developement we figured these missing links and have added them to help community