### PR TITLE
Fix Grok Realtime voice type validation for server responses

### DIFF
--- a/changelog/3720.fixed.md
+++ b/changelog/3720.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Grok Realtime `session.updated` event parsing failure caused by the API returning prefixed voice names (e.g. `"human_Ara"` instead of `"Ara"`).

--- a/src/pipecat/services/grok/realtime/events.py
+++ b/src/pipecat/services/grok/realtime/events.py
@@ -216,7 +216,7 @@ class SessionProperties(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     instructions: Optional[str] = None
-    voice: Optional[GrokVoice] = "Ara"
+    voice: Optional[GrokVoice | str] = "Ara"
     turn_detection: Optional[TurnDetection] = Field(
         default_factory=lambda: TurnDetection(type="server_vad")
     )


### PR DESCRIPTION
## Summary

- Fixed Grok Realtime `session.updated` event parsing failure caused by the API now returning prefixed voice names (e.g. `"human_Ara"` instead of `"Ara"`)
- Widened `SessionProperties.voice` type from `GrokVoice` to `GrokVoice | str` so known voice names still provide autocomplete while server-returned values are also accepted

## Testing

- Run a Grok Realtime voice agent and verify `session.updated` events parse without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3716 