### PR TITLE
Fix SentryMetrics method signatures to match base class

### DIFF
--- a/changelog/3808.fixed.md
+++ b/changelog/3808.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SentryMetrics` method signatures to match updated `FrameProcessorMetrics` base class, resolving `TypeError` when using `start_time`/`end_time` keyword arguments.


### PR DESCRIPTION
## Summary
- Updated `SentryMetrics` method signatures (`start_ttfb_metrics`, `stop_ttfb_metrics`, `start_processing_metrics`, `stop_processing_metrics`) to accept `start_time`/`end_time` keyword arguments, matching the updated `FrameProcessorMetrics` base class.
- Forwarded the new kwargs to `super()` calls so timestamps propagate correctly.

Closes #3808

## Test plan
- [ ] Verify `SentryMetrics` works with services that pass `start_time`/`end_time` (e.g. STT services)
- [ ] Run `examples/foundational/47-sentry-metrics.py` with Sentry initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)