### PR TITLE
fix: pass frame class instead of instance to broadcast_frame in websocket transports

### DIFF
--- a/src/pipecat/transports/websocket/client.py
+++ b/src/pipecat/transports/websocket/client.py
@@ -300,7 +300,7 @@ class WebsocketClientInputTransport(BaseInputTransport):
         if isinstance(frame, InputAudioRawFrame) and self._params.audio_in_enabled:
             await self.push_audio_frame(frame)
         elif isinstance(frame, InputTransportMessageFrame):
-            await self.broadcast_frame(frame)
+            await self.broadcast_frame(InputTransportMessageFrame, message=frame.message)
         else:
             await self.push_frame(frame)
 

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -313,7 +313,7 @@ class FastAPIWebsocketInputTransport(BaseInputTransport):
                 if isinstance(frame, InputAudioRawFrame):
                     await self.push_audio_frame(frame)
                 elif isinstance(frame, InputTransportMessageFrame):
-                    await self.broadcast_frame(frame)
+                    await self.broadcast_frame(InputTransportMessageFrame, message=frame.message)
                 else:
                     await self.push_frame(frame)
         except Exception as e:

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -217,7 +217,7 @@ class WebsocketServerInputTransport(BaseInputTransport):
                 if isinstance(frame, InputAudioRawFrame):
                     await self.push_audio_frame(frame)
                 elif isinstance(frame, InputTransportMessageFrame):
-                    await self.broadcast_frame(frame)
+                    await self.broadcast_frame(InputTransportMessageFrame, message=frame.message)
                 else:
                     await self.push_frame(frame)
         except Exception as e:


### PR DESCRIPTION
## Summary
Fix https://github.com/pipecat-ai/pipecat/issues/3613
Relates to https://github.com/pipecat-ai/pipecat/pull/3519

`broadcast_frame()` expects a frame **class** and `**kwargs`, but all three websocket input transports (fastapi, client, server) were incorrectly passing a frame **instance**, causing a `TypeError` at runtime when an `InputTransportMessageFrame` was received.