### PR TITLE
fix(smallwebrtc): respect audio_out_10ms_chunks parameter in RawAudioTrack

### DIFF
--- a/changelog/3645.fixed.md
+++ b/changelog/3645.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SmallWebRTCTransport` not respecting `TransportParams.audio_out_10ms_chunks` parameter. The transport was hardcoded to produce 10ms audio frames regardless of the configured chunk size.

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -84,7 +84,12 @@ class RawAudioTrack(AudioStreamTrack):
         Args:
             sample_rate: The audio sample rate in Hz.
             num_10ms_chunks: Number of 10ms chunks per output frame (default 1).
+
+        Raises:
+            ValueError: If num_10ms_chunks is not a positive integer.
         """
+        if num_10ms_chunks < 1:
+            raise ValueError(f"num_10ms_chunks must be a positive integer, got {num_10ms_chunks}")
         super().__init__()
         self._sample_rate = sample_rate
         self._num_10ms_chunks = num_10ms_chunks

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -115,15 +115,16 @@ class TestRawAudioTrack:
         num_chunks = 4  # 40ms
         track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
 
-        # Initial timestamp should be 0
-        assert track._timestamp == 0
+        # Receive first frame and check its timestamp
+        frame1 = await track.recv()
+        first_pts = frame1.pts
 
-        # Receive one frame (silence is fine)
-        await track.recv()
+        # Receive second frame
+        frame2 = await track.recv()
 
-        # Timestamp should advance by samples_per_chunk
+        # Timestamp should advance by samples_per_chunk between frames
         expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
-        assert track._timestamp == expected_samples
+        assert frame2.pts - first_pts == expected_samples
 
     def test_different_sample_rates(self):
         """Test chunk size calculation at different sample rates."""

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import pytest
+
+from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+
+
+class TestRawAudioTrack:
+    """Tests for the RawAudioTrack class."""
+
+    def test_default_chunk_size_is_10ms(self):
+        """Test that default chunk size is 10ms (num_10ms_chunks=1)."""
+        sample_rate = 16000
+        track = RawAudioTrack(sample_rate=sample_rate)
+
+        # 10ms at 16kHz = 160 samples, 2 bytes per sample = 320 bytes
+        expected_bytes = int(sample_rate * 10 / 1000) * 2
+        assert track._bytes_per_chunk == expected_bytes
+        assert track._bytes_per_chunk == 320
+
+    def test_custom_chunk_size_40ms(self):
+        """Test that num_10ms_chunks=4 produces 40ms chunks."""
+        sample_rate = 16000
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=4)
+
+        # 40ms at 16kHz = 640 samples, 2 bytes per sample = 1280 bytes
+        expected_bytes = int(sample_rate * 40 / 1000) * 2
+        assert track._bytes_per_chunk == expected_bytes
+        assert track._bytes_per_chunk == 1280
+
+    def test_custom_chunk_size_20ms(self):
+        """Test that num_10ms_chunks=2 produces 20ms chunks."""
+        sample_rate = 16000
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=2)
+
+        # 20ms at 16kHz = 320 samples, 2 bytes per sample = 640 bytes
+        expected_bytes = int(sample_rate * 20 / 1000) * 2
+        assert track._bytes_per_chunk == expected_bytes
+        assert track._bytes_per_chunk == 640
+
+    @pytest.mark.asyncio
+    async def test_add_audio_bytes_queues_correct_chunks(self):
+        """Test that add_audio_bytes breaks audio into correct chunk sizes."""
+        sample_rate = 16000
+        num_chunks = 4  # 40ms
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
+
+        # Create 80ms of audio (2 chunks of 40ms each)
+        audio_bytes = bytes(track._bytes_per_chunk * 2)
+        track.add_audio_bytes(audio_bytes)
+
+        # Should have exactly 2 chunks in the queue
+        assert len(track._chunk_queue) == 2
+
+        # Each chunk should be the correct size
+        chunk1, _ = track._chunk_queue[0]
+        chunk2, _ = track._chunk_queue[1]
+        assert len(chunk1) == track._bytes_per_chunk
+        assert len(chunk2) == track._bytes_per_chunk
+
+    @pytest.mark.asyncio
+    async def test_add_audio_bytes_rejects_invalid_size(self):
+        """Test that add_audio_bytes rejects audio not a multiple of chunk size."""
+        sample_rate = 16000
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=4)
+
+        # Create audio that's not a multiple of 40ms chunk size
+        invalid_audio = bytes(track._bytes_per_chunk + 100)
+
+        with pytest.raises(ValueError) as exc_info:
+            track.add_audio_bytes(invalid_audio)
+
+        assert "40ms" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_recv_returns_correct_frame_size(self):
+        """Test that recv() returns AudioFrames with correct sample count."""
+        sample_rate = 16000
+        num_chunks = 4  # 40ms
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
+
+        # Add one 40ms chunk of audio
+        audio_bytes = bytes(track._bytes_per_chunk)
+        track.add_audio_bytes(audio_bytes)
+
+        # Receive the frame
+        frame = await track.recv()
+
+        # Frame should have correct number of samples (40ms worth)
+        expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
+        assert frame.samples == expected_samples
+
+    @pytest.mark.asyncio
+    async def test_recv_silence_has_correct_size(self):
+        """Test that silence frames have correct size when queue is empty."""
+        sample_rate = 16000
+        num_chunks = 4  # 40ms
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
+
+        # Don't add any audio - should get silence
+        frame = await track.recv()
+
+        # Silence frame should have correct number of samples
+        expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
+        assert frame.samples == expected_samples
+
+    @pytest.mark.asyncio
+    async def test_timestamp_advances_by_chunk_samples(self):
+        """Test that timestamp advances correctly based on chunk size."""
+        sample_rate = 16000
+        num_chunks = 4  # 40ms
+        track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
+
+        # Initial timestamp should be 0
+        assert track._timestamp == 0
+
+        # Receive one frame (silence is fine)
+        await track.recv()
+
+        # Timestamp should advance by samples_per_chunk
+        expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
+        assert track._timestamp == expected_samples
+
+    def test_different_sample_rates(self):
+        """Test chunk size calculation at different sample rates."""
+        test_cases = [
+            (8000, 4, 640),  # 8kHz, 40ms = 320 samples * 2 bytes = 640 bytes
+            (16000, 4, 1280),  # 16kHz, 40ms = 640 samples * 2 bytes = 1280 bytes
+            (24000, 4, 1920),  # 24kHz, 40ms = 960 samples * 2 bytes = 1920 bytes
+            (48000, 4, 3840),  # 48kHz, 40ms = 1920 samples * 2 bytes = 3840 bytes
+        ]
+
+        for sample_rate, num_chunks, expected_bytes in test_cases:
+            track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
+            assert track._bytes_per_chunk == expected_bytes

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -137,3 +137,17 @@ class TestRawAudioTrack:
         for sample_rate, num_chunks, expected_bytes in test_cases:
             track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
             assert track._bytes_per_chunk == expected_bytes
+
+    def test_invalid_num_10ms_chunks_zero(self):
+        """Test that num_10ms_chunks=0 raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            RawAudioTrack(sample_rate=16000, num_10ms_chunks=0)
+
+        assert "positive integer" in str(exc_info.value)
+
+    def test_invalid_num_10ms_chunks_negative(self):
+        """Test that negative num_10ms_chunks raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            RawAudioTrack(sample_rate=16000, num_10ms_chunks=-1)
+
+        assert "positive integer" in str(exc_info.value)

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -4,12 +4,29 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import pytest
+# pyright: reportConstantRedefinition=false
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false
+# pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false
+# pyright: reportOperatorIssue=false
+# pyright: reportOptionalCall=false
 
-from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+import unittest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+
+try:
+    from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+
+    WEBRTC_AVAILABLE = True
+except (ImportError, Exception):
+    WEBRTC_AVAILABLE = False
+    RawAudioTrack = None  # type: ignore[misc,assignment]
 
 
-class TestRawAudioTrack:
+@unittest.skipUnless(WEBRTC_AVAILABLE, "webrtc dependencies not installed")
+class TestRawAudioTrack(unittest.IsolatedAsyncioTestCase):
     """Tests for the RawAudioTrack class."""
 
     def test_default_chunk_size_is_10ms(self):
@@ -19,8 +36,8 @@ class TestRawAudioTrack:
 
         # 10ms at 16kHz = 160 samples, 2 bytes per sample = 320 bytes
         expected_bytes = int(sample_rate * 10 / 1000) * 2
-        assert track._bytes_per_chunk == expected_bytes
-        assert track._bytes_per_chunk == 320
+        self.assertEqual(track._bytes_per_chunk, expected_bytes)
+        self.assertEqual(track._bytes_per_chunk, 320)
 
     def test_custom_chunk_size_40ms(self):
         """Test that num_10ms_chunks=4 produces 40ms chunks."""
@@ -29,8 +46,8 @@ class TestRawAudioTrack:
 
         # 40ms at 16kHz = 640 samples, 2 bytes per sample = 1280 bytes
         expected_bytes = int(sample_rate * 40 / 1000) * 2
-        assert track._bytes_per_chunk == expected_bytes
-        assert track._bytes_per_chunk == 1280
+        self.assertEqual(track._bytes_per_chunk, expected_bytes)
+        self.assertEqual(track._bytes_per_chunk, 1280)
 
     def test_custom_chunk_size_20ms(self):
         """Test that num_10ms_chunks=2 produces 20ms chunks."""
@@ -39,10 +56,9 @@ class TestRawAudioTrack:
 
         # 20ms at 16kHz = 320 samples, 2 bytes per sample = 640 bytes
         expected_bytes = int(sample_rate * 20 / 1000) * 2
-        assert track._bytes_per_chunk == expected_bytes
-        assert track._bytes_per_chunk == 640
+        self.assertEqual(track._bytes_per_chunk, expected_bytes)
+        self.assertEqual(track._bytes_per_chunk, 640)
 
-    @pytest.mark.asyncio
     async def test_add_audio_bytes_queues_correct_chunks(self):
         """Test that add_audio_bytes breaks audio into correct chunk sizes."""
         sample_rate = 16000
@@ -54,15 +70,14 @@ class TestRawAudioTrack:
         track.add_audio_bytes(audio_bytes)
 
         # Should have exactly 2 chunks in the queue
-        assert len(track._chunk_queue) == 2
+        self.assertEqual(len(track._chunk_queue), 2)
 
         # Each chunk should be the correct size
         chunk1, _ = track._chunk_queue[0]
         chunk2, _ = track._chunk_queue[1]
-        assert len(chunk1) == track._bytes_per_chunk
-        assert len(chunk2) == track._bytes_per_chunk
+        self.assertEqual(len(chunk1), track._bytes_per_chunk)
+        self.assertEqual(len(chunk2), track._bytes_per_chunk)
 
-    @pytest.mark.asyncio
     async def test_add_audio_bytes_rejects_invalid_size(self):
         """Test that add_audio_bytes rejects audio not a multiple of chunk size."""
         sample_rate = 16000
@@ -71,12 +86,11 @@ class TestRawAudioTrack:
         # Create audio that's not a multiple of 40ms chunk size
         invalid_audio = bytes(track._bytes_per_chunk + 100)
 
-        with pytest.raises(ValueError) as exc_info:
+        with self.assertRaises(ValueError) as ctx:
             track.add_audio_bytes(invalid_audio)
 
-        assert "40ms" in str(exc_info.value)
+        self.assertIn("40ms", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_recv_returns_correct_frame_size(self):
         """Test that recv() returns AudioFrames with correct sample count."""
         sample_rate = 16000
@@ -92,9 +106,8 @@ class TestRawAudioTrack:
 
         # Frame should have correct number of samples (40ms worth)
         expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
-        assert frame.samples == expected_samples
+        self.assertEqual(frame.samples, expected_samples)
 
-    @pytest.mark.asyncio
     async def test_recv_silence_has_correct_size(self):
         """Test that silence frames have correct size when queue is empty."""
         sample_rate = 16000
@@ -106,9 +119,8 @@ class TestRawAudioTrack:
 
         # Silence frame should have correct number of samples
         expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
-        assert frame.samples == expected_samples
+        self.assertEqual(frame.samples, expected_samples)
 
-    @pytest.mark.asyncio
     async def test_timestamp_advances_by_chunk_samples(self):
         """Test that timestamp advances correctly based on chunk size."""
         sample_rate = 16000
@@ -117,14 +129,14 @@ class TestRawAudioTrack:
 
         # Receive first frame and check its timestamp
         frame1 = await track.recv()
-        first_pts = frame1.pts
-
         # Receive second frame
         frame2 = await track.recv()
 
         # Timestamp should advance by samples_per_chunk between frames
+        self.assertIsNotNone(frame1.pts)
+        self.assertIsNotNone(frame2.pts)
         expected_samples = int(sample_rate * 40 / 1000)  # 640 samples
-        assert frame2.pts - first_pts == expected_samples
+        self.assertEqual(frame2.pts - frame1.pts, expected_samples)
 
     def test_different_sample_rates(self):
         """Test chunk size calculation at different sample rates."""
@@ -137,18 +149,22 @@ class TestRawAudioTrack:
 
         for sample_rate, num_chunks, expected_bytes in test_cases:
             track = RawAudioTrack(sample_rate=sample_rate, num_10ms_chunks=num_chunks)
-            assert track._bytes_per_chunk == expected_bytes
+            self.assertEqual(track._bytes_per_chunk, expected_bytes)
 
     def test_invalid_num_10ms_chunks_zero(self):
         """Test that num_10ms_chunks=0 raises ValueError."""
-        with pytest.raises(ValueError) as exc_info:
+        with self.assertRaises(ValueError) as ctx:
             RawAudioTrack(sample_rate=16000, num_10ms_chunks=0)
 
-        assert "positive integer" in str(exc_info.value)
+        self.assertIn("positive integer", str(ctx.exception))
 
     def test_invalid_num_10ms_chunks_negative(self):
         """Test that negative num_10ms_chunks raises ValueError."""
-        with pytest.raises(ValueError) as exc_info:
+        with self.assertRaises(ValueError) as ctx:
             RawAudioTrack(sample_rate=16000, num_10ms_chunks=-1)
 
-        assert "positive integer" in str(exc_info.value)
+        self.assertIn("positive integer", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixed an issue where `SmallWebRTCTransport` was not respecting the `audio_out_10ms_chunks` parameter from `TransportParams`. The `RawAudioTrack` class was hardcoded to always produce 10ms audio frames, causing firmware clients to receive incorrect chunk sizes (e.g., receiving 20ms chunks when 40ms was configured).

## Problem

When using `SmallWebRTCTransport` on Pipecat Cloud with `audio_out_10ms_chunks=4` (40ms), firmware clients were still receiving 20ms audio chunks. This happened because:

1. The base transport correctly chunked audio into 40ms pieces based on `audio_out_10ms_chunks`
2. However, `RawAudioTrack` in SmallWebRTC was re-chunking the audio back to 10ms for WebRTC transmission
3. The `recv()` method always produced 10ms frames regardless of configuration

## Solution

Updated `RawAudioTrack` to accept and respect a configurable chunk size:

- Added `num_10ms_chunks` parameter to `RawAudioTrack` constructor (default 1 for backward compatibility)
- Updated `add_audio_bytes()` to validate and chunk audio using the configured chunk size
- Updated `recv()` to produce audio frames of the configured size and advance timestamps correctly
- Modified `_handle_client_connected()` to pass `audio_out_10ms_chunks` from `TransportParams` when creating the track

## Testing

- Verified that setting `audio_out_10ms_chunks=4` now correctly produces 40ms audio frames over WebRTC
- Backward compatible: default behavior (10ms chunks) remains unchanged when parameter is not specified
