### PR TITLE
Fixed an issue where the TTS providers did not close the context after the audio context finished processing all audio.

### DIFF
--- a/changelog/3814.added.md
+++ b/changelog/3814.added.md
@@ -1,0 +1,1 @@
+- Added `on_audio_context_interrupted()` and `on_audio_context_completed()` callbacks to `AudioContextTTSService`. Subclasses can override these to perform provider-specific cleanup instead of overriding `_handle_interruption()`.

--- a/changelog/3814.fixed.md
+++ b/changelog/3814.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `AudioContextTTSService`-based providers (AsyncAI, ElevenLabs, Inworld, Rime) did not close or clean up their server-side audio contexts after normal speech completion, only on interruption.


### PR DESCRIPTION
## Summary                                                                                                           
                              
- Added two new lifecycle callbacks to `AudioContextTTSService`: `on_audio_context_interrupted()` and `on_audio_context_completed()`
- Fixed a bug where TTS providers (AsyncAI, ElevenLabs, Inworld, Rime) did not close or clean up their server side audio contexts after normal playback completion, only on interruption
- Refactored all `AudioContextTTSService` based providers to override the new callbacks instead of `_handle_interruption()`, making provider-specific cleanup cleaner and more explicit
- `AudioContextTTSService` subclasses that previously overrode `_handle_interruption()` for cleanup should now override `on_audio_context_interrupted()` instead. The old approach still works but the new callbacks are the recommended pattern.