### PR TITLE
Add SIP transfer and SIP REFER frames to Daily transport

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -26,7 +26,7 @@ Create changelog files for the important commits in this PR. The PR number is pr
    - `{PR_NUMBER}.performance.md` - for performance improvements
    - `{PR_NUMBER}.other.md` - for other changes
 
-4. Each changelog file should at least contain a main single line starting with `- ` followed by a clear description of the change.
+4. Each changelog file should at least contain a main single line starting with `- ` followed by a clear description of the change. No line wrapping.
 
 5. If the change is complicated, changelog files can have indented lines after the main line with additional details or code samples.
 

--- a/changelog/3719.added.2.md
+++ b/changelog/3719.added.2.md
@@ -1,0 +1,1 @@
+- Added `write_transport_frame()` hook to `BaseOutputTransport` allowing transport subclasses to handle custom frame types that flow through the audio queue.

--- a/changelog/3719.added.md
+++ b/changelog/3719.added.md
@@ -1,0 +1,1 @@
+- Added `DailySIPTransferFrame` and `DailySIPReferFrame` to the Daily transport.  These frames queue SIP transfer and SIP REFER operations with audio, so the operation executes only after the bot finishes its current utterance.

--- a/changelog/3719.changed.md
+++ b/changelog/3719.changed.md
@@ -1,0 +1,1 @@
+- `DailyUpdateRemoteParticipantsFrame` is no longer deprecated and is now queued with audio like other transport frames.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -237,6 +237,18 @@ class BaseOutputTransport(FrameProcessor):
         else:
             await self._write_dtmf_audio(frame)
 
+    async def write_transport_frame(self, frame: Frame):
+        """Handle a queued frame after preceding audio has been sent.
+
+        Override in transport subclasses to handle custom frame types that
+        flow through the audio queue. Called by the media sender after the
+        frame has waited for any preceding audio to finish.
+
+        Args:
+            frame: The frame to handle.
+        """
+        pass
+
     def _supports_native_dtmf(self) -> bool:
         """Override in transport implementations that support native DTMF.
 
@@ -681,6 +693,8 @@ class BaseOutputTransport(FrameProcessor):
                 await self._transport.send_message(frame)
             elif isinstance(frame, OutputDTMFFrame):
                 await self._transport.write_dtmf(frame)
+            else:
+                await self._transport.write_transport_frame(frame)
 
         def _next_frame(self) -> AsyncGenerator[Frame, None]:
             """Generate the next frame for audio processing.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -15,7 +15,7 @@ import asyncio
 import time
 from concurrent.futures import CancelledError as FuturesCancelledError
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Tuple
 
 import aiohttp
@@ -26,6 +26,7 @@ from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 from pipecat.frames.frames import (
     CancelFrame,
     ControlFrame,
+    DataFrame,
     EndFrame,
     Frame,
     InputAudioRawFrame,
@@ -180,6 +181,36 @@ class DailyInputTransportMessageUrgentFrame(DailyInputTransportMessageFrame):
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+
+@dataclass
+class DailySIPTransferFrame(DataFrame):
+    """SIP call transfer frame for transport queuing.
+
+    A SIP call transfer that will be queued. The transfer will happen after any
+    preceding audio finishes playing, allowing the bot to complete its current
+    utterance before the transfer occurs.
+
+    Parameters:
+        settings: SIP call transfer settings.
+    """
+
+    settings: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DailySIPReferFrame(DataFrame):
+    """SIP REFER frame for transport queuing.
+
+    A SIP REFER that will be queued. The REFER will happen after any preceding
+    audio finishes playing, allowing the bot to complete its current utterance
+    before the REFER occurs.
+
+    Parameters:
+        settings: SIP REFER settings.
+    """
+
+    settings: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -1968,7 +1999,7 @@ class DailyOutputTransport(BaseOutputTransport):
         """
         error = await self._client.send_message(frame)
         if error:
-            logger.error(f"Unable to send message: {error}")
+            await self.push_error(f"{self}: Unable to send message: {error}")
 
     async def register_video_destination(self, destination: str):
         """Register a video output destination.
@@ -2010,6 +2041,21 @@ class DailyOutputTransport(BaseOutputTransport):
             True if the video frame was written successfully, False otherwise.
         """
         return await self._client.write_video_frame(frame)
+
+    async def write_transport_frame(self, frame: Frame):
+        """Handle queued SIP frames after preceding audio has been sent.
+
+        Args:
+            frame: The frame to handle.
+        """
+        if isinstance(frame, DailySIPTransferFrame):
+            error = await self._client.sip_call_transfer(frame.settings)
+            if error:
+                await self.push_error(f"{self}: Unable to transfer SIP call: {error}")
+        elif isinstance(frame, DailySIPReferFrame):
+            error = await self._client.sip_refer(frame.settings)
+            if error:
+                await self.push_error(f"{self}: Unable to perform SIP REFER: {error}")
 
     def _supports_native_dtmf(self) -> bool:
         """Daily supports native DTMF via telephone events.


### PR DESCRIPTION
## Summary

- Added `DailySIPTransferFrame` and `DailySIPReferFrame` to queue SIP operations with audio, so they execute only after the bot finishes its current utterance
- Added `write_transport_frame()` hook to `BaseOutputTransport` so transport subclasses can handle custom frame types flowing through the audio queue
- Undeprecated `DailyUpdateRemoteParticipantsFrame` and changed it from `ControlFrame` to `DataFrame` so it is also queued with audio via `write_transport_frame`
- Switched error handling in `DailyOutputTransport` to use `push_error` instead of `logger.error`

## Testing

- `uv run ruff check` and `uv run ruff format --check` pass
- `uv run pytest` passes (607/607, 1 pre-existing integration failure)
