### PR TITLE
Fix WebsocketService infinite reconnection loop on immediate server close

### DIFF
--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -7,6 +7,7 @@
 """Base websocket service with automatic reconnection and error handling."""
 
 import asyncio
+import time
 from abc import ABC, abstractmethod
 from typing import Awaitable, Callable, Optional
 
@@ -17,6 +18,21 @@ from websockets.protocol import State
 
 from pipecat.frames.frames import ErrorFrame
 from pipecat.utils.network import exponential_backoff_time
+
+# Close codes that indicate permanent errors where reconnection will never succeed.
+# See RFC 6455 Section 7.4.1 and https://www.iana.org/assignments/websocket/websocket.xhtml
+_NON_RECOVERABLE_CLOSE_CODES = {
+    1002,  # Protocol error
+    1003,  # Unsupported data
+    1008,  # Policy violation (e.g., invalid API key)
+    1009,  # Message too big
+    1010,  # Mandatory extension
+    1015,  # TLS handshake failure
+}
+
+# Minimum connection duration (seconds) to consider a reconnection "stable".
+# If the connection drops faster than this, it counts toward the rapid failure limit.
+_MIN_STABLE_CONNECTION_SECS = 5.0
 
 
 class WebsocketService(ABC):
@@ -38,6 +54,8 @@ class WebsocketService(ABC):
         self._reconnect_on_error = reconnect_on_error
         self._reconnect_in_progress: bool = False
         self._disconnecting: bool = False
+        self._rapid_failure_count: int = 0
+        self._last_connect_time: float = 0.0
 
     async def _verify_connection(self) -> bool:
         """Verify the websocket connection is active and responsive.
@@ -106,6 +124,23 @@ class WebsocketService(ABC):
         finally:
             self._reconnect_in_progress = False
 
+    def _is_non_recoverable_close_code(self, error: ConnectionClosedError) -> bool:
+        """Check if a close code indicates a permanent error.
+
+        Args:
+            error: The ConnectionClosedError to check.
+
+        Returns:
+            True if the close code indicates reconnection will never succeed.
+        """
+        code = error.rcvd.code if error.rcvd else None
+        if code is None:
+            return False
+        # 4000-4999 are application-specific private codes (typically permanent errors)
+        if 4000 <= code <= 4999:
+            return True
+        return code in _NON_RECOVERABLE_CLOSE_CODES
+
     async def send_with_retry(self, message, report_error: Callable[[ErrorFrame], Awaitable[None]]):
         """Attempt to send a message, retrying after reconnect if necessary."""
         try:
@@ -145,6 +180,40 @@ class WebsocketService(ABC):
                 logger.debug(f"{self} receive loop ended during disconnect")
             return False
 
+        # Don't reconnect on non-recoverable close codes (e.g., invalid API key)
+        if isinstance(error, ConnectionClosedError) and self._is_non_recoverable_close_code(error):
+            code = error.rcvd.code if error.rcvd else None
+            reason = error.rcvd.reason if error.rcvd else ""
+            fatal_msg = (
+                f"{self} connection closed with non-recoverable error "
+                f"(code {code}: {reason}), not reconnecting"
+            )
+            logger.error(fatal_msg)
+            await report_error(ErrorFrame(fatal_msg, fatal=True))
+            return False
+
+        # Track rapid failures: if the connection didn't last long enough,
+        # it counts toward the rapid failure limit
+        elapsed = time.monotonic() - self._last_connect_time
+        if self._last_connect_time > 0 and elapsed < _MIN_STABLE_CONNECTION_SECS:
+            self._rapid_failure_count += 1
+            logger.warning(
+                f"{self} connection lasted only {elapsed:.1f}s "
+                f"(rapid failure {self._rapid_failure_count}/3)"
+            )
+            if self._rapid_failure_count >= 3:
+                fatal_msg = (
+                    f"{self} connection keeps failing immediately after reconnecting "
+                    f"({self._rapid_failure_count} rapid failures), giving up"
+                )
+                logger.error(fatal_msg)
+                await report_error(ErrorFrame(fatal_msg, fatal=True))
+                self._rapid_failure_count = 0
+                return False
+        else:
+            # Connection was stable, reset the counter
+            self._rapid_failure_count = 0
+
         # Log the message
         logger.warning(error_message)
 
@@ -169,6 +238,7 @@ class WebsocketService(ABC):
         """
         while True:
             try:
+                self._last_connect_time = time.monotonic()
                 await self._receive_messages()
                 # _receive_messages() returned normally. This happens when the websocket
                 # closes gracefully (server sent close frame). The async for loop over
@@ -205,6 +275,7 @@ class WebsocketService(ABC):
         additional setup required.
         """
         self._disconnecting = False
+        self._rapid_failure_count = 0
 
     async def _disconnect(self):
         """Disconnect from the service and set disconnecting flag.

--- a/tests/test_websocket_service.py
+++ b/tests/test_websocket_service.py
@@ -1,0 +1,192 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import asyncio
+import unittest
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from pipecat.frames.frames import ErrorFrame
+from pipecat.services.websocket_service import WebsocketService
+
+
+class MockWebsocketService(WebsocketService):
+    """Concrete subclass for testing."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.connect_count = 0
+        self.disconnect_count = 0
+        self.receive_side_effect = None
+
+    async def _connect_websocket(self):
+        self.connect_count += 1
+
+    async def _disconnect_websocket(self):
+        self.disconnect_count += 1
+
+    async def _receive_messages(self):
+        if self.receive_side_effect:
+            effect = self.receive_side_effect
+            raise effect
+
+
+def make_close_error(code: int, reason: str = "") -> ConnectionClosedError:
+    """Create a ConnectionClosedError with a specific close code."""
+    rcvd = Close(code, reason)
+    sent = Close(1000, "")
+    return ConnectionClosedError(rcvd, sent, rcvd_then_sent=True)
+
+
+class TestWebsocketServiceNonRecoverableCodes(unittest.IsolatedAsyncioTestCase):
+    async def test_policy_violation_stops_reconnection(self):
+        """Close code 1008 (policy violation) should emit fatal error, not reconnect."""
+        service = MockWebsocketService()
+        errors = []
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        error = make_close_error(1008, "Invalid API key")
+        service.receive_side_effect = error
+
+        await service._receive_task_handler(report_error)
+
+        # Should have emitted exactly one fatal error
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(errors[0].fatal)
+        self.assertIn("non-recoverable", errors[0].error)
+        # Should NOT have attempted reconnection (connect_count stays at 0)
+        self.assertEqual(service.connect_count, 0)
+
+    async def test_private_close_code_stops_reconnection(self):
+        """Close codes 4000-4999 (private/application) should not reconnect."""
+        service = MockWebsocketService()
+        errors = []
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        error = make_close_error(4001, "Custom application error")
+        service.receive_side_effect = error
+
+        await service._receive_task_handler(report_error)
+
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(errors[0].fatal)
+        self.assertEqual(service.connect_count, 0)
+
+    async def test_protocol_error_stops_reconnection(self):
+        """Close code 1002 (protocol error) should not reconnect."""
+        service = MockWebsocketService()
+        errors = []
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        error = make_close_error(1002, "Protocol error")
+        service.receive_side_effect = error
+
+        await service._receive_task_handler(report_error)
+
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(errors[0].fatal)
+
+
+class TestWebsocketServiceRapidFailureDetection(unittest.IsolatedAsyncioTestCase):
+    async def test_rapid_failures_stop_reconnection(self):
+        """Connections that die immediately after reconnecting should trigger fatal error."""
+        service = MockWebsocketService()
+        errors = []
+        call_count = 0
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        # Simulate a recoverable error (code 1006 = abnormal closure)
+        error = make_close_error(1006, "Abnormal closure")
+
+        original_reconnect = service._reconnect_websocket
+
+        async def mock_reconnect(attempt):
+            nonlocal call_count
+            call_count += 1
+            # Always "succeed" to simulate the handshake-succeeds-but-immediately-drops pattern
+            return True
+
+        service._reconnect_websocket = mock_reconnect
+        # Pre-set the last connect time to "now" so elapsed time is ~0
+        service._last_connect_time = __import__("time").monotonic()
+
+        # First rapid failure
+        service.receive_side_effect = error
+        result = await service._maybe_try_reconnect("error 1", report_error, error)
+        self.assertTrue(result)  # First rapid failure, still retries
+
+        service._last_connect_time = __import__("time").monotonic()
+        result = await service._maybe_try_reconnect("error 2", report_error, error)
+        self.assertTrue(result)  # Second rapid failure, still retries
+
+        service._last_connect_time = __import__("time").monotonic()
+        result = await service._maybe_try_reconnect("error 3", report_error, error)
+        self.assertFalse(result)  # Third rapid failure, gives up
+
+        # Should have emitted a fatal error
+        fatal_errors = [e for e in errors if e.fatal]
+        self.assertEqual(len(fatal_errors), 1)
+        self.assertIn("rapid failures", fatal_errors[0].error)
+
+    async def test_stable_connection_resets_rapid_failure_count(self):
+        """A connection that lasts long enough should reset the failure counter."""
+        service = MockWebsocketService()
+        errors = []
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        async def mock_reconnect(attempt):
+            return True
+
+        service._reconnect_websocket = mock_reconnect
+        error = make_close_error(1006, "Abnormal closure")
+
+        # Simulate a connection that was established long enough ago (stable)
+        service._last_connect_time = __import__("time").monotonic() - 10.0
+
+        result = await service._maybe_try_reconnect("error", report_error, error)
+        self.assertTrue(result)
+        # Rapid failure count should be 0 (reset by stable connection)
+        self.assertEqual(service._rapid_failure_count, 0)
+
+
+class TestWebsocketServiceDisconnectFlag(unittest.IsolatedAsyncioTestCase):
+    async def test_intentional_disconnect_does_not_reconnect(self):
+        """Setting _disconnecting should prevent reconnection attempts."""
+        service = MockWebsocketService()
+        service._disconnecting = True
+        errors = []
+
+        async def report_error(frame: ErrorFrame):
+            errors.append(frame)
+
+        result = await service._maybe_try_reconnect("error", report_error)
+        self.assertFalse(result)
+        self.assertEqual(len(errors), 0)
+
+    async def test_connect_resets_rapid_failure_count(self):
+        """Calling _connect should reset the rapid failure counter."""
+        service = MockWebsocketService()
+        service._rapid_failure_count = 5
+        await service._connect()
+        self.assertEqual(service._rapid_failure_count, 0)
+        self.assertFalse(service._disconnecting)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3711

`_try_reconnect` only counts failed handshakes toward its retry limit. When a server accepts the handshake but immediately closes (e.g., `1008` for invalid API key), reconnection "succeeds" every time and the loop never exits.

### Changes

- Detect non-recoverable close codes (1002, 1003, 1008, 1009, 1010, 1015, 4000-4999) and emit a fatal `ErrorFrame` without retrying
- Track rapid failures: if a connection drops within 5s of establishment, count it toward a 3-strike limit before emitting a fatal `ErrorFrame`
- Reset failure tracking on `_connect()`