### PR TITLE
fix: use pull_request_target for docs workflow to access secrets from fork PRs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,7 +1,7 @@
 name: Update Documentation on PR Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
     paths:


### PR DESCRIPTION
## Context

Last update-docs.yml update. We need this update to generate docs for PRs from forks.

## Summary

- Fixed intermittent "Input required and not supplied: token" error in the `update-docs` workflow by switching from `pull_request` to `pull_request_target`
- `pull_request` events from fork PRs don't have access to repository secrets, causing `DOCS_SYNC_TOKEN` to be empty when checking out the docs repo
- `pull_request_target` runs in the base repo's context, so secrets are always available — this is safe since the workflow only triggers on already-merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)