### PR TITLE
feat: Add PreemptiveUserTurnStopStrategy for reduced response latency

### DIFF
--- a/changelog/3794.added.md
+++ b/changelog/3794.added.md
@@ -1,0 +1,1 @@
+Added `PreemptiveUserTurnStopStrategy` and `PreemptiveUserTurnStrategies` for low-latency response generation. The preemptive strategy triggers LLM generation as soon as VAD detects silence and any transcription text is available, without waiting for ML turn analysis or finalized transcripts.

--- a/src/pipecat/turns/user_stop/__init__.py
+++ b/src/pipecat/turns/user_stop/__init__.py
@@ -6,12 +6,14 @@
 
 from .base_user_turn_stop_strategy import BaseUserTurnStopStrategy, UserTurnStoppedParams
 from .external_user_turn_stop_strategy import ExternalUserTurnStopStrategy
+from .preemptive_user_turn_stop_strategy import PreemptiveUserTurnStopStrategy
 from .speech_timeout_user_turn_stop_strategy import SpeechTimeoutUserTurnStopStrategy
 from .turn_analyzer_user_turn_stop_strategy import TurnAnalyzerUserTurnStopStrategy
 
 __all__ = [
     "BaseUserTurnStopStrategy",
     "ExternalUserTurnStopStrategy",
+    "PreemptiveUserTurnStopStrategy",
     "SpeechTimeoutUserTurnStopStrategy",
     "UserTurnStoppedParams",
     "TurnAnalyzerUserTurnStopStrategy",

--- a/src/pipecat/turns/user_stop/preemptive_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/preemptive_user_turn_stop_strategy.py
@@ -1,0 +1,171 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Preemptive user turn stop strategy for low-latency response generation."""
+
+import asyncio
+from typing import Optional
+
+from pipecat.frames.frames import (
+    Frame,
+    STTMetadataFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.turns.user_stop.base_user_turn_stop_strategy import BaseUserTurnStopStrategy
+from pipecat.utils.asyncio.task_manager import BaseTaskManager
+
+
+class PreemptiveUserTurnStopStrategy(BaseUserTurnStopStrategy):
+    """User turn stop strategy that triggers LLM generation as soon as possible.
+
+    This strategy triggers the end of the user's turn as soon as VAD detects
+    silence and any transcription text is available, without waiting for ML
+    turn analysis or finalized transcripts. The existing interruption mechanism
+    handles cancellation if the user resumes speaking.
+
+    Trigger conditions (any one sufficient):
+
+    - **VAD-first:** VAD has stopped and any transcription text exists — trigger
+      immediately.
+    - **STT-first:** Transcription arrives while user is not speaking (no VAD) —
+      trigger after a fallback STT timeout.
+    - **Fallback:** VAD stopped but no transcript arrives — wait for the STT P99
+      timeout, then trigger.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize the preemptive user turn stop strategy.
+
+        Args:
+            **kwargs: Additional keyword arguments passed to parent.
+        """
+        super().__init__(**kwargs)
+        self._stt_timeout: float = 0.0
+        self._stop_secs: float = 0.0
+        self._text: str = ""
+        self._vad_user_speaking: bool = False
+        self._vad_stopped: bool = False
+        self._has_triggered: bool = False
+        self._timeout_task: Optional[asyncio.Task] = None
+
+    async def reset(self):
+        """Reset the strategy to its initial state."""
+        await super().reset()
+        self._text = ""
+        self._vad_user_speaking = False
+        self._vad_stopped = False
+        self._has_triggered = False
+
+    async def setup(self, task_manager: BaseTaskManager):
+        """Initialize the strategy with the given task manager.
+
+        Args:
+            task_manager: The task manager to be associated with this instance.
+        """
+        await super().setup(task_manager)
+
+    async def cleanup(self):
+        """Cleanup the strategy."""
+        await super().cleanup()
+        if self._timeout_task:
+            await self.task_manager.cancel_task(self._timeout_task)
+            self._timeout_task = None
+
+    async def process_frame(self, frame: Frame):
+        """Process an incoming frame to update strategy state.
+
+        Args:
+            frame: The frame to be analyzed.
+        """
+        if isinstance(frame, STTMetadataFrame):
+            self._stt_timeout = frame.ttfs_p99_latency
+        elif isinstance(frame, VADUserStartedSpeakingFrame):
+            await self._handle_vad_user_started_speaking(frame)
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            await self._handle_vad_user_stopped_speaking(frame)
+        elif isinstance(frame, TranscriptionFrame):
+            await self._handle_transcription(frame)
+
+    async def _handle_vad_user_started_speaking(self, _: VADUserStartedSpeakingFrame):
+        """Handle when the VAD indicates the user is speaking."""
+        self._vad_user_speaking = True
+        self._vad_stopped = False
+        # Cancel any pending timeout
+        if self._timeout_task:
+            await self.task_manager.cancel_task(self._timeout_task)
+            self._timeout_task = None
+
+    async def _handle_vad_user_stopped_speaking(self, frame: VADUserStoppedSpeakingFrame):
+        """Handle when the VAD indicates the user has stopped speaking."""
+        self._vad_user_speaking = False
+        self._vad_stopped = True
+        self._stop_secs = frame.stop_secs
+
+        # Try to trigger immediately if we already have text
+        await self._maybe_trigger_user_turn_stopped()
+
+        # If we haven't triggered yet (no text), start a fallback timeout
+        if not self._has_triggered:
+            timeout = max(0, self._stt_timeout - self._stop_secs)
+            self._timeout_task = self.task_manager.create_task(
+                self._timeout_handler(timeout), f"{self}::_timeout_handler"
+            )
+
+    async def _handle_transcription(self, frame: TranscriptionFrame):
+        """Handle user transcription."""
+        self._text += frame.text
+
+        if self._has_triggered:
+            return
+
+        # VAD path: if VAD has stopped and we have text, trigger immediately
+        if self._vad_stopped:
+            await self._trigger()
+            return
+
+        # No-VAD fallback: start/reset timeout on each transcription.
+        # The timeout handler will trigger when it completes.
+        if not self._vad_user_speaking:
+            if self._timeout_task:
+                await self.task_manager.cancel_task(self._timeout_task)
+            timeout = max(0, self._stt_timeout - self._stop_secs)
+            self._timeout_task = self.task_manager.create_task(
+                self._timeout_handler(timeout), f"{self}::_timeout_handler"
+            )
+
+    async def _timeout_handler(self, timeout: float):
+        """Wait for the timeout then trigger user turn stopped if conditions met.
+
+        Args:
+            timeout: The timeout in seconds to wait.
+        """
+        try:
+            await asyncio.sleep(timeout)
+        except asyncio.CancelledError:
+            return
+        finally:
+            self._timeout_task = None
+
+        if not self._has_triggered and not self._vad_user_speaking and self._text:
+            await self._trigger()
+
+    async def _trigger(self):
+        """Trigger user turn stopped and cancel any pending timeout."""
+        self._has_triggered = True
+        if self._timeout_task:
+            await self.task_manager.cancel_task(self._timeout_task)
+            self._timeout_task = None
+        await self.trigger_user_turn_stopped()
+
+    async def _maybe_trigger_user_turn_stopped(self):
+        """Trigger user turn stopped if VAD has stopped and text exists."""
+        if self._has_triggered or self._vad_user_speaking or not self._text:
+            return
+
+        if self._vad_stopped:
+            await self._trigger()

--- a/src/pipecat/turns/user_turn_strategies.py
+++ b/src/pipecat/turns/user_turn_strategies.py
@@ -19,6 +19,7 @@ from pipecat.turns.user_start import (
 from pipecat.turns.user_stop import (
     BaseUserTurnStopStrategy,
     ExternalUserTurnStopStrategy,
+    PreemptiveUserTurnStopStrategy,
     TurnAnalyzerUserTurnStopStrategy,
 )
 
@@ -48,6 +49,26 @@ class UserTurnStrategies:
             self.start = [VADUserTurnStartStrategy(), TranscriptionUserTurnStartStrategy()]
         if not self.stop:
             self.stop = [TurnAnalyzerUserTurnStopStrategy(turn_analyzer=LocalSmartTurnAnalyzerV3())]
+
+
+@dataclass
+class PreemptiveUserTurnStrategies(UserTurnStrategies):
+    """Default container for preemptive user turn start and stop strategies.
+
+    This class provides a convenience default for configuring preemptive turn
+    detection. It preconfigures `UserTurnStrategies` with
+    `PreemptiveUserTurnStopStrategy`, which triggers LLM generation as soon as
+    VAD detects silence and any transcription text is available, without waiting
+    for ML turn analysis or finalized transcripts.
+
+    The existing interruption mechanism handles cancellation if the user resumes
+    speaking, so no additional cancellation logic is needed.
+    """
+
+    def __post_init__(self):
+        if not self.start:
+            self.start = [VADUserTurnStartStrategy(), TranscriptionUserTurnStartStrategy()]
+        self.stop = [PreemptiveUserTurnStopStrategy()]
 
 
 @dataclass

--- a/tests/test_user_turn_stop_strategy.py
+++ b/tests/test_user_turn_stop_strategy.py
@@ -16,7 +16,11 @@ from pipecat.frames.frames import (
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
-from pipecat.turns.user_stop import ExternalUserTurnStopStrategy, SpeechTimeoutUserTurnStopStrategy
+from pipecat.turns.user_stop import (
+    ExternalUserTurnStopStrategy,
+    PreemptiveUserTurnStopStrategy,
+    SpeechTimeoutUserTurnStopStrategy,
+)
 from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
 
 AGGREGATION_TIMEOUT = 0.1
@@ -492,6 +496,238 @@ class TestSpeechTimeoutUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
 
         # Finalized transcript received after timeout, triggers immediately
         self.assertTrue(should_start)
+
+
+class TestPreemptiveUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.task_manager = TaskManager()
+        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+
+    async def _create_strategy(self):
+        """Create strategy and configure STT timeout via metadata frame."""
+        strategy = PreemptiveUserTurnStopStrategy()
+        await strategy.setup(self.task_manager)
+        # Set STT timeout via metadata frame (as would happen in real pipeline)
+        await strategy.process_frame(
+            STTMetadataFrame(service_name="test", ttfs_p99_latency=STT_TIMEOUT)
+        )
+        return strategy
+
+    async def test_ste(self):
+        """VAD start → Transcription → VAD stop: fires immediately on stop."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # T
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertIsNone(should_start)
+
+        # E - triggers immediately since we have text
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertTrue(should_start)
+
+    async def test_set(self):
+        """VAD start → VAD stop → Transcription: fires immediately on transcription."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # E
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # T - triggers immediately since VAD already stopped
+        await strategy.process_frame(
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        self.assertTrue(should_start)
+
+    async def test_seit(self):
+        """VAD start → VAD stop → Interim → Transcription: fires immediately on transcription."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # E
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # I - interim transcription, not a TranscriptionFrame
+        await strategy.process_frame(
+            InterimTranscriptionFrame(text="How", user_id="cat", timestamp="")
+        )
+        self.assertIsNone(should_start)
+
+        # T - triggers immediately since VAD already stopped
+        await strategy.process_frame(
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        self.assertTrue(should_start)
+
+    async def test_site(self):
+        """VAD start → Interim → Transcription → VAD stop: fires immediately on stop."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # I
+        await strategy.process_frame(
+            InterimTranscriptionFrame(text="Hello!", user_id="cat", timestamp="")
+        )
+        self.assertIsNone(should_start)
+
+        # T
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertIsNone(should_start)
+
+        # E - triggers immediately since we have text
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertTrue(should_start)
+
+    async def test_se_no_text(self):
+        """VAD start → VAD stop with no transcription: does NOT fire."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # E
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        # Wait for any fallback timeout to expire
+        await asyncio.sleep(0.2)
+        self.assertIsNone(should_start)
+
+    async def test_st1et2(self):
+        """Two clean turns: fires on each VAD stop, resets between turns."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # Turn 1: S → T1 → E
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertIsNone(should_start)
+
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertTrue(should_start)
+
+        # Reset for next turn
+        should_start = None
+        await strategy.reset()
+
+        # Turn 2: S → T2 → E
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsNone(should_start)
+
+        await strategy.process_frame(
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        self.assertIsNone(should_start)
+
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertTrue(should_start)
+
+    async def test_t(self):
+        """Transcription without VAD: fires after fallback timeout."""
+        strategy = await self._create_strategy()
+
+        should_start = None
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        # T - no VAD, starts fallback timeout
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertIsNone(should_start)
+
+        # Fallback timeout fires (STT_TIMEOUT is 0, so it fires quickly)
+        await asyncio.sleep(0.1)
+        self.assertTrue(should_start)
+
+    async def test_set1t2(self):
+        """VAD start → VAD stop → T1 → T2: fires on T1 immediately, ignores T2."""
+        strategy = await self._create_strategy()
+
+        trigger_count = 0
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal trigger_count
+            trigger_count += 1
+
+        # S
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertEqual(trigger_count, 0)
+
+        # E
+        await strategy.process_frame(VADUserStoppedSpeakingFrame())
+        self.assertEqual(trigger_count, 0)
+
+        # T1 - triggers immediately
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertEqual(trigger_count, 1)
+
+        # T2 - should NOT trigger again (already triggered this turn)
+        await strategy.process_frame(
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        self.assertEqual(trigger_count, 1)
 
 
 class TestExternalUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
                                                                                                  
  - Added **PreemptiveUserTurnStopStrategy** - a new user turn stop strategy that triggers LLM generation
  as soon as VAD detects silence and any transcription text is available, without waiting for ML
  turn analysis or finalized transcripts
  - Added **PreemptiveUserTurnStrategies** convenience class for easy configuration
  - Added 8 tests covering all trigger paths (VAD-first, STT-first, no-text guard, multi-turn reset,
  no-VAD fallback, double-trigger prevention)

 The default TurnAnalyzerUserTurnStopStrategy waits for VAD silence + ML turn completion prediction + finalized transcript (or timeout), which adds latency between when the user stops speaking and when the agent begins responding. The preemptive strategy trades turn-boundary accuracy for lower latency, the existing interruption mechanism (InterruptionFrame) handles cancellation if the user resumes speaking.