### PR TITLE
Fix double execution of service functions on tracing errors

### DIFF
--- a/changelog/3735.fixed.md
+++ b/changelog/3735.fixed.md
@@ -1,0 +1,1 @@
+- Fixed tracing service decorators executing the wrapped function twice when the function itself raised an exception (e.g., LLM rate limit, TTS timeout).


### PR DESCRIPTION
## Summary

- Fixed a bug where all five tracing service decorators (`traced_tts`, `traced_stt`, `traced_llm`, `traced_gemini_live`, `traced_openai_realtime`) would execute the wrapped function **twice** when the function itself raised an exception (e.g., LLM rate limit, TTS provider timeout). The outer `try/except` intended to catch tracing setup failures was also catching application errors, triggering an untraced fallback re-execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)