### PR TITLE
Add `append_trailing_space` to all Rime websocket services

### DIFF
--- a/changelog/3837.fixed.md
+++ b/changelog/3837.fixed.md
@@ -1,0 +1,1 @@
+- Fixed issues with `RimeNonJsonTTSService` where trailing punctuation is sometimes vocalized

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -846,6 +846,7 @@ class RimeNonJsonTTSService(InterruptibleTTSService):
             aggregate_sentences=aggregate_sentences,
             push_stop_frames=True,
             pause_frame_processing=True,
+            append_trailing_space=True,
             **kwargs,
         )
         params = params or RimeNonJsonTTSService.InputParams()


### PR DESCRIPTION
This was added in 31daa889e83b960fab79d66b2ab014d930e15a2e, but only to `RimeTTSService`, not to `RimeNonJsonTTSService. Bringing these to parity means that users switching between the two, with the same inputs, have more consistent vocalization behaviors.

(changelog entry to be added once I know the PR number I'm assigned)

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.