### PR TITLE
daily-transport: add cloud-audio-only recording option

### DIFF
--- a/changelog/3916.added.md
+++ b/changelog/3916.added.md
@@ -1,0 +1,1 @@
+- Added `cloud-audio-only` recording option to Daily transport's `enable_recording` property.

--- a/src/pipecat/transports/daily/utils.py
+++ b/src/pipecat/transports/daily/utils.py
@@ -108,7 +108,7 @@ class DailyRoomProperties(BaseModel):
     enable_emoji_reactions: bool = False
     eject_at_room_exp: bool = False
     enable_dialout: Optional[bool] = None
-    enable_recording: Optional[Literal["cloud", "local", "raw-tracks"]] = None
+    enable_recording: Optional[Literal["cloud", "cloud-audio-only", "local", "raw-tracks"]] = None
     enable_transcription_storage: Optional[bool] = None
     geo: Optional[str] = None
     max_participants: Optional[int] = None
@@ -202,7 +202,7 @@ class DailyMeetingTokenProperties(BaseModel):
     enable_screenshare: Optional[bool] = None
     start_video_off: Optional[bool] = None
     start_audio_off: Optional[bool] = None
-    enable_recording: Optional[Literal["cloud", "local", "raw-tracks"]] = None
+    enable_recording: Optional[Literal["cloud", "cloud-audio-only", "local", "raw-tracks"]] = None
     enable_prejoin_ui: Optional[bool] = None
     start_cloud_recording: Optional[bool] = None
     permissions: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

as per daily docs here: https://docs.daily.co/guides/products/live-streaming-recording/recording-calls-with-the-daily-api#cloud-audio-only