### PR TITLE
Fix race condition where context times out after sending second transcript

### DIFF
--- a/changelog/3787.fixed.md
+++ b/changelog/3787.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a race condition in `AudioContextTTSService` where the audio context could time out between consecutive TTS requests within the same turn, causing audio to be discarded.


### PR DESCRIPTION
This PR fixes the issue reported and fixed by @dakshdua [here](https://github.com/pipecat-ai/pipecat/pull/3781).

1. LLM emits sentence 1 and run_tts creates new context and sends it to TTS service
2. On audio, append_to_audio_context is called and frames go on the queue
3. Audio for sentence 1 finishes — nothing more on the queue
4. LLM takes ~2.5s and generates a second sentence. run_tts is called again but self._context_id is still set so it skips creation
5. _handle_audio_context times out since it's been > 3s since the last audio on the context and deletes the context
6. TTS service returns audio for the second sentence in the deleted context and append_to_audio_context drops the audio