### PR TITLE
Fix mutable default arguments in LLMContextAggregatorPair

### DIFF
--- a/changelog/3782.fixed.md
+++ b/changelog/3782.fixed.md
@@ -1,0 +1,1 @@
+- Fixed mutable default arguments in `LLMContextAggregatorPair.__init__()` that could cause shared state across instances.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1257,8 +1257,8 @@ class LLMContextAggregatorPair:
         self,
         context: LLMContext,
         *,
-        user_params: LLMUserAggregatorParams = LLMUserAggregatorParams(),
-        assistant_params: LLMAssistantAggregatorParams = LLMAssistantAggregatorParams(),
+        user_params: Optional[LLMUserAggregatorParams] = None,
+        assistant_params: Optional[LLMAssistantAggregatorParams] = None,
     ):
         """Initialize the LLM context aggregator pair.
 
@@ -1267,6 +1267,8 @@ class LLMContextAggregatorPair:
             user_params: Parameters for the user context aggregator.
             assistant_params: Parameters for the assistant context aggregator.
         """
+        user_params = user_params or LLMUserAggregatorParams()
+        assistant_params = assistant_params or LLMAssistantAggregatorParams()
         self._user = LLMUserAggregator(context, params=user_params)
         self._assistant = LLMAssistantAggregator(context, params=assistant_params)
 


### PR DESCRIPTION
## Summary

- Fixed mutable default arguments (`LLMUserAggregatorParams()`, `LLMAssistantAggregatorParams()`) in `LLMContextAggregatorPair.__init__()` that could cause shared state across instances. Defaults are now `None` with instantiation inside the method body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)