### PR TITLE
Fix tracing to use ServiceSettings API instead of dict access

### DIFF
--- a/changelog/3879.changed.md
+++ b/changelog/3879.changed.md
@@ -1,0 +1,1 @@
+- Updated tracing code to use `ServiceSettings` dataclass API (`given_fields()`, attribute access) instead of dict-style access (`.items()`, `in`, subscript).

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
+    from pipecat.services.settings import ServiceSettings
+
 from pipecat.utils.tracing.setup import is_tracing_available
 
 if is_tracing_available():
@@ -68,7 +70,7 @@ def add_tts_span_attributes(
     model: str,
     voice_id: str,
     text: Optional[str] = None,
-    settings: Optional[Dict[str, Any]] = None,
+    settings: Optional["ServiceSettings"] = None,
     character_count: Optional[int] = None,
     operation_name: str = "tts",
     ttfb: Optional[float] = None,
@@ -107,7 +109,7 @@ def add_tts_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in settings.given_fields().items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
 
@@ -126,7 +128,7 @@ def add_stt_span_attributes(
     is_final: Optional[bool] = None,
     language: Optional[str] = None,
     user_id: Optional[str] = None,
-    settings: Optional[Dict[str, Any]] = None,
+    settings: Optional["ServiceSettings"] = None,
     vad_enabled: bool = False,
     ttfb: Optional[float] = None,
     **kwargs,
@@ -171,7 +173,7 @@ def add_stt_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in settings.given_fields().items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
 
@@ -282,7 +284,7 @@ def add_gemini_live_span_attributes(
     voice_id: Optional[str] = None,
     language: Optional[str] = None,
     modalities: Optional[str] = None,
-    settings: Optional[Dict[str, Any]] = None,
+    settings: Optional["ServiceSettings"] = None,
     tools: Optional[List[Dict]] = None,
     tools_serialized: Optional[str] = None,
     transcript: Optional[str] = None,
@@ -359,7 +361,7 @@ def add_gemini_live_span_attributes(
 
     # Add settings if provided
     if settings:
-        for key, value in settings.items():
+        for key, value in settings.given_fields().items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
             elif key == "vad" and value:

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -219,7 +219,7 @@ def traced_tts(func: Optional[Callable] = None, *, name: Optional[str] = None) -
             tracer = trace.get_tracer("pipecat")
             with tracer.start_as_current_span(span_name, context=parent_context) as span:
                 try:
-                    settings = getattr(self, "_settings", {})
+                    settings = getattr(self, "_settings", None)
                     add_tts_span_attributes(
                         span=span,
                         service_name=service_class_name,
@@ -338,7 +338,7 @@ def traced_stt(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                         )
 
                         # Use settings from the service if available
-                        settings = getattr(self, "_settings", {})
+                        settings = getattr(self, "_settings", None)
 
                         add_stt_span_attributes(
                             span=current_span,
@@ -510,15 +510,10 @@ def traced_llm(func: Optional[Callable] = None, *, name: Optional[str] = None) -
                             # Get settings from the service
                             params = {}
                             if hasattr(self, "_settings"):
-                                for key, value in self._settings.items():
-                                    if key == "extra":
-                                        continue
-                                    # Add value directly if it's a basic type
+                                for key, value in self._settings.given_fields().items():
                                     if isinstance(value, (int, float, bool, str)):
                                         params[key] = value
-                                    elif value is None or (
-                                        hasattr(value, "__name__") and value.__name__ == "NOT_GIVEN"
-                                    ):
+                                    elif value is None:
                                         params[key] = "NOT_GIVEN"
 
                             # Add all available attributes to the span
@@ -627,12 +622,12 @@ def traced_gemini_live(operation: str) -> Callable:
                         model_name = _get_model_name(self)
                         voice_id = getattr(self, "_voice_id", None)
                         language_code = getattr(self, "_language_code", None)
-                        settings = getattr(self, "_settings", {})
+                        settings = getattr(self, "_settings", None)
 
                         # Get modalities if available
                         modalities = None
-                        if hasattr(self, "_settings") and "modalities" in self._settings:
-                            modality_obj = self._settings["modalities"]
+                        if settings and hasattr(settings, "modalities"):
+                            modality_obj = settings.modalities
                             if hasattr(modality_obj, "value"):
                                 modalities = modality_obj.value
                             else:


### PR DESCRIPTION
## Summary

- Fixed tracing code to use `ServiceSettings` dataclass API instead of dict-style access (`.items()`, `in`, subscript), which broke after the ServiceSettings refactor (PR #3714)
- In `service_attributes.py`: changed `settings` parameter type to `ServiceSettings` and use `given_fields().items()` for iteration (TTS, STT, Gemini Live)
- In `service_decorators.py`: changed `getattr` defaults from `{}` to `None`, replaced `self._settings.items()` with `given_fields().items()` in LLM decorator, replaced dict containment/subscript with attribute access in Gemini Live decorator
- Removed unnecessary `extra` key skip and `NOT_GIVEN` checks since `given_fields()` already handles both

## Fixes

- Fixes #3858