### PR TITLE
Fix race condition in finalized transcript early trigger

### DIFF
--- a/changelog/3722.fixed.md
+++ b/changelog/3722.fixed.md
@@ -1,0 +1,5 @@
+- Fixed a race condition in `SpeechTimeoutUserTurnStopStrategy` where a finalized
+  transcript arriving after `user_speech_timeout` elapsed from VAD stop would
+  immediately trigger a turn stop, even if the user was still speaking. STT
+  processing latency was consuming the `user_speech_timeout` window, leaving no
+  time for the user to resume speaking.

--- a/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
@@ -34,8 +34,12 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
       after the user stops speaking, adjusted by the VAD stop_secs.
 
     For services that support finalization (TranscriptionFrame.finalized=True),
-    the turn can be triggered immediately once the finalized transcript is
-    received and the user resume speaking timeout has elapsed.
+    receiving the finalized transcript allows the strategy to shorten the
+    timeout by removing the STT wait component, since only the
+    `user_speech_timeout` portion is still needed. If `user_speech_timeout`
+    has already elapsed when the transcript arrives, the original timeout
+    continues running to provide a buffer for VAD to detect any resumed
+    speech before triggering.
     """
 
     def __init__(self, *, user_speech_timeout: float = 0.6, **kwargs):


### PR DESCRIPTION
## Summary
  - Fixed a race condition in SpeechTimeoutUserTurnStopStrategy where a finalized transcript arriving after
  user_speech_timeout elapsed from VAD stop would immediately trigger a turn stop, even if the user was still
  mid-sentence
  - The root cause: when a finalized transcript arrived, the strategy checked `time.time() - vad_stopped_time >=
  user_speech_timeout and triggered immediately` — but STT processing latency consumed the user_speech_timeout window, leaving zero actual time for the user to resume speaking
  - Removed the early trigger path in _maybe_trigger_user_turn_stopped() and replaced it with smarter timeout
  recalculation in _handle_transcription(): when the finalized transcript arrives and user_speech_timeout still has
  time remaining, the timeout is shortened (no more STT wait needed); when it has elapsed, the original timeout
  continues running, providing a buffer for VAD to detect resumed speech
  - Added regression test reproducing the race condition with high STT latency

## Test plan
- [x] All 15 existing `test_user_turn_stop_strategy.py` tests pass
- [x] New `test_finalized_transcript_does_not_trigger_early_with_slow_stt` test passes
- [ ] Manual testing with high-latency STT service to verify no premature interruptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)