### PR TITLE
Fixing an issue in RTVI where we were sometimes receiving bot output messages before the bot started speaking.

### DIFF
--- a/changelog/3718.fixed.md
+++ b/changelog/3718.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a race condition in `RTVIObserver` where bot output messages could be sent before the bot-started-speaking event.


### PR DESCRIPTION
## Summary                                                                                                                        
 - Fixed a race condition in `RTVIObserver` where aggregated LLM text messages could be sent before the bot started speaking event
- Added queueing mechanism to ensure bot output messages are sent in the correct order                                         
- Bot output messages are now queued until `BotStartedSpeakingFrame` is received, then flushed in order                          

## Technical Details
The issue occurred when `AggregatedTextFrame` instances arrived before the `BotStartedSpeakingFrame`, causing clients to receive bot output messages before the bot-started-speaking event. This could break client side logic that depends on proper event ordering.
