### PR TITLE
Fix orphan otel spans during flow initialization and transitions

### DIFF
--- a/changelog/3649.fixed.md
+++ b/changelog/3649.fixed.md
@@ -1,0 +1,1 @@
+- Fixed orphan OpenTelemetry spans during flow initialization and transitions in tracing.

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 from pipecat.processors.aggregators.llm_context import NOT_GIVEN, LLMContext
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+from pipecat.utils.tracing.conversation_context_provider import get_current_conversation_context
 from pipecat.utils.tracing.service_attributes import (
     add_gemini_live_span_attributes,
     add_llm_span_attributes,
@@ -32,7 +33,6 @@ from pipecat.utils.tracing.service_attributes import (
     add_stt_span_attributes,
     add_tts_span_attributes,
 )
-from pipecat.utils.tracing.conversation_context_provider import get_current_conversation_context
 from pipecat.utils.tracing.setup import is_tracing_available
 from pipecat.utils.tracing.turn_context_provider import get_current_turn_context
 


### PR DESCRIPTION
This fixes an issue where `pipecat-flows` creates multiple trace sessions for a single conversation. 

## Problem

Service spans (TTS, LLM) were being created without a parent context, causing OpenTelemetry to auto-generate new trace IDs and create orphan sessions.   

Here is an example (single conversation, multiple conversation ids from the [pipecat-flows quickstart example](https://github.com/pipecat-ai/pipecat-flows/tree/main/examples/quickstart)):

<img width="814" height="196" alt="image" src="https://github.com/user-attachments/assets/c525701a-f3b9-4778-9667-e011e34d82f4" />

I believe this occurs because:
                                                                                                                                   
1. `flow_manager.initialize()` triggers LLM/TTS before Turn 1 starts                                                                                              
2. Flow transitions (between turns) also trigger LLM/TTS when no turn context is active                                                                           
3. Without a parent context, each span gets an auto-generated trace ID

## Solution

Two parts:

**Fix 1: Start conversation tracing on StartFrame** (`turn_trace_observer.py`)                                                                                    
  - Previously, conversation tracing started when Turn 1 began                                                                                                      
  - Now it starts when the pipeline starts (StartFrame)                                                                                                             
  - Ensures spans created during flow initialization have a parent context                                                                                          
                                                                                                                                                                    
  **Fix 2: Fall back to conversation context** (`service_decorators.py`)                                                                                            
  - `_get_parent_service_context()` now falls back to conversation context when no turn context exists                                                              
  - Ensures spans created between turns (during flow transitions) have a parent context

## Testing                                                                                                                                                        
                                                                                                                                                                    
Tested with `pipecat-flows` 0.0.22, `pipecat-ai` 0.0.101 and [Finchvox](https://github.com/finchvox/finchvox) as the otel tracing collector. 

Now, a single session is created per pipecat flows conversation:

<img width="811" height="62" alt="image" src="https://github.com/user-attachments/assets/735cabdb-e400-4866-ab31-9978e1a40d0c" />

<img width="1489" height="659" alt="image" src="https://github.com/user-attachments/assets/27275715-476b-4a38-a60f-652f146edd67" />

## Caveats

I'm still getting comfortable with how the otel instrumentation works within pipecat.

I've attached logs, the otel spans, etc. from a successful pipecat flows trace.
[finchvox_session_4905059bd2adc7b0a0934a78cae8886e.zip](https://github.com/user-attachments/files/25097329/finchvox_session_4905059bd2adc7b0a0934a78cae8886e.zip)                                                
                                                                                              

   
