### PR TITLE
[inworld] Allow Async delivery of timestamps info

### DIFF
--- a/changelog/3625.added.md
+++ b/changelog/3625.added.md
@@ -1,0 +1,1 @@
+- Added `"timestampTransportStrategy": "ASYNC"` to `InworldAITTSService`. This allows timestamps info to trail audio chunks arrival, resulting in much better first audio chunk latency


### PR DESCRIPTION
* speed up first audio chunk latency

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

There might be requirements to keep the timestamp info synced with the audio chunks. E.g. if a response chunk `{audio_bytes: asdflksdafja}` has the audio for "Hello", then the same response must also have `{audio_bytes: asdflksdafja, timestamp_info: {... "Hello" ...}}`, such as in some latency sensitive lipsync use cases.

But IIUC, Pipecat doesn't really care about this because the timestamps and audios are emitted to two independent channels anyway. If my understanding is incorrect, I will refactor the PR to allow SDK users to configure `SYNC` vs `ASYNC` in case some have this requirement for backward compatibility

Official docs for this mode will be up shortly. 