### PR TITLE
Skip empty audio frames after filter buffering

### DIFF
--- a/changelog/3828.fixed.md
+++ b/changelog/3828.fixed.md
@@ -1,0 +1,1 @@
+- Fixed misleading "Empty audio frame received for STT service" warnings when using audio filters (e.g. `RNNoiseFilter`, `KrispVivaFilter`, `AICFilter`) that buffer audio internally.

--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -424,6 +424,11 @@ class BaseInputTransport(FrameProcessor):
                 if self._params.audio_in_filter:
                     frame.audio = await self._params.audio_in_filter.filter(frame.audio)
 
+                # Skip frames with no audio data (e.g. filter is buffering).
+                if not frame.audio:
+                    self._audio_in_queue.task_done()
+                    continue
+
                 ###################################################################
                 # DEPRECATED.
                 #


### PR DESCRIPTION
## Summary

- Audio filters like `RNNoiseFilter`, `KrispVivaFilter`, and `AICFilter` return empty bytes (`b""`) while buffering audio to accumulate their required frame size. These empty frames were flowing downstream through VAD and into the STT service, causing misleading "Empty audio frame received for STT service" warnings.
- Skip the frame in `BaseInputTransport` when the audio filter returns empty audio, preventing unnecessary processing in VAD and downstream processors.

## Fixes

- Fixes #3517