### PR TITLE
Deprecate unused class_decorators tracing module and fix stale comments

### DIFF
--- a/changelog/3733.deprecated.md
+++ b/changelog/3733.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated unused `Traceable`, `@traceable`, `@traced`, and `AttachmentStrategy` in `pipecat.utils.tracing.class_decorators`. This module will be removed in a future release.

--- a/src/pipecat/utils/tracing/class_decorators.py
+++ b/src/pipecat/utils/tracing/class_decorators.py
@@ -7,6 +7,11 @@
 
 """Base OpenTelemetry tracing decorators and utilities for Pipecat.
 
+.. deprecated:: 0.0.103
+    This module is unused and will be removed in a future release.
+    Service tracing is handled by the decorators in
+    :mod:`pipecat.utils.tracing.service_decorators`.
+
 This module provides class and method level tracing capabilities
 similar to the original NVIDIA implementation.
 """
@@ -16,7 +21,15 @@ import contextlib
 import enum
 import functools
 import inspect
+import warnings
 from typing import Callable, Optional, TypeVar
+
+warnings.warn(
+    "pipecat.utils.tracing.class_decorators is deprecated and will be removed in a future "
+    "release. Use pipecat.utils.tracing.service_decorators instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 from pipecat.utils.tracing.setup import is_tracing_available
 

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -82,11 +82,12 @@ def _get_parent_service_context(self):
     if not is_tracing_available():
         return None
 
-    # The parent span was created when Traceable was initialized and stored as self._span
+    # TODO: Remove this block and delete class_decorators.py once Traceable is removed.
+    # Legacy: support for classes inheriting from Traceable (currently unused, deprecated).
     if hasattr(self, "_span") and self._span:
         return trace.set_span_in_context(self._span)
 
-    # Fall back to conversation context if available
+    # Use the conversation context set by TurnTraceObserver via TracingContext.
     tracing_ctx = getattr(self, "_tracing_context", None)
     conversation_context = tracing_ctx.get_conversation_context() if tracing_ctx else None
     if conversation_context:


### PR DESCRIPTION
## Context

This is just dead code. We aren't using it and aren't maintaining. I'm deprecating and we should remove in 1.0.

## Summary

- Added tests for `TracingContext` and `TurnTraceObserver`, covering conversation/turn span lifecycle, parent-child relationships, interruption handling, concurrent pipeline isolation, and `TracingContext` state management
- Enabled the `tracing` extra in CI test and coverage workflows so tracing tests run with OpenTelemetry installed
- Deprecated the unused `class_decorators.py` module (`Traceable`, `@traceable`, `@traced`, `AttachmentStrategy`) which is not imported anywhere in the codebase
- Fixed stale comments in `service_decorators.py` that incorrectly described `Traceable` as active; added TODO for future removal

## Testing

```bash
uv run pytest tests/test_tracing_context.py tests/test_turn_trace_observer.py -v
```