### PR TITLE
Change default endpointing mode for SpeechmaticsSTTService.

### DIFF
--- a/changelog/3618.changed.md
+++ b/changelog/3618.changed.md
@@ -1,0 +1,2 @@
+- Changed default mode to be `EXTERNAL` for Pipecat VAD.
+- Added `model` parameter to `SpeechmaticsSTTService` to allow for setting operating point to `standard` or `enhanced` (default).


### PR DESCRIPTION
## What's Changed?

- Changed default mode to be `EXTERNAL` for Pipecat VAD. Use `FIXED` when no VAD is being used and `ADAPTIVE` or `SMART_TURN` if using the service's VAD.
- Added `model` parameter to `SpeechmaticsSTTService` to allow for setting operating point to `standard` or `enhanced` (default).
