### PR TITLE
Update OpenAI Realtime default model to gpt-realtime-1.5

### DIFF
--- a/changelog/3807.changed.md
+++ b/changelog/3807.changed.md
@@ -1,0 +1,1 @@
+- Updated `OpenAIRealtimeLLMService` default model to `gpt-realtime-1.5`.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -121,7 +121,7 @@ class OpenAIRealtimeLLMService(LLMService):
         self,
         *,
         api_key: str,
-        model: str = "gpt-realtime",
+        model: str = "gpt-realtime-1.5",
         base_url: str = "wss://api.openai.com/v1/realtime",
         session_properties: Optional[events.SessionProperties] = None,
         start_audio_paused: bool = False,


### PR DESCRIPTION
## Summary
- Updates the default model for `OpenAIRealtimeLLMService` from `gpt-realtime` to `gpt-realtime-1.5`

## Test plan
- [x] Verify OpenAI Realtime service connects successfully with the new default model
- [x] Verify existing usage that explicitly passes a model string is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)