### PR TITLE
A few Groq-related tweaks:

### DIFF
--- a/src/pipecat/services/groq/tts.py
+++ b/src/pipecat/services/groq/tts.py
@@ -152,6 +152,9 @@ class GroqTTSService(TTSService):
                 model=self._settings.model,
                 voice=self._settings.voice,
                 response_format=self._output_format,
+                # Note: as of 2026-02-25, only a speed of 1.0 is supported, but
+                # here we pass it for completeness and future-proofing
+                speed=self._settings.speed,
                 input=text,
             )
 


### PR DESCRIPTION
- Wire up passing speed setting to Groq, even though only a value of 1.0 is supported today
- Update the 55y example to switch voices instead of changing speed
- Add a 55zn example to exercise runtime updates of Groq STT