### PR TITLE
Fix assistant aggregator incorrectly aggregating transcription frames

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -901,6 +901,8 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
             await self._handle_llm_start(frame)
         elif isinstance(frame, LLMFullResponseEndFrame):
             await self._handle_llm_end(frame)
+        elif isinstance(frame, (TranscriptionFrame, InterimTranscriptionFrame)):
+            await self.push_frame(frame, direction)
         elif isinstance(frame, TextFrame):
             await self._handle_text(frame)
         elif isinstance(frame, LLMRunFrame):

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -879,6 +879,8 @@ class LLMAssistantAggregator(LLMContextAggregator):
             await self._handle_llm_start(frame)
         elif isinstance(frame, LLMFullResponseEndFrame):
             await self._handle_llm_end(frame)
+        elif isinstance(frame, (TranscriptionFrame, InterimTranscriptionFrame, TranslationFrame)):
+            await self.push_frame(frame, direction)
         elif isinstance(frame, TextFrame):
             await self._handle_text(frame)
         elif isinstance(frame, LLMThoughtStartFrame):
@@ -1110,10 +1112,6 @@ class LLMAssistantAggregator(LLMContextAggregator):
         await self._trigger_assistant_turn_stopped()
 
     async def _handle_text(self, frame: TextFrame):
-        # Skip TextFrame types not intended to build the assistant context
-        if isinstance(frame, (TranscriptionFrame, TranslationFrame, InterimTranscriptionFrame)):
-            return
-
         if not frame.append_to_context:
             return
 

--- a/tests/test_context_aggregators.py
+++ b/tests/test_context_aggregators.py
@@ -774,6 +774,34 @@ class BaseTestAssistantContextAggregator:
         self.check_message_multi_content(context, 0, 0, "Hello Pipecat.")
         self.check_message_multi_content(context, 0, 1, "How are you?")
 
+    async def test_transcription_frames_not_aggregated(self):
+        """TranscriptionFrame and InterimTranscriptionFrame should pass through the assistant
+        aggregator without being aggregated as assistant text (fixes #3638)."""
+        assert self.CONTEXT_CLASS is not None, "CONTEXT_CLASS must be set in a subclass"
+        assert self.AGGREGATOR_CLASS is not None, "AGGREGATOR_CLASS must be set in a subclass"
+
+        context = self.CONTEXT_CLASS()
+        aggregator = self.AGGREGATOR_CLASS(context)
+        frames_to_send = [
+            LLMFullResponseStartFrame(),
+            TextFrame(text="Hello!"),
+            TranscriptionFrame(text="user speech", user_id="user1", timestamp="now"),
+            InterimTranscriptionFrame(text="partial user", user_id="user1", timestamp="now"),
+            LLMFullResponseEndFrame(),
+        ]
+        expected_down_frames = [
+            TranscriptionFrame,
+            InterimTranscriptionFrame,
+            *self.EXPECTED_CONTEXT_FRAMES,
+        ]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+        # Only the TextFrame text should appear in the assistant message
+        self.check_message_content(context, 0, "Hello!")
+
     async def test_function_call(self):
         assert self.CONTEXT_CLASS is not None, "CONTEXT_CLASS must be set in a subclass"
         assert self.AGGREGATOR_CLASS is not None, "AGGREGATOR_CLASS must be set in a subclass"

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -12,6 +12,7 @@ from pipecat.frames.frames import (
     FunctionCallFromLLM,
     FunctionCallResultFrame,
     FunctionCallsStartedFrame,
+    InterimTranscriptionFrame,
     InterruptionFrame,
     LLMContextAssistantTimestampFrame,
     LLMContextFrame,
@@ -669,6 +670,70 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         # The incomplete marker should be stripped (resulting in empty content)
         self.assertEqual(len(stop_messages), 1)
         self.assertEqual(stop_messages[0].content, "")
+
+    async def test_transcription_frames_not_aggregated(self):
+        """TranscriptionFrame should pass through, not be aggregated as assistant text."""
+        context = LLMContext()
+
+        aggregator = LLMAssistantAggregator(context)
+
+        stop_messages = []
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            stop_messages.append(message)
+
+        frames_to_send = [
+            LLMFullResponseStartFrame(),
+            LLMTextFrame("Hello!"),
+            TranscriptionFrame(text="user speech", user_id="user1", timestamp="now"),
+            LLMFullResponseEndFrame(),
+        ]
+        expected_down_frames = [
+            TranscriptionFrame,
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+        ]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+        # Only LLM text should be in the assistant message, not user transcription
+        self.assertEqual(len(stop_messages), 1)
+        self.assertEqual(stop_messages[0].content, "Hello!")
+
+    async def test_interim_transcription_frames_not_aggregated(self):
+        """InterimTranscriptionFrame should pass through, not be aggregated as assistant text."""
+        context = LLMContext()
+
+        aggregator = LLMAssistantAggregator(context)
+
+        stop_messages = []
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            stop_messages.append(message)
+
+        frames_to_send = [
+            LLMFullResponseStartFrame(),
+            LLMTextFrame("Hi there!"),
+            InterimTranscriptionFrame(text="partial user", user_id="user1", timestamp="now"),
+            LLMFullResponseEndFrame(),
+        ]
+        expected_down_frames = [
+            InterimTranscriptionFrame,
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+        ]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+        # Only LLM text should be in the assistant message, not interim transcription
+        self.assertEqual(len(stop_messages), 1)
+        self.assertEqual(stop_messages[0].content, "Hi there!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #3638

`TranscriptionFrame` and `InterimTranscriptionFrame` were caught by the generic `TextFrame` handler in both `LLMAssistantContextAggregator` and `LLMAssistantAggregator`, causing user speech to appear as assistant messages in the LLM context.

Added explicit handlers before the `TextFrame` check to push transcription frames through instead of aggregating them. Removed the redundant guard in the universal aggregator's `_handle_text()` that was silently dropping these frames.

## Test plan

- Added `test_transcription_frames_not_aggregated` across all 5 provider aggregators (OpenAI, Anthropic, AWS, Google, Universal)
- Added separate `TranscriptionFrame` and `InterimTranscriptionFrame` tests for the universal aggregator
- All 151 tests pass