### PR TITLE
Align DeepgramSageMakerSTTService finalize pattern with DeepgramSTTService

### DIFF
--- a/changelog/3784.fixed.md
+++ b/changelog/3784.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` to properly track finalize lifecycle using `request_finalize()` / `confirm_finalize()` and use `is_final` (instead of `is_final and speech_final`) for final transcription detection, matching `DeepgramSTTService` behavior.

--- a/src/pipecat/services/deepgram/stt_sagemaker.py
+++ b/src/pipecat/services/deepgram/stt_sagemaker.py
@@ -368,7 +368,6 @@ class DeepgramSageMakerSTTService(STTService):
             return
 
         is_final = parsed.get("is_final", False)
-        speech_final = parsed.get("speech_final", False)
 
         # Extract language if available
         language = None
@@ -376,8 +375,12 @@ class DeepgramSageMakerSTTService(STTService):
             language = alternatives[0]["languages"][0]
             language = Language(language)
 
-        if is_final and speech_final:
-            # Final transcription
+        if is_final:
+            # Check if this response is from a finalize() call.
+            # Only mark as finalized when both we requested it AND Deepgram confirms it.
+            from_finalize = parsed.get("from_finalize", False)
+            if from_finalize:
+                self.confirm_finalize()
             await self.push_frame(
                 TranscriptionFrame(
                     transcript,
@@ -435,10 +438,12 @@ class DeepgramSageMakerSTTService(STTService):
         if isinstance(frame, VADUserStartedSpeakingFrame):
             await self._start_metrics()
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
-            # Send finalize message to Deepgram when user stops speaking
-            # This tells Deepgram to flush any remaining audio and return final results
+            # https://developers.deepgram.com/docs/finalize
+            # Mark that we're awaiting a from_finalize response
+            self.request_finalize()
             if self._client and self._client.is_active:
                 try:
                     await self._client.send_json({"type": "Finalize"})
                 except Exception as e:
                     logger.warning(f"Error sending Finalize message: {e}")
+            logger.trace(f"Triggered finalize event on: {frame.name=}, {direction=}")


### PR DESCRIPTION
## Summary
- Align `DeepgramSageMakerSTTService` transcription and finalize handling with the patterns used in `DeepgramSTTService`
- Add `request_finalize()` / `confirm_finalize()` tracking for proper finalize lifecycle
- Use `is_final` (not `is_final and speech_final`) as the condition for final transcriptions, matching the regular Deepgram service

## Test plan
- [x] Verify final transcriptions are correctly detected with `is_final` check
- [x] Verify `request_finalize()` is called before sending the Finalize message
- [x] Verify `confirm_finalize()` is called when `from_finalize` is present in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)