### PR TITLE
Add dataclass vs Pydantic BaseModel convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,9 @@ All data flows as **Frame** objects through a pipeline of **FrameProcessors**:
 - **Docstrings**: Google-style. Classes describe purpose; `__init__` has `Args:` section; dataclasses use `Parameters:` section.
 - **Linting**: Ruff (line length 100). Pre-commit hooks enforce formatting.
 - **Type hints**: Required for complex async code.
+- **Dataclass vs Pydantic**: Use `@dataclass` for frames and internal pipeline data (high-frequency, no validation needed). Use Pydantic `BaseModel` for configuration, parameters, metrics, and external API data (benefits from validation and serialization). Specifically:
+  - `@dataclass`: Frame types, context aggregator pairs, internal data containers
+  - `BaseModel`: Service `InputParams`, transport/VAD/turn params, metrics data, API request/response models, serializer params
 
 ### Docstring Example
 


### PR DESCRIPTION
## Summary
- Documents the existing convention for when to use `@dataclass` vs Pydantic `BaseModel`
- `@dataclass` for frames and internal pipeline data (high-frequency, no validation needed)
- `BaseModel` for configuration, parameters, metrics, and external API data (validation and serialization)

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)