### PR TITLE
HeyGen improvements.

### DIFF
--- a/changelog/3653.added.2.md
+++ b/changelog/3653.added.2.md
@@ -1,0 +1,1 @@
+- Added support for `video_settings` parameter in `LiveAvatarNewSessionRequest` to configure video encoding (H264/VP8) and quality levels.

--- a/changelog/3653.added.md
+++ b/changelog/3653.added.md
@@ -1,0 +1,1 @@
+- Added support for `is_sandbox` parameter in `LiveAvatarNewSessionRequest` to enable sandbox mode for HeyGen LiveAvatar sessions.

--- a/changelog/3653.changed.md
+++ b/changelog/3653.changed.md
@@ -1,0 +1,1 @@
+- Changed default session mode from "CUSTOM" to "LITE" in HeyGen LiveAvatar integration, with VP8 as the default video encoding.

--- a/examples/foundational/43-heygen-transport.py
+++ b/examples/foundational/43-heygen-transport.py
@@ -25,6 +25,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.heygen.api_liveavatar import LiveAvatarNewSessionRequest
 from pipecat.transports.heygen.transport import HeyGenParams, HeyGenTransport, ServiceType
 
 load_dotenv(override=True)
@@ -42,6 +43,12 @@ async def main():
             params=HeyGenParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
+            ),
+            session_request=LiveAvatarNewSessionRequest(
+                is_sandbox=True,
+                # Sandbox mode only works with this specific avatar
+                # https://docs.liveavatar.com/docs/developing-in-sandbox-mode#sandbox-mode-behaviors
+                avatar_id="dd73ea75-1218-4ef3-92ce-606d5f7fbc0a",
             ),
         )
 

--- a/examples/foundational/43a-heygen-video-service.py
+++ b/examples/foundational/43a-heygen-video-service.py
@@ -25,6 +25,7 @@ from pipecat.runner.utils import create_transport
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.heygen.api_liveavatar import LiveAvatarNewSessionRequest
 from pipecat.services.heygen.client import ServiceType
 from pipecat.services.heygen.video import HeyGenVideoService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
@@ -71,6 +72,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             api_key=os.getenv("HEYGEN_LIVE_AVATAR_API_KEY"),
             service_type=ServiceType.LIVE_AVATAR,
             session=session,
+            session_request=LiveAvatarNewSessionRequest(
+                is_sandbox=True,
+                # Sandbox mode only works with this specific avatar
+                # https://docs.liveavatar.com/docs/developing-in-sandbox-mode#sandbox-mode-behaviors
+                avatar_id="dd73ea75-1218-4ef3-92ce-606d5f7fbc0a",
+            ),
         )
 
         messages = [


### PR DESCRIPTION
## Summary                                                                                                         
- Added support for sandbox mode in HeyGen LiveAvatar integration via `is_sandbox` parameter
- Added configurable video settings (encoding type and quality level) via `video_settings` parameter
- Changed default session mode from "CUSTOM" to "LITE" with VP8 as default encoding
- Updated examples to use sandbox mode with the official sandbox avatar