### PR TITLE
Fix STT TTFB timeout measuring to use transcript arrival time

### DIFF
--- a/changelog/3822.fixed.md
+++ b/changelog/3822.fixed.md
@@ -1,0 +1,1 @@
+- Fixed STT TTFB metrics measuring timeout expiry time instead of actual transcript arrival time.


### PR DESCRIPTION
## Summary

- Fixed STT TTFB metrics reporting timeout expiry time instead of actual transcript arrival time. PR #3776 replaced manual timestamp tracking with `stop_ttfb_metrics()` in the timeout handler, but without an `end_time` it used `time.time()` at timeout expiry — producing TTFB = timeout + stop_secs (~2.2s) instead of the actual transcript latency.
- Restored `_last_transcript_time` tracking so the timeout handler measures to when the transcript arrived, and skips reporting if none arrived.

## Test plan

- [x] Verify STT TTFB metrics report actual transcript latency, not timeout duration
- [x] Verify no TTFB is reported when no transcript arrives before timeout


🤖 Generated with [Claude Code](https://claude.com/claude-code)