### PR TITLE
Update Nvidia example to use llama-3.3-70b-instruct

### DIFF
--- a/examples/foundational/07r-interruptible-nvidia.py
+++ b/examples/foundational/07r-interruptible-nvidia.py
@@ -55,7 +55,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     stt = NvidiaSTTService(api_key=os.getenv("NVIDIA_API_KEY"))
 
     llm = NvidiaLLMService(
-        api_key=os.getenv("NVIDIA_API_KEY"), model="meta/llama-3.1-405b-instruct"
+        api_key=os.getenv("NVIDIA_API_KEY"),
+        model="meta/llama-3.3-70b-instruct",
     )
 
     tts = NvidiaTTSService(api_key=os.getenv("NVIDIA_API_KEY"))


### PR DESCRIPTION
## Summary

- Updated Nvidia example (`07r-interruptible-nvidia.py`) to use `meta/llama-3.3-70b-instruct` model instead of the previous `meta/llama-3.1-405b-instruct`

🤖 Generated with [Claude Code](https://claude.com/claude-code)