### PR TITLE
[inworld] aggregate_sentence mode needs trailing space

### DIFF
--- a/changelog/3667.fixed.md
+++ b/changelog/3667.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue in `InworldTTSService` where punctuation was pronounced. Now, the `InworldTTSService` ensures proper spacing between sentences, resolving pronunciation issues.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -439,6 +439,7 @@ class InworldTTSService(AudioContextWordTTSService):
         encoding: str = "LINEAR16",
         params: InputParams = None,
         aggregate_sentences: bool = True,
+        append_trailing_space: bool = True,
         **kwargs: Any,
     ):
         """Initialize the Inworld WebSocket TTS service.
@@ -452,6 +453,7 @@ class InworldTTSService(AudioContextWordTTSService):
             encoding: Audio encoding format.
             params: Input parameters for Inworld WebSocket TTS configuration.
             aggregate_sentences: Whether to aggregate sentences before synthesis.
+            append_trailing_space: Whether to append a trailing space to text before sending to TTS.
             **kwargs: Additional arguments passed to the parent class.
         """
         super().__init__(
@@ -460,6 +462,7 @@ class InworldTTSService(AudioContextWordTTSService):
             pause_frame_processing=True,
             sample_rate=sample_rate,
             aggregate_sentences=aggregate_sentences,
+            append_trailing_space=append_trailing_space,
             **kwargs,
         )
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Spaces from the LLM generations are stripped in the text aggregator. Inworld server does not append additional space in its own aggregation, resulting in words to be joined, such as in `assistant.How` in `Hello! I’m your friendly AI assistant. How can I assist you today?`. The model could still synthesize `assistant.How` correctly but it causes the timestamps alignment to have this joined word instead.