### PR TITLE
Fix concurrency race condition in tracing and resource leaks in aggregators

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -845,6 +845,15 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
         """
         return bool(self._function_calls_in_progress)
 
+    async def reset(self):
+        """Reset the aggregation state."""
+        await super().reset()
+        # Cancel any pending context updated tasks
+        for task in list(self._context_updated_tasks):
+            if not task.done():
+                task.cancel()
+        self._context_updated_tasks.clear()
+
     async def handle_aggregation(self, aggregation: str):
         """Add the aggregated assistant text to the context.
 

--- a/src/pipecat/processors/frameworks/langchain.py
+++ b/src/pipecat/processors/frameworks/langchain.py
@@ -74,7 +74,11 @@ class LangchainProcessor(FrameProcessor):
                 if isinstance(frame, OpenAILLMContextFrame)
                 else frame.context.get_messages()
             )
-            text: str = messages[-1]["content"]
+            content = messages[-1]["content"]
+            if isinstance(content, list):
+                text = " ".join([c["text"] for c in content if isinstance(c, dict) and c.get("type") == "text"])
+            else:
+                text = content
 
             await self._ainvoke(text.strip())
         else:

--- a/src/pipecat/transports/local/tk.py
+++ b/src/pipecat/transports/local/tk.py
@@ -38,7 +38,8 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 try:
-    import tkinter as tk
+    # tkinter is already imported at the top
+    pass
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error("tkinter missing. Try `apt install python3-tk` or `brew install python-tk@3.10`.")

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -541,12 +541,16 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                         return result
 
                     finally:
-                        # Always restore the original methods
-                        self.push_frame = original_push_frame
+                        # Always restore the original methods, but only if they haven't been
+                        # changed by another task in the meantime.
+                        if getattr(self, "push_frame", None) == traced_push_frame:
+                            self.push_frame = original_push_frame
 
                         if (
                             "original_start_llm_usage_metrics" in locals()
                             and original_start_llm_usage_metrics
+                            and getattr(self, "start_llm_usage_metrics", None)
+                            == wrapped_start_llm_usage_metrics
                         ):
                             self.start_llm_usage_metrics = original_start_llm_usage_metrics
 


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Working with the codebase revealed several stability issues in high-concurrency environments and multimodal use cases.

Safety improvements were prioritized in `service_decorators.py` to handle `traced_llm` method restoration. Current monkey-patching logic can lead to race conditions when multiple tasks share a service instance, so I added checks to ensure methods are only restored if they match the patched versions.

Memory leaks in `LLMAssistantContextAggregator` are now mitigated by cancelling pending `on_context_updated` tasks during reset. This ensures long-running bots don't accumulate stale tasks over time.

Robustness for `LangchainProcessor` has been enhanced to handle list-based message content. Previously, multimodal inputs would cause a crash during the `.strip()` call on non-string content.

Redundant imports in `tk.py` have also been removed for general cleanup.

Summary of changes:
- Mitigated race condition in `traced_llm` monkey-patching logic.
- Added resource cleanup (task cancellation) in `LLMAssistantContextAggregator.reset()`.
- Enhanced `LangchainProcessor` robustness for multimodal content.
- Removed redundant `import tkinter` in `tk.py`.