### PR TITLE
Fix RTVIObserver missing transcriptions from Realtime LLMs

### DIFF
--- a/changelog/3751.fixed.md
+++ b/changelog/3751.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `RTVIObserver` not sending user transcription messages when using Realtime LLMs (OpenAI Realtime, Gemini Live) that push transcription frames upstream.


### PR DESCRIPTION
## Context

We added a filter for downstream frames only in 0.0.102 because of double messages, which in general works. The exception is realtime LLMs, which push transcription frames upstream. This change removes the direction restriction for `InterimTranscriptionFrame` and `TranscriptionFrame`.

In surveying other frames, these are the only two that need to be allow listed like this.

There are other ways to solve this, but this will patch the issue. I'm open to other ideas of how to solve this one.

## Summary

- Fixed `RTVIObserver` not sending `user-transcription` RTVI messages when using Realtime LLMs (OpenAI Realtime, Gemini Live)
- Realtime LLMs push `TranscriptionFrame` and `InterimTranscriptionFrame` upstream only, but the observer previously filtered to downstream-only frames
- Transcription frames are now allowed regardless of direction, while all other frame types still use the downstream-only filter to prevent duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3749 