### PR TITLE
Consume InterimTranscriptionFrame and TranslationFrame in LLMUserAggregator

### DIFF
--- a/changelog/3825.fixed.md
+++ b/changelog/3825.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InterimTranscriptionFrame` and `TranslationFrame` being unintentionally pushed downstream in `LLMUserAggregator`. They are now consumed like `TranscriptionFrame`.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -461,6 +461,10 @@ class LLMUserAggregator(LLMContextAggregator):
             await self.push_frame(frame, direction)
         elif isinstance(frame, TranscriptionFrame):
             await self._handle_transcription(frame)
+        elif isinstance(frame, (InterimTranscriptionFrame, TranslationFrame)):
+            # Interim transcriptions and translations are consumed here
+            # and not pushed downstream, same as final TranscriptionFrame.
+            pass
         elif isinstance(frame, LLMRunFrame):
             await self._handle_llm_run(frame)
         elif isinstance(frame, LLMMessagesAppendFrame):


### PR DESCRIPTION
## Summary

- `InterimTranscriptionFrame` and `TranslationFrame` were falling through to the `else` branch in `LLMUserAggregator.process_frame()` and being pushed downstream, unlike `TranscriptionFrame` which is explicitly consumed
- Added explicit handling to consume these frames, consistent with how the assistant aggregator already filters them in `_handle_text`
- Added tests verifying neither frame type is pushed downstream

## Test plan

- [x] `test_interim_transcription_not_pushed_downstream` — verifies `InterimTranscriptionFrame` is consumed
- [x] `test_translation_not_pushed_downstream` — verifies `TranslationFrame` is consumed
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/pipecat-ai/pipecat/issues/3638