### PR TITLE
fix(realtime): handle response_cancel_not_active as non-fatal

### DIFF
--- a/changelog/3795.fixed.md
+++ b/changelog/3795.fixed.md
@@ -1,0 +1,1 @@
+- Treated `response_cancel_not_active` as a non-fatal error in realtime services (`OpenAIRealtimeLLMService`, `GrokRealtimeLLMService`, `OpenAIRealtimeBetaLLMService`) to prevent WebSocket disconnection when cancelling an inactive response.

--- a/src/pipecat/services/grok/realtime/llm.py
+++ b/src/pipecat/services/grok/realtime/llm.py
@@ -512,7 +512,7 @@ class GrokRealtimeLLMService(LLMService):
                 await self._handle_evt_function_call_arguments_done(evt)
             elif evt.type == "error":
                 if evt.error.code == "response_cancel_not_active":
-                    logger.warning(f"Non-fatal API error: {evt.error.message}")
+                    logger.debug(f"{self} {evt.error.message}")
                 else:
                     await self._handle_evt_error(evt)
                     return

--- a/src/pipecat/services/grok/realtime/llm.py
+++ b/src/pipecat/services/grok/realtime/llm.py
@@ -511,8 +511,11 @@ class GrokRealtimeLLMService(LLMService):
             elif evt.type == "response.function_call_arguments.done":
                 await self._handle_evt_function_call_arguments_done(evt)
             elif evt.type == "error":
-                await self._handle_evt_error(evt)
-                return
+                if evt.error.code == "response_cancel_not_active":
+                    logger.warning(f"Non-fatal API error: {evt.error.message}")
+                else:
+                    await self._handle_evt_error(evt)
+                    return
 
     async def _handle_evt_conversation_created(self, evt):
         """Handle conversation.created event - first event after connecting."""

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -578,7 +578,7 @@ class OpenAIRealtimeLLMService(LLMService):
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
                     if evt.error.code == "response_cancel_not_active":
-                        logger.warning(f"Non-fatal API error: {evt.error.message}")
+                        logger.debug(f"{self} {evt.error.message}")
                     else:
                         await self._handle_evt_error(evt)
                         # errors are fatal, so exit the receive loop

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -577,9 +577,12 @@ class OpenAIRealtimeLLMService(LLMService):
                 await self._handle_evt_function_call_arguments_done(evt)
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
-                    await self._handle_evt_error(evt)
-                    # errors are fatal, so exit the receive loop
-                    return
+                    if evt.error.code == "response_cancel_not_active":
+                        logger.warning(f"Non-fatal API error: {evt.error.message}")
+                    else:
+                        await self._handle_evt_error(evt)
+                        # errors are fatal, so exit the receive loop
+                        return
 
     @traced_openai_realtime(operation="llm_setup")
     async def _handle_evt_session_created(self, evt):

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -504,7 +504,7 @@ class OpenAIRealtimeBetaLLMService(LLMService):
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
                     if evt.error.code == "response_cancel_not_active":
-                        logger.warning(f"Non-fatal API error: {evt.error.message}")
+                        logger.debug(f"{self} {evt.error.message}")
                     else:
                         await self._handle_evt_error(evt)
                         # errors are fatal, so exit the receive loop

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -503,9 +503,12 @@ class OpenAIRealtimeBetaLLMService(LLMService):
                 await self._handle_evt_audio_transcript_delta(evt)
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
-                    await self._handle_evt_error(evt)
-                    # errors are fatal, so exit the receive loop
-                    return
+                    if evt.error.code == "response_cancel_not_active":
+                        logger.warning(f"Non-fatal API error: {evt.error.message}")
+                    else:
+                        await self._handle_evt_error(evt)
+                        # errors are fatal, so exit the receive loop
+                        return
 
     @traced_openai_realtime(operation="llm_setup")
     async def _handle_evt_session_created(self, evt):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3755 

**Change** : `response_cancel_not_active` errors from the API are now logged as warnings instead of fatally killing the ws connection in realtime services.