### PR TITLE
Deprecate processing metrics (ProcessingMetricsData)

### DIFF
--- a/changelog/3852.deprecated.md
+++ b/changelog/3852.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated `ProcessingMetricsData` and `start_processing_metrics()`/`stop_processing_metrics()` on `FrameProcessor` and `FrameProcessorMetrics`. These metrics don't accurately depict a service's performance. Instead, TTFB metrics are recommended. Processing metrics will be removed in the 1.0.0 version.

--- a/src/pipecat/metrics/metrics.py
+++ b/src/pipecat/metrics/metrics.py
@@ -41,6 +41,10 @@ class TTFBMetricsData(MetricsData):
 class ProcessingMetricsData(MetricsData):
     """General processing time metrics data.
 
+    .. deprecated:: 0.0.104
+        Processing metrics are deprecated and will be removed in a future version.
+        Use TTFB metrics instead.
+
     Parameters:
         value: Processing time measurement in seconds.
     """

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -441,18 +441,34 @@ class FrameProcessor(BaseObject):
             if frame:
                 await self.push_frame(frame)
 
+    _processing_metrics_warned = False
+
     async def start_processing_metrics(self, *, start_time: Optional[float] = None):
         """Start processing metrics collection.
+
+        .. deprecated:: 0.0.104
+            Processing metrics are deprecated and will be removed in a future version.
+            Use TTFB metrics instead.
 
         Args:
             start_time: Optional timestamp to use as the start time. If None,
                 uses the current time.
         """
         if self.can_generate_metrics() and self.metrics_enabled:
+            if not FrameProcessor._processing_metrics_warned:
+                FrameProcessor._processing_metrics_warned = True
+                logger.warning(
+                    "Processing metrics are deprecated and will be removed in a future version. "
+                    "Use TTFB metrics instead."
+                )
             await self._metrics.start_processing_metrics(start_time=start_time)
 
     async def stop_processing_metrics(self, *, end_time: Optional[float] = None):
         """Stop processing metrics collection and push results.
+
+        .. deprecated:: 0.0.104
+            Processing metrics are deprecated and will be removed in a future version.
+            Use TTFB metrics instead.
 
         Args:
             end_time: Optional timestamp to use as the end time. If None, uses

--- a/src/pipecat/processors/metrics/frame_processor_metrics.py
+++ b/src/pipecat/processors/metrics/frame_processor_metrics.py
@@ -150,6 +150,10 @@ class FrameProcessorMetrics(BaseObject):
     async def start_processing_metrics(self, *, start_time: Optional[float] = None):
         """Start measuring processing time.
 
+        .. deprecated:: 0.0.104
+            Processing metrics are deprecated and will be removed in a future version.
+            Use TTFB metrics instead.
+
         Args:
             start_time: Optional timestamp to use as the start time. If None,
                 uses the current time.
@@ -158,6 +162,10 @@ class FrameProcessorMetrics(BaseObject):
 
     async def stop_processing_metrics(self, *, end_time: Optional[float] = None):
         """Stop processing time measurement and generate metrics frame.
+
+        .. deprecated:: 0.0.104
+            Processing metrics are deprecated and will be removed in a future version.
+            Use TTFB metrics instead.
 
         Args:
             end_time: Optional timestamp to use as the end time. If None, uses


### PR DESCRIPTION
## Summary

- Add deprecation warnings and docstrings to `ProcessingMetricsData`, `start_processing_metrics()`, and `stop_processing_metrics()` on both `FrameProcessor` and `FrameProcessorMetrics`
- Warning is emitted once at runtime (class-level flag) when any service calls `start_processing_metrics()`
- No behavioral changes — all existing metrics continue to be collected and reported as before

## Context

Processing metrics are inconsistently implemented across services and overlap with the better-defined TTFB metric. This deprecation prepares for full removal in a future version.

## Test plan

- [x] All tests pass (`uv run pytest` — 702 passed)
- [x] Verified warning appears once at runtime when running an example
- [x] Verified no behavioral changes — metrics still collected and reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)