### PR TITLE
Emit RTVI events for user mute/unmute

### DIFF
--- a/changelog/3687.added.md
+++ b/changelog/3687.added.md
@@ -1,0 +1,1 @@
+- Added `UserMuteStartedFrame` and `UserMuteStoppedFrame` system frames, and corresponding `user-mute-started` / `user-mute-stopped` RTVI messages, so clients can observe when mute strategies activate or deactivate.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1209,6 +1209,28 @@ class UserStoppedSpeakingFrame(SystemFrame):
 
 
 @dataclass
+class UserMuteStartedFrame(SystemFrame):
+    """Frame indicating that the user has been muted.
+
+    Emitted when a mute strategy activates, suppressing user frames (audio,
+    transcription, interruption) from propagating through the pipeline.
+    """
+
+    pass
+
+
+@dataclass
+class UserMuteStoppedFrame(SystemFrame):
+    """Frame indicating that the user has been unmuted.
+
+    Emitted when a mute strategy deactivates, allowing user frames to
+    propagate through the pipeline again.
+    """
+
+    pass
+
+
+@dataclass
 class UserSpeakingFrame(SystemFrame):
     """Frame indicating the user is speaking.
 

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -53,6 +53,8 @@ from pipecat.frames.frames import (
     TextFrame,
     TranscriptionFrame,
     UserImageRawFrame,
+    UserMuteStartedFrame,
+    UserMuteStoppedFrame,
     UserSpeakingFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
@@ -569,8 +571,10 @@ class LLMUserAggregator(LLMContextAggregator):
             # Emit mute state change events
             if self._user_is_muted:
                 await self._call_event_handler("on_user_mute_started")
+                await self.broadcast_frame(UserMuteStartedFrame)
             else:
                 await self._call_event_handler("on_user_mute_stopped")
+                await self.broadcast_frame(UserMuteStoppedFrame)
 
         return should_mute_frame
 


### PR DESCRIPTION
## Summary

- Added `UserMuteStartedFrame` / `UserMuteStoppedFrame` system frames to bridge mute strategy state changes into the frame pipeline
- `LLMUserAggregator` now pushes these frames alongside the existing `on_user_mute_started` / `on_user_mute_stopped` event handlers, enabling `RTVIObserver` to observe mute transitions
- Added `RTVIUserMuteStartedMessage` (`user-mute-started`) and `RTVIUserMuteStoppedMessage` (`user-mute-stopped`) RTVI message types so clients can react to mute state changes
- Added `user_mute_enabled` param to `RTVIObserverParams` (defaults to `True`) for controlling emission

## Testing

- All existing tests pass (568 passed, 1 skipped)
- Ruff lint/format checks pass