### PR TITLE
GeminiLiveLLMService: let the transcription timeout handler be scheduled

### DIFF
--- a/changelog/3605.fixed.md
+++ b/changelog/3605.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GeminiLiveLLMService` transcription timeout handler not being scheduled by yielding to the event loop after task creation.

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1689,6 +1689,8 @@ class GeminiLiveLLMService(LLMService):
             self._transcription_timeout_task = self.create_task(
                 self._transcription_timeout_handler()
             )
+            # Let the event loop schedule the taks before it gets cancelled.
+            await asyncio.sleep(0)
 
     async def _handle_msg_output_transcription(self, message: LiveServerMessage):
         """Handle the output transcription message."""


### PR DESCRIPTION
## Summary

- Fixed `GeminiLiveLLMService` transcription timeout handler not being properly scheduled by adding an `await asyncio.sleep(0)` after task creation, allowing the event loop to schedule the task before it potentially gets cancelled.