### PR TITLE
DeepgramSTTService: disable smart_format by default

### DIFF
--- a/changelog/3666.changed.md
+++ b/changelog/3666.changed.md
@@ -1,0 +1,1 @@
+- Changed the `DeepgramSTTService` default setting for `smart_format` to `False`, as agents don't need smart formatting. Disabling this setting provides a small performance improvement, as well.

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -106,7 +106,7 @@ class DeepgramSTTService(STTService):
             model="nova-3-general",
             channels=1,
             interim_results=True,
-            smart_format=True,
+            smart_format=False,
             punctuate=True,
             profanity_filter=True,
             vad_events=False,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Recommended change by the Deepgram team. Agents don't need smart formatting to understand the user's speech. This provides a small latency improvement (~30ms).