### PR TITLE
Fixed race condition in OpenAIRealtimeLLMService

### DIFF
--- a/changelog/3581.fixed.md
+++ b/changelog/3581.fixed.md
@@ -1,0 +1,1 @@
+- Fixed race condition in `OpenAIRealtimeLLMService` that could cause an error when truncating the conversation.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -599,6 +599,14 @@ class OpenAIRealtimeLLMService(LLMService):
         # note: ttfb is faster by 1/2 RTT than ttfb as measured for other services, since we're getting
         # this event from the server
         await self.stop_ttfb_metrics()
+
+        if self._current_audio_response and self._current_audio_response.item_id != evt.item_id:
+            logger.warning(
+                f"Received a new audio delta for an already completed audio response before receiving the BotStoppedSpeakingFrame."
+            )
+            logger.debug("Forcing previous audio response to None")
+            self._current_audio_response = None
+
         if not self._current_audio_response:
             self._current_audio_response = CurrentAudioResponse(
                 item_id=evt.item_id,


### PR DESCRIPTION
Fixed race condition in `OpenAIRealtimeLLMService` that could cause an error when truncating the conversation.
