### PR TITLE
Filter RTVIObserver to downstream frames only and broadcast FunctionCallCancelFrame

### DIFF
--- a/changelog/3672.changed.md
+++ b/changelog/3672.changed.md
@@ -1,0 +1,1 @@
+- Changed `FunctionCallCancelFrame` to broadcast in both directions for consistency with other function call frames.

--- a/changelog/3672.fixed.md
+++ b/changelog/3672.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `RTVIObserver` sending duplicate client messages for frames that are broadcast in both directions (e.g. `UserStartedSpeakingFrame`, `FunctionCallResultFrame`).

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -1023,7 +1023,7 @@ class RTVIObserverParams:
             sets the default level for unlisted functions::
 
                 function_call_report_level={
-                    "*": RTVIFunctionCallReportLevel.DISABLED,  # Default: no events
+                    "*": RTVIFunctionCallReportLevel.NONE,  # Default: events with no metadata
                     "get_weather": RTVIFunctionCallReportLevel.FULL,  # Expose everything
                 }
 
@@ -1198,6 +1198,12 @@ class RTVIObserver(BaseObserver):
         src = data.source
         frame = data.frame
         direction = data.direction
+
+        # Only process downstream frames. Some frames are broadcast in both
+        # directions (e.g. UserStartedSpeakingFrame, FunctionCallResultFrame),
+        # and we only want to send one RTVI message per event.
+        if direction != FrameDirection.DOWNSTREAM:
+            return
 
         # If we have already seen this frame, let's skip it.
         if frame.id in self._frames_seen:

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -745,8 +745,9 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
                     await self.cancel_task(task)
                     cancelled_tasks.add(task)
 
-                frame = FunctionCallCancelFrame(function_name=name, tool_call_id=tool_call_id)
-                await self.push_frame(frame)
+                await self.broadcast_frame(
+                    FunctionCallCancelFrame, function_name=name, tool_call_id=tool_call_id
+                )
 
                 logger.debug(f"{self} Function call [{name}:{tool_call_id}] has been cancelled")
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

@mattieruth found that we were sending multiple events. This started as we moved everything to broadcasting unique frames. I audited current frames and everything goes downstream (and some upstream). I'm adding filtering for the RTVIObserver to only emit events on downstream frames as a convention.

I don't know of a better solution to this, but I think it works for now.