### PR TITLE
Add TTSSpeakFrame.push_assistant_aggregation to force context flush after TTS.

### DIFF
--- a/changelog/3845.fixed.md
+++ b/changelog/3845.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TTSSpeakFrame` not committing spoken text to the conversation context when used outside of an LLM response (e.g., bot greetings or injected speech).

--- a/examples/foundational/52-live-translation.py
+++ b/examples/foundational/52-live-translation.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -110,6 +111,14 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
+        await task.queue_frames(
+            [
+                TTSSpeakFrame(
+                    text="Hello, welcome to live translation. Everything you say will be automatically translated to Spanish. Let's begin!",
+                    append_to_context=True,
+                ),
+            ]
+        )
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1991,6 +1991,16 @@ class LLMFullResponseEndFrame(ControlFrame):
 
 
 @dataclass
+class LLMAssistantPushAggregationFrame(ControlFrame):
+    """Frame that forces the LLM assistant aggregator to push its current aggregation to context.
+
+    When received by ``LLMAssistantAggregator``, any text that has been accumulated
+    in the aggregation buffer is immediately committed to the conversation context as
+    an assistant message, without waiting for an ``LLMFullResponseEndFrame``.
+    """
+
+
+@dataclass
 class LLMContextSummaryRequestFrame(ControlFrame):
     """Frame requesting context summarization from an LLM service.
 

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -35,6 +35,7 @@ from pipecat.frames.frames import (
     InputAudioRawFrame,
     InterimTranscriptionFrame,
     InterruptionFrame,
+    LLMAssistantPushAggregationFrame,
     LLMContextAssistantTimestampFrame,
     LLMContextFrame,
     LLMContextSummaryRequestFrame,
@@ -879,6 +880,8 @@ class LLMAssistantAggregator(LLMContextAggregator):
         elif isinstance(frame, (EndFrame, CancelFrame)):
             await self._handle_end_or_cancel(frame)
             await self.push_frame(frame, direction)
+        elif isinstance(frame, LLMAssistantPushAggregationFrame):
+            await self.push_aggregation()
         elif isinstance(frame, LLMFullResponseStartFrame):
             await self._handle_llm_start(frame)
         elif isinstance(frame, LLMFullResponseEndFrame):

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -125,7 +125,7 @@ async def test_run_piper_tts_error(aiohttp_client):
         )
 
         frames_to_send = [
-            TTSSpeakFrame(text="Error case."),
+            TTSSpeakFrame(text="Error case.", append_to_context=False),
         ]
 
         expected_down_frames = [AggregatedTextFrame, TTSStoppedFrame, TTSTextFrame]


### PR DESCRIPTION
## Summary                                                                                                           
- Fixed `TTSSpeakFrame` not automatically committing spoken text to the conversation context when used outside of an LLM response (e.g., for bot greeting messages or injected speech)
- Added a new `LLMAssistantPushAggregationFrame` control frame that signals `LLMAssistantAggregator` to immediately flush its text buffer to the conversation context
- When a `TTSSpeakFrame` is processed while an LLM response is **not** in progress, the TTS service now automatically emits an `LLMAssistantPushAggregationFrame` after the text has been spoken, ensuring the spoken text is committed to context without waiting for an `LLMFullResponseEndFrame`
- Updated the `52-live-translation.py` example to demonstrate the fix