### PR TITLE
Rename RequestMetadataFrame to ServiceSwitcherRequestMetadataFrame with service targeting

### DIFF
--- a/changelog/3692.changed.md
+++ b/changelog/3692.changed.md
@@ -1,0 +1,1 @@
+- Renamed `RequestMetadataFrame` to `ServiceSwitcherRequestMetadataFrame` and added a `service` field to target a specific service. The frame is now pushed downstream by services after handling instead of being silently consumed.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1721,16 +1721,19 @@ class STTMetadataFrame(ServiceMetadataFrame):
 
 
 @dataclass
-class RequestMetadataFrame(ControlFrame):
-    """Request services to re-emit their metadata frames.
+class ServiceSwitcherRequestMetadataFrame(ControlFrame):
+    """Request a service to re-emit its metadata frames.
 
     Used by ServiceSwitcher when switching active services to ensure
     downstream processors receive updated metadata from the newly active service.
     Services that receive this frame should re-push their metadata frame
     (e.g., STTMetadataFrame for STT services).
+
+    Parameters:
+        service: The target service that should re-emit its metadata.
     """
 
-    pass
+    service: "FrameProcessor"
 
 
 #

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -21,7 +21,7 @@ from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
     MetricsFrame,
-    RequestMetadataFrame,
+    ServiceSwitcherRequestMetadataFrame,
     StartFrame,
     STTMetadataFrame,
     STTMuteFrame,
@@ -264,9 +264,9 @@ class STTService(AIService):
             # Push StartFrame first, then metadata so downstream receives them in order
             await self.push_frame(frame, direction)
             await self._push_stt_metadata()
-        elif isinstance(frame, RequestMetadataFrame):
-            # Don't push the RequestMetadataFrame, just push the metadata
+        elif isinstance(frame, ServiceSwitcherRequestMetadataFrame):
             await self._push_stt_metadata()
+            await self.push_frame(frame, direction)
         elif isinstance(frame, AudioRawFrame):
             # In this service we accumulate audio internally and at the end we
             # push a TextFrame. We also push audio downstream in case someone


### PR DESCRIPTION
## Summary
- Renamed `RequestMetadataFrame` to `ServiceSwitcherRequestMetadataFrame` and added a `service` field to target a specific service
- `ServiceSwitcher.push_frame` now only consumes the frame when the targeted service matches the active service (instead of blocking all instances)
- `STTService` and test mocks now push the frame downstream after handling instead of silently consuming it

## Test plan
- [x] All 12 existing `test_service_switcher.py` tests pass
- [x] Ruff lint and format checks pass
- [x] Grepped for any remaining references to old `RequestMetadataFrame` name — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)