### PR TITLE
Fix ElevenLabs TTS word timestamp interleaving across sentences

### DIFF
--- a/changelog/3727.fixed.md
+++ b/changelog/3727.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ElevenLabsTTSService` word timestamps being interleaved across sentences within the same context, causing incorrect word ordering.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -700,9 +700,6 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
             try:
                 await self.start_ttfb_metrics()
                 yield TTSStartedFrame(context_id=context_id)
-                self._cumulative_time = 0
-                self._partial_word = ""
-                self._partial_word_start_time = 0.0
                 # If a context ID does not exist, use the provided one.
                 # If an ID exists, that means the Pipeline doesn't allow
                 # user interruptions, so continue using the current ID.
@@ -710,6 +707,12 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
                 # an interruption, which resets the context ID.
                 if not self._context_id:
                     self._context_id = context_id
+                    # Reset timing state only when starting a new context.
+                    # Within a context, cumulative_time must accumulate across
+                    # sentences so word timestamps are properly sequenced.
+                    self._cumulative_time = 0
+                    self._partial_word = ""
+                    self._partial_word_start_time = 0.0
                 if not self.audio_context_available(self._context_id):
                     await self.create_audio_context(self._context_id)
 


### PR DESCRIPTION
## Summary

- Fixed `ElevenLabsTTSService` word timestamps being interleaved across sentences, causing garbled word ordering in the assistant context
- `_cumulative_time` and partial word state were being reset to zero on every `run_tts` call, but with the multi-stream WebSocket API multiple sentences share the same context -- so each sentence's word timestamps started from zero instead of accumulating after the previous sentence
- Moved the timing state reset into the new-context creation block so it only resets when a fresh context begins (e.g., after an interruption)

## Testing

- Run the ElevenLabs interruptible example and verify multi-sentence responses have words in the correct order in the assistant context

Fixes #3723 