### PR TITLE
Fix STT TTFB metrics for Soniox and AWS Transcribe

### DIFF
--- a/changelog/3813.fixed.md
+++ b/changelog/3813.fixed.md
@@ -1,0 +1,1 @@
+- Fixed STT TTFB metrics not being reported for `SonioxSTTService` and `AWSTranscribeSTTService` due to missing `can_generate_metrics()` override.

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -126,6 +126,14 @@ class AWSTranscribeSTTService(WebsocketSTTService):
 
         self._receive_task = None
 
+    def can_generate_metrics(self) -> bool:
+        """Check if this service can generate processing metrics.
+
+        Returns:
+            True, as AWS Transcribe STT supports metrics generation.
+        """
+        return True
+
     def get_service_encoding(self, encoding: str) -> str:
         """Convert internal encoding format to AWS Transcribe format.
 

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -208,6 +208,14 @@ class SonioxSTTService(WebsocketSTTService):
 
         self._receive_task = None
 
+    def can_generate_metrics(self) -> bool:
+        """Check if this service can generate processing metrics.
+
+        Returns:
+            True, as Soniox STT supports metrics generation.
+        """
+        return True
+
     async def start(self, frame: StartFrame):
         """Start the Soniox STT websocket connection.
 

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -301,10 +301,8 @@ class SonioxSTTService(WebsocketSTTService):
         Yields:
             Frame: None (transcription results come via WebSocket callbacks).
         """
-        await self.start_processing_metrics()
         if self._websocket and self._websocket.state is State.OPEN:
             await self._websocket.send(audio)
-        await self.stop_processing_metrics()
 
         yield None
 
@@ -485,6 +483,8 @@ class SonioxSTTService(WebsocketSTTService):
                             # the rest will be sent as interim tokens (even final tokens).
                             await send_endpoint_transcript()
                         else:
+                            if not self._final_transcription_buffer:
+                                await self.start_processing_metrics()
                             self._final_transcription_buffer.append(token)
                     else:
                         non_final_transcription.append(token)


### PR DESCRIPTION
## Summary

- Fixed STT TTFB (time-to-final-segment) metrics not being reported for `SonioxSTTService` and `AWSTranscribeSTTService`
- Regression from 859cd7c9 which refactored TTFB measurement to use the base class `start_ttfb_metrics`/`stop_ttfb_metrics` — these are gated behind `can_generate_metrics()`, which defaults to `False`. Soniox and AWS Transcribe never overrode it, so TTFB calls became silent no-ops.
- Adds `can_generate_metrics() -> True` to both services, matching all other STT service implementations

## Testing

- [ ] Verify Soniox STT reports TTFB metrics after VAD stop
- [ ] Verify AWS Transcribe STT reports TTFB metrics after VAD stop