### PR TITLE
Fix CI: add apt-get update before installing system packages

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install system packages
         run: |
+          sudo apt-get update
           sudo apt-get install -y portaudio19-dev
 
       - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install system packages
         run: |
+          sudo apt-get update
           sudo apt-get install -y portaudio19-dev
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Added `apt-get update` before `apt-get install` in CI workflows (tests and coverage)
- Fixes 404 errors when the runner's pre-installed package index is stale and references old package versions (e.g. `libasound2-dev`)

🤖 Generated with [Claude Code](https://claude.ai/code)