### PR TITLE
Fix tracing crashes on dataclass settings (.items() called on non-dict objects)

### DIFF
--- a/changelog/3858.fixed.md
+++ b/changelog/3858.fixed.md
@@ -1,0 +1,1 @@
+- Fixed tracing utilities crashing with `AttributeError` when service settings are dataclass instances (e.g. `GoogleLLMSettings`, `InworldTTSSettings`) instead of plain dicts. The four affected call sites now use a shared `_settings_to_dict()` helper that handles both dataclass and dict settings objects.

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -23,6 +23,34 @@ if is_tracing_available():
     from opentelemetry.trace import Span
 
 
+def _settings_to_dict(settings: Any) -> Dict[str, Any]:
+    """Convert a settings object to a dictionary for span attributes.
+
+    Service settings may be a dict or a dataclass (e.g. ``GoogleLLMSettings``,
+    ``InworldTTSSettings``).  Dataclass instances do not have an ``.items()``
+    method, so calling it directly raises ``AttributeError``.
+
+    This helper normalises the input: if the object exposes ``given_fields()``
+    (the ``ServiceSettings`` API) that is used; otherwise ``dataclasses.asdict``
+    is tried; plain dicts are returned as-is.
+
+    Args:
+        settings: A dict or dataclass settings object.
+
+    Returns:
+        A plain dictionary of settings fields.
+    """
+    if isinstance(settings, dict):
+        return settings
+    if hasattr(settings, "given_fields"):
+        return settings.given_fields()
+    import dataclasses
+
+    if dataclasses.is_dataclass(settings):
+        return dataclasses.asdict(settings)
+    return {}
+
+
 def _get_gen_ai_system_from_service_name(service_name: str) -> str:
     """Extract the standardized gen_ai.system value from a service class name.
 
@@ -107,7 +135,7 @@ def add_tts_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in _settings_to_dict(settings).items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
 
@@ -171,7 +199,7 @@ def add_stt_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in _settings_to_dict(settings).items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
 
@@ -359,7 +387,7 @@ def add_gemini_live_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in _settings_to_dict(settings).items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
             elif key == "vad" and value:

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from pipecat.processors.aggregators.llm_context import NOT_GIVEN, LLMContext
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.utils.tracing.service_attributes import (
+    _settings_to_dict,
     add_gemini_live_span_attributes,
     add_llm_span_attributes,
     add_openai_realtime_span_attributes,
@@ -510,7 +511,8 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             # Get settings from the service
                             params = {}
                             if hasattr(self, "_settings"):
-                                for key, value in self._settings.items():
+                                settings_dict = _settings_to_dict(self._settings)
+                                for key, value in settings_dict.items():
                                     if key == "extra":
                                         continue
                                     # Add value directly if it's a basic type


### PR DESCRIPTION
## Summary

- Added a shared `_settings_to_dict()` helper that safely converts service settings to a plain dict, whether the settings object is a dict or a dataclass
- Fixed all four call sites where `.items()` was called directly on dataclass settings objects
- Tracing no longer crashes on services that use dataclass-based settings (Google LLM, Google STT, Inworld TTS, and others)

## Root Cause

The tracing utilities assumed `self._settings` is always a dict and called `.items()` on it directly. However, many services use dataclass instances for their settings (e.g. `GoogleLLMSettings`, `InworldTTSSettings`). Dataclass objects do not have an `.items()` method, so this raised `AttributeError` on every traced LLM, TTS, and STT call.

The errors were caught and logged as warnings, so execution continued, but the log noise was significant in production:

```
WARNING:root:Error setting up LLM tracing: 'GoogleLLMSettings' object has no attribute 'items'
WARNING:root:Error in TTS tracing: 'InworldTTSSettings' object has no attribute 'items'
```

## Approach

Added a `_settings_to_dict()` helper in `service_attributes.py` that normalises settings objects to plain dicts:

1. If the object is already a `dict`, return it as-is
2. If it has `given_fields()` (the `ServiceSettings` API), use that
3. If it is a dataclass, fall back to `dataclasses.asdict()`
4. Otherwise return an empty dict

This follows the existing `ServiceSettings.given_fields()` pattern already used elsewhere in the codebase (e.g. `fal/stt.py`).

### Files changed

| File | Change |
|------|--------|
| `src/pipecat/utils/tracing/service_attributes.py` | Added `_settings_to_dict()` helper, fixed 3 call sites (`add_tts_span_attributes`, `add_stt_span_attributes`, `add_gemini_live_span_attributes`) |
| `src/pipecat/utils/tracing/service_decorators.py` | Fixed 1 call site (LLM tracing decorator), imported the helper |

## Fixes

Fixes #3858

## Testing

- All existing tests pass (575 passed)
- Ruff lint and format checks pass
- The fix handles all three cases: plain dicts, `ServiceSettings` subclasses, and generic dataclasses

cc @markbackman @aconchillo