### PR TITLE
TTS services fixes.

### DIFF
--- a/changelog/3729.fixed.2.md
+++ b/changelog/3729.fixed.2.md
@@ -1,0 +1,1 @@
+- Fixed context ID reuse issue in `ElevenLabsTTSService`, `InworldTTSService`, `RimeTTSService`, `CartesiaTTSService`, `AsyncAITTSService`, and `PlayHTTTSService`. Services now properly reuse the same context ID across multiple `run_tts()` invocations within a single LLM turn, preventing context tracking issues and incorrect lifecycle signaling.

--- a/changelog/3729.fixed.md
+++ b/changelog/3729.fixed.md
@@ -1,0 +1,1 @@
+- Fixed word timestamp interleaving issue in `ElevenLabsTTSService` when processing multiple sentences within a single LLM turn.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -8,6 +8,7 @@
 
 import base64
 import json
+import uuid
 import warnings
 from enum import Enum
 from typing import AsyncGenerator, List, Literal, Optional
@@ -538,6 +539,20 @@ class CartesiaTTSService(AudioContextWordTTSService):
             cancel_msg = json.dumps({"context_id": self._context_id, "cancel": True})
             await self._get_websocket().send(cancel_msg)
             self._context_id = None
+
+    def create_context_id(self) -> str:
+        """Generate a unique context ID for a TTS request in case we don't have one already in progress.
+
+        Returns:
+            A unique string identifier for the TTS context.
+        """
+        # If a context ID does not exist, create a new one.
+        # If an ID exists, continue using the current ID.
+        # When interruptions happen, user speech results in
+        # an interruption, which resets the context ID.
+        if not self._context_id:
+            return str(uuid.uuid4())
+        return self._context_id
 
     async def flush_audio(self):
         """Flush any pending audio and finalize the current context."""

--- a/src/pipecat/services/playht/tts.py
+++ b/src/pipecat/services/playht/tts.py
@@ -13,6 +13,7 @@ supporting both WebSocket streaming and HTTP-based synthesis.
 import io
 import json
 import struct
+import uuid
 import warnings
 from typing import AsyncGenerator, Optional
 
@@ -322,6 +323,20 @@ class PlayHTTTSService(InterruptibleTTSService):
         if self._websocket:
             return self._websocket
         raise Exception("Websocket not connected")
+
+    def create_context_id(self) -> str:
+        """Generate a unique context ID for a TTS request in case we don't have one already in progress.
+
+        Returns:
+            A unique string identifier for the TTS context.
+        """
+        # If a context ID does not exist, create a new one.
+        # If an ID exists, continue using the current ID.
+        # When interruptions happen, user speech results in
+        # an interruption, which resets the context ID.
+        if not self._context_id:
+            return str(uuid.uuid4())
+        return self._context_id
 
     async def _handle_interruption(self, frame: InterruptionFrame, direction: FrameDirection):
         """Handle interruption by stopping metrics and clearing request ID."""

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -12,6 +12,7 @@ using Rime's API for streaming and batch audio synthesis.
 
 import base64
 import json
+import uuid
 from typing import Any, AsyncGenerator, Mapping, Optional
 
 import aiohttp
@@ -368,6 +369,20 @@ class RimeTTSService(AudioContextWordTTSService):
                 word_pairs.append((word, adjusted_start))
 
         return word_pairs
+
+    def create_context_id(self) -> str:
+        """Generate a unique context ID for a TTS request in case we don't have one already in progress.
+
+        Returns:
+            A unique string identifier for the TTS context.
+        """
+        # If a context ID does not exist, create a new one.
+        # If an ID exists, continue using the current ID.
+        # When interruptions happen, user speech results in
+        # an interruption, which resets the context ID.
+        if not self._context_id:
+            return str(uuid.uuid4())
+        return self._context_id
 
     async def flush_audio(self):
         """Flush any pending audio synthesis."""


### PR DESCRIPTION
## Summary                                                                                                                     

- Fixed word timestamp interleaving issue in `ElevenLabsTTS` when processing multiple sentences
- Added `create_context_id()` override to 6 TTS services to properly reuse context IDs across multiple `run_tts` invocations   
- Fixed initialization logic to only emit `TTSStartedFrame` and start metrics once per turn, not once per sentence

### The Problem

When an LLM generates multiple sentences in a single turn (before `LLMFullResponseEndFrame`), the base `TTSService.create_context_id()` creates a new UUID for each sentence. This caused:

1. **Word timestamp interleaving** - timestamps tracked in separate contexts instead of one continuous stream
2. **Multiple TTSStartedFrame emissions** - incorrect lifecycle signaling
3. **Context tracking issues** - base class tracking multiple contexts when only one is actively used

The root cause: frames are only paused when receiving `LLMFullResponseEndFrame`, but by that point `run_tts()` has been invoked multiple times (once per sentence). Some services need to reuse the same `context_id` across all invocations within a turn.

  ### The Solution

Services that extend `AudioContextTTSService` or `AudioContextWordTTSService` and maintain `self._context_id` for turn tracking now override `create_context_id()` to:

1. Return existing `self._context_id` if one is already in progress
2. Create a new UUID only when starting a new turn
3. Reset `self._context_id` on interruptions or turn completion

### Services Fixed

1. **ElevenLabsTTSService** - Context reuse + Word timestamp interleaving across sentences
2. **InworldTTSService** - Context reuse + Moved initialization inside guard
3. **RimeTTSService** - Context reuse
4. **CartesiaTTSService** - Context reuse
5. **AsyncAITTSService** - Context reuse + Moved initialization inside guard
6. **PlayHTTTSService** - Context reuse

Fixes #3723 