### PR TITLE
Make clearer the distinction between "storage-mode" and "delta-mode" …

### DIFF
--- a/COMMUNITY_INTEGRATIONS.md
+++ b/COMMUNITY_INTEGRATIONS.md
@@ -260,9 +260,11 @@ class MySTTService(STTService):
 
     _settings: MySTTSettings
 
-    def __init__(self, *, model: str, region: str, **kwargs):
+    def __init__(self, *, model: str, language: str, region: str, **kwargs):
         super().__init__(**kwargs)
-        self._settings = MySTTSettings(model=model, region=region)
+        # Initial value must be provided for every field in self._settings
+        # before service is started
+        self._settings = MySTTSettings(model=model, language=language, region=region)
         self._sync_model_name_to_metrics()
 ```
 
@@ -298,7 +300,7 @@ async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
     if "language" in changed:
         await self._update_language()
     else:
-        # TODO: handle changes to other settings soon!
+        # TODO: this should be temporary - handle changes to other settings soon!
         self._warn_unhandled_updated_settings(changed.keys() - {"language"})
 
     return changed

--- a/changelog/3714.added.md
+++ b/changelog/3714.added.md
@@ -12,7 +12,7 @@
 
   ```python
   await task.queue_frame(
-      STTUpdateSettingsFrame(update=DeepgramSTTSettings(language=Language.ES))
+      STTUpdateSettingsFrame(delta=DeepgramSTTSettings(language=Language.ES))
   )
   ```
 

--- a/changelog/3714.deprecated.2.md
+++ b/changelog/3714.deprecated.2.md
@@ -1,1 +1,1 @@
-- Dict-based `*UpdateSettingsFrame(settings={...})` is deprecated in favor of passing typed settings delta objects with `*UpdateSettingsFrame(update={...})`.
+- Dict-based `*UpdateSettingsFrame(settings={...})` is deprecated in favor of passing typed settings delta objects with `*UpdateSettingsFrame(delta={...})`.

--- a/examples/foundational/55a-update-settings-deepgram-flux-stt.py
+++ b/examples/foundational/55a-update-settings-deepgram-flux-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Deepgram Flux STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=DeepgramFluxSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=DeepgramFluxSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55a-update-settings-deepgram-sagemaker-stt.py
+++ b/examples/foundational/55a-update-settings-deepgram-sagemaker-stt.py
@@ -109,7 +109,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Deepgram SageMaker STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=DeepgramSageMakerSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=DeepgramSageMakerSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55a-update-settings-deepgram-stt.py
+++ b/examples/foundational/55a-update-settings-deepgram-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Deepgram STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=DeepgramSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=DeepgramSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55b-update-settings-azure-stt.py
+++ b/examples/foundational/55b-update-settings-azure-stt.py
@@ -105,9 +105,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Azure STT settings: language=es")
-        await task.queue_frame(
-            STTUpdateSettingsFrame(update=AzureSTTSettings(language=Language.ES))
-        )
+        await task.queue_frame(STTUpdateSettingsFrame(delta=AzureSTTSettings(language=Language.ES)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55c-update-settings-google-stt.py
+++ b/examples/foundational/55c-update-settings-google-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Google STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=GoogleSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=GoogleSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55d-update-settings-assemblyai-stt.py
+++ b/examples/foundational/55d-update-settings-assemblyai-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating AssemblyAI STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=AssemblyAISTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=AssemblyAISTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55e-update-settings-gladia-stt.py
+++ b/examples/foundational/55e-update-settings-gladia-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Gladia STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=GladiaSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=GladiaSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55f-update-settings-elevenlabs-realtime-stt.py
+++ b/examples/foundational/55f-update-settings-elevenlabs-realtime-stt.py
@@ -106,7 +106,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating ElevenLabs Realtime STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=ElevenLabsRealtimeSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=ElevenLabsRealtimeSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55g-update-settings-elevenlabs-stt.py
+++ b/examples/foundational/55g-update-settings-elevenlabs-stt.py
@@ -108,7 +108,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info("Updating ElevenLabs STT settings: language=es")
             await task.queue_frame(
-                STTUpdateSettingsFrame(update=ElevenLabsSTTSettings(language=Language.ES))
+                STTUpdateSettingsFrame(delta=ElevenLabsSTTSettings(language=Language.ES))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55h-update-settings-speechmatics-stt.py
+++ b/examples/foundational/55h-update-settings-speechmatics-stt.py
@@ -110,13 +110,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Speechmatics STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=SpeechmaticsSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=SpeechmaticsSTTSettings(language=Language.ES))
         )
 
         await asyncio.sleep(10)
         logger.info("Updating Speechmatics STT settings: focus_speakers=['S1']")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=SpeechmaticsSTTSettings(focus_speakers=["S1"]))
+            STTUpdateSettingsFrame(delta=SpeechmaticsSTTSettings(focus_speakers=["S1"]))
         )
 
         await asyncio.sleep(10)
@@ -125,7 +125,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         )
         await task.queue_frame(
             STTUpdateSettingsFrame(
-                update=SpeechmaticsSTTSettings(
+                delta=SpeechmaticsSTTSettings(
                     speaker_active_format="<SPEAKER_{speaker_id}>{text}</SPEAKER_{speaker_id}>"
                 )
             )

--- a/examples/foundational/55i-update-settings-whisper-api-stt.py
+++ b/examples/foundational/55i-update-settings-whisper-api-stt.py
@@ -108,7 +108,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info('Updating OpenAI STT settings: language="es"')
-        await task.queue_frame(STTUpdateSettingsFrame(update=BaseWhisperSTTSettings(language="es")))
+        await task.queue_frame(STTUpdateSettingsFrame(delta=BaseWhisperSTTSettings(language="es")))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55j-update-settings-sarvam-stt.py
+++ b/examples/foundational/55j-update-settings-sarvam-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Sarvam STT settings: language=en-IN")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=SarvamSTTSettings(language=Language.EN_IN))
+            STTUpdateSettingsFrame(delta=SarvamSTTSettings(language=Language.EN_IN))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55k-update-settings-soniox-stt.py
+++ b/examples/foundational/55k-update-settings-soniox-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Soniox STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=SonioxSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=SonioxSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55l-update-settings-aws-transcribe-stt.py
+++ b/examples/foundational/55l-update-settings-aws-transcribe-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating AWS Transcribe STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=AWSTranscribeSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=AWSTranscribeSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55m-update-settings-cartesia-stt.py
+++ b/examples/foundational/55m-update-settings-cartesia-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Cartesia STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=CartesiaSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=CartesiaSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55n-update-settings-cartesia-http-tts.py
+++ b/examples/foundational/55n-update-settings-cartesia-http-tts.py
@@ -107,7 +107,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating Cartesia HTTP TTS settings: speed increased to 1.5")
         await task.queue_frame(
             TTSUpdateSettingsFrame(
-                update=CartesiaTTSSettings(generation_config=GenerationConfig(speed=1.5))
+                delta=CartesiaTTSSettings(generation_config=GenerationConfig(speed=1.5))
             )
         )
 

--- a/examples/foundational/55n-update-settings-cartesia-tts.py
+++ b/examples/foundational/55n-update-settings-cartesia-tts.py
@@ -106,7 +106,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating Cartesia TTS settings: speed increased to 1.5")
         await task.queue_frame(
             TTSUpdateSettingsFrame(
-                update=CartesiaTTSSettings(generation_config=GenerationConfig(speed=1.5))
+                delta=CartesiaTTSSettings(generation_config=GenerationConfig(speed=1.5))
             )
         )
 

--- a/examples/foundational/55o-update-settings-elevenlabs-http-tts.py
+++ b/examples/foundational/55o-update-settings-elevenlabs-http-tts.py
@@ -107,7 +107,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info("Updating ElevenLabs TTS settings: speed=0.7")
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=ElevenLabsHttpTTSSettings(speed=0.7))
+                TTSUpdateSettingsFrame(delta=ElevenLabsHttpTTSSettings(speed=0.7))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55o-update-settings-elevenlabs-tts.py
+++ b/examples/foundational/55o-update-settings-elevenlabs-tts.py
@@ -102,13 +102,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating ElevenLabs TTS settings: speed=0.7")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=ElevenLabsTTSSettings(speed=0.7)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=ElevenLabsTTSSettings(speed=0.7)))
 
         await asyncio.sleep(10)
         logger.info("Updating ElevenLabs TTS settings: switching to a different voice")
         await task.queue_frame(
             TTSUpdateSettingsFrame(
-                update=ElevenLabsTTSSettings(voice=os.getenv("ELEVENLABS_VOICE_ID_ALT"))
+                delta=ElevenLabsTTSSettings(voice=os.getenv("ELEVENLABS_VOICE_ID_ALT"))
             )
         )
 

--- a/examples/foundational/55p-update-settings-openai-tts.py
+++ b/examples/foundational/55p-update-settings-openai-tts.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating OpenAI TTS settings: speed=2.0")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=OpenAITTSSettings(speed=2.0)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=OpenAITTSSettings(speed=2.0)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55q-update-settings-deepgram-http-tts.py
+++ b/examples/foundational/55q-update-settings-deepgram-http-tts.py
@@ -106,13 +106,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info('Updating Deepgram TTS settings: voice="aura-2-aries-en"')
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=DeepgramTTSSettings(voice="aura-2-aries-en"))
+                TTSUpdateSettingsFrame(delta=DeepgramTTSSettings(voice="aura-2-aries-en"))
             )
 
             await asyncio.sleep(10)
             logger.info('Updating Deepgram TTS settings: voice="aura-2-luna-en"')
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=DeepgramTTSSettings(voice="aura-2-luna-en"))
+                TTSUpdateSettingsFrame(delta=DeepgramTTSSettings(voice="aura-2-luna-en"))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55q-update-settings-deepgram-sagemaker-tts.py
+++ b/examples/foundational/55q-update-settings-deepgram-sagemaker-tts.py
@@ -106,13 +106,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Deepgram SageMaker TTS settings: voice="aura-2-aries-en"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=DeepgramSageMakerTTSSettings(voice="aura-2-aries-en"))
+            TTSUpdateSettingsFrame(delta=DeepgramSageMakerTTSSettings(voice="aura-2-aries-en"))
         )
 
         await asyncio.sleep(10)
         logger.info('Updating Deepgram SageMaker TTS settings: voice="aura-2-luna-en"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=DeepgramSageMakerTTSSettings(voice="aura-2-luna-en"))
+            TTSUpdateSettingsFrame(delta=DeepgramSageMakerTTSSettings(voice="aura-2-luna-en"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55q-update-settings-deepgram-tts.py
+++ b/examples/foundational/55q-update-settings-deepgram-tts.py
@@ -99,13 +99,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Deepgram TTS settings: voice="aura-2-aries-en"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=DeepgramTTSSettings(voice="aura-2-aries-en"))
+            TTSUpdateSettingsFrame(delta=DeepgramTTSSettings(voice="aura-2-aries-en"))
         )
 
         await asyncio.sleep(10)
         logger.info('Updating Deepgram TTS settings: voice="aura-2-luna-en"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=DeepgramTTSSettings(voice="aura-2-luna-en"))
+            TTSUpdateSettingsFrame(delta=DeepgramTTSSettings(voice="aura-2-luna-en"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55r-update-settings-azure-http-tts.py
+++ b/examples/foundational/55r-update-settings-azure-http-tts.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Azure TTS settings: rate="0.7", style="sad"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=AzureTTSSettings(rate="0.7", style="sad"))
+            TTSUpdateSettingsFrame(delta=AzureTTSSettings(rate="0.7", style="sad"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55r-update-settings-azure-tts.py
+++ b/examples/foundational/55r-update-settings-azure-tts.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Azure TTS settings: rate="0.7", style="sad"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=AzureTTSSettings(rate="0.7", style="sad"))
+            TTSUpdateSettingsFrame(delta=AzureTTSSettings(rate="0.7", style="sad"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55s-update-settings-google-http-tts.py
+++ b/examples/foundational/55s-update-settings-google-http-tts.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Google HTTP TTS settings: speaking_rate=1.4")
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=GoogleHttpTTSSettings(speaking_rate=1.4))
+            TTSUpdateSettingsFrame(delta=GoogleHttpTTSSettings(speaking_rate=1.4))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55s-update-settings-google-stream-tts.py
+++ b/examples/foundational/55s-update-settings-google-stream-tts.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Google Stream TTS settings: speaking_rate=1.4")
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=GoogleStreamTTSSettings(speaking_rate=1.4))
+            TTSUpdateSettingsFrame(delta=GoogleStreamTTSSettings(speaking_rate=1.4))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55t-update-settings-playht-tts.py
+++ b/examples/foundational/55t-update-settings-playht-tts.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating PlayHT TTS settings: speed=1.3")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=PlayHTTTSSettings(speed=1.3)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=PlayHTTTSSettings(speed=1.3)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55u-update-settings-rime-http-tts.py
+++ b/examples/foundational/55u-update-settings-rime-http-tts.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
             await asyncio.sleep(10)
             logger.info("Updating Rime TTS settings: voice=rex")
-            await task.queue_frame(TTSUpdateSettingsFrame(update=RimeTTSSettings(voice="rex")))
+            await task.queue_frame(TTSUpdateSettingsFrame(delta=RimeTTSSettings(voice="rex")))
 
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):

--- a/examples/foundational/55u-update-settings-rime-tts.py
+++ b/examples/foundational/55u-update-settings-rime-tts.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Rime TTS settings: voice=bond")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=RimeTTSSettings(voice="bond")))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=RimeTTSSettings(voice="bond")))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55v-update-settings-lmnt-tts.py
+++ b/examples/foundational/55v-update-settings-lmnt-tts.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info('Updating LMNT TTS settings: voice="tyler"')
-        await task.queue_frame(TTSUpdateSettingsFrame(update=LmntTTSSettings(voice="tyler")))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=LmntTTSSettings(voice="tyler")))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55w-update-settings-fish-tts.py
+++ b/examples/foundational/55w-update-settings-fish-tts.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Fish Audio TTS settings: prosody_speed=1.5")
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=FishAudioTTSSettings(prosody_speed=1.5))
+            TTSUpdateSettingsFrame(delta=FishAudioTTSSettings(prosody_speed=1.5))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55x-update-settings-minimax-tts.py
+++ b/examples/foundational/55x-update-settings-minimax-tts.py
@@ -105,7 +105,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info('Updating MiniMax TTS settings: speed=1.5, emotion="happy"')
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=MiniMaxTTSSettings(speed=1.5, emotion="happy"))
+                TTSUpdateSettingsFrame(delta=MiniMaxTTSSettings(speed=1.5, emotion="happy"))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55y-update-settings-groq-tts.py
+++ b/examples/foundational/55y-update-settings-groq-tts.py
@@ -98,7 +98,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Groq TTS settings: speed=1.5")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=GroqTTSSettings(speed=1.5)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=GroqTTSSettings(speed=1.5)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55z-update-settings-hume-tts.py
+++ b/examples/foundational/55z-update-settings-hume-tts.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info('Updating Hume TTS settings: speed=2.0, description="Speak with excitement"')
         await task.queue_frame(
             TTSUpdateSettingsFrame(
-                update=HumeTTSSettings(speed=2.0, description="Speak with excitement")
+                delta=HumeTTSSettings(speed=2.0, description="Speak with excitement")
             )
         )
 

--- a/examples/foundational/55za-update-settings-neuphonic-http-tts.py
+++ b/examples/foundational/55za-update-settings-neuphonic-http-tts.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
             await asyncio.sleep(10)
             logger.info("Updating Neuphonic HTTP TTS settings: speed=1.4")
-            await task.queue_frame(TTSUpdateSettingsFrame(update=NeuphonicTTSSettings(speed=1.4)))
+            await task.queue_frame(TTSUpdateSettingsFrame(delta=NeuphonicTTSSettings(speed=1.4)))
 
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):

--- a/examples/foundational/55za-update-settings-neuphonic-tts.py
+++ b/examples/foundational/55za-update-settings-neuphonic-tts.py
@@ -98,7 +98,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Neuphonic TTS settings: speed=1.4")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=NeuphonicTTSSettings(speed=1.4)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=NeuphonicTTSSettings(speed=1.4)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zb-update-settings-inworld-http-tts.py
+++ b/examples/foundational/55zb-update-settings-inworld-http-tts.py
@@ -103,9 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info("Updating Inworld TTS settings: speaking_rate=1.5, temperature=0.8")
             await task.queue_frame(
-                TTSUpdateSettingsFrame(
-                    update=InworldTTSSettings(speaking_rate=1.5, temperature=0.8)
-                )
+                TTSUpdateSettingsFrame(delta=InworldTTSSettings(speaking_rate=1.5, temperature=0.8))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zb-update-settings-inworld-tts.py
+++ b/examples/foundational/55zb-update-settings-inworld-tts.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Inworld TTS settings: speaking_rate=1.5, temperature=0.8")
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=InworldTTSSettings(speaking_rate=1.5, temperature=0.8))
+            TTSUpdateSettingsFrame(delta=InworldTTSSettings(speaking_rate=1.5, temperature=0.8))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zc-update-settings-gemini-tts.py
+++ b/examples/foundational/55zc-update-settings-gemini-tts.py
@@ -108,7 +108,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Gemini TTS settings: prompt="Speak slowly and dramatically"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=GeminiTTSSettings(prompt="Speak slowly and dramatically"))
+            TTSUpdateSettingsFrame(delta=GeminiTTSSettings(prompt="Speak slowly and dramatically"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zd-update-settings-aws-polly-tts.py
+++ b/examples/foundational/55zd-update-settings-aws-polly-tts.py
@@ -98,7 +98,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info('Updating AWS Polly TTS settings: rate="fast"')
-        await task.queue_frame(TTSUpdateSettingsFrame(update=AWSPollyTTSSettings(rate="fast")))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=AWSPollyTTSSettings(rate="fast")))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55ze-update-settings-sarvam-http-tts.py
+++ b/examples/foundational/55ze-update-settings-sarvam-http-tts.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
             await asyncio.sleep(10)
             logger.info("Updating Sarvam TTS settings: pace=1.5")
-            await task.queue_frame(TTSUpdateSettingsFrame(update=SarvamHttpTTSSettings(pace=1.5)))
+            await task.queue_frame(TTSUpdateSettingsFrame(delta=SarvamHttpTTSSettings(pace=1.5)))
 
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):

--- a/examples/foundational/55ze-update-settings-sarvam-tts.py
+++ b/examples/foundational/55ze-update-settings-sarvam-tts.py
@@ -98,7 +98,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Sarvam TTS settings: pace=1.5")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=SarvamTTSSettings(pace=1.5)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=SarvamTTSSettings(pace=1.5)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zf-update-settings-camb-tts.py
+++ b/examples/foundational/55zf-update-settings-camb-tts.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Camb TTS settings: language -> Spanish")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=CambTTSSettings(language=Language.ES)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=CambTTSSettings(language=Language.ES)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zg-update-settings-hathora-tts.py
+++ b/examples/foundational/55zg-update-settings-hathora-tts.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Hathora TTS settings: speed=1.3")
-        await task.queue_frame(TTSUpdateSettingsFrame(update=HathoraTTSSettings(speed=1.3)))
+        await task.queue_frame(TTSUpdateSettingsFrame(delta=HathoraTTSSettings(speed=1.3)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zh-update-settings-resembleai-tts.py
+++ b/examples/foundational/55zh-update-settings-resembleai-tts.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating ResembleAI TTS settings: voice (changed)")
         await task.queue_frame(
             TTSUpdateSettingsFrame(
-                update=ResembleAITTSSettings(voice=os.getenv("RESEMBLE_VOICE_UUID_ALT"))
+                delta=ResembleAITTSSettings(voice=os.getenv("RESEMBLE_VOICE_UUID_ALT"))
             )
         )
 

--- a/examples/foundational/55zi-update-settings-azure-llm.py
+++ b/examples/foundational/55zi-update-settings-azure-llm.py
@@ -106,7 +106,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Azure LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zi-update-settings-openai-llm.py
+++ b/examples/foundational/55zi-update-settings-openai-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating OpenAI LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zj-update-settings-anthropic-llm.py
+++ b/examples/foundational/55zj-update-settings-anthropic-llm.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Anthropic LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=AnthropicLLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=AnthropicLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zk-update-settings-google-llm.py
+++ b/examples/foundational/55zk-update-settings-google-llm.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Google LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=GoogleLLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=GoogleLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zk-update-settings-google-vertex-llm.py
+++ b/examples/foundational/55zk-update-settings-google-vertex-llm.py
@@ -106,7 +106,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Google Vertex LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=GoogleLLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=GoogleLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zl-update-settings-azure-realtime.py
+++ b/examples/foundational/55zl-update-settings-azure-realtime.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating Azure Realtime LLM settings: output_modalities=['text']")
         await task.queue_frame(
             LLMUpdateSettingsFrame(
-                update=OpenAIRealtimeLLMSettings(
+                delta=OpenAIRealtimeLLMSettings(
                     session_properties=events.SessionProperties(output_modalities=["text"])
                 )
             )
@@ -112,7 +112,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating Azure Realtime LLM settings: output_modalities=['audio']")
         await task.queue_frame(
             LLMUpdateSettingsFrame(
-                update=OpenAIRealtimeLLMSettings(
+                delta=OpenAIRealtimeLLMSettings(
                     session_properties=events.SessionProperties(output_modalities=["audio"])
                 )
             )

--- a/examples/foundational/55zl-update-settings-openai-realtime.py
+++ b/examples/foundational/55zl-update-settings-openai-realtime.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating OpenAI Realtime LLM settings: output_modalities=['text']")
         await task.queue_frame(
             LLMUpdateSettingsFrame(
-                update=OpenAIRealtimeLLMSettings(
+                delta=OpenAIRealtimeLLMSettings(
                     session_properties=events.SessionProperties(output_modalities=["text"])
                 )
             )
@@ -111,7 +111,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating OpenAI Realtime LLM settings: output_modalities=['audio']")
         await task.queue_frame(
             LLMUpdateSettingsFrame(
-                update=OpenAIRealtimeLLMSettings(
+                delta=OpenAIRealtimeLLMSettings(
                     session_properties=events.SessionProperties(output_modalities=["audio"])
                 )
             )

--- a/examples/foundational/55zm-update-settings-gemini-live-vertex.py
+++ b/examples/foundational/55zm-update-settings-gemini-live-vertex.py
@@ -91,9 +91,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Gemini Live Vertex LLM settings: temperature=0.1")
-        await task.queue_frame(
-            LLMUpdateSettingsFrame(update=GeminiLiveLLMSettings(temperature=0.1))
-        )
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=GeminiLiveLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zm-update-settings-gemini-live.py
+++ b/examples/foundational/55zm-update-settings-gemini-live.py
@@ -89,9 +89,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Gemini Live LLM settings: temperature=0.1")
-        await task.queue_frame(
-            LLMUpdateSettingsFrame(update=GeminiLiveLLMSettings(temperature=0.1))
-        )
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=GeminiLiveLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zn-update-settings-ultravox-realtime.py
+++ b/examples/foundational/55zn-update-settings-ultravox-realtime.py
@@ -112,13 +112,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Ultravox Realtime LLM settings: output_medium=text")
         await task.queue_frame(
-            LLMUpdateSettingsFrame(update=UltravoxRealtimeLLMSettings(output_medium="text"))
+            LLMUpdateSettingsFrame(delta=UltravoxRealtimeLLMSettings(output_medium="text"))
         )
 
         await asyncio.sleep(10)
         logger.info("Updating Ultravox Realtime LLM settings: output_medium=voice")
         await task.queue_frame(
-            LLMUpdateSettingsFrame(update=UltravoxRealtimeLLMSettings(output_medium="voice"))
+            LLMUpdateSettingsFrame(delta=UltravoxRealtimeLLMSettings(output_medium="voice"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zo-update-settings-grok-realtime.py
+++ b/examples/foundational/55zo-update-settings-grok-realtime.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Updating Grok Realtime LLM settings: voice='Rex'")
         await task.queue_frame(
             LLMUpdateSettingsFrame(
-                update=GrokRealtimeLLMSettings(
+                delta=GrokRealtimeLLMSettings(
                     session_properties=events.SessionProperties(voice="Rex")
                 )
             )

--- a/examples/foundational/55zp-update-settings-aws-bedrock-llm.py
+++ b/examples/foundational/55zp-update-settings-aws-bedrock-llm.py
@@ -105,9 +105,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating AWS Bedrock LLM settings: temperature=0.1")
-        await task.queue_frame(
-            LLMUpdateSettingsFrame(update=AWSBedrockLLMSettings(temperature=0.1))
-        )
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=AWSBedrockLLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zq-update-settings-fal-stt.py
+++ b/examples/foundational/55zq-update-settings-fal-stt.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info('Updating Fal STT settings: task="translate"')
-        await task.queue_frame(STTUpdateSettingsFrame(update=FalSTTSettings(task="translate")))
+        await task.queue_frame(STTUpdateSettingsFrame(delta=FalSTTSettings(task="translate")))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zr-update-settings-gradium-stt.py
+++ b/examples/foundational/55zr-update-settings-gradium-stt.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Gradium STT settings: delay_in_frames=5")
-        await task.queue_frame(STTUpdateSettingsFrame(update=GradiumSTTSettings(delay_in_frames=5)))
+        await task.queue_frame(STTUpdateSettingsFrame(delta=GradiumSTTSettings(delay_in_frames=5)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zs-update-settings-hathora-stt.py
+++ b/examples/foundational/55zs-update-settings-hathora-stt.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating Hathora STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=HathoraSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=HathoraSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zt-update-settings-nvidia-segmented-stt.py
+++ b/examples/foundational/55zt-update-settings-nvidia-segmented-stt.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating NVIDIA Segmented STT settings: profanity_filter=True")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=NvidiaSegmentedSTTSettings(profanity_filter=True))
+            STTUpdateSettingsFrame(delta=NvidiaSegmentedSTTSettings(profanity_filter=True))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zt-update-settings-nvidia-stt.py
+++ b/examples/foundational/55zt-update-settings-nvidia-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating NVIDIA STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=NvidiaSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=NvidiaSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zu-update-settings-openai-realtime-stt.py
+++ b/examples/foundational/55zu-update-settings-openai-realtime-stt.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating OpenAI Realtime STT settings: language=es")
         await task.queue_frame(
-            STTUpdateSettingsFrame(update=OpenAIRealtimeSTTSettings(language=Language.ES))
+            STTUpdateSettingsFrame(delta=OpenAIRealtimeSTTSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zv-update-settings-asyncai-http-tts.py
+++ b/examples/foundational/55zv-update-settings-asyncai-http-tts.py
@@ -108,7 +108,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info("Updating AsyncAI HTTP TTS settings: language=es")
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=AsyncAITTSSettings(language=Language.ES))
+                TTSUpdateSettingsFrame(delta=AsyncAITTSSettings(language=Language.ES))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zv-update-settings-asyncai-tts.py
+++ b/examples/foundational/55zv-update-settings-asyncai-tts.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating AsyncAI TTS settings: language=es")
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=AsyncAITTSSettings(language=Language.ES))
+            TTSUpdateSettingsFrame(delta=AsyncAITTSSettings(language=Language.ES))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zw-update-settings-gradium-tts.py
+++ b/examples/foundational/55zw-update-settings-gradium-tts.py
@@ -103,7 +103,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating Gradium TTS settings: voice="LFZvm12tW_z0xfGo"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=GradiumTTSSettings(voice="LFZvm12tW_z0xfGo"))
+            TTSUpdateSettingsFrame(delta=GradiumTTSSettings(voice="LFZvm12tW_z0xfGo"))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zx-update-settings-cerebras-llm.py
+++ b/examples/foundational/55zx-update-settings-cerebras-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Cerebras LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zy-update-settings-deepseek-llm.py
+++ b/examples/foundational/55zy-update-settings-deepseek-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating DeepSeek LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zz-update-settings-fireworks-llm.py
+++ b/examples/foundational/55zz-update-settings-fireworks-llm.py
@@ -105,7 +105,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Fireworks LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zza-update-settings-grok-llm.py
+++ b/examples/foundational/55zza-update-settings-grok-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Grok LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzb-update-settings-groq-llm.py
+++ b/examples/foundational/55zzb-update-settings-groq-llm.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Groq LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzc-update-settings-mistral-llm.py
+++ b/examples/foundational/55zzc-update-settings-mistral-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Mistral LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzd-update-settings-nvidia-llm.py
+++ b/examples/foundational/55zzd-update-settings-nvidia-llm.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating NVIDIA LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zze-update-settings-ollama-llm.py
+++ b/examples/foundational/55zze-update-settings-ollama-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating OLLama LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzf-update-settings-openrouter-llm.py
+++ b/examples/foundational/55zzf-update-settings-openrouter-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating OpenRouter LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzg-update-settings-perplexity-llm.py
+++ b/examples/foundational/55zzg-update-settings-perplexity-llm.py
@@ -101,7 +101,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Perplexity LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzh-update-settings-qwen-llm.py
+++ b/examples/foundational/55zzh-update-settings-qwen-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Qwen LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzi-update-settings-sambanova-llm.py
+++ b/examples/foundational/55zzi-update-settings-sambanova-llm.py
@@ -102,7 +102,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating SambaNova LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzj-update-settings-together-llm.py
+++ b/examples/foundational/55zzj-update-settings-together-llm.py
@@ -105,7 +105,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         await asyncio.sleep(10)
         logger.info("Updating Together LLM settings: temperature=0.1")
-        await task.queue_frame(LLMUpdateSettingsFrame(update=OpenAILLMSettings(temperature=0.1)))
+        await task.queue_frame(LLMUpdateSettingsFrame(delta=OpenAILLMSettings(temperature=0.1)))
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/55zzk-update-settings-aws-nova-sonic-llm.py
+++ b/examples/foundational/55zzk-update-settings-aws-nova-sonic-llm.py
@@ -99,7 +99,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info("Updating AWS Nova Sonic LLM settings: temperature=0.1")
         await task.queue_frame(
-            LLMUpdateSettingsFrame(update=AWSNovaSonicLLMSettings(temperature=0.1))
+            LLMUpdateSettingsFrame(delta=AWSNovaSonicLLMSettings(temperature=0.1))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zzl-update-settings-nvidia-tts.py
+++ b/examples/foundational/55zzl-update-settings-nvidia-tts.py
@@ -100,7 +100,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await asyncio.sleep(10)
         logger.info('Updating NVIDIA TTS settings: language="ES_US"')
         await task.queue_frame(
-            TTSUpdateSettingsFrame(update=NvidiaTTSSettings(language=Language.ES_US))
+            TTSUpdateSettingsFrame(delta=NvidiaTTSSettings(language=Language.ES_US))
         )
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/foundational/55zzm-update-settings-speechmatics-tts.py
+++ b/examples/foundational/55zzm-update-settings-speechmatics-tts.py
@@ -104,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             await asyncio.sleep(10)
             logger.info('Updating Speechmatics TTS settings: voice="theo"')
             await task.queue_frame(
-                TTSUpdateSettingsFrame(update=SpeechmaticsTTSSettings(voice="theo"))
+                TTSUpdateSettingsFrame(delta=SpeechmaticsTTSSettings(voice="theo"))
             )
 
         @transport.event_handler("on_client_disconnected")

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2127,7 +2127,7 @@ class ServiceUpdateSettingsFrame(ControlFrame):
     Parameters:
         settings: Dictionary of setting name to value mappings.
 
-            .. deprecated:: 0.0.103
+            .. deprecated:: 0.0.104
                 Use ``delta`` with a typed settings object instead.
 
         delta: :class:`~pipecat.services.settings.ServiceSettings` delta-mode

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2121,21 +2121,21 @@ class TTSStoppedFrame(ControlFrame):
 class ServiceUpdateSettingsFrame(ControlFrame):
     """Base frame for updating service settings.
 
-    Supports both a ``settings`` dict (for backward compatibility) and an
-    ``update`` object.  When both are provided, ``update`` takes precedence.
+    Supports both a ``settings`` dict (for backward compatibility) and a
+    ``delta`` object.  When both are provided, ``delta`` takes precedence.
 
     Parameters:
         settings: Dictionary of setting name to value mappings.
 
             .. deprecated:: 0.0.103
-                Use ``update`` with a typed settings object instead.
+                Use ``delta`` with a typed settings object instead.
 
-        update: :class:`~pipecat.services.settings.ServiceSettings` object
-            describing the delta to apply.
+        delta: :class:`~pipecat.services.settings.ServiceSettings` delta-mode
+            object describing the fields to change.
     """
 
     settings: Mapping[str, Any] = field(default_factory=dict)
-    update: Optional["ServiceSettings"] = None
+    delta: Optional["ServiceSettings"] = None
 
 
 @dataclass

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -254,6 +254,11 @@ class AnthropicLLMService(LLMService):
             temperature=params.temperature,
             top_k=params.top_k,
             top_p=params.top_p,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             thinking=params.thinking,
             extra=params.extra if isinstance(params.extra, dict) else {},
         )

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -116,6 +116,7 @@ class AssemblyAISTTService(WebsocketSTTService):
 
         self._api_key = api_key
         self._settings = AssemblyAISTTSettings(
+            model=None,
             language=language,
             connection_params=connection_params,
         )
@@ -186,18 +187,18 @@ class AssemblyAISTTService(WebsocketSTTService):
         """
         return True
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
 
         Args:
-            update: A :class:`STTSettings` (or ``AssemblyAISTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``AssemblyAISTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -176,12 +176,12 @@ class AsyncAITTSService(AudioContextTTSService):
         self._receive_task = None
         self._keepalive_task = None
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -827,6 +827,12 @@ class AWSBedrockLLMService(LLMService):
             max_tokens=params.max_tokens,
             temperature=params.temperature,
             top_p=params.top_p,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             latency=params.latency,
             additional_model_request_fields=params.additional_model_request_fields
             if isinstance(params.additional_model_request_fields, dict)

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -267,6 +267,12 @@ class AWSNovaSonicLLMService(LLMService):
             temperature=params.temperature,
             max_tokens=params.max_tokens,
             top_p=params.top_p,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             endpointing_sensitivity=params.endpointing_sensitivity,
         )
         self._sync_model_name_to_metrics()
@@ -338,12 +344,12 @@ class AWSNovaSonicLLMService(LLMService):
     # settings
     #
 
-    async def _update_settings(self, update: AWSNovaSonicLLMSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: AWSNovaSonicLLMSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -148,12 +148,12 @@ class AWSTranscribeSTTService(WebsocketSTTService):
         }
         return encoding_map.get(encoding, encoding)
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/aws/tts.py
+++ b/src/pipecat/services/aws/tts.py
@@ -209,6 +209,7 @@ class AWSPollyTTSService(TTSService):
 
         self._aws_session = aioboto3.Session()
         self._settings = AWSPollyTTSSettings(
+            model=None,
             voice=voice_id,
             engine=params.engine,
             language=self.language_to_service_language(params.language)

--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -110,6 +110,7 @@ class AzureSTTService(STTService):
         self._audio_stream = None
         self._speech_recognizer = None
         self._settings = AzureSTTSettings(
+            model=None,
             region=region,
             language=language_to_azure_language(language),
             sample_rate=sample_rate,
@@ -134,12 +135,12 @@ class AzureSTTService(STTService):
         """
         return language_to_azure_language(language)
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active recognizer.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         # TODO: someday we could reconnect here to apply updated settings.
         # Code might look something like the below:

--- a/src/pipecat/services/azure/tts.py
+++ b/src/pipecat/services/azure/tts.py
@@ -156,6 +156,7 @@ class AzureBaseTTSService:
         params = params or AzureBaseTTSService.InputParams()
 
         self._settings = AzureTTSSettings(
+            model=None,
             emphasis=params.emphasis,
             language=self.language_to_service_language(params.language)
             if params.language

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -294,16 +294,16 @@ class CartesiaSTTService(WebsocketSTTService):
 
         await self._disconnect_websocket()
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Args:
-            update: A :class:`STTSettings` (or ``CartesiaSTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``CartesiaSTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         # TODO: someday we could reconnect here to apply updated settings.
         # Code might look something like the below:

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -28,7 +28,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, is_given
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import AudioContextTTSService, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.text.base_text_aggregator import BaseTextAggregator
@@ -443,7 +443,7 @@ class CartesiaTTSService(AudioContextTTSService):
         voice_config["mode"] = "id"
         voice_config["id"] = self._settings.voice
 
-        if is_given(self._settings.emotion) and self._settings.emotion:
+        if self._settings.emotion:
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 warnings.warn(
@@ -469,18 +469,18 @@ class CartesiaTTSService(AudioContextTTSService):
             "use_original_timestamps": False if self._settings.model == "sonic" else True,
         }
 
-        if is_given(self._settings.language) and self._settings.language:
+        if self._settings.language:
             msg["language"] = self._settings.language
 
-        if is_given(self._settings.speed) and self._settings.speed:
+        if self._settings.speed:
             msg["speed"] = self._settings.speed
 
-        if is_given(self._settings.generation_config) and self._settings.generation_config:
+        if self._settings.generation_config:
             msg["generation_config"] = self._settings.generation_config.model_dump(
                 exclude_none=True
             )
 
-        if is_given(self._settings.pronunciation_dict_id) and self._settings.pronunciation_dict_id:
+        if self._settings.pronunciation_dict_id:
             msg["pronunciation_dict_id"] = self._settings.pronunciation_dict_id
 
         return json.dumps(msg)
@@ -811,7 +811,7 @@ class CartesiaHttpTTSService(TTSService):
         try:
             voice_config = {"mode": "id", "id": self._settings.voice}
 
-            if is_given(self._settings.emotion) and self._settings.emotion:
+            if self._settings.emotion:
                 with warnings.catch_warnings():
                     warnings.simplefilter("always")
                     warnings.warn(
@@ -836,21 +836,18 @@ class CartesiaHttpTTSService(TTSService):
                 "output_format": output_format,
             }
 
-            if is_given(self._settings.language) and self._settings.language:
+            if self._settings.language:
                 payload["language"] = self._settings.language
 
-            if is_given(self._settings.speed) and self._settings.speed:
+            if self._settings.speed:
                 payload["speed"] = self._settings.speed
 
-            if is_given(self._settings.generation_config) and self._settings.generation_config:
+            if self._settings.generation_config:
                 payload["generation_config"] = self._settings.generation_config.model_dump(
                     exclude_none=True
                 )
 
-            if (
-                is_given(self._settings.pronunciation_dict_id)
-                and self._settings.pronunciation_dict_id
-            ):
+            if self._settings.pronunciation_dict_id:
                 payload["pronunciation_dict_id"] = self._settings.pronunciation_dict_id
 
             yield TTSStartedFrame(context_id=context_id)

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -384,12 +384,12 @@ class DeepgramFluxSTTService(WebsocketSTTService):
         """
         return True
 
-    async def _update_settings(self, update: DeepgramFluxSTTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: DeepgramFluxSTTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -206,25 +206,25 @@ class DeepgramSTTService(STTService):
         """
         return True
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update, keeping ``live_options`` in sync.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta, keeping ``live_options`` in sync.
 
         Top-level ``model`` and ``language`` are the source of truth.  When
-        they are given in *update* their values are propagated into
+        they are given in *delta* their values are propagated into
         ``live_options``.  When only ``live_options`` is given, its ``model``
         and ``language`` are propagated *up* to the top-level fields.
 
         Any change triggers a WebSocket reconnect.
         """
         # Determine which top-level fields are explicitly provided.
-        model_given = isinstance(update, DeepgramSTTSettings) and is_given(
-            getattr(update, "model", NOT_GIVEN)
+        model_given = isinstance(delta, DeepgramSTTSettings) and is_given(
+            getattr(delta, "model", NOT_GIVEN)
         )
-        language_given = isinstance(update, DeepgramSTTSettings) and is_given(
-            getattr(update, "language", NOT_GIVEN)
+        language_given = isinstance(delta, DeepgramSTTSettings) and is_given(
+            getattr(delta, "language", NOT_GIVEN)
         )
 
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/deepgram/stt_sagemaker.py
+++ b/src/pipecat/services/deepgram/stt_sagemaker.py
@@ -163,25 +163,25 @@ class DeepgramSageMakerSTTService(STTService):
         """
         return True
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update, keeping ``live_options`` in sync.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta, keeping ``live_options`` in sync.
 
         Top-level ``model`` and ``language`` are the source of truth.  When
-        they are given in *update* their values are propagated into
+        they are given in *delta* their values are propagated into
         ``live_options``.  When only ``live_options`` is given, its ``model``
         and ``language`` are propagated *up* to the top-level fields.
 
         Any change triggers a reconnect.
         """
         # Determine which top-level fields are explicitly provided.
-        model_given = isinstance(update, DeepgramSageMakerSTTSettings) and is_given(
-            getattr(update, "model", NOT_GIVEN)
+        model_given = isinstance(delta, DeepgramSageMakerSTTSettings) and is_given(
+            getattr(delta, "model", NOT_GIVEN)
         )
-        language_given = isinstance(update, DeepgramSageMakerSTTSettings) and is_given(
-            getattr(update, "language", NOT_GIVEN)
+        language_given = isinstance(delta, DeepgramSageMakerSTTSettings) and is_given(
+            getattr(delta, "language", NOT_GIVEN)
         )
 
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -109,6 +109,7 @@ class DeepgramTTSService(WebsocketTTSService):
         self._settings = DeepgramTTSSettings(
             model=voice,
             voice=voice,
+            language=None,
             encoding=encoding,
         )
         self._sync_model_name_to_metrics()
@@ -183,16 +184,16 @@ class DeepgramTTSService(WebsocketTTSService):
 
         await self._disconnect_websocket()
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Args:
-            update: A :class:`TTSSettings` (or ``DeepgramTTSSettings``) delta.
+            delta: A :class:`TTSSettings` (or ``DeepgramTTSSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         # Deepgram uses voice as the model, so keep them in sync for metrics
         if "voice" in changed:
@@ -401,6 +402,7 @@ class DeepgramHttpTTSService(TTSService):
         self._settings = DeepgramTTSSettings(
             model=voice,
             voice=voice,
+            language=None,
             encoding=encoding,
         )
         self._sync_model_name_to_metrics()

--- a/src/pipecat/services/deepgram/tts_sagemaker.py
+++ b/src/pipecat/services/deepgram/tts_sagemaker.py
@@ -107,6 +107,7 @@ class DeepgramSageMakerTTSService(TTSService):
         self._settings = DeepgramSageMakerTTSSettings(
             model=voice,
             voice=voice,
+            language=None,
             encoding=encoding,
         )
         self._sync_model_name_to_metrics()
@@ -220,13 +221,13 @@ class DeepgramSageMakerTTSService(TTSService):
             logger.debug("Disconnected from Deepgram TTS on SageMaker")
             await self._call_event_handler("on_disconnected")
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update and reconnect if necessary.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta and reconnect if necessary.
 
         Since all settings are part of the SageMaker session query string,
         any setting change requires reconnecting to apply the new values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -302,19 +302,19 @@ class ElevenLabsSTTService(SegmentedSTTService):
         """
         return language_to_elevenlabs_language(language)
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Converts language to ElevenLabs format before applying and keeps
         ``_model_id`` in sync with the model setting.
 
         Args:
-            update: A :class:`STTSettings` (or ``ElevenLabsSTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``ElevenLabsSTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if "model" in changed:
             self._model_id = self._settings.model
@@ -541,19 +541,19 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         """
         return True
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update and reconnect if anything changed.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta and reconnect if anything changed.
 
         Converts language to ElevenLabs format before applying and keeps
         ``_model_id`` in sync.
 
         Args:
-            update: A :class:`STTSettings` (or ``ElevenLabsRealtimeSTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``ElevenLabsRealtimeSTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/fal/stt.py
+++ b/src/pipecat/services/fal/stt.py
@@ -224,6 +224,7 @@ class FalSTTService(SegmentedSTTService):
 
         self._fal_client = fal_client.AsyncClient(key=api_key or os.getenv("FAL_KEY"))
         self._settings = FalSTTSettings(
+            model=None,
             language=self.language_to_service_language(params.language)
             if params.language
             else "en",

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -196,18 +196,18 @@ class FishAudioTTSService(InterruptibleTTSService):
         """
         return True
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update and reconnect if needed.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta and reconnect if needed.
 
         Any change to voice or model triggers a WebSocket reconnect.
 
         Args:
-            update: A :class:`TTSSettings` (or ``FishAudioTTSSettings``) delta.
+            delta: A :class:`TTSSettings` (or ``FishAudioTTSSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if changed:
             await self._disconnect()

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -32,7 +32,13 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
-from pipecat.services.gladia.config import GladiaInputParams
+from pipecat.services.gladia.config import (
+    GladiaInputParams,
+    LanguageConfig,
+    MessagesConfig,
+    PreProcessingConfig,
+    RealtimeProcessingConfig,
+)
 from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven
 from pipecat.services.stt_latency import GLADIA_TTFS_P99
 from pipecat.services.stt_service import WebsocketSTTService
@@ -185,10 +191,36 @@ class GladiaSTTSettings(STTSettings):
     """Settings for Gladia STT service.
 
     Parameters:
-        input_params: Gladia ``GladiaInputParams`` for detailed configuration.
+        encoding: Audio encoding format.
+        bit_depth: Audio bit depth.
+        channels: Number of audio channels.
+        custom_metadata: Additional metadata to include with requests.
+        endpointing: Silence duration in seconds to mark end of speech.
+        maximum_duration_without_endpointing: Maximum utterance duration without silence.
+        language_config: Detailed language configuration.
+        pre_processing: Audio pre-processing options.
+        realtime_processing: Real-time processing features.
+        messages_config: WebSocket message filtering options.
+        enable_vad: Enable VAD to trigger end of utterance detection.
     """
 
-    input_params: GladiaInputParams | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    encoding: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    bit_depth: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    channels: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    custom_metadata: Dict[str, Any] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    endpointing: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    maximum_duration_without_endpointing: int | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+    language_config: LanguageConfig | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    pre_processing: PreProcessingConfig | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+    realtime_processing: RealtimeProcessingConfig | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+    messages_config: MessagesConfig | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    enable_vad: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class GladiaSTTService(WebsocketSTTService):
@@ -280,7 +312,29 @@ class GladiaSTTService(WebsocketSTTService):
         self._region = region
         self._url = url
         self._receive_task = None
-        self._settings = GladiaSTTSettings(model=model, language=None, input_params=params)
+
+        # Resolve deprecated language → language_config at init time
+        language_config = params.language_config
+        if not language_config and params.language:
+            language_code = self.language_to_service_language(params.language)
+            if language_code:
+                language_config = LanguageConfig(languages=[language_code], code_switching=False)
+
+        self._settings = GladiaSTTSettings(
+            model=model,
+            language=None,
+            encoding=params.encoding,
+            bit_depth=params.bit_depth,
+            channels=params.channels,
+            custom_metadata=params.custom_metadata,
+            endpointing=params.endpointing,
+            maximum_duration_without_endpointing=params.maximum_duration_without_endpointing,
+            language_config=language_config,
+            pre_processing=params.pre_processing,
+            realtime_processing=params.realtime_processing,
+            messages_config=params.messages_config,
+            enable_vad=params.enable_vad,
+        )
         self._sync_model_name_to_metrics()
 
         # Session management
@@ -321,52 +375,43 @@ class GladiaSTTService(WebsocketSTTService):
         return language_to_gladia_language(language)
 
     def _prepare_settings(self) -> Dict[str, Any]:
-        params = self._settings.input_params
+        s = self._settings
 
         settings = {
-            "encoding": params.encoding or "wav/pcm",
-            "bit_depth": params.bit_depth or 16,
+            "encoding": s.encoding or "wav/pcm",
+            "bit_depth": s.bit_depth or 16,
             "sample_rate": self.sample_rate,
-            "channels": params.channels or 1,
-            "model": self._settings.model,
+            "channels": s.channels or 1,
+            "model": s.model,
         }
 
         # Add custom_metadata if provided
-        settings["custom_metadata"] = dict(params.custom_metadata or {})
+        settings["custom_metadata"] = dict(s.custom_metadata or {})
         settings["custom_metadata"]["pipecat"] = pipecat_version()
 
         # Add endpointing parameters if provided
-        if params.endpointing is not None:
-            settings["endpointing"] = params.endpointing
-        if params.maximum_duration_without_endpointing is not None:
+        if s.endpointing is not None:
+            settings["endpointing"] = s.endpointing
+        if s.maximum_duration_without_endpointing is not None:
             settings["maximum_duration_without_endpointing"] = (
-                params.maximum_duration_without_endpointing
+                s.maximum_duration_without_endpointing
             )
 
-        # Add language configuration (prioritize language_config over deprecated language)
-        if params.language_config:
-            settings["language_config"] = params.language_config.model_dump(exclude_none=True)
-        elif params.language:  # Backward compatibility for deprecated parameter
-            language_code = self.language_to_service_language(params.language)
-            if language_code:
-                settings["language_config"] = {
-                    "languages": [language_code],
-                    "code_switching": False,
-                }
+        # Add language configuration
+        if s.language_config:
+            settings["language_config"] = s.language_config.model_dump(exclude_none=True)
 
         # Add pre_processing configuration if provided
-        if params.pre_processing:
-            settings["pre_processing"] = params.pre_processing.model_dump(exclude_none=True)
+        if s.pre_processing:
+            settings["pre_processing"] = s.pre_processing.model_dump(exclude_none=True)
 
         # Add realtime_processing configuration if provided
-        if params.realtime_processing:
-            settings["realtime_processing"] = params.realtime_processing.model_dump(
-                exclude_none=True
-            )
+        if s.realtime_processing:
+            settings["realtime_processing"] = s.realtime_processing.model_dump(exclude_none=True)
 
         # Add messages_config if provided
-        if params.messages_config:
-            settings["messages_config"] = params.messages_config.model_dump(exclude_none=True)
+        if s.messages_config:
+            settings["messages_config"] = s.messages_config.model_dump(exclude_none=True)
 
         return settings
 
@@ -562,7 +607,7 @@ class GladiaSTTService(WebsocketSTTService):
         Broadcasts UserStartedSpeakingFrame and optionally triggers interruption
         when VAD is enabled.
         """
-        if not self._settings.input_params.enable_vad or self._is_speaking:
+        if not self._settings.enable_vad or self._is_speaking:
             return
 
         logger.debug(f"{self} User started speaking")
@@ -577,7 +622,7 @@ class GladiaSTTService(WebsocketSTTService):
 
         Broadcasts UserStoppedSpeakingFrame when VAD is enabled.
         """
-        if not self._settings.input_params.enable_vad or not self._is_speaking:
+        if not self._settings.enable_vad or not self._is_speaking:
             return
         self._is_speaking = False
         await self.broadcast_frame(UserStoppedSpeakingFrame)

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -280,7 +280,7 @@ class GladiaSTTService(WebsocketSTTService):
         self._region = region
         self._url = url
         self._receive_task = None
-        self._settings = GladiaSTTSettings(model=model, input_params=params)
+        self._settings = GladiaSTTSettings(model=model, language=None, input_params=params)
         self._sync_model_name_to_metrics()
 
         # Session management
@@ -379,18 +379,18 @@ class GladiaSTTService(WebsocketSTTService):
         await super().start(frame)
         await self._connect()
 
-    async def _update_settings(self, update: GladiaSTTSettings) -> dict[str, Any]:
-        """Apply settings update.
+    async def _update_settings(self, delta: GladiaSTTSettings) -> dict[str, Any]:
+        """Apply settings delta.
 
         Settings are stored but not applied to the active session.
 
         Args:
-            update: A settings delta.
+            delta: A settings delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -750,6 +750,9 @@ class GeminiLiveLLMService(LLMService):
             temperature=params.temperature,
             top_k=params.top_k,
             top_p=params.top_p,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             modalities=params.modalities,
             language=self._language_code,
             media_resolution=params.media_resolution,
@@ -806,12 +809,12 @@ class GeminiLiveLLMService(LLMService):
         """
         return True
 
-    async def _update_settings(self, update: LLMSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: LLMSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -807,6 +807,11 @@ class GoogleLLMService(LLMService):
             temperature=params.temperature,
             top_k=params.top_k,
             top_p=params.top_p,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             thinking=params.thinking,
             extra=params.extra if isinstance(params.extra, dict) else {},
         )

--- a/src/pipecat/services/google/stt.py
+++ b/src/pipecat/services/google/stt.py
@@ -554,7 +554,9 @@ class GoogleSTTService(STTService):
         self._client = speech_v2.SpeechAsyncClient(credentials=creds, client_options=client_options)
 
         self._settings = GoogleSTTSettings(
+            language=None,
             languages=list(params.language_list),
+            language_codes=None,
             model=params.model,
             use_separate_recognition_per_channel=params.use_separate_recognition_per_channel,
             enable_automatic_punctuation=params.enable_automatic_punctuation,
@@ -597,11 +599,9 @@ class GoogleSTTService(STTService):
         Returns:
             List[str]: Google STT language code strings.
         """
-        from pipecat.services.settings import is_given
-
-        if is_given(self._settings.languages):
+        if self._settings.languages:
             return [self.language_to_service_language(lang) for lang in self._settings.languages]
-        if is_given(self._settings.language_codes):
+        if self._settings.language_codes:
             return list(self._settings.language_codes)
         return ["en-US"]
 
@@ -632,8 +632,8 @@ class GoogleSTTService(STTService):
         logger.debug(f"Switching STT languages to: {languages}")
         await self._update_settings(GoogleSTTSettings(languages=list(languages)))
 
-    async def _update_settings(self, update: GoogleSTTSettings) -> dict[str, Any]:
-        """Apply settings update and reconnect if anything changed.
+    async def _update_settings(self, delta: GoogleSTTSettings) -> dict[str, Any]:
+        """Apply settings delta and reconnect if anything changed.
 
         Handles ``language`` from base ``set_language`` by converting it to
         ``languages``. Emits a deprecation warning if ``language_codes`` is
@@ -641,7 +641,7 @@ class GoogleSTTService(STTService):
         Reconnects the stream on any change.
 
         Args:
-            update: A settings delta.
+            delta: A settings delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
@@ -649,13 +649,13 @@ class GoogleSTTService(STTService):
         from pipecat.services.settings import is_given
 
         # If base set_language sent a Language value, convert to languages list
-        if is_given(update.language):
-            update.languages = [update.language]
+        if is_given(delta.language):
+            delta.languages = [delta.language]
             # Clear language so the base class doesn't try to store it
-            update.language = NOT_GIVEN
+            delta.language = NOT_GIVEN
 
         # Warn on deprecated language_codes usage
-        if is_given(update.language_codes):
+        if is_given(delta.language_codes):
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 warnings.warn(
@@ -665,7 +665,7 @@ class GoogleSTTService(STTService):
                     stacklevel=2,
                 )
 
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if changed:
             await self._reconnect_if_needed()
@@ -745,34 +745,34 @@ class GoogleSTTService(STTService):
                 DeprecationWarning,
             )
         # Build a settings delta from the provided options
-        update = GoogleSTTSettings()
+        delta = GoogleSTTSettings()
 
         if languages is not None:
-            update.languages = list(languages)
+            delta.languages = list(languages)
         if model is not None:
-            update.model = model
+            delta.model = model
         if enable_automatic_punctuation is not None:
-            update.enable_automatic_punctuation = enable_automatic_punctuation
+            delta.enable_automatic_punctuation = enable_automatic_punctuation
         if enable_spoken_punctuation is not None:
-            update.enable_spoken_punctuation = enable_spoken_punctuation
+            delta.enable_spoken_punctuation = enable_spoken_punctuation
         if enable_spoken_emojis is not None:
-            update.enable_spoken_emojis = enable_spoken_emojis
+            delta.enable_spoken_emojis = enable_spoken_emojis
         if profanity_filter is not None:
-            update.profanity_filter = profanity_filter
+            delta.profanity_filter = profanity_filter
         if enable_word_time_offsets is not None:
-            update.enable_word_time_offsets = enable_word_time_offsets
+            delta.enable_word_time_offsets = enable_word_time_offsets
         if enable_word_confidence is not None:
-            update.enable_word_confidence = enable_word_confidence
+            delta.enable_word_confidence = enable_word_confidence
         if enable_interim_results is not None:
-            update.enable_interim_results = enable_interim_results
+            delta.enable_interim_results = enable_interim_results
         if enable_voice_activity_events is not None:
-            update.enable_voice_activity_events = enable_voice_activity_events
+            delta.enable_voice_activity_events = enable_voice_activity_events
 
         if location is not None:
             logger.debug(f"Updating location to: {location}")
             self._location = location
 
-        await self._update_settings(update)
+        await self._update_settings(delta)
 
     async def _connect(self):
         """Initialize streaming recognition config and stream."""

--- a/src/pipecat/services/google/stt.py
+++ b/src/pipecat/services/google/stt.py
@@ -368,7 +368,7 @@ class GoogleSTTSettings(STTSettings):
         language_codes: List of Google STT language code strings
             (e.g. ``["en-US"]``).
 
-            .. deprecated:: 0.0.103
+            .. deprecated:: 0.0.104
                 Use ``languages`` instead. If both are provided, ``languages``
                 takes precedence. This field is here just for backward
                 compatibility with dict-based settings updates.

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -105,6 +105,7 @@ class GradiumTTSService(AudioContextTTSService):
         self._settings = GradiumTTSSettings(
             model=model,
             voice=voice_id,
+            language=None,
             output_format="pcm",
         )
 
@@ -119,16 +120,16 @@ class GradiumTTSService(AudioContextTTSService):
         """
         return True
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update and reconnect if voice changed.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta and reconnect if voice changed.
 
         Args:
-            update: A :class:`TTSSettings` (or ``GradiumTTSSettings``) delta.
+            delta: A :class:`TTSSettings` (or ``GradiumTTSSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
         if "voice" in changed:
             await self._disconnect()
             await self._connect()

--- a/src/pipecat/services/hume/tts.py
+++ b/src/pipecat/services/hume/tts.py
@@ -210,7 +210,7 @@ class HumeTTSService(TTSService):
     async def update_setting(self, key: str, value: Any) -> None:
         """Runtime updates via key/value pair.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Use ``TTSUpdateSettingsFrame(delta=HumeTTSSettings(...))`` instead.
 
         Args:

--- a/src/pipecat/services/hume/tts.py
+++ b/src/pipecat/services/hume/tts.py
@@ -137,6 +137,7 @@ class HumeTTSService(TTSService):
 
         params = params or HumeTTSService.InputParams()
         self._settings = HumeTTSSettings(
+            model=None,
             voice=voice_id,
             description=params.description,
             speed=params.speed,
@@ -210,7 +211,7 @@ class HumeTTSService(TTSService):
         """Runtime updates via key/value pair.
 
         .. deprecated:: 0.0.103
-            Use ``TTSUpdateSettingsFrame(update=HumeTTSSettings(...))`` instead.
+            Use ``TTSUpdateSettingsFrame(delta=HumeTTSSettings(...))`` instead.
 
         Args:
             key: The name of the setting to update. Recognized keys are:
@@ -224,7 +225,7 @@ class HumeTTSService(TTSService):
             warnings.simplefilter("always")
             warnings.warn(
                 "'update_setting' is deprecated, use "
-                "'TTSUpdateSettingsFrame(update=HumeTTSSettings(...))' instead.",
+                "'TTSUpdateSettingsFrame(delta=HumeTTSSettings(...))' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/pipecat/services/kokoro/tts.py
+++ b/src/pipecat/services/kokoro/tts.py
@@ -144,6 +144,7 @@ class KokoroTTSService(TTSService):
         self._lang_code = language_to_kokoro_language(params.language)
 
         self._settings = KokoroTTSSettings(
+            model=None,
             voice=voice_id,
             language=language_to_kokoro_language(params.language),
             lang_code=language_to_kokoro_language(params.language),

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -359,7 +359,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
                     warnings.simplefilter("always")
                     warnings.warn(
                         "Passing a dict via LLMUpdateSettingsFrame(settings={...}) is deprecated "
-                        "since 0.0.103, use LLMUpdateSettingsFrame(delta=LLMSettings(...)) instead.",
+                        "since 0.0.104, use LLMUpdateSettingsFrame(delta=LLMSettings(...)) instead.",
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/src/pipecat/services/lmnt/tts.py
+++ b/src/pipecat/services/lmnt/tts.py
@@ -206,16 +206,16 @@ class LmntTTSService(InterruptibleTTSService):
 
         await self._disconnect_websocket()
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Args:
-            update: A :class:`TTSSettings` (or ``LmntTTSSettings``) delta.
+            delta: A :class:`TTSSettings` (or ``LmntTTSSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if changed:
             await self._disconnect()

--- a/src/pipecat/services/minimax/tts.py
+++ b/src/pipecat/services/minimax/tts.py
@@ -26,7 +26,7 @@ from pipecat.frames.frames import (
     TTSStartedFrame,
     TTSStoppedFrame,
 )
-from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, is_given
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
@@ -240,13 +240,19 @@ class MiniMaxHttpTTSService(TTSService):
         self._settings = MiniMaxTTSSettings(
             model=model,
             voice=voice_id,
+            language=None,
             stream=True,
             speed=params.speed,
             volume=params.volume,
             pitch=params.pitch,
+            language_boost=None,
+            emotion=None,
+            text_normalization=None,
+            latex_read=None,
             audio_bitrate=128000,
             audio_format="pcm",
             audio_channel=1,
+            audio_sample_rate=0,
         )
         self._sync_model_name_to_metrics()
 
@@ -351,11 +357,11 @@ class MiniMaxHttpTTSService(TTSService):
             "vol": self._settings.volume,
             "pitch": self._settings.pitch,
         }
-        if is_given(self._settings.emotion):
+        if self._settings.emotion is not None:
             voice_setting["emotion"] = self._settings.emotion
-        if is_given(self._settings.text_normalization):
+        if self._settings.text_normalization is not None:
             voice_setting["text_normalization"] = self._settings.text_normalization
-        if is_given(self._settings.latex_read):
+        if self._settings.latex_read is not None:
             voice_setting["latex_read"] = self._settings.latex_read
 
         # Build audio_setting dict for API
@@ -374,7 +380,7 @@ class MiniMaxHttpTTSService(TTSService):
             "model": self._settings.model,
             "text": text,
         }
-        if is_given(self._settings.language_boost):
+        if self._settings.language_boost is not None:
             payload["language_boost"] = self._settings.language_boost
 
         try:

--- a/src/pipecat/services/neuphonic/tts.py
+++ b/src/pipecat/services/neuphonic/tts.py
@@ -147,6 +147,7 @@ class NeuphonicTTSService(InterruptibleTTSService):
         self._api_key = api_key
         self._url = url
         self._settings = NeuphonicTTSSettings(
+            model=None,
             language=self.language_to_service_language(params.language),
             speed=params.speed,
             encoding=encoding,
@@ -179,9 +180,9 @@ class NeuphonicTTSService(InterruptibleTTSService):
         """
         return language_to_neuphonic_lang_code(language)
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update and reconnect with new configuration."""
-        changed = await super()._update_settings(update)
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta and reconnect with new configuration."""
+        changed = await super()._update_settings(delta)
         if changed:
             await self._disconnect()
             await self._connect()
@@ -450,6 +451,7 @@ class NeuphonicHttpTTSService(TTSService):
         self._session = aiohttp_session
         self._base_url = url.rstrip("/")
         self._settings = NeuphonicTTSSettings(
+            model=None,
             voice=voice_id,
             language=self.language_to_service_language(params.language) or "en",
             speed=params.speed,

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -579,16 +579,16 @@ class NvidiaSegmentedSTTService(SegmentedSTTService):
         self._config = self._create_recognition_config()
         logger.debug(f"Initialized NvidiaSegmentedSTTService with model: {self._settings.model}")
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update and sync internal state.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta and sync internal state.
 
         Args:
-            update: A :class:`STTSettings` (or ``NvidiaSegmentedSTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``NvidiaSegmentedSTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if changed:
             self._config = self._create_recognition_config()

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -241,7 +241,7 @@ class NvidiaSTTService(STTService):
     async def set_model(self, model: str):
         """Set the ASR model for transcription.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Model cannot be changed after initialization for NVIDIA Riva streaming STT.
             Set model and function id in the constructor instead, e.g.::
 

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -125,7 +125,7 @@ class NvidiaTTSService(TTSService):
     async def set_model(self, model: str):
         """Set the TTS model.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Model cannot be changed after initialization for NVIDIA Riva TTS.
             Set model and function id in the constructor instead, e.g.::
 

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -150,12 +150,12 @@ class NvidiaTTSService(TTSService):
                 stacklevel=2,
             )
 
-    async def _update_settings(self, update: NvidiaTTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: NvidiaTTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
         if not changed:
             return changed
         # TODO: reconnect gRPC client to apply changed settings.

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -144,9 +144,12 @@ class BaseOpenAILLMService(LLMService):
             seed=params.seed,
             temperature=params.temperature,
             top_p=params.top_p,
+            top_k=None,
             max_tokens=params.max_tokens,
             max_completion_tokens=params.max_completion_tokens,
             service_tier=params.service_tier,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             extra=params.extra if isinstance(params.extra, dict) else {},
         )
         self._retry_timeout_secs = retry_timeout_secs

--- a/src/pipecat/services/openai/stt.py
+++ b/src/pipecat/services/openai/stt.py
@@ -35,7 +35,7 @@ from pipecat.frames.frames import (
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven, is_given
+from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven
 from pipecat.services.stt_latency import OPENAI_REALTIME_TTFS_P99, OPENAI_TTFS_P99
 from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.services.whisper.base_stt import BaseWhisperSTTService, Transcription
@@ -268,19 +268,19 @@ class OpenAIRealtimeSTTService(WebsocketSTTService):
         """
         return True
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update and send session update if needed.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta and send session update if needed.
 
         Keeps ``_language_code`` and ``_prompt`` in sync with settings
         and sends a ``session.update`` to the server when the session is active.
 
         Args:
-            update: A :class:`STTSettings` (or ``OpenAIRealtimeSTTSettings``) delta.
+            delta: A :class:`STTSettings` (or ``OpenAIRealtimeSTTSettings``) delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -163,6 +163,15 @@ class OpenAIRealtimeBetaLLMService(LLMService):
 
         self._settings = OpenAIRealtimeBetaLLMSettings(
             model=model,
+            temperature=None,
+            max_tokens=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
             session_properties=session_properties or events.SessionProperties(),
         )
         self._sync_model_name_to_metrics()
@@ -361,9 +370,9 @@ class OpenAIRealtimeBetaLLMService(LLMService):
         """
         # Backward-compatible dict path: frame.settings contains SessionProperties
         # fields, not our Settings fields, so we construct SessionProperties
-        # directly. The frame.update path falls through to super, which calls
+        # directly. The frame.delta path falls through to super, which calls
         # _update_settings → our override handles the rest.
-        if isinstance(frame, LLMUpdateSettingsFrame) and frame.update is None:
+        if isinstance(frame, LLMUpdateSettingsFrame) and frame.delta is None:
             self._settings.session_properties = events.SessionProperties(**frame.settings)
             await self._send_session_update()
             await self.push_frame(frame, direction)
@@ -480,9 +489,9 @@ class OpenAIRealtimeBetaLLMService(LLMService):
             # treat a send-side error as fatal.
             await self.push_error(error_msg=f"Error sending client event: {e}", exception=e)
 
-    async def _update_settings(self, update):
-        """Apply a settings update, sending a session update if needed."""
-        changed = await super()._update_settings(update)
+    async def _update_settings(self, delta):
+        """Apply a settings delta, sending a session update if needed."""
+        changed = await super()._update_settings(delta)
         if "session_properties" in changed:
             await self._send_session_update()
         return changed

--- a/src/pipecat/services/perplexity/llm.py
+++ b/src/pipecat/services/perplexity/llm.py
@@ -11,8 +11,6 @@ an OpenAI-compatible interface. It handles Perplexity's unique token usage
 reporting patterns while maintaining compatibility with the Pipecat framework.
 """
 
-from openai import NOT_GIVEN
-
 from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
 from pipecat.metrics.metrics import LLMTokenUsage
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -72,15 +70,15 @@ class PerplexityLLMService(OpenAILLMService):
         }
 
         # Add OpenAI-compatible parameters if they're set
-        if self._settings.frequency_penalty is not NOT_GIVEN:
+        if self._settings.frequency_penalty is not None:
             params["frequency_penalty"] = self._settings.frequency_penalty
-        if self._settings.presence_penalty is not NOT_GIVEN:
+        if self._settings.presence_penalty is not None:
             params["presence_penalty"] = self._settings.presence_penalty
-        if self._settings.temperature is not NOT_GIVEN:
+        if self._settings.temperature is not None:
             params["temperature"] = self._settings.temperature
-        if self._settings.top_p is not NOT_GIVEN:
+        if self._settings.top_p is not None:
             params["top_p"] = self._settings.top_p
-        if self._settings.max_tokens is not NOT_GIVEN:
+        if self._settings.max_tokens is not None:
             params["max_tokens"] = self._settings.max_tokens
 
         return params

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -71,7 +71,7 @@ class PiperTTSService(TTSService):
         """
         super().__init__(**kwargs)
 
-        self._settings = PiperTTSSettings(voice=voice_id)
+        self._settings = PiperTTSSettings(model=None, voice=voice_id, language=None)
 
         download_dir = download_dir or Path.cwd()
 
@@ -96,12 +96,12 @@ class PiperTTSService(TTSService):
         """
         return True
 
-    async def _update_settings(self, update: PiperTTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: PiperTTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
         if not changed:
             return changed
         # TODO: voice changes would require re-downloading and loading the model.
@@ -207,7 +207,7 @@ class PiperHttpTTSService(TTSService):
 
         self._base_url = base_url
         self._session = aiohttp_session
-        self._settings = PiperHttpTTSSettings(voice=voice_id)
+        self._settings = PiperHttpTTSSettings(model=None, voice=voice_id, language=None)
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.

--- a/src/pipecat/services/playht/tts.py
+++ b/src/pipecat/services/playht/tts.py
@@ -34,7 +34,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, is_given
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import InterruptibleTTSService, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
@@ -204,6 +204,7 @@ class PlayHTTTSService(InterruptibleTTSService):
             voice_engine=voice_engine,
             speed=params.speed,
             seed=params.seed,
+            playht_sample_rate=0,
         )
         self._sync_model_name_to_metrics()
 
@@ -215,12 +216,12 @@ class PlayHTTTSService(InterruptibleTTSService):
         """
         return True
 
-    async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
-        """Apply a settings update.
+    async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
+        """Apply a settings delta.
 
         Settings are stored but not applied to the active connection.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed
@@ -569,6 +570,7 @@ class PlayHTHttpTTSService(TTSService):
             voice_engine=voice_engine,
             speed=params.speed,
             seed=params.seed,
+            playht_sample_rate=0,
         )
         self._sync_model_name_to_metrics()
 

--- a/src/pipecat/services/resembleai/tts.py
+++ b/src/pipecat/services/resembleai/tts.py
@@ -100,6 +100,7 @@ class ResembleAITTSService(AudioContextTTSService):
         self._api_key = api_key
         self._url = url
         self._settings = ResembleAITTSSettings(
+            model=None,
             voice=voice_id,
             precision=precision,
             output_format=output_format,

--- a/src/pipecat/services/resembleai/tts.py
+++ b/src/pipecat/services/resembleai/tts.py
@@ -102,6 +102,7 @@ class ResembleAITTSService(AudioContextTTSService):
         self._settings = ResembleAITTSSettings(
             model=None,
             voice=voice_id,
+            language=None,
             precision=precision,
             output_format=output_format,
             resemble_sample_rate=sample_rate,

--- a/src/pipecat/services/sarvam/tts.py
+++ b/src/pipecat/services/sarvam/tts.py
@@ -42,7 +42,7 @@ import base64
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, ClassVar, Dict, List, Optional, Tuple
 
 import aiohttp
 from loguru import logger
@@ -280,7 +280,8 @@ class SarvamTTSSettings(TTSSettings):
     """Settings for Sarvam WebSocket TTS service.
 
     Parameters:
-        target_language_code: Sarvam language code.
+        language: Sarvam language code (e.g. ``"hi-IN"``).  Uses the standard
+            ``TTSSettings.language`` field.
         speech_sample_rate: Audio sample rate as string.
         enable_preprocessing: Enable text preprocessing. Defaults to False.
             **Note:** Always enabled for bulbul:v3-beta.
@@ -304,7 +305,8 @@ class SarvamTTSSettings(TTSSettings):
             **Note:** Only supported for bulbul:v3-beta. Ignored for v2.
     """
 
-    target_language_code: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    _aliases: ClassVar[Dict[str, str]] = {"target_language_code": "language"}
+
     speech_sample_rate: str | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     enable_preprocessing: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     min_buffer_size: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -840,7 +842,7 @@ class SarvamTTSService(InterruptibleTTSService):
 
         # Build base settings
         self._settings = SarvamTTSSettings(
-            target_language_code=(
+            language=(
                 self.language_to_service_language(params.language) if params.language else "en-IN"
             ),
             speech_sample_rate=str(sample_rate),
@@ -1022,7 +1024,7 @@ class SarvamTTSService(InterruptibleTTSService):
             raise Exception("WebSocket not connected")
         # Build config dict for the API
         config_data = {
-            "target_language_code": self._settings.target_language_code,
+            "target_language_code": self._settings.language,
             "speaker": self._settings.voice,
             "speech_sample_rate": self._settings.speech_sample_rate,
             "enable_preprocessing": self._settings.enable_preprocessing,

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -225,25 +225,25 @@ class SonioxSTTService(WebsocketSTTService):
         await super().start(frame)
         await self._connect()
 
-    async def _update_settings(self, update: SonioxSTTSettings) -> dict[str, Any]:
-        """Apply a settings update, keeping ``input_params`` in sync.
+    async def _update_settings(self, delta: SonioxSTTSettings) -> dict[str, Any]:
+        """Apply a settings delta, keeping ``input_params`` in sync.
 
         Top-level ``model`` is the source of truth.  When it is given in
-        *update* its value is propagated into ``input_params``.  When only
+        *delta* its value is propagated into ``input_params``.  When only
         ``input_params`` is given, its ``model`` is propagated *up* to the
         top-level field.
 
         Settings are stored but not applied to the active connection.
 
         Args:
-            update: A settings delta.
+            delta: A settings delta.
 
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        model_given = is_given(getattr(update, "model", NOT_GIVEN))
+        model_given = is_given(getattr(delta, "model", NOT_GIVEN))
 
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if not changed:
             return changed

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -24,7 +24,7 @@ from pipecat.frames.frames import (
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven, is_given
+from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven
 from pipecat.services.stt_latency import SONIOX_TTFS_P99
 from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
@@ -141,10 +141,28 @@ class SonioxSTTSettings(STTSettings):
     """Settings for Soniox STT service.
 
     Parameters:
-        input_params: Soniox ``SonioxInputParams`` for detailed configuration.
+        audio_format: Audio format to use for transcription.
+        num_channels: Number of channels to use for transcription.
+        language_hints: List of language hints to use for transcription.
+        language_hints_strict: If true, strictly enforce language hints.
+        context: Customization for transcription. String for models with
+            context_version 1 and SonioxContextObject for models with
+            context_version 2.
+        enable_speaker_diarization: Whether to enable speaker diarization.
+        enable_language_identification: Whether to enable language identification.
+        client_reference_id: Client reference ID to use for transcription.
     """
 
-    input_params: SonioxInputParams | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    audio_format: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    num_channels: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    language_hints: List[Language] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    language_hints_strict: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    context: SonioxContextObject | str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    enable_speaker_diarization: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    enable_language_identification: bool | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+    client_reference_id: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class SonioxSTTService(WebsocketSTTService):
@@ -199,7 +217,15 @@ class SonioxSTTService(WebsocketSTTService):
 
         self._settings = SonioxSTTSettings(
             model=params.model,
-            input_params=params,
+            language=None,
+            audio_format=params.audio_format,
+            num_channels=params.num_channels,
+            language_hints=params.language_hints,
+            language_hints_strict=params.language_hints_strict,
+            context=params.context,
+            enable_speaker_diarization=params.enable_speaker_diarization,
+            enable_language_identification=params.enable_language_identification,
+            client_reference_id=params.client_reference_id,
         )
         self._sync_model_name_to_metrics()
 
@@ -226,12 +252,7 @@ class SonioxSTTService(WebsocketSTTService):
         await self._connect()
 
     async def _update_settings(self, delta: SonioxSTTSettings) -> dict[str, Any]:
-        """Apply a settings delta, keeping ``input_params`` in sync.
-
-        Top-level ``model`` is the source of truth.  When it is given in
-        *delta* its value is propagated into ``input_params``.  When only
-        ``input_params`` is given, its ``model`` is propagated *up* to the
-        top-level field.
+        """Apply settings delta.
 
         Settings are stored but not applied to the active connection.
 
@@ -241,21 +262,10 @@ class SonioxSTTService(WebsocketSTTService):
         Returns:
             Dict mapping changed field names to their previous values.
         """
-        model_given = is_given(getattr(delta, "model", NOT_GIVEN))
-
         changed = await super()._update_settings(delta)
 
         if not changed:
             return changed
-
-        # --- Sync model --------------------------------------------------
-        if model_given:
-            # Top-level model wins → push into input_params.
-            self._settings.input_params.model = self._settings.model
-        elif "input_params" in changed and self._settings.input_params.model is not None:
-            # Only input_params was given → pull model up.
-            self._settings.model = self._settings.input_params.model
-            self._sync_model_name_to_metrics()
 
         # TODO: someday we could reconnect here to apply updated settings.
         # Code might look something like the below:
@@ -377,26 +387,26 @@ class SonioxSTTService(WebsocketSTTService):
             # Either one or the other is required.
             enable_endpoint_detection = not self._vad_force_turn_endpoint
 
-            params = self._settings.input_params
+            s = self._settings
 
-            context = params.context
+            context = s.context
             if isinstance(context, SonioxContextObject):
                 context = context.model_dump()
 
             # Send the initial configuration message.
             config = {
                 "api_key": self._api_key,
-                "model": self._settings.model,
-                "audio_format": params.audio_format,
-                "num_channels": params.num_channels or 1,
+                "model": s.model,
+                "audio_format": s.audio_format,
+                "num_channels": s.num_channels or 1,
                 "enable_endpoint_detection": enable_endpoint_detection,
                 "sample_rate": self.sample_rate,
-                "language_hints": _prepare_language_hints(params.language_hints),
-                "language_hints_strict": params.language_hints_strict,
+                "language_hints": _prepare_language_hints(s.language_hints),
+                "language_hints_strict": s.language_hints_strict,
                 "context": context,
-                "enable_speaker_diarization": params.enable_speaker_diarization,
-                "enable_language_identification": params.enable_language_identification,
-                "client_reference_id": params.client_reference_id,
+                "enable_speaker_diarization": s.enable_speaker_diarization,
+                "enable_language_identification": s.enable_language_identification,
+                "client_reference_id": s.client_reference_id,
             }
 
             # Send the configuration message.

--- a/src/pipecat/services/speechmatics/tts.py
+++ b/src/pipecat/services/speechmatics/tts.py
@@ -108,7 +108,9 @@ class SpeechmaticsTTSService(TTSService):
 
         params = params or SpeechmaticsTTSService.InputParams()
         self._settings = SpeechmaticsTTSSettings(
+            model=None,
             voice=voice_id,
+            language=None,
             max_retries=params.max_retries,
         )
 

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -184,7 +184,7 @@ class STTService(AIService):
     async def set_model(self, model: str):
         """Set the speech recognition model.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Use ``STTUpdateSettingsFrame(model=...)`` instead.
 
         Args:
@@ -204,7 +204,7 @@ class STTService(AIService):
     async def set_language(self, language: Language):
         """Set the language for speech recognition.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Use ``STTUpdateSettingsFrame(language=...)`` instead.
 
         Args:
@@ -357,7 +357,7 @@ class STTService(AIService):
                     warnings.simplefilter("always")
                     warnings.warn(
                         "Passing a dict via STTUpdateSettingsFrame(settings={...}) is deprecated "
-                        "since 0.0.103, use STTUpdateSettingsFrame(delta=STTSettings(...)) instead.",
+                        "since 0.0.104, use STTUpdateSettingsFrame(delta=STTSettings(...)) instead.",
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -275,7 +275,7 @@ class TTSService(AIService):
     async def set_model(self, model: str):
         """Set the TTS model to use.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Use ``TTSUpdateSettingsFrame(model=...)`` instead.
 
         Args:
@@ -295,7 +295,7 @@ class TTSService(AIService):
     async def set_voice(self, voice: str):
         """Set the voice for speech synthesis.
 
-        .. deprecated:: 0.0.103
+        .. deprecated:: 0.0.104
             Use ``TTSUpdateSettingsFrame(voice=...)`` instead.
 
         Args:
@@ -554,7 +554,7 @@ class TTSService(AIService):
                     warnings.simplefilter("always")
                     warnings.warn(
                         "Passing a dict via TTSUpdateSettingsFrame(settings={...}) is deprecated "
-                        "since 0.0.103, use TTSUpdateSettingsFrame(delta=TTSSettings(...)) instead.",
+                        "since 0.0.104, use TTSUpdateSettingsFrame(delta=TTSSettings(...)) instead.",
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/src/pipecat/services/ultravox/llm.py
+++ b/src/pipecat/services/ultravox/llm.py
@@ -177,7 +177,19 @@ class UltravoxRealtimeLLMService(LLMService):
             **kwargs: Additional arguments passed to parent LLMService.
         """
         super().__init__(**kwargs)
-        self._settings = UltravoxRealtimeLLMSettings()
+        self._settings = UltravoxRealtimeLLMSettings(
+            model=None,
+            temperature=None,
+            max_tokens=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=False,
+            user_turn_completion_config=None,
+            output_medium=None,
+        )
         self._params = params
         if one_shot_selected_tools:
             if not isinstance(self._params, OneShotInputParams):
@@ -325,8 +337,8 @@ class UltravoxRealtimeLLMService(LLMService):
             await self.cancel_task(self._receive_task, timeout=1.0)
             self._receive_task = None
 
-    async def _update_settings(self, update: UltravoxRealtimeLLMSettings):
-        changed = await super()._update_settings(update)
+    async def _update_settings(self, delta: UltravoxRealtimeLLMSettings):
+        changed = await super()._update_settings(delta)
         if "output_medium" in changed:
             await self._update_output_medium(self._settings.output_medium)
         self._warn_unhandled_updated_settings(changed.keys() - {"output_medium"})

--- a/src/pipecat/services/whisper/base_stt.py
+++ b/src/pipecat/services/whisper/base_stt.py
@@ -174,13 +174,13 @@ class BaseWhisperSTTService(SegmentedSTTService):
     def _create_client(self, api_key: Optional[str], base_url: Optional[str]):
         return AsyncOpenAI(api_key=api_key, base_url=base_url)
 
-    async def _update_settings(self, update: STTSettings) -> dict[str, Any]:
-        """Apply a settings update, syncing instance variables.
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta, syncing instance variables.
 
         Keeps ``_language``, ``_prompt``, and ``_temperature`` in sync with
         the settings fields.
         """
-        changed = await super()._update_settings(update)
+        changed = await super()._update_settings(delta)
 
         if "language" in changed:
             self._language = self._settings.language

--- a/src/pipecat/services/xtts/tts.py
+++ b/src/pipecat/services/xtts/tts.py
@@ -114,6 +114,7 @@ class XTTSService(TTSService):
         super().__init__(sample_rate=sample_rate, **kwargs)
 
         self._settings = XTTSTTSSettings(
+            model=None,
             voice=voice_id,
             language=self.language_to_service_language(language),
             base_url=base_url,


### PR DESCRIPTION
…usage of `*Settings` objects

- Storage mode: for use in `self._settings`. All fields should be specified, i.e. should not be `NOT_GIVEN`.
- Delta mode: for use in `*UpdateSettingsFrame`.

In service of this, this commit:
- Adds a runtime check that all fields are specified in storage mode
- Updates all services to specify all fields in stored settings
- Updates all services to no longer check for `is_given` in stored settings (not necessary anymore)
- Updates relevant docstrings
- Renames `update` to `delta` in `*UpdateSettingsFrame`
- Updates community integrations guide

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.