### PR TITLE
Ignoring RTVI messages inside the Serializers by default.

### DIFF
--- a/src/pipecat/serializers/base_serializer.py
+++ b/src/pipecat/serializers/base_serializer.py
@@ -7,8 +7,17 @@
 """Frame serialization interfaces for Pipecat."""
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
-from pipecat.frames.frames import Frame, StartFrame
+from pydantic import BaseModel
+
+from pipecat.frames.frames import (
+    Frame,
+    OutputTransportMessageFrame,
+    OutputTransportMessageUrgentFrame,
+    StartFrame,
+)
+from pipecat.processors.frameworks.rtvi import RTVI_MESSAGE_LABEL
 from pipecat.utils.base_object import BaseObject
 
 
@@ -19,6 +28,46 @@ class FrameSerializer(BaseObject):
     for transmission or storage. Subclasses must implement the core
     serialize/deserialize methods.
     """
+
+    class InputParams(BaseModel):
+        """Base configuration parameters for FrameSerializer.
+
+        Parameters:
+            ignore_rtvi_messages: Whether to ignore RTVI protocol messages during serialization.
+                Defaults to True to prevent RTVI messages from being sent to external transports.
+        """
+
+        ignore_rtvi_messages: bool = True
+
+    def __init__(self, params: Optional[InputParams] = None, **kwargs):
+        """Initialize the FrameSerializer.
+
+        Args:
+            params: Configuration parameters.
+            **kwargs: Additional arguments passed to BaseObject (e.g., name).
+        """
+        super().__init__(**kwargs)
+        self._params = params or FrameSerializer.InputParams()
+
+    def should_ignore_frame(self, frame: Frame) -> bool:
+        """Check if a frame should be ignored during serialization.
+
+        This method filters out RTVI protocol messages when ignore_rtvi_messages is enabled.
+        Subclasses can override this to add additional filtering logic.
+
+        Args:
+            frame: The frame to check.
+
+        Returns:
+            True if the frame should be ignored, False otherwise.
+        """
+        if (
+            self._params.ignore_rtvi_messages
+            and isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame))
+            and frame.message.get("label") == RTVI_MESSAGE_LABEL
+        ):
+            return True
+        return False
 
     async def setup(self, frame: StartFrame):
         """Initialize the serializer with startup configuration.

--- a/src/pipecat/serializers/protobuf.py
+++ b/src/pipecat/serializers/protobuf.py
@@ -8,6 +8,7 @@
 
 import dataclasses
 import json
+from typing import Optional
 
 from loguru import logger
 
@@ -60,9 +61,13 @@ class ProtobufFrameSerializer(FrameSerializer):
     }
     DESERIALIZABLE_FIELDS = {v: k for k, v in DESERIALIZABLE_TYPES.items()}
 
-    def __init__(self):
-        """Initialize the Protobuf frame serializer."""
-        pass
+    def __init__(self, params: Optional[FrameSerializer.InputParams] = None):
+        """Initialize the Protobuf frame serializer.
+
+        Args:
+            params: Configuration parameters.
+        """
+        super().__init__(params)
 
     async def serialize(self, frame: Frame) -> str | bytes | None:
         """Serialize a frame to Protocol Buffer binary format.
@@ -75,6 +80,8 @@ class ProtobufFrameSerializer(FrameSerializer):
         """
         # Wrapping this messages as a JSONFrame to send
         if isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame)):
+            if self.should_ignore_frame(frame):
+                return None
             frame = MessageFrame(
                 data=json.dumps(frame.message),
             )

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -27,6 +27,7 @@ from pipecat.frames.frames import (
     OutputTransportMessageUrgentFrame,
     StartFrame,
 )
+from pipecat.processors.frameworks.rtvi import RTVI_MESSAGE_LABEL
 from pipecat.serializers.base_serializer import FrameSerializer
 
 
@@ -54,6 +55,7 @@ class TwilioFrameSerializer(FrameSerializer):
         twilio_sample_rate: int = 8000
         sample_rate: Optional[int] = None
         auto_hang_up: bool = True
+        ignore_rtvi_messages: Optional[bool] = True
 
     def __init__(
         self,
@@ -167,6 +169,11 @@ class TwilioFrameSerializer(FrameSerializer):
 
             return json.dumps(answer)
         elif isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame)):
+            if (
+                self._params.ignore_rtvi_messages
+                and frame.message.get("label") == RTVI_MESSAGE_LABEL
+            ):
+                return None
             return json.dumps(frame.message)
 
         # Return None for unhandled frames


### PR DESCRIPTION
Ignoring RTVI messages inside TwilioSerializer by default.

Fixes: https://github.com/pipecat-ai/pipecat/pull/3650