### PR TITLE
Add /update-docs Claude Code skill

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -146,16 +146,16 @@ Guide directories:
 - `guides/features/` — feature-specific guides (Gemini Live, OpenAI audio, WhatsApp, etc.)
 - `guides/telephony/` — telephony integration guides (Twilio, Plivo, Telnyx, etc.)
 
-### Step 8: Handle unmapped files
+### Step 8: Identify doc gaps
 
-After processing all mapped pairs, report any source files that:
-- Had no doc page mapping (neither tier 1, 2, nor 3)
-- Are not marked as "(skip)" in the tier-1 table
+After processing all mapped pairs, check for two kinds of gaps:
 
-For each unmapped file, tell the user:
+**Missing pages**: Source files that had no doc page mapping (neither tier 1, 2, nor 3) and are not marked as "(skip)". For each, tell the user:
 - The source file path
 - The main class(es) it defines
 - Whether a new doc page should be created
+
+**Missing sections**: Mapped doc pages that are missing standard sections compared to the source. For example, a transport page with no Configuration section, or a service page with no InputParams table when the source defines `InputParams(BaseModel)`. Flag these and offer to add the missing sections.
 
 If the user wants a new page, create it using this template structure:
 ```

--- a/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
+++ b/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
@@ -22,7 +22,8 @@ These source paths don't follow the standard `services/{provider}/{type}.py` →
 | `processors/user_idle_processor.py` | `server/utilities/user-idle-processor.mdx` |
 | `processors/idle_frame_processor.py` | `server/pipeline/pipeline-idle-detection.mdx` |
 | `pipeline/task.py` | `server/pipeline/pipeline-task.mdx` |
-| `runner/run.py` | `server/utilities/runner/guide.mdx` |
+| `pipeline/runner.py` | `server/utilities/runner/guide.mdx` |
+| `transports/base_transport.py` | `server/services/transport/transport-params.mdx` |
 
 ## Skip list
 
@@ -40,7 +41,6 @@ These files should never trigger doc updates.
 | `services/gemini_multimodal_live/**` | Deprecated |
 | `services/aws/agent_core.py` | Internal |
 | `services/aws/sagemaker/**` | No doc page |
-| `transports/base_transport.py` | Internal base class |
 | `transports/base_input.py` | Internal base class |
 | `transports/base_output.py` | Internal base class |
 | `transports/websocket/client.py` | No doc page |


### PR DESCRIPTION
## Context

Claude is really good at reading changes and writing docs. This skill should make it easier to stay on top of docs updates. You can run this skill on your own branch to open a new docs branch with changes.

## Summary

- Added `/update-docs` Claude Code skill for keeping documentation pages in sync with source code changes
- Skill analyzes the current branch's diff against main, maps changed source files to doc pages, and makes targeted edits to Configuration, InputParams, Usage, Notes, and Event Handlers sections
- Source-to-doc mapping uses a tiered approach: known name mismatches → pattern matching → grep fallback
- Mapping table is in a separate file (`SOURCE_DOC_MAPPING.md`) for easy maintenance

## Testing

```
/update-docs /path/to/docs
```
