### PR TITLE
Set finalized flag on ElevenLabs Realtime STT for manual commit strategy

### DIFF
--- a/changelog/3865.changed.md
+++ b/changelog/3865.changed.md
@@ -1,0 +1,1 @@
+- `ElevenLabsRealtimeSTTService` now sets `TranscriptionFrame.finalized` to `True` when using `CommitStrategy.MANUAL`.

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -861,6 +861,8 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
 
         await self._handle_transcription(text, True, language)
 
+        finalized = self._settings.commit_strategy == CommitStrategy.MANUAL
+
         await self.push_frame(
             TranscriptionFrame(
                 text,
@@ -868,6 +870,7 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
                 time_now_iso8601(),
                 language,
                 result=data,
+                finalized=finalized,
             )
         )
 
@@ -902,6 +905,8 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
 
         await self._handle_transcription(text, True, language)
 
+        finalized = self._settings.commit_strategy == CommitStrategy.MANUAL
+
         # This message is sent after committed_transcript when include_timestamps=true.
         # It contains the full transcript data including text and word-level timestamps.
         await self.push_frame(
@@ -911,5 +916,6 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
                 time_now_iso8601(),
                 language,
                 result=data,
+                finalized=finalized,
             )
         )


### PR DESCRIPTION
## Summary

- Set `TranscriptionFrame.finalized` to `True` in `ElevenLabsRealtimeSTTService` when using `CommitStrategy.MANUAL`
- With manual commit, Pipecat's VAD explicitly triggers the commit, so the transcript is definitively finalized
- Applies to both `_on_committed_transcript` and `_on_committed_transcript_with_timestamps` handlers
- When using `CommitStrategy.VAD` (ElevenLabs' own VAD), `finalized` remains `False` (the default)

Fixes #3862 