### PR TITLE
Fix Gemini Live user transcriptions not propagating to clients

### DIFF
--- a/changelog/3780.fixed.md
+++ b/changelog/3780.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Gemini Live user transcriptions not being propagated to clients. User transcription frames are now properly pushed downstream from `LLMUserAggregator`, ensuring both user and assistant transcriptions appear in client UIs.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -461,6 +461,8 @@ class LLMUserAggregator(LLMContextAggregator):
             await self.push_frame(frame, direction)
         elif isinstance(frame, TranscriptionFrame):
             await self._handle_transcription(frame)
+            # Push TranscriptionFrame downstream so clients can receive user transcriptions
+            await self.push_frame(frame, direction)
         elif isinstance(frame, LLMRunFrame):
             await self._handle_llm_run(frame)
         elif isinstance(frame, LLMMessagesAppendFrame):


### PR DESCRIPTION
## Summary

Fixes #3780 - User transcriptions from Gemini Live are now properly propagated to clients, resolving an issue where only assistant transcriptions were visible in the client UI.

## Problem

When using Gemini Live without a separate speech-to-text service, user transcriptions were being received and processed by the server (visible in debug logs as `[Transcription:user]`) but were never reaching client applications. Only assistant transcriptions appeared in the UI.

## Root Cause

The `LLMUserAggregator.process_frame()` method was consuming `TranscriptionFrame` objects for internal aggregation but not pushing them downstream to other pipeline components. This prevented clients from receiving user transcription events.

## Solution

Modified `LLMUserAggregator.process_frame()` in `/src/pipecat/processors/aggregators/llm_response_universal.py` to push `TranscriptionFrame` objects downstream after handling them, consistent with how other frame types (e.g., `LLMSetToolsFrame`) are processed.

### Changes Made

- **Modified**: `src/pipecat/processors/aggregators/llm_response_universal.py`
  - Added `await self.push_frame(frame, direction)` after `_handle_transcription()` call
  - Added explanatory comment for clarity
- **Added**: `changelog/3780.fixed.md` documenting the fix

## Testing

The fix can be verified using the example file `examples/foundational/26a-gemini-live-transcription.py`. With this change, both user and assistant transcriptions should now appear in the client UI:

```
assistant: Hello! Do you want to hear a joke?
user: Yeah, sure.
assistant: Why did the chicken cross the road?
```

## Impact

- ✅ User transcriptions now propagate to clients
- ✅ No breaking changes to existing functionality
- ✅ Consistent with frame handling patterns used elsewhere in the codebase
- ✅ Resolves reported issue from multiple versions (0.0.102+)

