### PR TITLE
Changing the ‘no audio received’ log from warning to debug.

### DIFF
--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -449,9 +449,7 @@ class BaseInputTransport(FrameProcessor):
                 if not audio_received:
                     continue
 
-                logger.warning(
-                    f"{self}: audio not received for more than {AUDIO_INPUT_TIMEOUT_SECS}"
-                )
+                logger.debug(f"{self}: audio not received for more than {AUDIO_INPUT_TIMEOUT_SECS}")
 
                 ###################################################################
                 # DEPRECATED.


### PR DESCRIPTION
Changing the ‘no audio received’ log from warning to debug.

This warning was introduced in version 101, when we deprecated the `vad_analyzer` parameter on `BaseInputTransport`.

Aside from seeing this `warning`, users do not appear to be experiencing any call issues. So changing this log to debug to avoid confusion.
