### PR TITLE
fix(openai): use compatible stream closing for non-OpenAI providers

### DIFF
--- a/changelog/3707.fixed.md
+++ b/changelog/3707.fixed.md
@@ -1,0 +1,1 @@
+- Fixed stream closing compatibility for OpenAI-compatible providers (e.g. OpenPipe) that return async generators instead of `AsyncStream`.

--- a/tests/test_openai_llm_timeout.py
+++ b/tests/test_openai_llm_timeout.py
@@ -149,13 +149,9 @@ async def test_openai_llm_stream_closed_on_cancellation():
             def __init__(self):
                 self.iteration_count = 0
 
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
+            async def close(self):
                 nonlocal stream_closed
                 stream_closed = True
-                return False
 
             def __aiter__(self):
                 return self


### PR DESCRIPTION
## Summary

- Fixes `'async_generator' object does not support the asynchronous context manager protocol` error when using OpenPipe (and other OpenAI-compatible providers)
- The `async with chunk_stream:` added in #3589 relies on `AsyncStream.__aenter__`, which OpenAI's SDK provides but async generators (returned by e.g. OpenPipe's client) do not
- Replaces it with a small helper that closes the stream using `aclose()` (async generators) or `close()` (OpenAI's `AsyncStream`), maintaining the same socket-leak protection

## Test plan

- [x] Verify OpenAI LLM service works as before
- [ ] Verify OpenPipe LLM service no longer raises the async context manager error