### PR TITLE
runner: allow custom CLI arguments

### DIFF
--- a/changelog/3590.added.md
+++ b/changelog/3590.added.md
@@ -1,0 +1,1 @@
+- `main()` in `pipecat.runner.run` now accepts an optional `argparse.ArgumentParser`, allowing bots to define custom CLI arguments accessible via `runner_args.cli_args`.

--- a/examples/foundational/18-gstreamer-filesrc.py
+++ b/examples/foundational/18-gstreamer-filesrc.py
@@ -20,10 +20,6 @@ from pipecat.transports.daily.transport import DailyParams
 
 load_dotenv(override=True)
 
-parser = argparse.ArgumentParser(description="Pipecat Video Streaming Bot")
-parser.add_argument("-i", "--input", type=str, required=True, help="Input video file")
-args = parser.parse_args()
-
 # We store functions so objects (e.g. SileroVADAnalyzer) don't get
 # instantiated. The function will be called when the desired transport gets
 # selected.
@@ -46,10 +42,10 @@ transport_params = {
 
 
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
-    logger.info(f"Starting bot with video input: {args.input}")
+    logger.info(f"Starting bot with video input: {runner_args.cli_args.input}")
 
     gst = GStreamerPipelineSource(
-        pipeline=f"filesrc location={args.input}",
+        pipeline=f"filesrc location={runner_args.cli_args.input}",
         out_params=GStreamerPipelineSource.OutputParams(
             video_width=1280,
             video_height=720,
@@ -68,6 +64,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await task.cancel()
+
     runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.run(task)
@@ -82,4 +87,7 @@ async def bot(runner_args: RunnerArguments):
 if __name__ == "__main__":
     from pipecat.runner.run import main
 
-    main()
+    parser = argparse.ArgumentParser(description="Pipecat Video Streaming Bot")
+    parser.add_argument("-i", "--input", type=str, required=True, help="Input video file")
+
+    main(parser)

--- a/src/pipecat/runner/types.py
+++ b/src/pipecat/runner/types.py
@@ -10,6 +10,7 @@ These types are used by the development runner to pass transport-specific
 information to bot functions.
 """
 
+import argparse
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -64,6 +65,7 @@ class RunnerArguments:
     handle_sigterm: bool = field(init=False, kw_only=True)
     pipeline_idle_timeout_secs: int = field(init=False, kw_only=True)
     body: Optional[Any] = field(default_factory=dict, kw_only=True)
+    cli_args: Optional[argparse.Namespace] = field(default=None, init=False, kw_only=True)
 
     def __post_init__(self):
         self.handle_sigint = False


### PR DESCRIPTION
## Summary

- `main()` now accepts an optional `argparse.ArgumentParser`, allowing bots to define custom CLI arguments that are accessible via `runner_args.cli_args`
- Added `cli_args` field to `RunnerArguments` so all runner argument types carry parsed CLI args
- Refactored internal route setup functions to pass `args: Namespace` instead of unpacking individual keyword arguments
- Updated `18-gstreamer-filesrc.py` example to use the new custom parser pattern

## Example

```python
async def bot(runner_args: RunnerArguments):
    input_file = runner_args.cli_args.input
    ...

if __name__ == "__main__":
    from pipecat.runner.run import main

    parser = argparse.ArgumentParser()
    parser.add_argument("-i", "--input", required=True)
    main(parser)
```