### PR TITLE
Feature/genesys serializer

### DIFF
--- a/changelog/3800.fixed.md
+++ b/changelog/3800.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Genesys AudioHook session shutdown to emit a clean `disconnect`, avoid duplicate disconnects while waiting for `close`, and return session `outputVariables` in `closed`.

--- a/src/pipecat/serializers/genesys.py
+++ b/src/pipecat/serializers/genesys.py
@@ -496,9 +496,6 @@ class GenesysAudioHookSerializer(FrameSerializer):
     def create_disconnect_message(
         self,
         reason: str = "completed",
-        action: str = "transfer",
-        output_variables: Optional[Dict[str, Any]] = None,
-        info: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a 'disconnect' message to initiate session termination.
 
@@ -508,38 +505,23 @@ class GenesysAudioHookSerializer(FrameSerializer):
 
         Args:
             reason: Disconnect reason (e.g., "completed", "error").
-            action: Action to take ("transfer" to agent, "finished" if completed).
-            output_variables: Custom output variables to pass back to Genesys.
-            info: Optional additional information.
 
         Returns:
             Dictionary of the disconnect message.
         """
         parameters: Dict[str, Any] = {"reason": reason}
 
-        # Build outputVariables
-        out_vars = {"action": action}
-        if output_variables:
-            out_vars.update(output_variables)
-        parameters["outputVariables"] = out_vars
-
-        if info:
-            parameters["info"] = info
-
         msg = self._create_message(
             AudioHookMessageType.DISCONNECT,
             parameters=parameters,
         )
 
-        logger.debug(f"AudioHook disconnect: reason={reason}, action={action}")
+        logger.debug(f"AudioHook disconnect: reason={reason}")
         return msg
 
     def _start_disconnect(
         self,
         reason: str = "completed",
-        action: str = "transfer",
-        output_variables: Optional[Dict[str, Any]] = None,
-        info: Optional[str] = None,
     ) -> Dict[str, Any] | None:
         """Start server-initiated disconnect once per session."""
         if not self._is_open:
@@ -553,19 +535,11 @@ class GenesysAudioHookSerializer(FrameSerializer):
         self._waiting_for_close = True
         logger.info("AudioHook disconnect initiated by server, waiting for close from Genesys")
 
-        return self.create_disconnect_message(
-            reason=reason,
-            action=action,
-            output_variables=output_variables,
-            info=info,
-        )
+        return self.create_disconnect_message(reason=reason)
 
     def create_disconnect_frame(
         self,
         reason: str = "completed",
-        action: str = "transfer",
-        output_variables: Optional[Dict[str, Any]] = None,
-        info: Optional[str] = None,
     ) -> OutputTransportMessageUrgentFrame | None:
         """Create an urgent transport frame to initiate disconnect.
 
@@ -573,12 +547,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
         EndFrame/CancelFrame yet, so transport shutdown can happen after the
         close/closed handshake completes.
         """
-        disconnect_msg = self._start_disconnect(
-            reason=reason,
-            action=action,
-            output_variables=output_variables,
-            info=info,
-        )
+        disconnect_msg = self._start_disconnect(reason=reason)
         if not disconnect_msg:
             return None
 

--- a/src/pipecat/serializers/genesys.py
+++ b/src/pipecat/serializers/genesys.py
@@ -27,7 +27,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
-from pydantic import BaseModel
 
 from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.audio.resamplers.soxr_stream_resampler import SOXRStreamAudioResampler
@@ -185,6 +184,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
         self._is_open = False
         self._is_paused = False
         self._position = timedelta(0)
+        self._waiting_for_close = False
 
         # Session metadata
         self._conversation_id: Optional[str] = None
@@ -222,6 +222,11 @@ class GenesysAudioHookSerializer(FrameSerializer):
     def is_paused(self) -> bool:
         """Check if audio streaming is paused."""
         return self._is_paused
+
+    @property
+    def is_waiting_for_close(self) -> bool:
+        """Check if server-initiated disconnect is waiting for close."""
+        return self._waiting_for_close
 
     @property
     def participant(self) -> Optional[Dict[str, Any]]:
@@ -394,6 +399,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
         )
 
         self._is_open = True
+        self._waiting_for_close = False
 
         logger.debug(f"AudioHook session opened: {self._session_id}")
 
@@ -438,6 +444,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
         )
 
         self._is_open = False
+        self._waiting_for_close = False
         logger.debug(f"AudioHook session closed: {self._session_id}")
 
         return msg
@@ -495,6 +502,10 @@ class GenesysAudioHookSerializer(FrameSerializer):
     ) -> Dict[str, Any]:
         """Create a 'disconnect' message to initiate session termination.
 
+        This starts a server-initiated shutdown. The transport should keep the
+        websocket open until Genesys sends a `close` request, then answer with
+        `closed`.
+
         Args:
             reason: Disconnect reason (e.g., "completed", "error").
             action: Action to take ("transfer" to agent, "finished" if completed).
@@ -522,6 +533,56 @@ class GenesysAudioHookSerializer(FrameSerializer):
 
         logger.debug(f"AudioHook disconnect: reason={reason}, action={action}")
         return msg
+
+    def _start_disconnect(
+        self,
+        reason: str = "completed",
+        action: str = "transfer",
+        output_variables: Optional[Dict[str, Any]] = None,
+        info: Optional[str] = None,
+    ) -> Dict[str, Any] | None:
+        """Start server-initiated disconnect once per session."""
+        if not self._is_open:
+            logger.debug("Ignoring disconnect request because session is not open")
+            return None
+
+        if self._waiting_for_close:
+            logger.debug("Ignoring duplicate disconnect request while waiting for close")
+            return None
+
+        self._waiting_for_close = True
+        logger.info("AudioHook disconnect initiated by server, waiting for close from Genesys")
+
+        return self.create_disconnect_message(
+            reason=reason,
+            action=action,
+            output_variables=output_variables,
+            info=info,
+        )
+
+    def create_disconnect_frame(
+        self,
+        reason: str = "completed",
+        action: str = "transfer",
+        output_variables: Optional[Dict[str, Any]] = None,
+        info: Optional[str] = None,
+    ) -> OutputTransportMessageUrgentFrame | None:
+        """Create an urgent transport frame to initiate disconnect.
+
+        This lets applications request protocol disconnect without sending
+        EndFrame/CancelFrame yet, so transport shutdown can happen after the
+        close/closed handshake completes.
+        """
+        disconnect_msg = self._start_disconnect(
+            reason=reason,
+            action=action,
+            output_variables=output_variables,
+            info=info,
+        )
+        if not disconnect_msg:
+            return None
+
+        return OutputTransportMessageUrgentFrame(message=disconnect_msg)
 
     def create_error_message(
         self,
@@ -558,9 +619,14 @@ class GenesysAudioHookSerializer(FrameSerializer):
 
         Handles conversion of various frame types to AudioHook messages:
         - AudioRawFrame -> Binary PCMU audio data (resampled to 8kHz)
-        - EndFrame/CancelFrame -> Disconnect message (JSON)
+        - EndFrame/CancelFrame -> One disconnect message (JSON), then wait for close
         - InterruptionFrame -> Barge-in event (JSON)
         - OutputTransportMessageFrame -> Pass-through JSON
+
+        For strict AudioHook shutdown sequencing, applications can call
+        `create_disconnect_frame()` and delay EndFrame/CancelFrame until
+        the close/closed handshake has finished. Session output variables are
+        returned in `closed`, not in this automatic `disconnect` path.
 
         Args:
             frame: The Pipecat frame to serialize.
@@ -570,14 +636,13 @@ class GenesysAudioHookSerializer(FrameSerializer):
             the frame type is not handled or session is not open.
         """
         if isinstance(frame, (EndFrame, CancelFrame)):
-            return json.dumps(
-                self.create_disconnect_message(
-                    output_variables=self.output_variables, reason="completed"
-                )
+            disconnect_msg = self._start_disconnect(
+                reason="completed",
             )
+            return json.dumps(disconnect_msg) if disconnect_msg else None
 
         elif isinstance(frame, AudioRawFrame):
-            if not self._is_open or self._is_paused:
+            if not self._is_open or self._is_paused or self._waiting_for_close:
                 return None
 
             data = frame.audio
@@ -775,6 +840,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
             OutputTransportMessageUrgentFrame with the 'opened' response.
         """
         self._session_id = message.get("id", str(uuid.uuid4()))
+        self._waiting_for_close = False
 
         params = message.get("parameters", {})
         self._conversation_id = params.get("conversationId")
@@ -841,6 +907,7 @@ class GenesysAudioHookSerializer(FrameSerializer):
         logger.info(f"🔴 Genesys closed the connection: {reason}")
 
         self._is_open = False
+        self._waiting_for_close = False
 
         logger.info(f"Sending closed response to Genesys...")
 

--- a/tests/genesys/test_genesys_serializer.py
+++ b/tests/genesys/test_genesys_serializer.py
@@ -126,34 +126,27 @@ class TestGenesysAudioHookSerializer:
         """Test creating a disconnect message."""
         serializer = GenesysAudioHookSerializer()
 
-        msg = serializer.create_disconnect_message(
-            reason="completed",
-            action="transfer",
-        )
+        msg = serializer.create_disconnect_message(reason="completed")
 
         assert msg["type"] == "disconnect"
         assert msg["parameters"]["reason"] == "completed"
-        assert msg["parameters"]["outputVariables"]["action"] == "transfer"
+        assert "outputVariables" not in msg["parameters"]
 
-    def test_create_disconnect_message_with_output_variables(self):
-        """Test creating a disconnect message with custom output variables."""
+    def test_create_disconnect_message_with_custom_reason(self):
+        """Test creating a disconnect message with a custom reason."""
         serializer = GenesysAudioHookSerializer()
 
-        msg = serializer.create_disconnect_message(
-            reason="completed",
-            action="finished",
-            output_variables={"result": "success", "code": "123"},
-        )
+        msg = serializer.create_disconnect_message(reason="error")
 
-        assert msg["parameters"]["outputVariables"]["result"] == "success"
-        assert msg["parameters"]["outputVariables"]["code"] == "123"
+        assert msg["parameters"]["reason"] == "error"
+        assert "outputVariables" not in msg["parameters"]
 
     def test_create_disconnect_frame(self):
         """Test creating an urgent disconnect transport frame."""
         serializer = GenesysAudioHookSerializer()
         serializer._is_open = True
 
-        frame = serializer.create_disconnect_frame(reason="completed", action="finished")
+        frame = serializer.create_disconnect_frame(reason="completed")
 
         assert frame is not None
         assert isinstance(frame, OutputTransportMessageUrgentFrame)
@@ -445,7 +438,7 @@ class TestGenesysAudioHookSerializer:
         assert payload is not None
         message = json.loads(payload)
         assert message["type"] == "disconnect"
-        assert message["parameters"]["outputVariables"] == {"action": "transfer"}
+        assert "outputVariables" not in message["parameters"]
 
     @pytest.mark.asyncio
     async def test_serialize_audio_returns_none_while_waiting_for_close(self):

--- a/tests/genesys/test_genesys_serializer.py
+++ b/tests/genesys/test_genesys_serializer.py
@@ -10,7 +10,13 @@ import json
 
 import pytest
 
-from pipecat.frames.frames import InputDTMFFrame, OutputTransportMessageUrgentFrame
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    InputDTMFFrame,
+    OutputAudioRawFrame,
+    OutputTransportMessageUrgentFrame,
+)
 from pipecat.serializers.genesys import AudioHookChannel, GenesysAudioHookSerializer
 
 
@@ -142,6 +148,29 @@ class TestGenesysAudioHookSerializer:
         assert msg["parameters"]["outputVariables"]["result"] == "success"
         assert msg["parameters"]["outputVariables"]["code"] == "123"
 
+    def test_create_disconnect_frame(self):
+        """Test creating an urgent disconnect transport frame."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+
+        frame = serializer.create_disconnect_frame(reason="completed", action="finished")
+
+        assert frame is not None
+        assert isinstance(frame, OutputTransportMessageUrgentFrame)
+        assert frame.message["type"] == "disconnect"
+        assert serializer.is_waiting_for_close is True
+
+    def test_create_disconnect_frame_only_once_while_waiting(self):
+        """Test that disconnect frame is emitted once while waiting for close."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+
+        first_frame = serializer.create_disconnect_frame()
+        second_frame = serializer.create_disconnect_frame()
+
+        assert first_frame is not None
+        assert second_frame is None
+
     def test_create_error_message(self):
         """Test creating an error message."""
         serializer = GenesysAudioHookSerializer()
@@ -255,6 +284,21 @@ class TestGenesysAudioHookSerializer:
         assert result.message["parameters"]["outputVariables"]["intent"] == "support"
         assert result.message["parameters"]["outputVariables"]["resolved"] is True
         assert result.message["parameters"]["outputVariables"]["transfer_to"] == "agent_queue"
+
+    @pytest.mark.asyncio
+    async def test_handle_close_message_clears_waiting_for_close(self, sample_close_message):
+        """Test that close handling clears disconnect waiting state."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+        serializer.create_disconnect_frame()
+
+        assert serializer.is_waiting_for_close is True
+
+        result = await serializer.deserialize(json.dumps(sample_close_message))
+
+        assert isinstance(result, OutputTransportMessageUrgentFrame)
+        assert result.message["type"] == "closed"
+        assert serializer.is_waiting_for_close is False
 
     # ==================== Output Variables Tests ====================
 
@@ -373,3 +417,49 @@ class TestGenesysAudioHookSerializer:
         assert response1["seq"] == 1
         assert response2["seq"] == 2
         assert response3["seq"] == 3
+
+    @pytest.mark.asyncio
+    async def test_serialize_endframe_disconnect_only_once(self):
+        """Test EndFrame/CancelFrame emits one disconnect while waiting for close."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+
+        first_payload = await serializer.serialize(EndFrame())
+        second_payload = await serializer.serialize(CancelFrame())
+
+        assert first_payload is not None
+        first_message = json.loads(first_payload)
+        assert first_message["type"] == "disconnect"
+        assert serializer.is_waiting_for_close is True
+        assert second_payload is None
+
+    @pytest.mark.asyncio
+    async def test_serialize_endframe_disconnect_does_not_include_output_variables(self):
+        """Test automatic disconnect keeps output variables for closed response only."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+        serializer.set_output_variables({"intent": "billing", "resolved": True})
+
+        payload = await serializer.serialize(EndFrame())
+
+        assert payload is not None
+        message = json.loads(payload)
+        assert message["type"] == "disconnect"
+        assert message["parameters"]["outputVariables"] == {"action": "transfer"}
+
+    @pytest.mark.asyncio
+    async def test_serialize_audio_returns_none_while_waiting_for_close(self):
+        """Test audio is blocked while waiting for close after disconnect."""
+        serializer = GenesysAudioHookSerializer()
+        serializer._is_open = True
+        serializer._waiting_for_close = True
+
+        payload = await serializer.serialize(
+            OutputAudioRawFrame(
+                audio=b"\x00\x00" * 160,
+                sample_rate=16000,
+                num_channels=1,
+            )
+        )
+
+        assert payload is None


### PR DESCRIPTION
This pull request introduces improvements to the Genesys AudioHook serializer, focusing on stricter and safer session shutdown handling. The main changes are the addition of a new `_waiting_for_close` state to prevent duplicate disconnect messages, updates to the disconnect message structure, and enhancements to the test suite to cover these behaviors.

Session shutdown and disconnect handling:

* Introduced a `_waiting_for_close` flag in `GenesysAudioHookSerializer` to track when a server-initiated disconnect is in progress, preventing duplicate disconnect messages and ensuring proper shutdown sequencing. Added a `is_waiting_for_close` property for external checks. [[1]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R187) [[2]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R226-R230)
* Updated the disconnect logic: `create_disconnect_message` no longer includes `outputVariables` or `action`, and `_start_disconnect` ensures only one disconnect is sent per session. Audio frames are blocked while waiting for close. [[1]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25L492-R555) [[2]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25L573-R614)
* Modified serializer methods and session state transitions to reset `_waiting_for_close` on session open and close, ensuring the flag is cleared appropriately. [[1]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R402) [[2]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R447) [[3]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R812) [[4]](diffhunk://#diff-10a7023cc46964e3b4dce60eca1eac21c607390cf6d93c73a5755b8c289f0d25R879)

Test suite enhancements:

* Added tests for the new disconnect sequencing, including checks that only one disconnect frame is sent, that output variables are not included in automatic disconnects, and that audio is blocked while waiting for close. Also added tests to verify that session state resets correctly after close. [[1]](diffhunk://#diff-97890fe348790d6211f99f1cbfb721af80738270e9bb6fc64280ed96ecb903efL123-R165) [[2]](diffhunk://#diff-97890fe348790d6211f99f1cbfb721af80738270e9bb6fc64280ed96ecb903efR281-R295) [[3]](diffhunk://#diff-97890fe348790d6211f99f1cbfb721af80738270e9bb6fc64280ed96ecb903efR413-R458)

Other minor changes:

* Cleaned up imports and removed unused dependencies in `genesys.py`.

These changes improve reliability and correctness of session termination, preventing race conditions and ensuring output variables are returned only in the final closed response.