### PR TITLE
Update RimeTTSService for arcana and mistv2 model support

### DIFF
--- a/changelog/3642.added.md
+++ b/changelog/3642.added.md
@@ -1,0 +1,1 @@
+- Added model-specific `InputParams` to `RimeTTSService`: arcana params (`repetition_penalty`, `temperature`, `top_p`) and mistv2 params (`no_text_normalization`, `save_oovs`, `segment`). Model, voice, and param changes now trigger WebSocket reconnection.

--- a/changelog/3642.changed.md
+++ b/changelog/3642.changed.md
@@ -1,0 +1,1 @@
+- ⚠️ `RimeTTSService` now defaults to `model="arcana"` and the `wss://users-ws.rime.ai/ws3` endpoint. `InputParams` defaults changed from mistv2-specific values to `None` — only explicitly-set params are sent as query params.

--- a/examples/foundational/07q-interruptible-rime.py
+++ b/examples/foundational/07q-interruptible-rime.py
@@ -25,7 +25,6 @@ from pipecat.runner.utils import create_transport
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.rime.tts import RimeTTSService
-from pipecat.transcriptions.language import Language
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -58,12 +57,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = RimeTTSService(
         api_key=os.getenv("RIME_API_KEY", ""),
         voice_id="luna",
-        params=RimeTTSService.InputParams(
-            language=Language.EN,
-            repetition_penalty=1.0,
-            temperature=0.5,
-            top_p=0.9,
-        ),
     )
 
     llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))

--- a/examples/foundational/07q-interruptible-rime.py
+++ b/examples/foundational/07q-interruptible-rime.py
@@ -25,6 +25,7 @@ from pipecat.runner.utils import create_transport
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.rime.tts import RimeTTSService
+from pipecat.transcriptions.language import Language
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -56,7 +57,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     tts = RimeTTSService(
         api_key=os.getenv("RIME_API_KEY", ""),
-        voice_id="rex",
+        voice_id="luna",
+        params=RimeTTSService.InputParams(
+            language=Language.EN,
+            repetition_penalty=1.0,
+            temperature=0.5,
+            top_p=0.9,
+        ),
     )
 
     llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -98,8 +98,8 @@ class RimeTTSService(AudioContextWordTTSService):
         *,
         api_key: str,
         voice_id: str,
-        url: str = "wss://users.rime.ai/ws2",
-        model: str = "mistv2",
+        url: str = "wss://users-ws.rime.ai/ws3",
+        model: str = "arcana",
         sample_rate: Optional[int] = None,
         params: Optional[InputParams] = None,
         text_aggregator: Optional[BaseTextAggregator] = None,
@@ -383,7 +383,7 @@ class RimeTTSService(AudioContextWordTTSService):
         async for message in self._get_websocket():
             msg = json.loads(message)
 
-            if not msg or not self.audio_context_available(msg["contextId"]):
+            if not msg or not self.audio_context_available(msg.get("contextId")):
                 continue
 
             context_id = msg["contextId"]
@@ -626,20 +626,18 @@ class RimeHttpTTSService(TTSService):
 class RimeNonJsonTTSService(InterruptibleTTSService):
     """Pipecat TTS service for Rime's non-JSON WebSocket API.
 
+    .. deprecated:: 0.0.102
+        Arcana now supports JSON WebSocket with word-level timestamps via the
+        ``wss://users-ws.rime.ai/ws3`` endpoint. Use :class:`RimeTTSService`
+        with ``model="arcana"`` instead.
+
     This service enables Text-to-Speech synthesis over WebSocket endpoints
     that require plain text (not JSON) messages and return raw audio bytes.
-    It is designed for use with TTS models like Arcana, which currently do
-    not support JSON-based WebSocket protocols (though this may change in
-    the future).
 
     Limitations:
         - Does not support word-level timestamps or context IDs.
         - Intended specifically for integrations where the TTS provider only
           accepts and returns non-JSON messages.
-
-    Note:
-        - Arcana and similar models may add JSON WebSocket support in the
-          future. This service focuses on the current plain text protocol.
     """
 
     class InputParams(BaseModel):


### PR DESCRIPTION
## Summary

- Updated `RimeTTSService` default endpoint to `wss://users-ws.rime.ai/ws3` and default model to `arcana`, following [Rime Arcana v3 JSON WebSocket support](https://docs.rime.ai/docs/changelog#2026-02-04-2)
- Overhauled `InputParams` with model-specific parameters: arcana (`repetition_penalty`, `temperature`, `top_p`) and mistv2 (`no_text_normalization`, `save_oovs`, `segment`), all defaulting to `None` so only explicitly-set values are sent as query params
- Added `_build_settings()` to dynamically construct WebSocket query params based on the current model
- `set_model()` and `_update_settings()` now trigger WebSocket reconnection when settings change, since all params are URL query parameters
- Deprecated `RimeNonJsonTTSService` now that arcana supports the JSON WebSocket endpoint with word-level timestamps

## Breaking Changes

- `RimeTTSService` default model changed from `mistv2` to `arcana`
- Default WebSocket URL changed from `wss://users.rime.ai/ws2` to `wss://users-ws.rime.ai/ws3`
- `InputParams` defaults changed from mistv2-specific values (`speed_alpha=1.0`, `reduce_latency=False`, etc.) to `None` — only explicitly-set params are now sent as query params

## Testing

- Run `uv run python examples/foundational/07q-interruptible-rime.py` with arcana model
- Verify mistv2 still works by passing `model="mistv2"` with mistv2-specific params