### PR TITLE
Fix breakage when using a generic settings update (e.g. a `TTSSetting…

### DIFF
--- a/src/pipecat/services/settings.py
+++ b/src/pipecat/services/settings.py
@@ -221,7 +221,7 @@ class ServiceSettings:
         for f in fields(self):
             if f.name == "extra":
                 continue
-            new_val = getattr(delta, f.name)
+            new_val = getattr(delta, f.name, NOT_GIVEN)
             if not is_given(new_val):
                 continue
             old_val = getattr(self, f.name)


### PR DESCRIPTION
…s`) instead of a more specific one (e.g. a `RimeTTSSettings`). Both should work, assuming you're only changing fields present in the generic settings.

@filipi87 raised this issue [here](https://github.com/pipecat-ai/pipecat/pull/3714#discussion_r2827940250).