### PR TITLE
Add /pr-submit skill and clean up CLAUDE.md

### DIFF
--- a/.claude/skills/pr-submit/SKILL.md
+++ b/.claude/skills/pr-submit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: pr-submit
+description: Create and submit a GitHub PR from the current branch
+---
+
+Submit the current changes as a GitHub pull request.
+
+## Instructions
+
+1. Check the current state of the repository:
+   - Run `git status` to see staged, unstaged, and untracked changes
+   - Run `git diff` to see current changes
+   - Run `git log --oneline -10` to see recent commits
+
+2. If there are uncommitted changes relevant to the PR:
+   - Ask the user if they want a specific prefix for the branch name (e.g., `alice/`, `fix/`, `feat/`)
+   - Create a new branch based on the current branch
+   - Commit the changes using multiple commits if the changes are unrelated
+
+3. Push the branch and create the PR:
+   - Push with `-u` flag to set upstream tracking
+   - Create the PR using `gh pr create`
+
+4. After the PR is created:
+   - Run `/changelog <pr_number>` to generate changelog files, then commit and push them
+   - Run `/pr-description <pr_number>` to update the PR description
+
+5. Return the PR URL to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,3 @@ When adding a new service:
 
 Test utilities live in `src/pipecat/tests/utils.py`. Use `run_test()` to send frames through a pipeline and assert expected output frames in each direction. Use `SleepFrame(sleep=N)` to add delays between frames.
 
-## Pull Requests
-
-To submit a PR you should:
-
-1. Create a new branch. Ask the user if they want a specific prefix for the branch name.
-2. Commit the changes using multiple commits if the changes are unrelated.
-3. After creating the PR, use `/changelog <pr_number>` to generate the changelog files, commit and push them.
-4. Use `/pr-description <pr_number>` to update the PR description.


### PR DESCRIPTION
## Summary

- Added `/pr-submit` skill that automates the full PR submission workflow (branch creation, commit, push, changelog, description update)
- Moved procedural PR instructions out of `CLAUDE.md` into the skill, keeping `CLAUDE.md` focused on project context and conventions