### PR TITLE
Add shared Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "commit": ""
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with commit attribution disabled for the team

## Test plan
- Verify that Claude Code no longer adds `Co-Authored-By` trailers to commits when working in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)