### PR TITLE
Fix RTVIObserver missing upstream-only frames

### DIFF
--- a/changelog/3774.added.md
+++ b/changelog/3774.added.md
@@ -1,0 +1,1 @@
+- Added `broadcasted` field to the base `Frame` class. This field is automatically set to `True` by `broadcast_frame()` and `broadcast_frame_instance()` to distinguish broadcasted frames from single-direction frames.

--- a/changelog/3774.added.md
+++ b/changelog/3774.added.md
@@ -1,1 +1,1 @@
-- Added `broadcasted_sibling_id` field to the base `Frame` class. This field is automatically set by `broadcast_frame()` and `broadcast_frame_instance()` to the ID of the paired frame pushed in the opposite direction, allowing receivers to identify broadcast pairs.
+- Added `broadcast_sibling_id` field to the base `Frame` class. This field is automatically set by `broadcast_frame()` and `broadcast_frame_instance()` to the ID of the paired frame pushed in the opposite direction, allowing receivers to identify broadcast pairs.

--- a/changelog/3774.added.md
+++ b/changelog/3774.added.md
@@ -1,1 +1,1 @@
-- Added `broadcasted` field to the base `Frame` class. This field is automatically set to `True` by `broadcast_frame()` and `broadcast_frame_instance()` to distinguish broadcasted frames from single-direction frames.
+- Added `broadcasted_sibling_id` field to the base `Frame` class. This field is automatically set by `broadcast_frame()` and `broadcast_frame_instance()` to the ID of the paired frame pushed in the opposite direction, allowing receivers to identify broadcast pairs.

--- a/changelog/3774.fixed.md
+++ b/changelog/3774.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `RTVIObserver` not processing upstream-only frames. Previously, all upstream frames were filtered out to avoid duplicate messages from broadcasted frames. Now only upstream copies of broadcasted frames are skipped.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -131,6 +131,7 @@ class Frame:
     id: int = field(init=False)
     name: str = field(init=False)
     pts: Optional[int] = field(init=False)
+    broadcasted: bool = field(init=False)
     metadata: Dict[str, Any] = field(init=False)
     transport_source: Optional[str] = field(init=False)
     transport_destination: Optional[str] = field(init=False)
@@ -139,6 +140,7 @@ class Frame:
         self.id: int = obj_id()
         self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
         self.pts: Optional[int] = None
+        self.broadcasted: bool = False
         self.metadata: Dict[str, Any] = {}
         self.transport_source: Optional[str] = None
         self.transport_destination: Optional[str] = None

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -123,7 +123,7 @@ class Frame:
         id: Unique identifier for the frame instance.
         name: Human-readable name combining class name and instance count.
         pts: Presentation timestamp in nanoseconds.
-        broadcasted_sibling_id: ID of the paired frame when this frame was
+        broadcast_sibling_id: ID of the paired frame when this frame was
             broadcast in both directions. Set automatically by
             ``broadcast_frame()`` and ``broadcast_frame_instance()``.
         metadata: Dictionary for arbitrary frame metadata.
@@ -134,7 +134,7 @@ class Frame:
     id: int = field(init=False)
     name: str = field(init=False)
     pts: Optional[int] = field(init=False)
-    broadcasted_sibling_id: Optional[int] = field(init=False)
+    broadcast_sibling_id: Optional[int] = field(init=False)
     metadata: Dict[str, Any] = field(init=False)
     transport_source: Optional[str] = field(init=False)
     transport_destination: Optional[str] = field(init=False)
@@ -143,7 +143,7 @@ class Frame:
         self.id: int = obj_id()
         self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
         self.pts: Optional[int] = None
-        self.broadcasted_sibling_id: Optional[int] = None
+        self.broadcast_sibling_id: Optional[int] = None
         self.metadata: Dict[str, Any] = {}
         self.transport_source: Optional[str] = None
         self.transport_destination: Optional[str] = None

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -123,6 +123,9 @@ class Frame:
         id: Unique identifier for the frame instance.
         name: Human-readable name combining class name and instance count.
         pts: Presentation timestamp in nanoseconds.
+        broadcasted_sibling_id: ID of the paired frame when this frame was
+            broadcast in both directions. Set automatically by
+            ``broadcast_frame()`` and ``broadcast_frame_instance()``.
         metadata: Dictionary for arbitrary frame metadata.
         transport_source: Name of the transport source that created this frame.
         transport_destination: Name of the transport destination for this frame.
@@ -131,7 +134,7 @@ class Frame:
     id: int = field(init=False)
     name: str = field(init=False)
     pts: Optional[int] = field(init=False)
-    broadcasted: bool = field(init=False)
+    broadcasted_sibling_id: Optional[int] = field(init=False)
     metadata: Dict[str, Any] = field(init=False)
     transport_source: Optional[str] = field(init=False)
     transport_destination: Optional[str] = field(init=False)
@@ -140,7 +143,7 @@ class Frame:
         self.id: int = obj_id()
         self.name: str = f"{self.__class__.__name__}#{obj_count(self)}"
         self.pts: Optional[int] = None
-        self.broadcasted: bool = False
+        self.broadcasted_sibling_id: Optional[int] = None
         self.metadata: Dict[str, Any] = {}
         self.transport_source: Optional[str] = None
         self.transport_destination: Optional[str] = None

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -787,8 +787,12 @@ class FrameProcessor(BaseObject):
             frame_cls: The class of the frame to be broadcasted.
             **kwargs: Keyword arguments to be passed to the frame's constructor.
         """
-        await self.push_frame(frame_cls(**kwargs))
-        await self.push_frame(frame_cls(**kwargs), FrameDirection.UPSTREAM)
+        downstream_frame = frame_cls(**kwargs)
+        downstream_frame.broadcasted = True
+        await self.push_frame(downstream_frame)
+        upstream_frame = frame_cls(**kwargs)
+        upstream_frame.broadcasted = True
+        await self.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 
     async def broadcast_frame_instance(self, frame: Frame):
         """Broadcasts a frame instance upstream and downstream.
@@ -815,11 +819,13 @@ class FrameProcessor(BaseObject):
         new_frame = frame_cls(**init_fields)
         for k, v in extra_fields.items():
             setattr(new_frame, k, v)
+        new_frame.broadcasted = True
         await self.push_frame(new_frame)
 
         new_frame = frame_cls(**init_fields)
         for k, v in extra_fields.items():
             setattr(new_frame, k, v)
+        new_frame.broadcasted = True
         await self.push_frame(new_frame, FrameDirection.UPSTREAM)
 
     async def __start(self, frame: StartFrame):

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -789,8 +789,8 @@ class FrameProcessor(BaseObject):
         """
         downstream_frame = frame_cls(**kwargs)
         upstream_frame = frame_cls(**kwargs)
-        downstream_frame.broadcasted_sibling_id = upstream_frame.id
-        upstream_frame.broadcasted_sibling_id = downstream_frame.id
+        downstream_frame.broadcast_sibling_id = upstream_frame.id
+        upstream_frame.broadcast_sibling_id = downstream_frame.id
         await self.push_frame(downstream_frame)
         await self.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 
@@ -824,8 +824,8 @@ class FrameProcessor(BaseObject):
         for k, v in extra_fields.items():
             setattr(upstream_frame, k, v)
 
-        downstream_frame.broadcasted_sibling_id = upstream_frame.id
-        upstream_frame.broadcasted_sibling_id = downstream_frame.id
+        downstream_frame.broadcast_sibling_id = upstream_frame.id
+        upstream_frame.broadcast_sibling_id = downstream_frame.id
         await self.push_frame(downstream_frame)
         await self.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -788,10 +788,10 @@ class FrameProcessor(BaseObject):
             **kwargs: Keyword arguments to be passed to the frame's constructor.
         """
         downstream_frame = frame_cls(**kwargs)
-        downstream_frame.broadcasted = True
-        await self.push_frame(downstream_frame)
         upstream_frame = frame_cls(**kwargs)
-        upstream_frame.broadcasted = True
+        downstream_frame.broadcasted_sibling_id = upstream_frame.id
+        upstream_frame.broadcasted_sibling_id = downstream_frame.id
+        await self.push_frame(downstream_frame)
         await self.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 
     async def broadcast_frame_instance(self, frame: Frame):
@@ -816,17 +816,18 @@ class FrameProcessor(BaseObject):
             if not f.init and f.name not in ("id", "name")
         }
 
-        new_frame = frame_cls(**init_fields)
+        downstream_frame = frame_cls(**init_fields)
         for k, v in extra_fields.items():
-            setattr(new_frame, k, v)
-        new_frame.broadcasted = True
-        await self.push_frame(new_frame)
+            setattr(downstream_frame, k, v)
 
-        new_frame = frame_cls(**init_fields)
+        upstream_frame = frame_cls(**init_fields)
         for k, v in extra_fields.items():
-            setattr(new_frame, k, v)
-        new_frame.broadcasted = True
-        await self.push_frame(new_frame, FrameDirection.UPSTREAM)
+            setattr(upstream_frame, k, v)
+
+        downstream_frame.broadcasted_sibling_id = upstream_frame.id
+        upstream_frame.broadcasted_sibling_id = downstream_frame.id
+        await self.push_frame(downstream_frame)
+        await self.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 
     async def __start(self, frame: StartFrame):
         """Handle the start frame to initialize processor state.

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -1222,7 +1222,7 @@ class RTVIObserver(BaseObserver):
 
         # For broadcasted frames (pushed in both directions), only process
         # the downstream copy to avoid sending duplicate RTVI messages.
-        if frame.broadcasted and direction != FrameDirection.DOWNSTREAM:
+        if frame.broadcasted_sibling_id is not None and direction != FrameDirection.DOWNSTREAM:
             return
 
         # If we have already seen this frame, let's skip it.

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -1222,7 +1222,7 @@ class RTVIObserver(BaseObserver):
 
         # For broadcasted frames (pushed in both directions), only process
         # the downstream copy to avoid sending duplicate RTVI messages.
-        if frame.broadcasted_sibling_id is not None and direction != FrameDirection.DOWNSTREAM:
+        if frame.broadcast_sibling_id is not None and direction != FrameDirection.DOWNSTREAM:
             return
 
         # If we have already seen this frame, let's skip it.

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -1220,7 +1220,7 @@ class RTVIObserver(BaseObserver):
         frame = data.frame
         direction = data.direction
 
-        # For broadcasted frames (pushed in both directions), only process
+        # For broadcast frames (pushed in both directions), only process
         # the downstream copy to avoid sending duplicate RTVI messages.
         if frame.broadcast_sibling_id is not None and direction != FrameDirection.DOWNSTREAM:
             return

--- a/src/pipecat/processors/frameworks/rtvi.py
+++ b/src/pipecat/processors/frameworks/rtvi.py
@@ -1220,10 +1220,9 @@ class RTVIObserver(BaseObserver):
         frame = data.frame
         direction = data.direction
 
-        # Only process downstream frames. Some frames are broadcast in both
-        # directions (e.g. UserStartedSpeakingFrame, FunctionCallResultFrame),
-        # and we only want to send one RTVI message per event.
-        if direction != FrameDirection.DOWNSTREAM:
+        # For broadcasted frames (pushed in both directions), only process
+        # the downstream copy to avoid sending duplicate RTVI messages.
+        if frame.broadcasted and direction != FrameDirection.DOWNSTREAM:
             return
 
         # If we have already seen this frame, let's skip it.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -613,6 +613,11 @@ class BaseOutputTransport(FrameProcessor):
             downstream_frame.transport_destination = self._destination
             upstream_frame = BotStartedSpeakingFrame()
             upstream_frame.transport_destination = self._destination
+
+            # Setting the siblings id
+            upstream_frame.broadcasted_sibling_id = downstream_frame.id
+            downstream_frame.broadcasted_sibling_id = upstream_frame.id
+
             await self._transport.push_frame(downstream_frame)
             await self._transport.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 
@@ -635,6 +640,11 @@ class BaseOutputTransport(FrameProcessor):
             downstream_frame.transport_destination = self._destination
             upstream_frame = BotStoppedSpeakingFrame()
             upstream_frame.transport_destination = self._destination
+
+            # Setting the siblings id
+            upstream_frame.broadcasted_sibling_id = downstream_frame.id
+            downstream_frame.broadcasted_sibling_id = upstream_frame.id
+
             await self._transport.push_frame(downstream_frame)
             await self._transport.push_frame(upstream_frame, FrameDirection.UPSTREAM)
 

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -615,8 +615,8 @@ class BaseOutputTransport(FrameProcessor):
             upstream_frame.transport_destination = self._destination
 
             # Setting the siblings id
-            upstream_frame.broadcasted_sibling_id = downstream_frame.id
-            downstream_frame.broadcasted_sibling_id = upstream_frame.id
+            upstream_frame.broadcast_sibling_id = downstream_frame.id
+            downstream_frame.broadcast_sibling_id = upstream_frame.id
 
             await self._transport.push_frame(downstream_frame)
             await self._transport.push_frame(upstream_frame, FrameDirection.UPSTREAM)
@@ -642,8 +642,8 @@ class BaseOutputTransport(FrameProcessor):
             upstream_frame.transport_destination = self._destination
 
             # Setting the siblings id
-            upstream_frame.broadcasted_sibling_id = downstream_frame.id
-            downstream_frame.broadcasted_sibling_id = upstream_frame.id
+            upstream_frame.broadcast_sibling_id = downstream_frame.id
+            downstream_frame.broadcast_sibling_id = upstream_frame.id
 
             await self._transport.push_frame(downstream_frame)
             await self._transport.push_frame(upstream_frame, FrameDirection.UPSTREAM)


### PR DESCRIPTION
## Summary

- Fixed `RTVIObserver` silently ignoring upstream-only frames. The observer previously filtered out all upstream frames to prevent duplicate RTVI messages from broadcasted frames (frames pushed in both directions). This meant any frame that only traveled upstream was never converted to an RTVI client message.
- Added a `broadcasted` boolean field to the base `Frame` class, automatically set to `True` by `broadcast_frame()` and `broadcast_frame_instance()`.
- Updated `RTVIObserver` to only skip the upstream copy of broadcasted frames, allowing upstream-only frames to be observed normally.

## Testing

- All existing tests pass (576 passed, 55 skipped)
- Verify upstream-only frames are now observed by RTVIObserver
- Verify broadcasted frames still only produce one RTVI message (downstream copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)