### PR TITLE
Move STT keepalive from WebsocketSTTService to STTService base class

### DIFF
--- a/changelog/3730.added.md
+++ b/changelog/3730.added.md
@@ -1,0 +1,1 @@
+- Added keepalive support to `SarvamSTTService` to prevent idle connection timeouts (e.g. when used behind a `ServiceSwitcher`).

--- a/changelog/3730.changed.md
+++ b/changelog/3730.changed.md
@@ -1,0 +1,1 @@
+- Moved STT keepalive mechanism from `WebsocketSTTService` to the `STTService` base class, allowing any STT service (not just websocket-based ones) to use idle-connection keepalive via the `keepalive_timeout` and `keepalive_interval` parameters.


### PR DESCRIPTION
## Summary
- Moved the keepalive mechanism (idle-timeout silence sending) from `WebsocketSTTService` up to the `STTService` base class, making it available to any STT service
- Added `_is_keepalive_ready()` and `_send_keepalive()` hooks that subclasses override for their specific protocol
- Enabled keepalive support in `SarvamSTTService`, which uses the Sarvam Python SDK (not raw websockets) for connection management

## Test plan
- [x] All existing tests pass (603 passed)
- [x] Ruff lint and format checks pass
- [x] Verify keepalive works with a `ServiceSwitcher` pipeline using Sarvam STT
- [x] Verify existing `WebsocketSTTService` subclasses (Deepgram, ElevenLabs, Gladia, Soniox, Cartesia) still work correctly with keepalive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3699 