### PR TITLE
Fix race condition where context times out after sending second transcript

### DIFF
--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -402,6 +402,8 @@ class AsyncAITTSService(AudioContextTTSService):
 
                     if not self.audio_context_available(self._context_id):
                         await self.create_audio_context(self._context_id)
+                else:
+                    self.refresh_audio_context(self._context_id)
 
                 msg = self._build_msg(text=text, force=True, context_id=self._context_id)
                 await self._get_websocket().send(msg)

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -627,6 +627,8 @@ class CartesiaTTSService(AudioContextWordTTSService):
                 yield TTSStartedFrame(context_id=context_id)
                 self._context_id = context_id
                 await self.create_audio_context(self._context_id)
+            else:
+                self.refresh_audio_context(self._context_id)
 
             msg = self._build_msg(text=text)
 

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -735,6 +735,8 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
                         ]
                     await self._websocket.send(json.dumps(msg))
                     logger.trace(f"Created new context {self._context_id}")
+                else:
+                    self.refresh_audio_context(self._context_id)
 
                 await self._send_text(text)
                 await self.start_tts_usage_metrics(text)

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -343,6 +343,8 @@ class GradiumTTSService(AudioContextWordTTSService):
                     yield TTSStartedFrame(context_id=context_id)
                     self._context_id = context_id
                     await self.create_audio_context(self._context_id)
+                else:
+                    self.refresh_audio_context(self._context_id)
 
                 msg = self._build_msg(text=text)
                 await self._get_websocket().send(json.dumps(msg))

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -981,6 +981,8 @@ class InworldTTSService(AudioContextWordTTSService):
                     # Context exists on server but local tracking was removed
                     logger.trace(f"{self}: Recreating local audio context {self._context_id}")
                     await self.create_audio_context(self._context_id)
+                else:
+                    self.refresh_audio_context(self._context_id)
 
                 await self._send_text(self._context_id, text)
                 await self.start_tts_usage_metrics(text)

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -574,6 +574,8 @@ class RimeTTSService(AudioContextWordTTSService):
                     self._cumulative_time = 0
                     self._context_id = context_id
                     await self.create_audio_context(self._context_id)
+                else:
+                    self.refresh_audio_context(self._context_id)
 
                 msg = self._build_msg(text=text)
                 await self._get_websocket().send(json.dumps(msg))


### PR DESCRIPTION
One of our customers has seen an issue where audio from a context can sometimes be dropped. We're reasonably confident that this was the problem:
  1. LLM emits sentence 1 and `run_tts` creates new context and sends it to TTS service
  2. On audio, `append_to_audio_context` is called and frames go on the queue
  3. Audio for sentence 1 finishes — nothing more on the queue                                                                                
  4. LLM takes ~2.5s and generates a second sentence. `run_tts` is called again but `self._context_id` is still set so it skips creation
  5. `_handle_audio_context` times out since it's been > 3s since the last audio on the context and deletes the context 
  7. TTS service returns audio for the second sentence in the deleted context and `append_to_audio_context` drops the audio

The fix in this PR is to call `refresh_audio_context` whenever `run_tts` is called on an already existing context, which resets the 3s timeout so that the audio context is not deleted for at least 3s after the last text sent to the TTS service.