### PR TITLE
fix(daily): queue outbound messages until transport joins

### DIFF
--- a/changelog/3615.fixed.md
+++ b/changelog/3615.fixed.md
@@ -1,0 +1,1 @@
+- Fixed race condition where `RTVIObserver` could send messages before `DailyTransport` join completed. Outbound messages are now queued & delivered after the transport is ready.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -501,6 +501,8 @@ class DailyTransportClient(EventHandler):
         self._event_task = None
         self._audio_task = None
         self._video_task = None
+        self._message_queue: Optional[asyncio.Queue] = None
+        self._message_task = None
 
         # Input and ouput sample rates. They will be initialize on setup().
         self._in_sample_rate = 0
@@ -567,7 +569,9 @@ class DailyTransportClient(EventHandler):
             error: An error description or None.
         """
         if not self._joined:
-            return "Unable to send messages before joining."
+            if self._message_queue:
+                await self._message_queue.put((frame,))
+            return None
 
         participant_id = None
         if isinstance(
@@ -673,6 +677,12 @@ class DailyTransportClient(EventHandler):
             f"{self}::event_callback_task",
         )
 
+        self._message_queue = asyncio.Queue()
+        self._message_task = self._task_manager.create_task(
+            self._message_task_handler(self._message_queue),
+            f"{self}::message_task",
+        )
+
     async def cleanup(self):
         """Cleanup client resources and cancel tasks."""
         if self._event_task and self._task_manager:
@@ -684,6 +694,9 @@ class DailyTransportClient(EventHandler):
         if self._video_task and self._task_manager:
             await self._task_manager.cancel_task(self._video_task)
             self._video_task = None
+        if self._message_task and self._task_manager:
+            await self._task_manager.cancel_task(self._message_task)
+            self._message_task = None
         # Make sure we don't block the event loop in case `client.release()`
         # takes extra time.
         await self._get_event_loop().run_in_executor(self._executor, self._cleanup)
@@ -1539,6 +1552,14 @@ class DailyTransportClient(EventHandler):
             await self._joined_event.wait()
             (callback, *args) = await queue.get()
             await callback(*args)
+            queue.task_done()
+
+    async def _message_task_handler(self, queue: asyncio.Queue):
+        """Handle queued messages after transport is joined."""
+        while True:
+            await self._joined_event.wait()
+            (frame,) = await queue.get()
+            await self.send_message(frame)
             queue.task_done()
 
     def _get_event_loop(self) -> asyncio.AbstractEventLoop:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3578

### Problem
A race condition exists during pipeline startup when using `RTVIObserver` with `DailyTransport`. The observer emits messages (e.g., `bot-ready`, metrics) immediately upon receiving the `StartFrame`, but `DailyTransport.join()` is asynchronous. This causes the transport to reject messages with `ERROR | Unable to send message: Unable to send messages before joining`.

### Solution
Buffer outbound messages in `_join_message_queue` and flush them once join succeeds.

### Testing

Before :
<img width="2912" height="1780" alt="image" src="https://github.com/user-attachments/assets/15e439a6-58cc-4325-92b3-0e610dcca61f" />


After :
<img width="3018" height="1658" alt="image" src="https://github.com/user-attachments/assets/0ec77477-fe4e-492b-9582-14d0aa6bd6b7" />

Also verified(at client side) that initial messages are now successfully received after the transport joins.