### PR TITLE
Remove verbose audio chunk logging from GenesysAudioHookSerializer

### DIFF
--- a/changelog/3850.fixed.md
+++ b/changelog/3850.fixed.md
@@ -1,0 +1,1 @@
+- Removed verbose per-chunk audio logging from `GenesysAudioHookSerializer` that flooded production logs.

--- a/src/pipecat/serializers/genesys.py
+++ b/src/pipecat/serializers/genesys.py
@@ -642,7 +642,6 @@ class GenesysAudioHookSerializer(FrameSerializer):
         """
         # Binary data = audio
         if isinstance(data, bytes):
-            logger.debug(f"[AUDIO IN] Received {len(data)} bytes from Genesys")
             return await self._deserialize_audio(data)
 
         # Text data = JSON control message


### PR DESCRIPTION
## Summary

- Removed `logger.debug` call in `GenesysAudioHookSerializer.deserialize()` that logged every incoming audio chunk (1600 bytes), flooding production logs and increasing logging costs.
- No other serializer (Twilio, Telnyx, Exotel, Plivo, Vonage) logs every audio chunk, so this brings Genesys in line with the rest.

## Fixes

- Fixes #3777