### PR TITLE
PipelineTask: don't add RTVIObserver if already there

### DIFF
--- a/changelog/3610.fixed.md
+++ b/changelog/3610.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `PipelineTask` adding duplicate `RTVIProcessor` and `RTVIObserver` when they were already provided in the pipeline or observers list. They are now detected and skipped, with appropriate warnings and errors logged for mismatched configurations.


### PR DESCRIPTION
## Summary

- `PipelineTask` now skips adding a default `RTVIObserver` if the provided observers list already contains one, preventing duplicate RTVI observers.