### PR TITLE
Use TurnAnalyzerUserTurnStopStrategy as default stop strategy

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -39,6 +39,7 @@ jobs:
             --extra google \
             --extra langchain \
             --extra livekit \
+            --extra local-smart-turn-v3 \
             --extra piper \
             --extra websocket
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,7 @@ jobs:
             --extra google \
             --extra langchain \
             --extra livekit \
+            --extra local-smart-turn-v3 \
             --extra piper \
             --extra websocket
 

--- a/changelog/3689.changed.md
+++ b/changelog/3689.changed.md
@@ -1,0 +1,1 @@
+- Changed default user turn stop strategy from `TranscriptionUserTurnStopStrategy` to `TurnAnalyzerUserTurnStopStrategy` with `LocalSmartTurnAnalyzerV3`.

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -48,7 +48,7 @@ from pipecat.metrics.metrics import MetricsData
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.transports.base_transport import TransportParams
 
-AUDIO_INPUT_TIMEOUT_SECS = 1.0
+AUDIO_INPUT_TIMEOUT_SECS = 0.5
 
 
 class BaseInputTransport(FrameProcessor):
@@ -448,8 +448,6 @@ class BaseInputTransport(FrameProcessor):
             except asyncio.TimeoutError:
                 if not audio_received:
                     continue
-
-                logger.debug(f"{self}: audio not received for more than {AUDIO_INPUT_TIMEOUT_SECS}")
 
                 ###################################################################
                 # DEPRECATED.

--- a/src/pipecat/turns/user_turn_strategies.py
+++ b/src/pipecat/turns/user_turn_strategies.py
@@ -9,6 +9,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
 from pipecat.turns.user_start import (
     BaseUserTurnStartStrategy,
     ExternalUserTurnStartStrategy,
@@ -18,7 +19,7 @@ from pipecat.turns.user_start import (
 from pipecat.turns.user_stop import (
     BaseUserTurnStopStrategy,
     ExternalUserTurnStopStrategy,
-    SpeechTimeoutUserTurnStopStrategy,
+    TurnAnalyzerUserTurnStopStrategy,
 )
 
 
@@ -29,7 +30,7 @@ class UserTurnStrategies:
     If no strategies are specified, the following defaults are used:
 
         start: [VADUserTurnStartStrategy, TranscriptionUserTurnStartStrategy]
-         stop: [SpeechTimeoutUserTurnStopStrategy]
+         stop: [TurnAnalyzerUserTurnStopStrategy(LocalSmartTurnAnalyzerV3)]
 
     Attributes:
         start: A list of user turn start strategies used to detect when
@@ -46,7 +47,7 @@ class UserTurnStrategies:
         if not self.start:
             self.start = [VADUserTurnStartStrategy(), TranscriptionUserTurnStartStrategy()]
         if not self.stop:
-            self.stop = [SpeechTimeoutUserTurnStopStrategy()]
+            self.stop = [TurnAnalyzerUserTurnStopStrategy(turn_analyzer=LocalSmartTurnAnalyzerV3())]
 
 
 @dataclass

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -24,10 +24,15 @@ from pipecat.frames.frames import (
 )
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.processors.frameworks.langchain import LangchainProcessor
 from pipecat.tests.utils import SleepFrame, run_test
+from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 
 class TestLangchain(unittest.IsolatedAsyncioTestCase):
@@ -65,7 +70,12 @@ class TestLangchain(unittest.IsolatedAsyncioTestCase):
         self.mock_proc = self.MockProcessor("token_collector")
 
         context = LLMContext()
-        context_aggregator = LLMContextAggregatorPair(context)
+        context_aggregator = LLMContextAggregatorPair(
+            context,
+            user_params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(stop=[SpeechTimeoutUserTurnStopStrategy()])
+            ),
+        )
 
         pipeline = Pipeline(
             [context_aggregator.user(), proc, self.mock_proc, context_aggregator.assistant()]


### PR DESCRIPTION
## Summary
- Change the default user turn stop strategy from `TranscriptionUserTurnStopStrategy` to `TurnAnalyzerUserTurnStopStrategy` with `LocalSmartTurnAnalyzerV3`
- Reduce `AUDIO_INPUT_TIMEOUT_SECS` from 1.0s to 0.5s and remove its debug log

## Test plan
- [ ] Verify default turn detection works correctly with the new strategy
- [ ] Verify audio input timeout behavior with the reduced timeout