### PR TITLE
AIC Voice Focus version update & concurrency safety issue on audio buffer.

### DIFF
--- a/changelog/3889.changed.md
+++ b/changelog/3889.changed.md
@@ -1,0 +1,3 @@
+- Support for Voice Focus 2.0 models.
+  - Updated `aic-sdk` to `~=2.1.0` to support Voice Focus 2.0 models.
+  - Cleaned unused `ParameterFixedError` exception handling in `AICFilter` parameter setup. 

--- a/changelog/3889.fixed.md
+++ b/changelog/3889.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `BufferError: Existing exports of data: object cannot be re-sized` in `AICFilter` caused by holding a `memoryview` on the mutable audio buffer across async yield points.

--- a/examples/foundational/07zd-interruptible-aicoustics.py
+++ b/examples/foundational/07zd-interruptible-aicoustics.py
@@ -40,7 +40,7 @@ def _create_aic_filter() -> AICFilter:
 
     return AICFilter(
         license_key=license_key,
-        model_id="quail-vf-l-16khz",
+        model_id="quail-vf-2.0-l-16khz",
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ Issues = "https://github.com/pipecat-ai/pipecat/issues"
 Changelog = "https://github.com/pipecat-ai/pipecat/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
-aic = [ "aic-sdk~=2.0.1" ]
+aic = [ "aic-sdk~=2.1.0" ]
 anthropic = [ "anthropic~=0.49.0" ]
 assemblyai = [ "pipecat-ai[websockets-base]" ]
 asyncai = [ "pipecat-ai[websockets-base]" ]

--- a/src/pipecat/audio/filters/aic_filter.py
+++ b/src/pipecat/audio/filters/aic_filter.py
@@ -375,12 +375,7 @@ class AICFilter(BaseAudioFilter):
         self._vad_ctx = self._processor.get_vad_context()
 
         # Apply initial parameters
-        try:
-            self._processor_ctx.set_parameter(
-                ProcessorParameter.Bypass, 1.0 if self._bypass else 0.0
-            )
-        except ParameterFixedError as e:
-            logger.error(f"AIC parameter update failed: {e}")
+        self._processor_ctx.set_parameter(ProcessorParameter.Bypass, 1.0 if self._bypass else 0.0)
 
         # Log processor information
         logger.debug(f"ai-coustics filter started:")
@@ -389,7 +384,8 @@ class AICFilter(BaseAudioFilter):
         logger.debug(f"  Frames per chunk: {self._frames_per_block}")
         logger.debug(f"  Optimal sample rate: {self._model.get_optimal_sample_rate()} Hz")
         logger.debug(
-            f"  Optimal number of frames for {self._sample_rate} Hz: {self._model.get_optimal_num_frames(self._sample_rate)}"
+            f"  Optimal number of frames for {self._sample_rate} Hz: "
+            f"{self._model.get_optimal_num_frames(self._sample_rate)}"
         )
         logger.debug(
             f"  Output delay: {self._processor_ctx.get_output_delay()} samples "


### PR DESCRIPTION
# Summary

- **Fix BufferError:** Existing exports of data: object cannot be re-sized that occurs in production when concurrent filter() or stop() calls interleave with an in-flight filter() holding a memoryview on the mutable _audio_buffer bytearray across await yield points.
- The fix snapshots the needed audio blocks into immutable bytes and trims the buffer before any await, so no memoryview (or any reference to the mutable bytearray) is held across async yield points.
- Add two regression tests that reproduce the exact concurrency scenarios: concurrent filter()/filter() interleaving and stop() during filter().

# Problem

`AICFilter.filter()` created a `memoryview` on `self._audio_buffer` (a `bytearray`) and held it alive across await `self._processor.process_async(...)`. In production with concurrent calls, another task could run `filter()` (calling `_audio_buffer.extend()`) or `stop()` (calling `_audio_buffer.clear()`) while the `memoryview` still exported the buffer, causing Python to raise:

```
    BufferError: Existing exports of data: object cannot be re-sized
```

It's not easy to reproduce locally because it requires concurrent async interleaving but wrote a test for simulate it.

# Fix

Replace the `memoryview` on the mutable `bytearray` with a `bytes` snapshot taken before any await:

```
    blocks_data = bytes(self._audio_buffer[:total_size])
    self._audio_buffer = self._audio_buffer[total_size:]
    # all awaits below only reference the immutable blocks_data
```

The extra copy is negligible — typical block size is 320 bytes (10ms of 16kHz 16-bit audio).