### PR TITLE
feat(google-stt): add configurable encoding parameter to InputParams

### DIFF
--- a/src/pipecat/services/google/stt.py
+++ b/src/pipecat/services/google/stt.py
@@ -381,6 +381,7 @@ class GoogleSTTSettings(STTSettings):
         enable_word_confidence: Include confidence scores for each word.
         enable_interim_results: Stream partial recognition results.
         enable_voice_activity_events: Detect voice activity in audio.
+        encoding: Audio encoding format. Supported: LINEAR16 (default), MULAW, ALAW, FLAC, MP3, OGG_OPUS.
     """
 
     languages: List[Language] | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -396,6 +397,7 @@ class GoogleSTTSettings(STTSettings):
     enable_word_confidence: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     enable_interim_results: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     enable_voice_activity_events: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    encoding: str | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class GoogleSTTService(STTService):
@@ -437,6 +439,8 @@ class GoogleSTTService(STTService):
             enable_word_confidence: Include confidence scores for each word.
             enable_interim_results: Stream partial recognition results.
             enable_voice_activity_events: Detect voice activity in audio.
+            encoding: Audio encoding format for input audio. Supported values:
+                LINEAR16 (default), MULAW, ALAW, FLAC, MP3, OGG_OPUS.
         """
 
         languages: Union[Language, List[Language]] = Field(default_factory=lambda: [Language.EN_US])
@@ -450,6 +454,7 @@ class GoogleSTTService(STTService):
         enable_word_confidence: Optional[bool] = False
         enable_interim_results: Optional[bool] = True
         enable_voice_activity_events: Optional[bool] = False
+        encoding: Optional[str] = "LINEAR16"
 
         @field_validator("languages", mode="before")
         @classmethod
@@ -565,6 +570,7 @@ class GoogleSTTService(STTService):
             enable_word_confidence=params.enable_word_confidence,
             enable_interim_results=params.enable_interim_results,
             enable_voice_activity_events=params.enable_voice_activity_events,
+            encoding=params.encoding,
         )
 
     def can_generate_metrics(self) -> bool:
@@ -785,7 +791,11 @@ class GoogleSTTService(STTService):
         self._config = cloud_speech.StreamingRecognitionConfig(
             config=cloud_speech.RecognitionConfig(
                 explicit_decoding_config=cloud_speech.ExplicitDecodingConfig(
-                    encoding=cloud_speech.ExplicitDecodingConfig.AudioEncoding.LINEAR16,
+                    encoding=getattr(
+                        cloud_speech.ExplicitDecodingConfig.AudioEncoding,
+                        self._settings.encoding,
+                        cloud_speech.ExplicitDecodingConfig.AudioEncoding.LINEAR16,
+                    ),
                     sample_rate_hertz=self.sample_rate,
                     audio_channel_count=1,
                 ),


### PR DESCRIPTION
## Summary

- Adds an `encoding` field to `GoogleSTTService.InputParams` so callers can specify the audio encoding format (e.g., `MULAW`, `ALAW`) instead of always using `LINEAR16`
- Uses `getattr()` with `LINEAR16` fallback for safe enum resolution at connection time
- No breaking changes — default remains `LINEAR16`, fully backward compatible

## Problem

`GoogleSTTService._connect()` hardcodes `ExplicitDecodingConfig.AudioEncoding.LINEAR16`, forcing callers to convert audio to PCM before sending it to Google STT V2. However, the Google STT V2 API natively supports `MULAW`, `ALAW`, `FLAC`, `MP3`, and `OGG_OPUS` — making the PCM conversion unnecessary CPU overhead for telephony and other non-PCM audio sources.

## Solution

1. **`InputParams.encoding`** — New `Optional[str]` field (default: `"LINEAR16"`) accepting any value from `cloud_speech.ExplicitDecodingConfig.AudioEncoding` enum
2. **`self._settings["encoding"]`** — Stored alongside other settings for use at connection time
3. **`_connect()` encoding resolution** — Replaced hardcoded `LINEAR16` with `getattr(AudioEncoding, self._settings["encoding"], AudioEncoding.LINEAR16)` for safe runtime resolution with fallback

## Usage

```python
# Before: Always LINEAR16, caller must convert audio
stt = GoogleSTTService(
    credentials_path="sa.json",
    params=GoogleSTTService.InputParams(model="telephony"),
)

# After: Pass native encoding, skip conversion
stt = GoogleSTTService(
    credentials_path="sa.json",
    params=GoogleSTTService.InputParams(
        model="telephony",
        encoding="ALAW",  # or "MULAW", "FLAC", "MP3", "OGG_OPUS"
    ),
)
```

## Supported Encodings

| Value | Description |
|-------|-------------|
| `LINEAR16` | 16-bit signed little-endian PCM (default) |
| `MULAW` | 8-bit μ-law encoded audio |
| `ALAW` | 8-bit A-law encoded audio |
| `FLAC` | FLAC lossless audio |
| `MP3` | MP3 compressed audio |
| `OGG_OPUS` | Opus audio in Ogg container |

## Testing

Tested in production with a telephony voice AI application receiving A-law audio from Asterisk. Passing `encoding="ALAW"` directly to Google STT V2 eliminated the PCM conversion step while maintaining correct transcription.