### PR TITLE
Improve context summarization with dedicated LLM, timeout, and observability

### DIFF
--- a/changelog/3855.added.2.md
+++ b/changelog/3855.added.2.md
@@ -1,0 +1,1 @@
+- Added optional `llm` field to `LLMContextSummarizationConfig` for routing summarization to a dedicated LLM service (e.g., a cheaper/faster model) instead of the pipeline's primary model.

--- a/changelog/3855.added.3.md
+++ b/changelog/3855.added.3.md
@@ -1,0 +1,1 @@
+- Added `summarization_timeout` to `LLMContextSummarizationConfig` (default 120s) to prevent hung LLM calls from permanently blocking future summarizations.

--- a/changelog/3855.added.4.md
+++ b/changelog/3855.added.4.md
@@ -1,0 +1,1 @@
+- Added `on_summary_applied` event to `LLMContextSummarizer` for observability, providing message counts before and after context summarization.

--- a/changelog/3855.added.md
+++ b/changelog/3855.added.md
@@ -1,0 +1,1 @@
+- Added `summary_message_template` to `LLMContextSummarizationConfig` for customizing how summaries are formatted when injected into context (e.g., wrapping in XML tags).

--- a/changelog/3855.changed.md
+++ b/changelog/3855.changed.md
@@ -1,0 +1,1 @@
+- Updated context summarization to use `user` role instead of `assistant` for summary messages.

--- a/examples/foundational/54-context-summarization-openai.py
+++ b/examples/foundational/54-context-summarization-openai.py
@@ -20,14 +20,13 @@ from loguru import logger
 
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
-from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_context_summarizer import SummaryAppliedEvent
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMAssistantAggregatorParams,
     LLMContextAggregatorPair,
@@ -42,8 +41,6 @@ from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
-from pipecat.turns.user_stop import TurnAnalyzerUserTurnStopStrategy
-from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.utils.context.llm_context_summarization import LLMContextSummarizationConfig
 
 load_dotenv(override=True)
@@ -120,10 +117,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
         user_params=LLMUserAggregatorParams(
-            user_turn_strategies=UserTurnStrategies(
-                stop=[TurnAnalyzerUserTurnStopStrategy(turn_analyzer=LocalSmartTurnAnalyzerV3())]
-            ),
-            vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
+            vad_analyzer=SileroVADAnalyzer(),
         ),
         assistant_params=LLMAssistantAggregatorParams(
             enable_context_summarization=True,
@@ -137,6 +131,19 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             ),
         ),
     )
+
+    # Listen for summarization events
+    summarizer = assistant_aggregator._summarizer
+    if summarizer:
+
+        @summarizer.event_handler("on_summary_applied")
+        async def on_summary_applied(summarizer, event: SummaryAppliedEvent):
+            logger.info(
+                f"Context summarized: {event.original_message_count} messages -> "
+                f"{event.new_message_count} messages "
+                f"({event.summarized_message_count} summarized, "
+                f"{event.preserved_message_count} preserved)"
+            )
 
     pipeline = Pipeline(
         [

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2019,6 +2019,8 @@ class LLMContextSummaryRequestFrame(ControlFrame):
             the summary text.
         summarization_prompt: System prompt instructing the LLM how to generate
             the summary.
+        summarization_timeout: Maximum time in seconds for the LLM to generate a
+            summary. None means no timeout.
     """
 
     request_id: str
@@ -2026,6 +2028,7 @@ class LLMContextSummaryRequestFrame(ControlFrame):
     min_messages_to_keep: int
     target_context_tokens: int
     summarization_prompt: str
+    summarization_timeout: Optional[float] = None
 
 
 @dataclass

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2020,7 +2020,7 @@ class LLMContextSummaryRequestFrame(ControlFrame):
         summarization_prompt: System prompt instructing the LLM how to generate
             the summary.
         summarization_timeout: Maximum time in seconds for the LLM to generate a
-            summary. None means no timeout.
+            summary. When None, a default timeout of 120s is applied.
     """
 
     request_id: str

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -306,8 +306,10 @@ class LLMContextSummarizer(BaseObject):
         # Get recent messages to keep
         recent_messages = messages[last_summarized_index + 1 :]
 
-        # Create summary message as an user message
-        summary_message = {"role": "user", "content": f"Conversation summary: {summary}"}
+        # Create summary message as a user message (the summary is context
+        # provided *to* the assistant, not something the assistant said)
+        summary_content = self._config.summary_message_template.format(summary=summary)
+        summary_message = {"role": "user", "content": summary_content}
 
         # Reconstruct context
         new_messages = []

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -306,8 +306,8 @@ class LLMContextSummarizer(BaseObject):
         # Get recent messages to keep
         recent_messages = messages[last_summarized_index + 1 :]
 
-        # Create summary message as an assistant message
-        summary_message = {"role": "assistant", "content": f"Conversation summary: {summary}"}
+        # Create summary message as an user message
+        summary_message = {"role": "user", "content": f"Conversation summary: {summary}"}
 
         # Reconstruct context
         new_messages = []

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -218,6 +218,7 @@ class LLMContextSummarizer(BaseObject):
             min_messages_to_keep=min_keep,
             target_context_tokens=self._config.target_context_tokens,
             summarization_prompt=self._config.summary_prompt,
+            summarization_timeout=self._config.summarization_timeout,
         )
 
         # Emit event for aggregator to broadcast

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -73,6 +73,11 @@ class LLMContextSummarizationConfig:
             immediate conversational context.
         summarization_prompt: Custom prompt for the LLM to use when generating
             summaries. If None, uses DEFAULT_SUMMARIZATION_PROMPT.
+        summary_message_template: Template for formatting the summary when
+            injected into context. Must contain ``{summary}`` as a placeholder
+            for the generated summary text. Allows applications to wrap the
+            summary in custom delimiters (e.g., XML tags) so that system
+            prompts can distinguish summaries from live conversation.
     """
 
     max_context_tokens: int = 8000
@@ -80,6 +85,7 @@ class LLMContextSummarizationConfig:
     max_unsummarized_messages: int = 20
     min_messages_after_summary: int = 4
     summarization_prompt: Optional[str] = None
+    summary_message_template: str = "Conversation summary: {summary}"
 
     def __post_init__(self):
         """Validate configuration parameters."""

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -20,6 +20,9 @@ from loguru import logger
 
 from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
 
+# Fallback timeout (seconds) used when summarization_timeout is None.
+DEFAULT_SUMMARIZATION_TIMEOUT = 120.0
+
 # Token estimation constants
 CHARS_PER_TOKEN = 4  # Industry-standard heuristic: 1 token ≈ 4 characters
 TOKEN_OVERHEAD_PER_MESSAGE = 10  # Estimated structural overhead per message
@@ -89,7 +92,6 @@ class LLMContextSummarizationConfig:
         summarization_timeout: Maximum time in seconds to wait for the LLM to
             generate a summary. If the call exceeds this timeout, summarization
             is aborted with an error and future summarizations are unblocked.
-            Set to None to disable the timeout.
     """
 
     max_context_tokens: int = 8000
@@ -99,7 +101,7 @@ class LLMContextSummarizationConfig:
     summarization_prompt: Optional[str] = None
     summary_message_template: str = "Conversation summary: {summary}"
     llm: Optional["LLMService"] = None
-    summarization_timeout: Optional[float] = 120.0
+    summarization_timeout: float = DEFAULT_SUMMARIZATION_TIMEOUT
 
     def __post_init__(self):
         """Validate configuration parameters."""

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -11,7 +11,10 @@ context when token limits are reached, enabling efficient long-running conversat
 """
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from pipecat.services.llm_service import LLMService
 
 from loguru import logger
 
@@ -78,6 +81,11 @@ class LLMContextSummarizationConfig:
             for the generated summary text. Allows applications to wrap the
             summary in custom delimiters (e.g., XML tags) so that system
             prompts can distinguish summaries from live conversation.
+        llm: Optional separate LLM service for generating summaries. When set,
+            summarization requests are sent to this service instead of the
+            pipeline's primary LLM. Useful for routing summarization to a
+            cheaper/faster model (e.g., Gemini Flash) while keeping an
+            expensive model for conversation. If None, uses the pipeline LLM.
     """
 
     max_context_tokens: int = 8000
@@ -86,6 +94,7 @@ class LLMContextSummarizationConfig:
     min_messages_after_summary: int = 4
     summarization_prompt: Optional[str] = None
     summary_message_template: str = "Conversation summary: {summary}"
+    llm: Optional["LLMService"] = None
 
     def __post_init__(self):
         """Validate configuration parameters."""

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -86,6 +86,10 @@ class LLMContextSummarizationConfig:
             pipeline's primary LLM. Useful for routing summarization to a
             cheaper/faster model (e.g., Gemini Flash) while keeping an
             expensive model for conversation. If None, uses the pipeline LLM.
+        summarization_timeout: Maximum time in seconds to wait for the LLM to
+            generate a summary. If the call exceeds this timeout, summarization
+            is aborted with an error and future summarizations are unblocked.
+            Set to None to disable the timeout.
     """
 
     max_context_tokens: int = 8000
@@ -95,6 +99,7 @@ class LLMContextSummarizationConfig:
     summarization_prompt: Optional[str] = None
     summary_message_template: str = "Conversation summary: {summary}"
     llm: Optional["LLMService"] = None
+    summarization_timeout: Optional[float] = 120.0
 
     def __post_init__(self):
         """Validate configuration parameters."""

--- a/tests/test_context_summarization.py
+++ b/tests/test_context_summarization.py
@@ -654,85 +654,79 @@ class TestSummaryGenerationExceptions(unittest.IsolatedAsyncioTestCase):
 
 
 class TestDedicatedLLMSummarization(unittest.IsolatedAsyncioTestCase):
-    """Tests for dedicated LLM summarization in LLMAssistantAggregator."""
+    """Tests for dedicated LLM summarization in LLMContextSummarizer."""
 
-    def _create_context_and_frame(self):
-        """Create a context with enough messages and a matching request frame."""
-        context = LLMContext()
-        context.add_message({"role": "user", "content": "Message 1"})
-        context.add_message({"role": "assistant", "content": "Response 1"})
-        context.add_message({"role": "user", "content": "Message 2"})
-
-        frame = LLMContextSummaryRequestFrame(
-            request_id="dedicated_test",
-            context=context,
-            min_messages_to_keep=1,
-            target_context_tokens=1000,
-            summarization_prompt="Summarize this",
-            summarization_timeout=5.0,
-        )
-        return context, frame
-
-    async def test_dedicated_llm_success(self):
-        """Test that dedicated LLM generates summary and feeds result to summarizer."""
-        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
-        from pipecat.processors.aggregators.llm_response_universal import (
-            LLMAssistantAggregator,
-            LLMAssistantAggregatorParams,
-        )
+    async def asyncSetUp(self):
         from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
 
-        context, frame = self._create_context_and_frame()
+        self.task_manager = TaskManager()
+        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
-        # Create a mock dedicated LLM
-        dedicated_llm = LLMService()
-        dedicated_llm._generate_summary = AsyncMock(return_value=("Dedicated summary", 1))
+    def _create_context_and_config(self, dedicated_llm):
+        """Create a context with enough messages and a config with a dedicated LLM."""
+        context = LLMContext()
+        for i in range(10):
+            context.add_message(
+                {"role": "user", "content": f"Test message {i} that adds tokens to context."}
+            )
 
         config = LLMContextSummarizationConfig(
-            max_context_tokens=50,
+            max_context_tokens=50,  # Very low to trigger easily
             llm=dedicated_llm,
+            summarization_timeout=5.0,
         )
-        params = LLMAssistantAggregatorParams(
-            enable_context_summarization=True,
-            context_summarization_config=config,
-        )
-        aggregator = LLMAssistantAggregator(context, params=params)
+        return context, config
 
-        # Mock summarizer.process_frame to capture the result
-        result_frames = []
-        original_process = aggregator._summarizer.process_frame
+    async def test_dedicated_llm_success(self):
+        """Test that dedicated LLM generates summary and applies result."""
+        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
 
-        async def capture_process(frame):
-            result_frames.append(frame)
-            await original_process(frame)
+        dedicated_llm = LLMService()
+        dedicated_llm._generate_summary = AsyncMock(return_value=("Dedicated summary", 5))
 
-        aggregator._summarizer.process_frame = capture_process
+        context, config = self._create_context_and_config(dedicated_llm)
+        original_message_count = len(context.messages)
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(self.task_manager)
 
-        # Call the method directly
-        await aggregator._generate_summary_with_dedicated_llm(dedicated_llm, frame)
+        # Track whether on_request_summarization event fires (it should NOT)
+        event_fired = False
+
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal event_fired
+            event_fired = True
+
+        # Trigger summarization via LLM response start
+        from pipecat.frames.frames import LLMFullResponseStartFrame
+
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+
+        # Wait for the background task to complete
+        await asyncio.sleep(0.1)
+
+        # The event should NOT have fired (dedicated LLM handles it internally)
+        self.assertFalse(event_fired)
 
         # Verify the dedicated LLM was called
-        dedicated_llm._generate_summary.assert_called_once_with(frame)
+        dedicated_llm._generate_summary.assert_called_once()
 
-        # Verify result was fed to the summarizer
-        self.assertEqual(len(result_frames), 1)
-        result = result_frames[0]
-        self.assertIsInstance(result, LLMContextSummaryResultFrame)
-        self.assertEqual(result.request_id, "dedicated_test")
-        self.assertEqual(result.summary, "Dedicated summary")
-        self.assertEqual(result.last_summarized_index, 1)
-        self.assertIsNone(result.error)
+        # Verify summary was applied to context (message count should decrease)
+        self.assertLess(len(context.messages), original_message_count)
+
+        # Verify summary message is present
+        summary_messages = [
+            msg for msg in context.messages if "Conversation summary:" in msg.get("content", "")
+        ]
+        self.assertEqual(len(summary_messages), 1)
+        self.assertIn("Dedicated summary", summary_messages[0]["content"])
+
+        await summarizer.cleanup()
 
     async def test_dedicated_llm_timeout(self):
-        """Test that dedicated LLM timeout produces error result."""
-        from pipecat.processors.aggregators.llm_response_universal import (
-            LLMAssistantAggregator,
-            LLMAssistantAggregatorParams,
-        )
+        """Test that dedicated LLM timeout produces error and clears state."""
+        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
 
-        context, _ = self._create_context_and_frame()
-
-        # Create a mock dedicated LLM that hangs
         dedicated_llm = LLMService()
 
         async def slow_summary(frame):
@@ -741,161 +735,116 @@ class TestDedicatedLLMSummarization(unittest.IsolatedAsyncioTestCase):
 
         dedicated_llm._generate_summary = slow_summary
 
-        config = LLMContextSummarizationConfig(
-            max_context_tokens=50,
-            llm=dedicated_llm,
-        )
-        params = LLMAssistantAggregatorParams(
-            enable_context_summarization=True,
-            context_summarization_config=config,
-        )
-        aggregator = LLMAssistantAggregator(context, params=params)
+        context, config = self._create_context_and_config(dedicated_llm)
+        config.summarization_timeout = 0.1  # Very short timeout
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(self.task_manager)
 
-        # Mock summarizer.process_frame to capture the result
-        result_frames = []
+        original_message_count = len(context.messages)
 
-        async def capture_process(frame):
-            result_frames.append(frame)
+        # Trigger summarization
+        from pipecat.frames.frames import LLMFullResponseStartFrame
 
-        aggregator._summarizer.process_frame = capture_process
+        await summarizer.process_frame(LLMFullResponseStartFrame())
 
-        # Create frame with very short timeout
-        frame = LLMContextSummaryRequestFrame(
-            request_id="timeout_test",
-            context=context,
-            min_messages_to_keep=1,
-            target_context_tokens=1000,
-            summarization_prompt="Summarize this",
-            summarization_timeout=0.1,
-        )
+        # Wait for the background task to complete (timeout + some buffer)
+        await asyncio.sleep(0.3)
 
-        await aggregator._generate_summary_with_dedicated_llm(dedicated_llm, frame)
+        # Context should be unchanged (timeout = error = no summary applied)
+        self.assertEqual(len(context.messages), original_message_count)
 
-        # Verify error result was fed to summarizer
-        self.assertEqual(len(result_frames), 1)
-        result = result_frames[0]
-        self.assertIsInstance(result, LLMContextSummaryResultFrame)
-        self.assertEqual(result.request_id, "timeout_test")
-        self.assertEqual(result.summary, "")
-        self.assertEqual(result.last_summarized_index, -1)
-        self.assertIn("timed out", result.error)
+        # Summarization state should be cleared so new requests can be made
+        self.assertFalse(summarizer._summarization_in_progress)
+
+        await summarizer.cleanup()
 
     async def test_dedicated_llm_exception(self):
-        """Test that dedicated LLM exceptions produce error result."""
-        from pipecat.processors.aggregators.llm_response_universal import (
-            LLMAssistantAggregator,
-            LLMAssistantAggregatorParams,
-        )
+        """Test that dedicated LLM exceptions produce error and clear state."""
+        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
 
-        context, frame = self._create_context_and_frame()
-
-        # Create a mock dedicated LLM that raises
         dedicated_llm = LLMService()
         dedicated_llm._generate_summary = AsyncMock(
             side_effect=RuntimeError("LLM connection failed")
         )
 
-        config = LLMContextSummarizationConfig(
-            max_context_tokens=50,
-            llm=dedicated_llm,
-        )
-        params = LLMAssistantAggregatorParams(
-            enable_context_summarization=True,
-            context_summarization_config=config,
-        )
-        aggregator = LLMAssistantAggregator(context, params=params)
-        aggregator.push_error = AsyncMock()
+        context, config = self._create_context_and_config(dedicated_llm)
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(self.task_manager)
 
-        # Mock summarizer.process_frame to capture the result
-        result_frames = []
+        original_message_count = len(context.messages)
 
-        async def capture_process(frame):
-            result_frames.append(frame)
+        # Trigger summarization
+        from pipecat.frames.frames import LLMFullResponseStartFrame
 
-        aggregator._summarizer.process_frame = capture_process
+        await summarizer.process_frame(LLMFullResponseStartFrame())
 
-        await aggregator._generate_summary_with_dedicated_llm(dedicated_llm, frame)
+        # Wait for the background task to complete
+        await asyncio.sleep(0.1)
 
-        # Verify error result was fed to summarizer
-        self.assertEqual(len(result_frames), 1)
-        result = result_frames[0]
-        self.assertIsInstance(result, LLMContextSummaryResultFrame)
-        self.assertEqual(result.request_id, "dedicated_test")
-        self.assertEqual(result.summary, "")
-        self.assertEqual(result.last_summarized_index, -1)
-        self.assertIn("LLM connection failed", result.error)
+        # Context should be unchanged (exception = error = no summary applied)
+        self.assertEqual(len(context.messages), original_message_count)
 
-        # push_error should have been called
-        aggregator.push_error.assert_called_once()
+        # Summarization state should be cleared
+        self.assertFalse(summarizer._summarization_in_progress)
 
-    async def test_on_request_summarization_routes_to_dedicated_llm(self):
-        """Test that _on_request_summarization routes to dedicated LLM when configured."""
-        from pipecat.processors.aggregators.llm_response_universal import (
-            LLMAssistantAggregator,
-            LLMAssistantAggregatorParams,
-        )
+        await summarizer.cleanup()
 
-        context, frame = self._create_context_and_frame()
+    async def test_dedicated_llm_does_not_emit_event(self):
+        """Test that summarizer does NOT emit on_request_summarization when dedicated LLM is set."""
+        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
 
         dedicated_llm = LLMService()
         dedicated_llm._generate_summary = AsyncMock(return_value=("Summary", 1))
 
-        config = LLMContextSummarizationConfig(
-            max_context_tokens=50,
-            llm=dedicated_llm,
-        )
-        params = LLMAssistantAggregatorParams(
-            enable_context_summarization=True,
-            context_summarization_config=config,
-        )
-        aggregator = LLMAssistantAggregator(context, params=params)
-        aggregator.push_frame = AsyncMock()
+        context, config = self._create_context_and_config(dedicated_llm)
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(self.task_manager)
 
-        # Track what coroutine is passed to create_task
-        created_coros = []
-        original_create_task = aggregator.create_task
+        event_fired = False
 
-        def mock_create_task(coro, *args, **kwargs):
-            created_coros.append(coro)
-            # Actually run the coroutine to avoid "never awaited" warning
-            task = asyncio.ensure_future(coro)
-            return task
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal event_fired
+            event_fired = True
 
-        aggregator.create_task = mock_create_task
+        from pipecat.frames.frames import LLMFullResponseStartFrame
 
-        await aggregator._on_request_summarization(aggregator._summarizer, frame)
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+        await asyncio.sleep(0.1)
 
-        # Should NOT push frame upstream
-        aggregator.push_frame.assert_not_called()
+        self.assertFalse(event_fired)
 
-        # Should have created a task for the dedicated LLM
-        self.assertEqual(len(created_coros), 1)
+        await summarizer.cleanup()
 
-        # Wait for the task to complete
-        await asyncio.sleep(0.05)
+    async def test_no_dedicated_llm_emits_event(self):
+        """Test that summarizer emits on_request_summarization when no dedicated LLM."""
+        from pipecat.processors.aggregators.llm_context_summarizer import LLMContextSummarizer
 
-    async def test_on_request_summarization_pushes_upstream_without_dedicated_llm(self):
-        """Test that _on_request_summarization pushes upstream when no dedicated LLM."""
-        from pipecat.processors.aggregators.llm_response_universal import (
-            LLMAssistantAggregator,
-            LLMAssistantAggregatorParams,
-        )
-        from pipecat.processors.frame_processor import FrameDirection
-
-        context, frame = self._create_context_and_frame()
+        context = LLMContext()
+        for i in range(10):
+            context.add_message(
+                {"role": "user", "content": f"Test message {i} that adds tokens to context."}
+            )
 
         config = LLMContextSummarizationConfig(max_context_tokens=50)
-        params = LLMAssistantAggregatorParams(
-            enable_context_summarization=True,
-            context_summarization_config=config,
-        )
-        aggregator = LLMAssistantAggregator(context, params=params)
-        aggregator.push_frame = AsyncMock()
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(self.task_manager)
 
-        await aggregator._on_request_summarization(aggregator._summarizer, frame)
+        request_frame = None
 
-        # Should push frame upstream
-        aggregator.push_frame.assert_called_once_with(frame, FrameDirection.UPSTREAM)
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal request_frame
+            request_frame = frame
+
+        from pipecat.frames.frames import LLMFullResponseStartFrame
+
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+
+        self.assertIsNotNone(request_frame)
+        self.assertIsInstance(request_frame, LLMContextSummaryRequestFrame)
+
+        await summarizer.cleanup()
 
 
 class TestLLMSpecificMessageHandling(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Fixed summary message role to use `user` instead of `assistant`, preventing consecutive assistant messages that some LLM providers reject
- Added `summary_message_template` to `LLMContextSummarizationConfig` for customizing how summaries are formatted when injected into context (e.g., wrapping in XML tags)
- Added optional `llm` field to `LLMContextSummarizationConfig` for routing summarization to a dedicated LLM service (e.g., Gemini Flash) instead of the primary pipeline model
- Added `summarization_timeout` (default 120s) to prevent hung LLM calls from permanently blocking future summarizations
- Added `on_summary_applied` event to `LLMContextSummarizer` for observability, providing message counts before and after summarization
- Added example `54b` demonstrating all new summarization options together

## Testing

- `uv run python examples/foundational/54b-context-summarization-custom.py` to verify dedicated LLM, custom template, timeout, and event handling