### PR TITLE
Buffer internal frames during ParallelPipeline lifecycle sync

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -7,23 +7,30 @@ Create changelog files for the important commits in this PR. The PR number is pr
 
 ## Instructions
 
-1. First, check what commits are on the current branch compared to main:
+1. Skip changelog for: documentation-only, internal refactoring, test-only, CI changes.
+
+2. First, check what commits are on the current branch compared to main:
    ```
    git log main..HEAD --oneline
    ```
 
-2. For each significant change, create a changelog file in the `changelog/` folder using the format:
+3. For each significant change, create a changelog file in the `changelog/` folder using the format:
+   Allowed types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`, `performance`, `other`
    - `{PR_NUMBER}.added.md` - for new features
-   - `{PR_NUMBER}.added.2.md`, `{PR_NUMBER}.added.3.md` - for additional new features
+   - `{PR_NUMBER}.added.2.md`, `{PR_NUMBER}.added.3.md` - for additional entries of the same type
    - `{PR_NUMBER}.changed.md` - for changes to existing functionality
    - `{PR_NUMBER}.fixed.md` - for bug fixes
    - `{PR_NUMBER}.deprecated.md` - for deprecations
+   - `{PR_NUMBER}.removed.md` - for removed features
+   - `{PR_NUMBER}.security.md` - for security fixes
+   - `{PR_NUMBER}.performance.md` - for performance improvements
+   - `{PR_NUMBER}.other.md` - for other changes
 
-3. Each changelog file should at least contain a main single line starting with `- ` followed by a clear description of the change.
+4. Each changelog file should at least contain a main single line starting with `- ` followed by a clear description of the change.
 
-4. If the change is complicated, changelog files can have indented lines after the main line with additional details or code samples.
+5. If the change is complicated, changelog files can have indented lines after the main line with additional details or code samples.
 
-5. Use ⚠️ emoji prefix for breaking changes.
+6. Use ⚠️ emoji prefix for breaking changes.
 
 ## Example
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ uv run pytest tests/test_name.py::test_function_name
 # Preview changelog
 towncrier build --draft --version Unreleased
 
+# Lint and format check
+uv run ruff check
+uv run ruff format --check
+
 # Update dependencies (after editing pyproject.toml)
 uv lock && uv sync
 ```
@@ -122,24 +126,6 @@ class MyService(LLMService):
         super().__init__(**kwargs)
 ```
 
-## Changelog
-
-Every user-facing PR needs a changelog fragment in `changelog/`:
-
-```
-changelog/<PR_number>.<type>.md
-```
-
-Types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`, `other`
-
-Content format (include the `-`):
-
-```markdown
-- Added support for new feature X.
-```
-
-Skip changelog for: documentation-only, internal refactoring, test-only, CI changes.
-
 ## Service Implementation
 
 When adding a new service:
@@ -151,3 +137,7 @@ When adding a new service:
 5. Push `ErrorFrame` on failures
 6. Add metrics tracking via `MetricsData` if relevant
 7. Follow the pattern of existing services in `src/pipecat/services/`
+
+## Pull Requests
+
+After creating a PR, use `/changelog <pr_number>` to generate the changelog file and `/pr-description <pr_number>` to update the PR description.

--- a/changelog/3668.fixed.md
+++ b/changelog/3668.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ParallelPipeline` allowing frames pushed by internal processors to escape during lifecycle frame (`StartFrame`/`EndFrame`/`CancelFrame`) synchronization. These frames are now buffered and flushed after all branches complete.


### PR DESCRIPTION
## Summary
- Fixes a bug where processors inside parallel sub-pipelines could push frames that escape the `ParallelPipeline` before all branches finish processing a lifecycle frame (`StartFrame`/`EndFrame`/`CancelFrame`).
- Adds a `_synchronizing` flag and `_buffered_frames` list to `ParallelPipeline`. During lifecycle frame synchronization, non-lifecycle frames from internal processors are buffered and flushed only after all branches complete.
- Existing pause/resume mechanism is kept to prevent external lifecycle frames from entering during synchronization.

## Test plan
- [x] Added `test_parallel_internal_frames_buffered_during_start` to verify internal frames are buffered and released after `StartFrame` synchronization
- [x] All existing pipeline tests pass