### PR TITLE
Make `ServiceUpdateSettingsFrame` uninterruptible—settings updates ar…

### DIFF
--- a/changelog/3819.changed.md
+++ b/changelog/3819.changed.md
@@ -1,0 +1,4 @@
+- `ServiceSettingsUpdateFrame`s are now `UninterruptibleFrame`s. Generally speaking, you don't want a user interruption to prevent a service setting change from going into effect. Note that you usually don't use `ServiceSettingsUpdateFrame` directly, you use one of its subclasses:
+  - `LLMUpdateSettingsFrame`
+  - `TTSUpdateSettingsFrame`
+  - `STTUpdateSettingsFrame`

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2118,7 +2118,7 @@ class TTSStoppedFrame(ControlFrame):
 
 
 @dataclass
-class ServiceUpdateSettingsFrame(ControlFrame):
+class ServiceUpdateSettingsFrame(ControlFrame, UninterruptibleFrame):
     """Base frame for updating service settings.
 
     Supports both a ``settings`` dict (for backward compatibility) and a


### PR DESCRIPTION
…e generally independent of specific utterances.

Before this change, settings updates were often not applied. For example, a `TTSUpdateSettingsFrame` queued while the bot was speaking would only have an effect at the end of the bot's reply, and any interruption before the end of the reply would "cancel" the update.

This change was discussed in [this PR comment](https://github.com/pipecat-ai/pipecat/pull/3714#issuecomment-3923470697).