### PR TITLE
[Cartesia TTS] Clear `_context_id` when audio context completes

### DIFF
--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -573,6 +573,8 @@ class CartesiaTTSService(AudioContextWordTTSService):
                 await self.stop_ttfb_metrics()
                 await self.add_word_timestamps([("TTSStoppedFrame", 0), ("Reset", 0)], ctx_id)
                 await self.remove_audio_context(ctx_id)
+                if self._context_id == ctx_id:
+                    self._context_id = None
             elif msg["type"] == "timestamps":
                 # Process the timestamps based on language before adding them
                 processed_timestamps = self._process_word_timestamps_for_language(


### PR DESCRIPTION
When Cartesia sends a `"done"` message, `_context_id` is not cleared. In non-standard flows (e.g. direct `TTSSpeakFrame` usage), subsequent TTS requests reuse the stale context ID, which the API may error on due to a race condition.

This adds a guard in `_process_messages()` to clear `_context_id` when the completed context matches. It's a no-op in the normal LLM pipeline flow where `flush_audio()` already clears `_context_id` before `"done"` arrives.