### PR TITLE
Fixed an error in the WebSocket transport that occurred when an InputTransportMessageFrame was received and broadcast.

### DIFF
--- a/changelog/3635.fixed.md
+++ b/changelog/3635.fixed.md
@@ -1,0 +1,1 @@
+- Fixed WebSocket transport error when broadcasting `InputTransportMessageFrame` by correctly instantiating the frame with its message parameter.


### PR DESCRIPTION
Fixed an error in the WebSocket transport that occurred when an InputTransportMessageFrame was received and broadcast.