### PR TITLE
Add ServiceSwitcherStrategyFailover for automatic failover on service errors

### DIFF
--- a/changelog/3861.added.md
+++ b/changelog/3861.added.md
@@ -1,1 +1,1 @@
-- Added `ServiceSwitcherStrategyAutomatic` that automatically switches to a backup service when the active service reports a non-fatal error. Unhealthy services recover after a configurable timeout (default 30s) and the strategy can optionally switch back to the primary service on recovery.
+- Added `ServiceSwitcherStrategyAutomatic` that automatically switches to the next service when the active service reports a non-fatal error. Recovery policies can be implemented via the `on_service_switched` event handler.

--- a/changelog/3861.added.md
+++ b/changelog/3861.added.md
@@ -1,1 +1,1 @@
-- Added `ServiceSwitcherStrategyAutomatic` that automatically switches to the next service when the active service reports a non-fatal error. Recovery policies can be implemented via the `on_service_switched` event handler.
+- Added `ServiceSwitcherStrategyFailover` that automatically switches to the next service when the active service reports a non-fatal error. Recovery policies can be implemented via the `on_service_switched` event handler.

--- a/changelog/3861.added.md
+++ b/changelog/3861.added.md
@@ -1,0 +1,1 @@
+- Added `ServiceSwitcherStrategyAutomatic` that automatically switches to a backup service when the active service reports a non-fatal error. Unhealthy services recover after a configurable timeout (default 30s) and the strategy can optionally switch back to the primary service on recovery.

--- a/changelog/3861.changed.md
+++ b/changelog/3861.changed.md
@@ -1,1 +1,1 @@
-- `ServiceSwitcherStrategy` base class now handles `ManuallySwitchServiceFrame` and `handle_error()` directly, making manual switching and error hooks available to all strategies.
+- `ServiceSwitcherStrategy` base class now provides a `handle_error()` hook for subclasses to implement error-based switching. `ServiceSwitcher` defaults to `ServiceSwitcherStrategyManual` and `strategy_type` is now optional.

--- a/changelog/3861.changed.md
+++ b/changelog/3861.changed.md
@@ -1,1 +1,1 @@
-- Added `handle_error()` hook to `ServiceSwitcherStrategy` base class. `ServiceSwitcher` now calls this method when a non-fatal `ErrorFrame` is pushed upstream, allowing strategies to implement automatic failover.
+- `ServiceSwitcherStrategy` base class now handles `ManuallySwitchServiceFrame` and `handle_error()` directly, making manual switching and error hooks available to all strategies.

--- a/changelog/3861.changed.md
+++ b/changelog/3861.changed.md
@@ -1,0 +1,1 @@
+- Added `handle_error()` hook to `ServiceSwitcherStrategy` base class. `ServiceSwitcher` now calls this method when a non-fatal `ErrorFrame` is pushed upstream, allowing strategies to implement automatic failover.

--- a/changelog/3861.deprecated.md
+++ b/changelog/3861.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated `ServiceSwitcherStrategyManual`. Manual switching is now the default behavior of `ServiceSwitcher`. If you provide a separate `ServiceSwitcherStrategy`, manual switching will be available as well.

--- a/changelog/3861.deprecated.md
+++ b/changelog/3861.deprecated.md
@@ -1,1 +1,0 @@
-- Deprecated `ServiceSwitcherStrategyManual`. Manual switching is now the default behavior of `ServiceSwitcher`. If you provide a separate `ServiceSwitcherStrategy`, manual switching will be available as well.

--- a/examples/foundational/48-service-switcher.py
+++ b/examples/foundational/48-service-switcher.py
@@ -96,6 +96,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     stt_cartesia = CartesiaSTTService(api_key=os.getenv("CARTESIA_API_KEY"))
     stt_deepgram = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    # Uses ServiceSwitcherStrategyManual by default
     stt_switcher = ServiceSwitcher(services=[stt_cartesia, stt_deepgram])
 
     tts_cartesia = CartesiaTTSService(
@@ -110,11 +111,20 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             voice="aura-2-helena-en",
         ),
     )
-    tts_deepgram = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    # Uses ServiceSwitcherStrategyManual by default
     tts_switcher = ServiceSwitcher(services=[tts_cartesia, tts_deepgram])
 
-    llm_openai = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))
-    llm_google = GoogleLLMService(api_key=os.getenv("GOOGLE_API_KEY"))
+    system_prompt = "You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. Your output will be spoken aloud, so avoid special characters that can't easily be spoken, such as emojis or bullet points. Respond to what the user said in a creative and helpful way."
+
+    llm_openai = OpenAILLMService(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        settings=OpenAILLMService.Settings(system_instruction=system_prompt),
+    )
+    llm_google = GoogleLLMService(
+        api_key=os.getenv("GOOGLE_API_KEY"),
+        settings=GoogleLLMService.Settings(system_instruction=system_prompt),
+    )
+    # Uses ServiceSwitcherStrategyManual by default
     llm_switcher = LLMSwitcher(llms=[llm_openai, llm_google])
     # Register a "classic" function
     llm_switcher.register_function("get_current_weather", fetch_weather_from_api)

--- a/examples/foundational/48-service-switcher.py
+++ b/examples/foundational/48-service-switcher.py
@@ -17,7 +17,7 @@ from pipecat.frames.frames import LLMRunFrame, ManuallySwitchServiceFrame
 from pipecat.pipeline.llm_switcher import LLMSwitcher
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
-from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategyManual
+from pipecat.pipeline.service_switcher import ServiceSwitcher
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
@@ -96,9 +96,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     stt_cartesia = CartesiaSTTService(api_key=os.getenv("CARTESIA_API_KEY"))
     stt_deepgram = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
-    stt_switcher = ServiceSwitcher(
-        services=[stt_cartesia, stt_deepgram], strategy_type=ServiceSwitcherStrategyManual
-    )
+    stt_switcher = ServiceSwitcher(services=[stt_cartesia, stt_deepgram])
 
     tts_cartesia = CartesiaTTSService(
         api_key=os.getenv("CARTESIA_API_KEY"),
@@ -112,23 +110,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             voice="aura-2-helena-en",
         ),
     )
-    tts_switcher = ServiceSwitcher(
-        services=[tts_cartesia, tts_deepgram], strategy_type=ServiceSwitcherStrategyManual
-    )
+    tts_deepgram = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    tts_switcher = ServiceSwitcher(services=[tts_cartesia, tts_deepgram])
 
-    system_prompt = "You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. Your output will be spoken aloud, so avoid special characters that can't easily be spoken, such as emojis or bullet points. Respond to what the user said in a creative and helpful way."
-
-    llm_openai = OpenAILLMService(
-        api_key=os.getenv("OPENAI_API_KEY"),
-        settings=OpenAILLMService.Settings(system_instruction=system_prompt),
-    )
-    llm_google = GoogleLLMService(
-        api_key=os.getenv("GOOGLE_API_KEY"),
-        settings=GoogleLLMService.Settings(system_instruction=system_prompt),
-    )
-    llm_switcher = LLMSwitcher(
-        llms=[llm_openai, llm_google], strategy_type=ServiceSwitcherStrategyManual
-    )
+    llm_openai = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))
+    llm_google = GoogleLLMService(api_key=os.getenv("GOOGLE_API_KEY"))
+    llm_switcher = LLMSwitcher(llms=[llm_openai, llm_google])
     # Register a "classic" function
     llm_switcher.register_function("get_current_weather", fetch_weather_from_api)
     # Register a "direct" function

--- a/src/pipecat/pipeline/llm_switcher.py
+++ b/src/pipecat/pipeline/llm_switcher.py
@@ -9,7 +9,11 @@
 from typing import Any, List, Optional, Type
 
 from pipecat.adapters.schemas.direct_function import DirectFunction
-from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategy, StrategyType
+from pipecat.pipeline.service_switcher import (
+    ServiceSwitcher,
+    ServiceSwitcherStrategyManual,
+    StrategyType,
+)
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.llm_service import LLMService
 
@@ -23,14 +27,16 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
     """
 
     def __init__(
-        self, llms: List[LLMService], strategy_type: Type[StrategyType] = ServiceSwitcherStrategy
+        self,
+        llms: List[LLMService],
+        strategy_type: Type[StrategyType] = ServiceSwitcherStrategyManual,
     ):
         """Initialize the service switcher with a list of LLMs and a switching strategy.
 
         Args:
             llms: List of LLM services to switch between.
             strategy_type: The strategy class to use for switching between LLMs.
-                Defaults to ``ServiceSwitcherStrategy`` (the base strategy; manual switching only).
+                Defaults to ``ServiceSwitcherStrategyManual``.
         """
         super().__init__(llms, strategy_type)
 

--- a/src/pipecat/pipeline/llm_switcher.py
+++ b/src/pipecat/pipeline/llm_switcher.py
@@ -30,7 +30,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
         Args:
             llms: List of LLM services to switch between.
             strategy_type: The strategy class to use for switching between LLMs.
-                Defaults to ``ServiceSwitcherStrategy`` (manual switching).
+                Defaults to ``ServiceSwitcherStrategy`` (the base strategy; manual switching only).
         """
         super().__init__(llms, strategy_type)
 

--- a/src/pipecat/pipeline/llm_switcher.py
+++ b/src/pipecat/pipeline/llm_switcher.py
@@ -9,7 +9,7 @@
 from typing import Any, List, Optional, Type
 
 from pipecat.adapters.schemas.direct_function import DirectFunction
-from pipecat.pipeline.service_switcher import ServiceSwitcher, StrategyType
+from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategy, StrategyType
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.llm_service import LLMService
 
@@ -19,18 +19,18 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
 
     Example::
 
-        llm_switcher = LLMSwitcher(
-            llms=[openai_llm, anthropic_llm],
-            strategy_type=ServiceSwitcherStrategyManual
-        )
+        llm_switcher = LLMSwitcher(llms=[openai_llm, anthropic_llm])
     """
 
-    def __init__(self, llms: List[LLMService], strategy_type: Type[StrategyType]):
+    def __init__(
+        self, llms: List[LLMService], strategy_type: Type[StrategyType] = ServiceSwitcherStrategy
+    ):
         """Initialize the service switcher with a list of LLMs and a switching strategy.
 
         Args:
             llms: List of LLM services to switch between.
             strategy_type: The strategy class to use for switching between LLMs.
+                Defaults to ``ServiceSwitcherStrategy`` (manual switching).
         """
         super().__init__(llms, strategy_type)
 

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -6,9 +6,8 @@
 
 """Service switcher for switching between different services at runtime, with different switching strategies."""
 
-import asyncio
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Optional, Set, Type, TypeVar
+from typing import Any, Generic, List, Optional, Type, TypeVar
 
 from loguru import logger
 
@@ -159,11 +158,9 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
 class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
     """A strategy that automatically switches to a backup service on failure.
 
-    When the active service produces a non-fatal error, this strategy marks it
-    as unhealthy and switches to the next healthy service in the list. After a
-    configurable recovery period the unhealthy service is marked healthy again.
-    If ``prefer_primary`` is enabled (the default) and the primary service
-    recovers, the strategy switches back to it automatically.
+    When the active service produces a non-fatal error, this strategy switches
+    to the next available service in the list. Recovery and fallback policies
+    are left to application code via the ``on_service_switched`` event.
 
     Manual switching via ``ManuallySwitchServiceFrame`` is still supported.
 
@@ -178,9 +175,10 @@ class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
             strategy_type=ServiceSwitcherStrategyAutomatic,
         )
 
-        # Optionally customise parameters after construction:
-        switcher.strategy.recovery_timeout = 60.0
-        switcher.strategy.prefer_primary = False
+        @switcher.strategy.event_handler("on_service_switched")
+        async def on_switched(strategy, service):
+            # App decides when/how to recover the failed service
+            ...
     """
 
     def __init__(self, services: List[FrameProcessor]):
@@ -188,23 +186,8 @@ class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
 
         Args:
             services: List of frame processors to switch between.
-                The first service is the primary.
         """
         super().__init__(services)
-        self._primary_service: FrameProcessor = services[0]
-        self._unhealthy_services: Set[FrameProcessor] = set()
-        self._recovery_timers: Dict[FrameProcessor, asyncio.TimerHandle] = {}
-
-        self.recovery_timeout: float = 30.0
-        """Seconds before an unhealthy service is marked healthy again."""
-
-        self.prefer_primary: bool = True
-        """When True, automatically switch back to the primary once it recovers."""
-
-    @property
-    def unhealthy_services(self) -> Set[FrameProcessor]:
-        """Return the set of services currently marked as unhealthy."""
-        return set(self._unhealthy_services)
 
     async def handle_frame(
         self, frame: ServiceSwitcherFrame, direction: FrameDirection
@@ -227,84 +210,39 @@ class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
     async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
         """Handle an error from the active service by failing over.
 
-        Marks the active service as unhealthy, schedules a recovery timer,
-        and switches to the next healthy service in the list.
+        Switches to the next service in the list. The failed service remains
+        in the list and can be switched back to manually or via application
+        logic in the ``on_service_switched`` event handler.
 
         Args:
             error: The error frame pushed by the active service.
 
         Returns:
             The newly active service if a switch occurred, or None if no
-            healthy backup is available.
+            other service is available.
         """
         failed_service = self._active_service
 
-        logger.warning(
-            f"Service {failed_service.name} reported an error, marking unhealthy: {error.error}"
-        )
+        logger.warning(f"Service {failed_service.name} reported an error: {error.error}")
 
-        self._unhealthy_services.add(failed_service)
-        self._schedule_recovery(failed_service)
-
-        next_service = self._next_healthy_service()
+        next_service = self._next_service()
         if next_service is None:
-            logger.error("All services are unhealthy, no backup available")
+            logger.error("No other service available to switch to")
             return None
 
         return await self._set_active_if_available(next_service)
 
-    def _next_healthy_service(self) -> Optional[FrameProcessor]:
-        """Find the next healthy service in the list.
-
-        Searches from the beginning of the service list so that
-        higher-priority services are preferred.
+    def _next_service(self) -> Optional[FrameProcessor]:
+        """Find the next service in the list after the active one.
 
         Returns:
-            The next healthy service, or None if all are unhealthy.
+            The next service, or None if there is only one service.
         """
-        for service in self._services:
-            if service not in self._unhealthy_services:
-                return service
-        return None
-
-    def _schedule_recovery(self, service: FrameProcessor):
-        """Schedule a recovery timer for an unhealthy service.
-
-        If a timer is already running for this service it is cancelled and
-        restarted so that repeated errors extend the cooldown.
-
-        Args:
-            service: The service to schedule recovery for.
-        """
-        existing = self._recovery_timers.pop(service, None)
-        if existing is not None:
-            existing.cancel()
-
-        loop = asyncio.get_event_loop()
-        handle = loop.call_later(
-            self.recovery_timeout,
-            lambda s=service: asyncio.ensure_future(self._recover_service(s)),
-        )
-        self._recovery_timers[service] = handle
-
-    async def _recover_service(self, service: FrameProcessor):
-        """Mark a service as healthy after its recovery timeout expires.
-
-        If ``prefer_primary`` is enabled and the recovered service is the
-        primary, the strategy switches back to it automatically.
-
-        Args:
-            service: The service that has recovered.
-        """
-        self._unhealthy_services.discard(service)
-        self._recovery_timers.pop(service, None)
-
-        logger.info(f"Service {service.name} marked healthy after recovery timeout")
-
-        if self.prefer_primary and service == self._primary_service:
-            if self._active_service != self._primary_service:
-                logger.info(f"Switching back to primary service {service.name}")
-                await self._set_active_if_available(self._primary_service)
+        if len(self._services) <= 1:
+            return None
+        current_idx = self._services.index(self._active_service)
+        next_idx = (current_idx + 1) % len(self._services)
+        return self._services[next_idx]
 
     async def _set_active_if_available(self, service: FrameProcessor) -> Optional[FrameProcessor]:
         """Set the active service if it is in the service list.

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -76,9 +76,8 @@ class ServiceSwitcherStrategy(BaseObject):
     ) -> Optional[FrameProcessor]:
         """Handle a frame that controls service switching.
 
-        By default, handles ``ManuallySwitchServiceFrame`` to allow manual
-        switching in all strategies. Subclasses can override this to handle
-        additional frame types.
+        The base implementation returns ``None`` for all frames. Subclasses
+        override this to implement specific switching behaviors.
 
         Args:
             frame: The frame to handle.
@@ -87,8 +86,6 @@ class ServiceSwitcherStrategy(BaseObject):
         Returns:
             The newly active service if a switch occurred, or None otherwise.
         """
-        if isinstance(frame, ManuallySwitchServiceFrame):
-            return await self._set_active_if_available(frame.service)
         return None
 
     async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
@@ -128,25 +125,36 @@ class ServiceSwitcherStrategy(BaseObject):
 class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
     """A strategy for switching between services manually.
 
-    .. deprecated:: 0.0.104
-        Manual switching is now the default behavior of ``ServiceSwitcher``.
-        Omit ``strategy_type`` when initializing.
+    This strategy allows the user to manually select which service is active.
+    The initial active service is the first one in the list.
+
+    Example::
+
+        stt_switcher = ServiceSwitcher(
+            services=[stt_1, stt_2],
+            strategy_type=ServiceSwitcherStrategyManual
+        )
     """
 
-    def __init__(self, services: List[FrameProcessor]):
-        """Initialize the service switcher strategy for manual switching.
+    async def handle_frame(
+        self, frame: ServiceSwitcherFrame, direction: FrameDirection
+    ) -> Optional[FrameProcessor]:
+        """Handle a frame that controls service switching.
 
         Args:
-            services: List of frame processors to switch between.
+            frame: The frame to handle.
+            direction: The direction of the frame (upstream or downstream).
+
+        Returns:
+            The newly active service if a switch occurred, or None otherwise.
         """
-        super().__init__(services)
-        logger.warning(
-            "ServiceSwitcherStrategyManual is deprecated. "
-            "Manual switching is now the default behavior of ServiceSwitcher."
-        )
+        if isinstance(frame, ManuallySwitchServiceFrame):
+            return await self._set_active_if_available(frame.service)
+
+        return None
 
 
-class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
+class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategyManual):
     """A strategy that automatically switches to a backup service on failure.
 
     When the active service produces a non-fatal error, this strategy switches
@@ -214,14 +222,14 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
     def __init__(
         self,
         services: List[FrameProcessor],
-        strategy_type: Type[StrategyType] = ServiceSwitcherStrategy,
+        strategy_type: Type[StrategyType] = ServiceSwitcherStrategyManual,
     ):
         """Initialize the service switcher with a list of services and a switching strategy.
 
         Args:
             services: List of frame processors to switch between.
             strategy_type: The strategy class to use for switching between services.
-                Defaults to ``ServiceSwitcherStrategy`` (the base strategy; manual switching only).
+                Defaults to ``ServiceSwitcherStrategyManual``.
         """
         _strategy = strategy_type(services)
         super().__init__(*self._make_pipeline_definitions(services, _strategy))

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -157,8 +157,6 @@ class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
     to the next available service in the list. Recovery and fallback policies
     are left to application code via the ``on_service_switched`` event.
 
-    Manual switching via ``ManuallySwitchServiceFrame`` is still supported.
-
     Event handlers available:
 
     - on_service_switched: Called when the active service changes.
@@ -190,28 +188,15 @@ class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
             The newly active service if a switch occurred, or None if no
             other service is available.
         """
-        failed_service = self._active_service
+        logger.warning(f"Service {self._active_service.name} reported an error: {error.error}")
 
-        logger.warning(f"Service {failed_service.name} reported an error: {error.error}")
-
-        next_service = self._next_service()
-        if next_service is None:
+        if len(self._services) <= 1:
             logger.error("No other service available to switch to")
             return None
 
-        return await self._set_active_if_available(next_service)
-
-    def _next_service(self) -> Optional[FrameProcessor]:
-        """Find the next service in the list after the active one.
-
-        Returns:
-            The next service, or None if there is only one service.
-        """
-        if len(self._services) <= 1:
-            return None
         current_idx = self._services.index(self._active_service)
         next_idx = (current_idx + 1) % len(self._services)
-        return self._services[next_idx]
+        return await self._set_active_if_available(self._services[next_idx])
 
 
 StrategyType = TypeVar("StrategyType", bound=ServiceSwitcherStrategy)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -130,11 +130,7 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
 
     .. deprecated:: 0.0.104
         Manual switching is now the default behavior of ``ServiceSwitcher``.
-        Pass ``services`` without a ``strategy_type`` instead.
-
-    Example::
-
-        stt_switcher = ServiceSwitcher(services=[stt_1, stt_2])
+        Omit ``strategy_type`` when initializing.
     """
 
     def __init__(self, services: List[FrameProcessor]):
@@ -225,7 +221,7 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         Args:
             services: List of frame processors to switch between.
             strategy_type: The strategy class to use for switching between services.
-                Defaults to ``ServiceSwitcherStrategy`` (manual switching).
+                Defaults to ``ServiceSwitcherStrategy`` (the base strategy; manual switching only).
         """
         _strategy = strategy_type(services)
         super().__init__(*self._make_pipeline_definitions(services, _strategy))

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -117,6 +117,7 @@ class ServiceSwitcherStrategy(BaseObject):
         """
         if service in self.services:
             self._active_service = service
+            await service.queue_frame(ServiceSwitcherRequestMetadataFrame(service=service))
             await self._call_event_handler("on_service_switched", service)
             return service
         return None
@@ -313,9 +314,7 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
 
         # Let the strategy react to non-fatal errors from the active service.
         if isinstance(frame, ErrorFrame) and not frame.fatal:
-            service = await self.strategy.handle_error(frame)
-            if service:
-                await service.queue_frame(ServiceSwitcherRequestMetadataFrame(service=service))
+            await self.strategy.handle_error(frame)
 
         await super().push_frame(frame, direction)
 
@@ -333,9 +332,5 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
             # frame. If we switched, we just swallow the frame.
             if not service:
                 await super().process_frame(frame, direction)
-
-            # If we switched to a new service, request its metadata.
-            if service:
-                await service.queue_frame(ServiceSwitcherRequestMetadataFrame(service=service))
         else:
             await super().process_frame(frame, direction)

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -6,7 +6,6 @@
 
 """Service switcher for switching between different services at runtime, with different switching strategies."""
 
-from abc import abstractmethod
 from typing import Any, Generic, List, Optional, Type, TypeVar
 
 from loguru import logger
@@ -72,13 +71,14 @@ class ServiceSwitcherStrategy(BaseObject):
         """Return the currently active service."""
         return self._active_service
 
-    @abstractmethod
     async def handle_frame(
         self, frame: ServiceSwitcherFrame, direction: FrameDirection
     ) -> Optional[FrameProcessor]:
         """Handle a frame that controls service switching.
 
-        Subclasses implement this to decide whether a switch should occur.
+        By default, handles ``ManuallySwitchServiceFrame`` to allow manual
+        switching in all strategies. Subclasses can override this to handle
+        additional frame types.
 
         Args:
             frame: The frame to handle.
@@ -87,7 +87,9 @@ class ServiceSwitcherStrategy(BaseObject):
         Returns:
             The newly active service if a switch occurred, or None otherwise.
         """
-        pass
+        if isinstance(frame, ManuallySwitchServiceFrame):
+            return await self._set_active_if_available(frame.service)
+        return None
 
     async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
         """Handle an error from the active service.
@@ -102,38 +104,6 @@ class ServiceSwitcherStrategy(BaseObject):
         Returns:
             The newly active service if a switch occurred, or None otherwise.
         """
-        return None
-
-
-class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
-    """A strategy for switching between services manually.
-
-    This strategy allows the user to manually select which service is active.
-    The initial active service is the first one in the list.
-
-    Example::
-
-        stt_switcher = ServiceSwitcher(
-            services=[stt_1, stt_2],
-            strategy_type=ServiceSwitcherStrategyManual
-        )
-    """
-
-    async def handle_frame(
-        self, frame: ServiceSwitcherFrame, direction: FrameDirection
-    ) -> Optional[FrameProcessor]:
-        """Handle a frame that controls service switching.
-
-        Args:
-            frame: The frame to handle.
-            direction: The direction of the frame (upstream or downstream).
-
-        Returns:
-            The newly active service if a switch occurred, or None otherwise.
-        """
-        if isinstance(frame, ManuallySwitchServiceFrame):
-            return await self._set_active_if_available(frame.service)
-
         return None
 
     async def _set_active_if_available(self, service: FrameProcessor) -> Optional[FrameProcessor]:
@@ -153,6 +123,31 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
             await self._call_event_handler("on_service_switched", service)
             return service
         return None
+
+
+class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
+    """A strategy for switching between services manually.
+
+    .. deprecated:: 0.0.104
+        Manual switching is now the default behavior of ``ServiceSwitcher``.
+        Pass ``services`` without a ``strategy_type`` instead.
+
+    Example::
+
+        stt_switcher = ServiceSwitcher(services=[stt_1, stt_2])
+    """
+
+    def __init__(self, services: List[FrameProcessor]):
+        """Initialize the service switcher strategy for manual switching.
+
+        Args:
+            services: List of frame processors to switch between.
+        """
+        super().__init__(services)
+        logger.warning(
+            "ServiceSwitcherStrategyManual is deprecated. "
+            "Manual switching is now the default behavior of ServiceSwitcher."
+        )
 
 
 class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
@@ -180,32 +175,6 @@ class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
             # App decides when/how to recover the failed service
             ...
     """
-
-    def __init__(self, services: List[FrameProcessor]):
-        """Initialize the automatic service switcher strategy.
-
-        Args:
-            services: List of frame processors to switch between.
-        """
-        super().__init__(services)
-
-    async def handle_frame(
-        self, frame: ServiceSwitcherFrame, direction: FrameDirection
-    ) -> Optional[FrameProcessor]:
-        """Handle a frame that controls service switching.
-
-        Supports ``ManuallySwitchServiceFrame`` for explicit overrides.
-
-        Args:
-            frame: The frame to handle.
-            direction: The direction of the frame (upstream or downstream).
-
-        Returns:
-            The newly active service if a switch occurred, or None otherwise.
-        """
-        if isinstance(frame, ManuallySwitchServiceFrame):
-            return await self._set_active_if_available(frame.service)
-        return None
 
     async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
         """Handle an error from the active service by failing over.
@@ -244,21 +213,6 @@ class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
         next_idx = (current_idx + 1) % len(self._services)
         return self._services[next_idx]
 
-    async def _set_active_if_available(self, service: FrameProcessor) -> Optional[FrameProcessor]:
-        """Set the active service if it is in the service list.
-
-        Args:
-            service: The service to set as active.
-
-        Returns:
-            The newly active service, or None if the service was not found.
-        """
-        if service in self.services:
-            self._active_service = service
-            await self._call_event_handler("on_service_switched", service)
-            return service
-        return None
-
 
 StrategyType = TypeVar("StrategyType", bound=ServiceSwitcherStrategy)
 
@@ -273,18 +227,20 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
 
     Example::
 
-        switcher = ServiceSwitcher(
-            services=[stt_1, stt_2],
-            strategy_type=ServiceSwitcherStrategyManual,
-        )
+        switcher = ServiceSwitcher(services=[stt_1, stt_2])
     """
 
-    def __init__(self, services: List[FrameProcessor], strategy_type: Type[StrategyType]):
+    def __init__(
+        self,
+        services: List[FrameProcessor],
+        strategy_type: Type[StrategyType] = ServiceSwitcherStrategy,
+    ):
         """Initialize the service switcher with a list of services and a switching strategy.
 
         Args:
             services: List of frame processors to switch between.
             strategy_type: The strategy class to use for switching between services.
+                Defaults to ``ServiceSwitcherStrategy`` (manual switching).
         """
         _strategy = strategy_type(services)
         super().__init__(*self._make_pipeline_definitions(services, _strategy))

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -6,10 +6,14 @@
 
 """Service switcher for switching between different services at runtime, with different switching strategies."""
 
+import asyncio
 from abc import abstractmethod
-from typing import Any, Generic, List, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Set, Type, TypeVar
+
+from loguru import logger
 
 from pipecat.frames.frames import (
+    ErrorFrame,
     Frame,
     ManuallySwitchServiceFrame,
     ServiceMetadataFrame,
@@ -86,6 +90,21 @@ class ServiceSwitcherStrategy(BaseObject):
         """
         pass
 
+    async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
+        """Handle an error from the active service.
+
+        Called by ``ServiceSwitcher`` when a non-fatal ``ErrorFrame`` is pushed
+        upstream by the currently active service. Subclasses can override this
+        to implement automatic failover.
+
+        Args:
+            error: The error frame pushed by the active service.
+
+        Returns:
+            The newly active service if a switch occurred, or None otherwise.
+        """
+        return None
+
 
 class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
     """A strategy for switching between services manually.
@@ -123,6 +142,172 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
 
         If it's not in the list, the request is ignored, as it may have been
         intended for another ServiceSwitcher in the pipeline.
+
+        Args:
+            service: The service to set as active.
+
+        Returns:
+            The newly active service, or None if the service was not found.
+        """
+        if service in self.services:
+            self._active_service = service
+            await self._call_event_handler("on_service_switched", service)
+            return service
+        return None
+
+
+class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
+    """A strategy that automatically switches to a backup service on failure.
+
+    When the active service produces a non-fatal error, this strategy marks it
+    as unhealthy and switches to the next healthy service in the list. After a
+    configurable recovery period the unhealthy service is marked healthy again.
+    If ``prefer_primary`` is enabled (the default) and the primary service
+    recovers, the strategy switches back to it automatically.
+
+    Manual switching via ``ManuallySwitchServiceFrame`` is still supported.
+
+    Event handlers available:
+
+    - on_service_switched: Called when the active service changes.
+
+    Example::
+
+        switcher = ServiceSwitcher(
+            services=[primary_stt, backup_stt],
+            strategy_type=ServiceSwitcherStrategyAutomatic,
+        )
+
+        # Optionally customise parameters after construction:
+        switcher.strategy.recovery_timeout = 60.0
+        switcher.strategy.prefer_primary = False
+    """
+
+    def __init__(self, services: List[FrameProcessor]):
+        """Initialize the automatic service switcher strategy.
+
+        Args:
+            services: List of frame processors to switch between.
+                The first service is the primary.
+        """
+        super().__init__(services)
+        self._primary_service: FrameProcessor = services[0]
+        self._unhealthy_services: Set[FrameProcessor] = set()
+        self._recovery_timers: Dict[FrameProcessor, asyncio.TimerHandle] = {}
+
+        self.recovery_timeout: float = 30.0
+        """Seconds before an unhealthy service is marked healthy again."""
+
+        self.prefer_primary: bool = True
+        """When True, automatically switch back to the primary once it recovers."""
+
+    @property
+    def unhealthy_services(self) -> Set[FrameProcessor]:
+        """Return the set of services currently marked as unhealthy."""
+        return set(self._unhealthy_services)
+
+    async def handle_frame(
+        self, frame: ServiceSwitcherFrame, direction: FrameDirection
+    ) -> Optional[FrameProcessor]:
+        """Handle a frame that controls service switching.
+
+        Supports ``ManuallySwitchServiceFrame`` for explicit overrides.
+
+        Args:
+            frame: The frame to handle.
+            direction: The direction of the frame (upstream or downstream).
+
+        Returns:
+            The newly active service if a switch occurred, or None otherwise.
+        """
+        if isinstance(frame, ManuallySwitchServiceFrame):
+            return await self._set_active_if_available(frame.service)
+        return None
+
+    async def handle_error(self, error: ErrorFrame) -> Optional[FrameProcessor]:
+        """Handle an error from the active service by failing over.
+
+        Marks the active service as unhealthy, schedules a recovery timer,
+        and switches to the next healthy service in the list.
+
+        Args:
+            error: The error frame pushed by the active service.
+
+        Returns:
+            The newly active service if a switch occurred, or None if no
+            healthy backup is available.
+        """
+        failed_service = self._active_service
+
+        logger.warning(
+            f"Service {failed_service.name} reported an error, marking unhealthy: {error.error}"
+        )
+
+        self._unhealthy_services.add(failed_service)
+        self._schedule_recovery(failed_service)
+
+        next_service = self._next_healthy_service()
+        if next_service is None:
+            logger.error("All services are unhealthy, no backup available")
+            return None
+
+        return await self._set_active_if_available(next_service)
+
+    def _next_healthy_service(self) -> Optional[FrameProcessor]:
+        """Find the next healthy service in the list.
+
+        Searches from the beginning of the service list so that
+        higher-priority services are preferred.
+
+        Returns:
+            The next healthy service, or None if all are unhealthy.
+        """
+        for service in self._services:
+            if service not in self._unhealthy_services:
+                return service
+        return None
+
+    def _schedule_recovery(self, service: FrameProcessor):
+        """Schedule a recovery timer for an unhealthy service.
+
+        If a timer is already running for this service it is cancelled and
+        restarted so that repeated errors extend the cooldown.
+
+        Args:
+            service: The service to schedule recovery for.
+        """
+        existing = self._recovery_timers.pop(service, None)
+        if existing is not None:
+            existing.cancel()
+
+        loop = asyncio.get_event_loop()
+        handle = loop.call_later(
+            self.recovery_timeout,
+            lambda s=service: asyncio.ensure_future(self._recover_service(s)),
+        )
+        self._recovery_timers[service] = handle
+
+    async def _recover_service(self, service: FrameProcessor):
+        """Mark a service as healthy after its recovery timeout expires.
+
+        If ``prefer_primary`` is enabled and the recovered service is the
+        primary, the strategy switches back to it automatically.
+
+        Args:
+            service: The service that has recovered.
+        """
+        self._unhealthy_services.discard(service)
+        self._recovery_timers.pop(service, None)
+
+        logger.info(f"Service {service.name} marked healthy after recovery timeout")
+
+        if self.prefer_primary and service == self._primary_service:
+            if self._active_service != self._primary_service:
+                logger.info(f"Switching back to primary service {service.name}")
+                await self._set_active_if_available(self._primary_service)
+
+    async def _set_active_if_available(self, service: FrameProcessor) -> Optional[FrameProcessor]:
+        """Set the active service if it is in the service list.
 
         Args:
             service: The service to set as active.
@@ -227,6 +412,10 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         all the filters let it pass, and `StartFrame` causes the service to
         generate `ServiceMetadataFrame`.
 
+        Non-fatal ``ErrorFrame`` instances are forwarded to the strategy via
+        ``handle_error`` so strategies like ``ServiceSwitcherStrategyAutomatic``
+        can perform failover. The error frame is still propagated upstream so
+        that application-level error handlers can observe it.
         """
         # Consume ServiceSwitcherRequestMetadataFrame once the targeted service
         # has handled it (i.e. the active service).
@@ -238,6 +427,12 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         if isinstance(frame, ServiceMetadataFrame):
             if frame.service_name != self.strategy.active_service.name:
                 return
+
+        # Let the strategy react to non-fatal errors from the active service.
+        if isinstance(frame, ErrorFrame) and not frame.fatal:
+            service = await self.strategy.handle_error(frame)
+            if service:
+                await service.queue_frame(ServiceSwitcherRequestMetadataFrame(service=service))
 
         await super().push_frame(frame, direction)
 

--- a/src/pipecat/pipeline/service_switcher.py
+++ b/src/pipecat/pipeline/service_switcher.py
@@ -155,7 +155,7 @@ class ServiceSwitcherStrategyManual(ServiceSwitcherStrategy):
         return None
 
 
-class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
+class ServiceSwitcherStrategyFailover(ServiceSwitcherStrategy):
     """A strategy that automatically switches to a backup service on failure.
 
     When the active service produces a non-fatal error, this strategy switches
@@ -172,7 +172,7 @@ class ServiceSwitcherStrategyAutomatic(ServiceSwitcherStrategy):
 
         switcher = ServiceSwitcher(
             services=[primary_stt, backup_stt],
-            strategy_type=ServiceSwitcherStrategyAutomatic,
+            strategy_type=ServiceSwitcherStrategyFailover,
         )
 
         @switcher.strategy.event_handler("on_service_switched")
@@ -351,7 +351,7 @@ class ServiceSwitcher(ParallelPipeline, Generic[StrategyType]):
         generate `ServiceMetadataFrame`.
 
         Non-fatal ``ErrorFrame`` instances are forwarded to the strategy via
-        ``handle_error`` so strategies like ``ServiceSwitcherStrategyAutomatic``
+        ``handle_error`` so strategies like ``ServiceSwitcherStrategyFailover``
         can perform failover. The error frame is still propagated upstream so
         that application-level error handlers can observe it.
         """

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -23,6 +23,7 @@ from pipecat.frames.frames import (
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.service_switcher import (
     ServiceSwitcher,
+    ServiceSwitcherStrategy,
     ServiceSwitcherStrategyFailover,
     ServiceSwitcherStrategyManual,
 )
@@ -111,8 +112,8 @@ class DummySystemFrame(SystemFrame):
     text: str = ""
 
 
-class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
-    """Test cases for ServiceSwitcherStrategyManual."""
+class TestServiceSwitcherStrategy(unittest.IsolatedAsyncioTestCase):
+    """Test cases for the base ServiceSwitcherStrategy."""
 
     def setUp(self):
         """Set up test fixtures."""
@@ -123,38 +124,31 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
 
     def test_init_with_services(self):
         """Test initialization with a list of services."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
+        strategy = ServiceSwitcherStrategy(self.services)
 
         self.assertEqual(strategy.services, self.services)
-        self.assertEqual(strategy.active_service, self.service1)  # First service should be active
+        self.assertEqual(strategy.active_service, self.service1)
 
     async def test_handle_manually_switch_service_frame(self):
         """Test manual service switching with ManuallySwitchServiceFrame."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
+        strategy = ServiceSwitcherStrategy(self.services)
 
         # Initially service1 should be active
         self.assertEqual(strategy.active_service, self.service1)
-        self.assertNotEqual(strategy.active_service, self.service2)
 
         # Switch to service2
         switch_frame = ManuallySwitchServiceFrame(service=self.service2)
         await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-
-        self.assertNotEqual(strategy.active_service, self.service1)
         self.assertEqual(strategy.active_service, self.service2)
-        self.assertNotEqual(strategy.active_service, self.service3)
 
         # Switch to service3
         switch_frame = ManuallySwitchServiceFrame(service=self.service3)
         await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-
-        self.assertNotEqual(strategy.active_service, self.service1)
-        self.assertNotEqual(strategy.active_service, self.service2)
         self.assertEqual(strategy.active_service, self.service3)
 
     async def test_on_service_switched_event(self):
         """Test that on_service_switched event fires with correct arguments."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
+        strategy = ServiceSwitcherStrategy(self.services)
 
         switched_events = []
 
@@ -162,26 +156,17 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
         async def on_service_switched(strategy, service):
             switched_events.append((strategy, service))
 
-        # Switch to service2
         switch_frame = ManuallySwitchServiceFrame(service=self.service2)
-        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-        await asyncio.sleep(0)  # Let async event task run
-
-        self.assertEqual(len(switched_events), 1)
-        self.assertIsInstance(switched_events[0][0], ServiceSwitcherStrategyManual)
-        self.assertEqual(switched_events[0][1], self.service2)
-
-        # Switch to service3
-        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
         await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
         await asyncio.sleep(0)
 
-        self.assertEqual(len(switched_events), 2)
-        self.assertEqual(switched_events[1][1], self.service3)
+        self.assertEqual(len(switched_events), 1)
+        self.assertIsInstance(switched_events[0][0], ServiceSwitcherStrategy)
+        self.assertEqual(switched_events[0][1], self.service2)
 
     async def test_on_service_switched_event_not_fired_for_unknown_service(self):
         """Test that on_service_switched event does not fire for services not in the list."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
+        strategy = ServiceSwitcherStrategy(self.services)
 
         switched_events = []
 
@@ -189,23 +174,41 @@ class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
         async def on_service_switched(strategy, service):
             switched_events.append(service)
 
-        # Try switching to a service not in the list
         unknown_service = MockFrameProcessor("unknown")
         switch_frame = ManuallySwitchServiceFrame(service=unknown_service)
         await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
         await asyncio.sleep(0)
 
         self.assertEqual(len(switched_events), 0)
-        self.assertEqual(strategy.active_service, self.service1)  # Unchanged
+        self.assertEqual(strategy.active_service, self.service1)
 
     async def test_handle_frame_unsupported_frame_type(self):
-        """Test that unsupported frame types raise an error."""
-        strategy = ServiceSwitcherStrategyManual(self.services)
-        unsupported_frame = TextFrame(text="test")  # Not a ServiceSwitcherFrame
+        """Test that unsupported frame types return None."""
+        strategy = ServiceSwitcherStrategy(self.services)
+        unsupported_frame = TextFrame(text="test")
 
         result = await strategy.handle_frame(unsupported_frame, FrameDirection.DOWNSTREAM)
 
         self.assertIsNone(result)
+
+    async def test_handle_error_returns_none(self):
+        """Test that handle_error returns None by default."""
+        strategy = ServiceSwitcherStrategy(self.services)
+
+        result = await strategy.handle_error(ErrorFrame(error="error"))
+
+        self.assertIsNone(result)
+        self.assertEqual(strategy.active_service, self.service1)
+
+
+class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
+    """Test cases for ServiceSwitcherStrategyManual (deprecated)."""
+
+    def test_is_subclass_of_base_strategy(self):
+        """Test that ServiceSwitcherStrategyManual is a subclass of ServiceSwitcherStrategy."""
+        service = MockFrameProcessor("service1")
+        strategy = ServiceSwitcherStrategyManual([service])
+        self.assertIsInstance(strategy, ServiceSwitcherStrategy)
 
 
 class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
@@ -218,17 +221,17 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         self.service3 = MockFrameProcessor("service3")
         self.services = [self.service1, self.service2, self.service3]
 
-    def test_init_with_manual_strategy(self):
-        """Test initialization with manual strategy."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+    def test_init_with_default_strategy(self):
+        """Test initialization with default strategy."""
+        switcher = ServiceSwitcher(self.services)
 
         self.assertEqual(switcher.services, self.services)
-        self.assertIsInstance(switcher.strategy, ServiceSwitcherStrategyManual)
+        self.assertIsInstance(switcher.strategy, ServiceSwitcherStrategy)
         self.assertEqual(switcher.strategy.services, self.services)
 
     async def test_default_active_service(self):
         """Test that the initially-active service receives frames while others don't."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+        switcher = ServiceSwitcher(self.services)
 
         # Reset counters
         for service in self.services:
@@ -297,7 +300,7 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
 
     async def test_service_switching(self):
         """Test that after service switching using ManuallySwitchServiceFrame, the new active service receives frames while others don't."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+        switcher = ServiceSwitcher(self.services)
 
         # Reset counters
         for service in self.services:
@@ -346,8 +349,8 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         switcher2_services = [switcher2_service1, switcher2_service2]
 
         # Create two service switchers
-        switcher1 = ServiceSwitcher(switcher1_services, ServiceSwitcherStrategyManual)
-        switcher2 = ServiceSwitcher(switcher2_services, ServiceSwitcherStrategyManual)
+        switcher1 = ServiceSwitcher(switcher1_services)
+        switcher2 = ServiceSwitcher(switcher2_services)
 
         # Create a pipeline with both switchers: switcher1 -> switcher2
         pipeline = Pipeline([switcher1, switcher2])
@@ -433,7 +436,7 @@ class TestServiceSwitcherMetadata(unittest.IsolatedAsyncioTestCase):
 
     async def test_only_active_service_metadata_at_startup(self):
         """Test that only the active service's metadata leaves the ServiceSwitcher at startup."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+        switcher = ServiceSwitcher(self.services)
 
         # Run the pipeline (StartFrame triggers metadata emission)
         output_frames = []
@@ -455,7 +458,7 @@ class TestServiceSwitcherMetadata(unittest.IsolatedAsyncioTestCase):
 
     async def test_metadata_emitted_on_service_switch(self):
         """Test that switching services triggers metadata emission from the new active service."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+        switcher = ServiceSwitcher(self.services)
 
         # Reset counters after startup
         self.service1.reset_counters()
@@ -487,7 +490,7 @@ class TestServiceSwitcherMetadata(unittest.IsolatedAsyncioTestCase):
 
     async def test_inactive_service_metadata_blocked(self):
         """Test that metadata from inactive services is blocked."""
-        switcher = ServiceSwitcher(self.services, ServiceSwitcherStrategyManual)
+        switcher = ServiceSwitcher(self.services)
 
         # Run and collect output frames
         await run_test(

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -129,60 +129,17 @@ class TestServiceSwitcherStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(strategy.services, self.services)
         self.assertEqual(strategy.active_service, self.service1)
 
-    async def test_handle_manually_switch_service_frame(self):
-        """Test manual service switching with ManuallySwitchServiceFrame."""
+    async def test_handle_frame_returns_none_for_manual_switch(self):
+        """Test that base strategy does not handle ManuallySwitchServiceFrame."""
         strategy = ServiceSwitcherStrategy(self.services)
-
-        # Initially service1 should be active
-        self.assertEqual(strategy.active_service, self.service1)
-
-        # Switch to service2
-        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
-        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-        self.assertEqual(strategy.active_service, self.service2)
-
-        # Switch to service3
-        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
-        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-        self.assertEqual(strategy.active_service, self.service3)
-
-    async def test_on_service_switched_event(self):
-        """Test that on_service_switched event fires with correct arguments."""
-        strategy = ServiceSwitcherStrategy(self.services)
-
-        switched_events = []
-
-        @strategy.event_handler("on_service_switched")
-        async def on_service_switched(strategy, service):
-            switched_events.append((strategy, service))
 
         switch_frame = ManuallySwitchServiceFrame(service=self.service2)
-        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-        await asyncio.sleep(0)
+        result = await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
 
-        self.assertEqual(len(switched_events), 1)
-        self.assertIsInstance(switched_events[0][0], ServiceSwitcherStrategy)
-        self.assertEqual(switched_events[0][1], self.service2)
-
-    async def test_on_service_switched_event_not_fired_for_unknown_service(self):
-        """Test that on_service_switched event does not fire for services not in the list."""
-        strategy = ServiceSwitcherStrategy(self.services)
-
-        switched_events = []
-
-        @strategy.event_handler("on_service_switched")
-        async def on_service_switched(strategy, service):
-            switched_events.append(service)
-
-        unknown_service = MockFrameProcessor("unknown")
-        switch_frame = ManuallySwitchServiceFrame(service=unknown_service)
-        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
-        await asyncio.sleep(0)
-
-        self.assertEqual(len(switched_events), 0)
+        self.assertIsNone(result)
         self.assertEqual(strategy.active_service, self.service1)
 
-    async def test_handle_frame_unsupported_frame_type(self):
+    async def test_handle_frame_returns_none_for_unsupported_frame(self):
         """Test that unsupported frame types return None."""
         strategy = ServiceSwitcherStrategy(self.services)
         unsupported_frame = TextFrame(text="test")
@@ -202,13 +159,73 @@ class TestServiceSwitcherStrategy(unittest.IsolatedAsyncioTestCase):
 
 
 class TestServiceSwitcherStrategyManual(unittest.IsolatedAsyncioTestCase):
-    """Test cases for ServiceSwitcherStrategyManual (deprecated)."""
+    """Test cases for ServiceSwitcherStrategyManual."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.service1 = MockFrameProcessor("service1")
+        self.service2 = MockFrameProcessor("service2")
+        self.service3 = MockFrameProcessor("service3")
+        self.services = [self.service1, self.service2, self.service3]
 
     def test_is_subclass_of_base_strategy(self):
         """Test that ServiceSwitcherStrategyManual is a subclass of ServiceSwitcherStrategy."""
-        service = MockFrameProcessor("service1")
-        strategy = ServiceSwitcherStrategyManual([service])
+        strategy = ServiceSwitcherStrategyManual(self.services)
         self.assertIsInstance(strategy, ServiceSwitcherStrategy)
+
+    async def test_handle_manually_switch_service_frame(self):
+        """Test manual service switching with ManuallySwitchServiceFrame."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        # Initially service1 should be active
+        self.assertEqual(strategy.active_service, self.service1)
+
+        # Switch to service2
+        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
+        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # Switch to service3
+        switch_frame = ManuallySwitchServiceFrame(service=self.service3)
+        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+        self.assertEqual(strategy.active_service, self.service3)
+
+    async def test_on_service_switched_event(self):
+        """Test that on_service_switched event fires with correct arguments."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        switched_events = []
+
+        @strategy.event_handler("on_service_switched")
+        async def on_service_switched(strategy, service):
+            switched_events.append((strategy, service))
+
+        switch_frame = ManuallySwitchServiceFrame(service=self.service2)
+        await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+        await asyncio.sleep(0)
+
+        self.assertEqual(len(switched_events), 1)
+        self.assertIsInstance(switched_events[0][0], ServiceSwitcherStrategyManual)
+        self.assertEqual(switched_events[0][1], self.service2)
+
+    async def test_unknown_service_ignored(self):
+        """Test that switching to an unknown service is ignored."""
+        strategy = ServiceSwitcherStrategyManual(self.services)
+
+        switched_events = []
+
+        @strategy.event_handler("on_service_switched")
+        async def on_service_switched(strategy, service):
+            switched_events.append(service)
+
+        unknown_service = MockFrameProcessor("unknown")
+        switch_frame = ManuallySwitchServiceFrame(service=unknown_service)
+        result = await strategy.handle_frame(switch_frame, FrameDirection.DOWNSTREAM)
+        await asyncio.sleep(0)
+
+        self.assertIsNone(result)
+        self.assertEqual(len(switched_events), 0)
+        self.assertEqual(strategy.active_service, self.service1)
 
 
 class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
@@ -226,7 +243,7 @@ class TestServiceSwitcher(unittest.IsolatedAsyncioTestCase):
         switcher = ServiceSwitcher(self.services)
 
         self.assertEqual(switcher.services, self.services)
-        self.assertIsInstance(switcher.strategy, ServiceSwitcherStrategy)
+        self.assertIsInstance(switcher.strategy, ServiceSwitcherStrategyManual)
         self.assertEqual(switcher.strategy.services, self.services)
 
     async def test_default_active_service(self):

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -515,14 +515,10 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
     def test_init_defaults(self):
         """Test that default values are set correctly."""
         strategy = ServiceSwitcherStrategyAutomatic(self.services)
-
         self.assertEqual(strategy.active_service, self.service1)
-        self.assertEqual(strategy.recovery_timeout, 30.0)
-        self.assertTrue(strategy.prefer_primary)
-        self.assertEqual(len(strategy.unhealthy_services), 0)
 
-    async def test_error_switches_to_next_healthy_service(self):
-        """Test that an error on the active service switches to the next healthy one."""
+    async def test_error_switches_to_next_service(self):
+        """Test that an error on the active service switches to the next one."""
         strategy = ServiceSwitcherStrategyAutomatic(self.services)
 
         error = ErrorFrame(error="connection lost")
@@ -530,10 +526,9 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, self.service2)
         self.assertEqual(strategy.active_service, self.service2)
-        self.assertIn(self.service1, strategy.unhealthy_services)
 
-    async def test_consecutive_errors_cascade_through_services(self):
-        """Test that repeated errors cascade through all backup services."""
+    async def test_consecutive_errors_cycle_through_services(self):
+        """Test that repeated errors cycle through all services."""
         strategy = ServiceSwitcherStrategyAutomatic(self.services)
 
         # First error: service1 -> service2
@@ -544,62 +539,16 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
         await strategy.handle_error(ErrorFrame(error="error 2"))
         self.assertEqual(strategy.active_service, self.service3)
 
-        self.assertIn(self.service1, strategy.unhealthy_services)
-        self.assertIn(self.service2, strategy.unhealthy_services)
-
-    async def test_all_services_unhealthy_returns_none(self):
-        """Test that handle_error returns None when all services are unhealthy."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-
-        await strategy.handle_error(ErrorFrame(error="error 1"))
-        await strategy.handle_error(ErrorFrame(error="error 2"))
-        result = await strategy.handle_error(ErrorFrame(error="error 3"))
-
-        self.assertIsNone(result)
-        self.assertEqual(len(strategy.unhealthy_services), 3)
-
-    async def test_recovery_marks_service_healthy(self):
-        """Test that a service is marked healthy after recovery timeout."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-        strategy.recovery_timeout = 0.05  # 50ms for fast test
-
-        await strategy.handle_error(ErrorFrame(error="error"))
-        self.assertIn(self.service1, strategy.unhealthy_services)
-
-        # Wait for recovery
-        await asyncio.sleep(0.1)
-
-        self.assertNotIn(self.service1, strategy.unhealthy_services)
-
-    async def test_recovery_switches_back_to_primary(self):
-        """Test that recovery switches back to the primary when prefer_primary is True."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-        strategy.recovery_timeout = 0.05
-        strategy.prefer_primary = True
-
-        await strategy.handle_error(ErrorFrame(error="error"))
-        self.assertEqual(strategy.active_service, self.service2)
-
-        # Wait for recovery
-        await asyncio.sleep(0.1)
-
+        # Third error: service3 -> service1 (wraps around)
+        await strategy.handle_error(ErrorFrame(error="error 3"))
         self.assertEqual(strategy.active_service, self.service1)
 
-    async def test_recovery_does_not_switch_when_prefer_primary_is_false(self):
-        """Test that recovery does not switch back when prefer_primary is False."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-        strategy.recovery_timeout = 0.05
-        strategy.prefer_primary = False
+    async def test_single_service_returns_none(self):
+        """Test that handle_error returns None with only one service."""
+        strategy = ServiceSwitcherStrategyAutomatic([self.service1])
 
-        await strategy.handle_error(ErrorFrame(error="error"))
-        self.assertEqual(strategy.active_service, self.service2)
-
-        # Wait for recovery
-        await asyncio.sleep(0.1)
-
-        # Service1 is healthy again but we stay on service2
-        self.assertNotIn(self.service1, strategy.unhealthy_services)
-        self.assertEqual(strategy.active_service, self.service2)
+        result = await strategy.handle_error(ErrorFrame(error="error"))
+        self.assertIsNone(result)
 
     async def test_manual_switch_still_works(self):
         """Test that ManuallySwitchServiceFrame is still handled."""
@@ -626,43 +575,6 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(switched_events), 1)
         self.assertEqual(switched_events[0], self.service2)
-
-    async def test_repeated_errors_extend_recovery_cooldown(self):
-        """Test that repeated errors on the same service restart the recovery timer."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-        strategy.recovery_timeout = 0.1
-
-        # First error on service1
-        await strategy.handle_error(ErrorFrame(error="error 1"))
-        self.assertEqual(strategy.active_service, self.service2)
-
-        # Wait a bit, then trigger another error on service2
-        await asyncio.sleep(0.05)
-
-        # Manually mark service1 healthy and switch back to test re-error
-        strategy._unhealthy_services.discard(self.service1)
-        strategy._active_service = self.service1
-
-        # Error again on service1, should restart recovery timer
-        await strategy.handle_error(ErrorFrame(error="error 2"))
-        self.assertEqual(strategy.active_service, self.service2)
-
-        # After 0.05s, service1 should still be unhealthy (timer restarted)
-        await asyncio.sleep(0.05)
-        self.assertIn(self.service1, strategy.unhealthy_services)
-
-        # After full timeout from second error, should be healthy
-        await asyncio.sleep(0.1)
-        self.assertNotIn(self.service1, strategy.unhealthy_services)
-
-    async def test_healthy_services_preferred_by_priority(self):
-        """Test that higher-priority (earlier in list) healthy services are preferred."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
-
-        # Mark service1 unhealthy
-        await strategy.handle_error(ErrorFrame(error="error"))
-        # Should pick service2 (next in list), not service3
-        self.assertEqual(strategy.active_service, self.service2)
 
 
 if __name__ == "__main__":

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -11,6 +11,7 @@ import unittest
 from dataclasses import dataclass
 
 from pipecat.frames.frames import (
+    ErrorFrame,
     Frame,
     ManuallySwitchServiceFrame,
     ServiceMetadataFrame,
@@ -20,7 +21,11 @@ from pipecat.frames.frames import (
     TextFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.service_switcher import ServiceSwitcher, ServiceSwitcherStrategyManual
+from pipecat.pipeline.service_switcher import (
+    ServiceSwitcher,
+    ServiceSwitcherStrategyAutomatic,
+    ServiceSwitcherStrategyManual,
+)
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.tests.utils import run_test
 
@@ -495,6 +500,169 @@ class TestServiceSwitcherMetadata(unittest.IsolatedAsyncioTestCase):
         # service2 pushed metadata on StartFrame, but it should have been blocked
         self.assertGreaterEqual(self.service2.metadata_push_count, 1)
         # Only one MockMetadataFrame should have left (from service1)
+
+
+class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
+    """Test cases for ServiceSwitcherStrategyAutomatic."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.service1 = MockFrameProcessor("service1")
+        self.service2 = MockFrameProcessor("service2")
+        self.service3 = MockFrameProcessor("service3")
+        self.services = [self.service1, self.service2, self.service3]
+
+    def test_init_defaults(self):
+        """Test that default values are set correctly."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        self.assertEqual(strategy.active_service, self.service1)
+        self.assertEqual(strategy.recovery_timeout, 30.0)
+        self.assertTrue(strategy.prefer_primary)
+        self.assertEqual(len(strategy.unhealthy_services), 0)
+
+    async def test_error_switches_to_next_healthy_service(self):
+        """Test that an error on the active service switches to the next healthy one."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        error = ErrorFrame(error="connection lost")
+        result = await strategy.handle_error(error)
+
+        self.assertEqual(result, self.service2)
+        self.assertEqual(strategy.active_service, self.service2)
+        self.assertIn(self.service1, strategy.unhealthy_services)
+
+    async def test_consecutive_errors_cascade_through_services(self):
+        """Test that repeated errors cascade through all backup services."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        # First error: service1 -> service2
+        await strategy.handle_error(ErrorFrame(error="error 1"))
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # Second error: service2 -> service3
+        await strategy.handle_error(ErrorFrame(error="error 2"))
+        self.assertEqual(strategy.active_service, self.service3)
+
+        self.assertIn(self.service1, strategy.unhealthy_services)
+        self.assertIn(self.service2, strategy.unhealthy_services)
+
+    async def test_all_services_unhealthy_returns_none(self):
+        """Test that handle_error returns None when all services are unhealthy."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        await strategy.handle_error(ErrorFrame(error="error 1"))
+        await strategy.handle_error(ErrorFrame(error="error 2"))
+        result = await strategy.handle_error(ErrorFrame(error="error 3"))
+
+        self.assertIsNone(result)
+        self.assertEqual(len(strategy.unhealthy_services), 3)
+
+    async def test_recovery_marks_service_healthy(self):
+        """Test that a service is marked healthy after recovery timeout."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy.recovery_timeout = 0.05  # 50ms for fast test
+
+        await strategy.handle_error(ErrorFrame(error="error"))
+        self.assertIn(self.service1, strategy.unhealthy_services)
+
+        # Wait for recovery
+        await asyncio.sleep(0.1)
+
+        self.assertNotIn(self.service1, strategy.unhealthy_services)
+
+    async def test_recovery_switches_back_to_primary(self):
+        """Test that recovery switches back to the primary when prefer_primary is True."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy.recovery_timeout = 0.05
+        strategy.prefer_primary = True
+
+        await strategy.handle_error(ErrorFrame(error="error"))
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # Wait for recovery
+        await asyncio.sleep(0.1)
+
+        self.assertEqual(strategy.active_service, self.service1)
+
+    async def test_recovery_does_not_switch_when_prefer_primary_is_false(self):
+        """Test that recovery does not switch back when prefer_primary is False."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy.recovery_timeout = 0.05
+        strategy.prefer_primary = False
+
+        await strategy.handle_error(ErrorFrame(error="error"))
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # Wait for recovery
+        await asyncio.sleep(0.1)
+
+        # Service1 is healthy again but we stay on service2
+        self.assertNotIn(self.service1, strategy.unhealthy_services)
+        self.assertEqual(strategy.active_service, self.service2)
+
+    async def test_manual_switch_still_works(self):
+        """Test that ManuallySwitchServiceFrame is still handled."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        frame = ManuallySwitchServiceFrame(service=self.service3)
+        result = await strategy.handle_frame(frame, FrameDirection.DOWNSTREAM)
+
+        self.assertEqual(result, self.service3)
+        self.assertEqual(strategy.active_service, self.service3)
+
+    async def test_on_service_switched_event_fires_on_error(self):
+        """Test that on_service_switched event fires when an error triggers a switch."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        switched_events = []
+
+        @strategy.event_handler("on_service_switched")
+        async def on_service_switched(strategy, service):
+            switched_events.append(service)
+
+        await strategy.handle_error(ErrorFrame(error="error"))
+        await asyncio.sleep(0)
+
+        self.assertEqual(len(switched_events), 1)
+        self.assertEqual(switched_events[0], self.service2)
+
+    async def test_repeated_errors_extend_recovery_cooldown(self):
+        """Test that repeated errors on the same service restart the recovery timer."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy.recovery_timeout = 0.1
+
+        # First error on service1
+        await strategy.handle_error(ErrorFrame(error="error 1"))
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # Wait a bit, then trigger another error on service2
+        await asyncio.sleep(0.05)
+
+        # Manually mark service1 healthy and switch back to test re-error
+        strategy._unhealthy_services.discard(self.service1)
+        strategy._active_service = self.service1
+
+        # Error again on service1, should restart recovery timer
+        await strategy.handle_error(ErrorFrame(error="error 2"))
+        self.assertEqual(strategy.active_service, self.service2)
+
+        # After 0.05s, service1 should still be unhealthy (timer restarted)
+        await asyncio.sleep(0.05)
+        self.assertIn(self.service1, strategy.unhealthy_services)
+
+        # After full timeout from second error, should be healthy
+        await asyncio.sleep(0.1)
+        self.assertNotIn(self.service1, strategy.unhealthy_services)
+
+    async def test_healthy_services_preferred_by_priority(self):
+        """Test that higher-priority (earlier in list) healthy services are preferred."""
+        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+
+        # Mark service1 unhealthy
+        await strategy.handle_error(ErrorFrame(error="error"))
+        # Should pick service2 (next in list), not service3
+        self.assertEqual(strategy.active_service, self.service2)
 
 
 if __name__ == "__main__":

--- a/tests/test_service_switcher.py
+++ b/tests/test_service_switcher.py
@@ -23,7 +23,7 @@ from pipecat.frames.frames import (
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.service_switcher import (
     ServiceSwitcher,
-    ServiceSwitcherStrategyAutomatic,
+    ServiceSwitcherStrategyFailover,
     ServiceSwitcherStrategyManual,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -502,8 +502,8 @@ class TestServiceSwitcherMetadata(unittest.IsolatedAsyncioTestCase):
         # Only one MockMetadataFrame should have left (from service1)
 
 
-class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
-    """Test cases for ServiceSwitcherStrategyAutomatic."""
+class TestServiceSwitcherStrategyFailover(unittest.IsolatedAsyncioTestCase):
+    """Test cases for ServiceSwitcherStrategyFailover."""
 
     def setUp(self):
         """Set up test fixtures."""
@@ -514,12 +514,12 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
     def test_init_defaults(self):
         """Test that default values are set correctly."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy = ServiceSwitcherStrategyFailover(self.services)
         self.assertEqual(strategy.active_service, self.service1)
 
     async def test_error_switches_to_next_service(self):
         """Test that an error on the active service switches to the next one."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy = ServiceSwitcherStrategyFailover(self.services)
 
         error = ErrorFrame(error="connection lost")
         result = await strategy.handle_error(error)
@@ -529,7 +529,7 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
     async def test_consecutive_errors_cycle_through_services(self):
         """Test that repeated errors cycle through all services."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy = ServiceSwitcherStrategyFailover(self.services)
 
         # First error: service1 -> service2
         await strategy.handle_error(ErrorFrame(error="error 1"))
@@ -545,14 +545,14 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
     async def test_single_service_returns_none(self):
         """Test that handle_error returns None with only one service."""
-        strategy = ServiceSwitcherStrategyAutomatic([self.service1])
+        strategy = ServiceSwitcherStrategyFailover([self.service1])
 
         result = await strategy.handle_error(ErrorFrame(error="error"))
         self.assertIsNone(result)
 
     async def test_manual_switch_still_works(self):
         """Test that ManuallySwitchServiceFrame is still handled."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy = ServiceSwitcherStrategyFailover(self.services)
 
         frame = ManuallySwitchServiceFrame(service=self.service3)
         result = await strategy.handle_frame(frame, FrameDirection.DOWNSTREAM)
@@ -562,7 +562,7 @@ class TestServiceSwitcherStrategyAutomatic(unittest.IsolatedAsyncioTestCase):
 
     async def test_on_service_switched_event_fires_on_error(self):
         """Test that on_service_switched event fires when an error triggers a switch."""
-        strategy = ServiceSwitcherStrategyAutomatic(self.services)
+        strategy = ServiceSwitcherStrategyFailover(self.services)
 
         switched_events = []
 


### PR DESCRIPTION
## Summary

- Added `ServiceSwitcherStrategyFailover` that automatically switches to the next service when the active service reports a non-fatal error
- Moved manual switching (`ManuallySwitchServiceFrame`) and `handle_error()` into the base `ServiceSwitcherStrategy` class, making both available to all strategies
- `strategy_type` now defaults to `ServiceSwitcherStrategy`, so `ServiceSwitcher(services=[...])` works without specifying a strategy for the common manual-switching case
- Deprecated `ServiceSwitcherStrategyManual` — it is now an empty subclass of the base strategy
- `ServiceSwitcher.push_frame()` delegates non-fatal `ErrorFrame` instances to the strategy via `handle_error()`, enabling failover strategies
- Updated `LLMSwitcher` with the same default `strategy_type`
- Updated example `48-service-switcher.py` to use the simplified API

## Testing

- `uv run pytest tests/test_service_switcher.py` — 20 tests covering base strategy, deprecated manual strategy, default strategy in ServiceSwitcher, failover, and metadata handling

## Fixes

- Fixes #3861