### PR TITLE
[RimeTTS] Add `speedAlpha` parameter support to the `arcana` model 

### DIFF
--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -301,6 +301,8 @@ class RimeTTSService(AudioContextTTSService):
             params["lang"] = self._settings.language
         if self._settings.segment is not None:
             params["segment"] = self._settings.segment
+        if self._settings.speedAlpha is not None:
+            params["speedAlpha"] = self._settings.speedAlpha
 
         if self._settings.model == "arcana":
             if self._settings.repetition_penalty is not None:
@@ -310,8 +312,6 @@ class RimeTTSService(AudioContextTTSService):
             if self._settings.top_p is not None:
                 params["top_p"] = self._settings.top_p
         else:  # mistv2/mist
-            if self._settings.speedAlpha is not None:
-                params["speedAlpha"] = self._settings.speedAlpha
             if self._settings.reduceLatency is not None:
                 params["reduceLatency"] = self._settings.reduceLatency
             if self._settings.pauseBetweenBrackets is not None:


### PR DESCRIPTION
## Summary

The `speedAlpha` param can now be sent to the `arcana` model. This change allows a User set value for `speedAlpha` to be passed as a url param when opening up a websockets conn with Rime's APIs for any model requested. 