### PR TITLE
Fix async generator cleanup to prevent uvloop crash on Python 3.12+

### DIFF
--- a/changelog/3698.fixed.md
+++ b/changelog/3698.fixed.md
@@ -1,0 +1,1 @@
+- Fixed async generator cleanup in OpenAI LLM streaming to prevent `AttributeError` with uvloop on Python 3.12+ (MagicStack/uvloop#699).


### PR DESCRIPTION
## Summary

- [x] Modified `_closing` context manager to explicitly obtain and close the async iterator before closing the stream, cascading cleanup through nested async generators (httpx/httpcore internals).
- [x] Changed `async for` to iterate the yielded iterator directly so `__aiter__()` is only called once.
- [x] Added test verifying both the async iterator and stream are explicitly closed after consumption.
- [x] Added changelog entry.

## Problem

Users see `AttributeError: type object 'dict' has no attribute 'f_lineno'` spam in logs when using OpenAI-compatible LLM services with uvloop on Python 3.12+.

This is a [known uvloop bug](https://github.com/MagicStack/uvloop/issues/699) in its `_asyncgen_finalizer_hook`. When async generators are garbage-collected without being explicitly closed, uvloop's finalizer tries to extract the stack frame and crashes on Python 3.12+ due to incompatible frame objects.

In pipecat, `_process_context` iterates an OpenAI `AsyncStream` with `async for`. The existing `_closing` context manager closes the **stream** object, but the **async iterator** created internally by `__aiter__()` (the `_iter_events()` generator) is never explicitly `aclose()`d. When the iterator is GC'd, it triggers uvloop's broken finalizer. The nested httpx/httpcore generators inside the iterator are also left unclosed, causing the error to repeat 10+ times per request.

## Approach

`_closing` now calls `stream.__aiter__()` once, yields the resulting iterator for use in `async for`, and on exit closes **both** the iterator (first) and the stream (second). Closing the iterator cascades through all nested async generators via the async generator cleanup protocol, preventing GC finalization entirely.

## Tradeoffs

- **Calling `__aiter__()` directly** is slightly unconventional compared to using `async for` on the stream, but it's the only way to get a reference to the iterator for explicit cleanup. The `async for` then operates on the iterator directly, which is semantically equivalent.
- **Closing both iterator and stream** means two cleanup paths run in sequence. The iterator `aclose()` may already release some resources that `stream.close()` would also try to release, but both OpenAI's `AsyncStream` and httpx handle redundant closes gracefully.
- **This works around a uvloop bug** rather than fixing uvloop itself. However, explicit async generator cleanup is the correct practice regardless — relying on GC finalization for async generators is fragile by design (PEP 525). This fix is good hygiene even after uvloop is patched.

Closes #3698