### PR TITLE
Update GradiumTTSService to flush instead of ending stream

### DIFF
--- a/changelog/3597.fixed.md
+++ b/changelog/3597.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue in `GradiumTTSService` where the websocket was being disconnected at the end of every bot turn.

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -232,11 +232,15 @@ class GradiumTTSService(InterruptibleWordTTSService):
         raise Exception("Websocket not connected")
 
     async def flush_audio(self):
-        """Flush any pending audio synthesis."""
+        """Flush any pending audio synthesis.
+
+        Sends a <flush> tag to force the model to output audio for all text
+        that has been input so far, without closing the connection.
+        """
         if not self._websocket:
             return
         try:
-            msg = {"type": "end_of_stream"}
+            msg = {"type": "text", "text": "<flush>"}
             await self._websocket.send(json.dumps(msg))
         except ConnectionClosedOK:
             logger.debug(f"{self}: connection closed normally during flush")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

WIP: Waiting for confirmation from Gradium.

Flushing is dropping the last few words. If this can be fixed, this is a more reliable approach than sending `end_of_stream`, as `end_of_stream` disconnects the websocket.