### PR TITLE
Fix update-docs workflow OIDC failure with pull_request_target

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -59,6 +59,7 @@ jobs:
           DOCS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             You are updating documentation for the pipecat-ai/docs repository based on
             changes merged in PR #${{ steps.pr.outputs.number }} of pipecat-ai/pipecat.


### PR DESCRIPTION
## Summary

- Fixed `update-docs` workflow failing with "Invalid OIDC token" after switching to `pull_request_target` in #3878
- The `claude-code-action` OIDC token exchange doesn't support the `pull_request_target` event type
- Passing `github_token` explicitly bypasses OIDC and uses the workflow's built-in token instead
- This restores automated doc updates for both same-repo and fork PRs