### PR TITLE
Add logging to Daily transport event handlers

### DIFF
--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -1467,7 +1467,6 @@ class DailyTransportClient(EventHandler):
         Args:
             message: Error message.
         """
-        logger.error(f"Transcription error: {message}")
         self._call_event_callback(self._callbacks.on_transcription_error, message)
 
     def on_transcription_message(self, message):
@@ -2668,44 +2667,54 @@ class DailyTransport(BaseTransport):
 
     async def _on_dialin_connected(self, data):
         """Handle dial-in connected events."""
+        logger.debug(f"{self} dial-in connected: {data}")
         await self._call_event_handler("on_dialin_connected", data)
 
     async def _on_dialin_ready(self, sip_endpoint):
         """Handle dial-in ready events."""
+        logger.debug(f"{self} dial-in ready: {sip_endpoint}")
         if self._params.dialin_settings:
             await self._handle_dialin_ready(sip_endpoint)
         await self._call_event_handler("on_dialin_ready", sip_endpoint)
 
     async def _on_dialin_stopped(self, data):
         """Handle dial-in stopped events."""
+        logger.debug(f"{self} dial-in stopped: {data}")
         await self._call_event_handler("on_dialin_stopped", data)
 
     async def _on_dialin_error(self, data):
         """Handle dial-in error events."""
+        logger.error(f"{self} dial-in error: {data}")
         await self._call_event_handler("on_dialin_error", data)
 
     async def _on_dialin_warning(self, data):
         """Handle dial-in warning events."""
+        logger.warning(f"{self} dial-in warning: {data}")
         await self._call_event_handler("on_dialin_warning", data)
 
     async def _on_dialout_answered(self, data):
         """Handle dial-out answered events."""
+        logger.debug(f"{self} dial-out answered: {data}")
         await self._call_event_handler("on_dialout_answered", data)
 
     async def _on_dialout_connected(self, data):
         """Handle dial-out connected events."""
+        logger.debug(f"{self} dial-out connected: {data}")
         await self._call_event_handler("on_dialout_connected", data)
 
     async def _on_dialout_stopped(self, data):
         """Handle dial-out stopped events."""
+        logger.debug(f"{self} dial-out stopped: {data}")
         await self._call_event_handler("on_dialout_stopped", data)
 
     async def _on_dialout_error(self, data):
         """Handle dial-out error events."""
+        logger.error(f"{self} dial-out error: {data}")
         await self._call_event_handler("on_dialout_error", data)
 
     async def _on_dialout_warning(self, data):
         """Handle dial-out warning events."""
+        logger.warning(f"{self} dial-out warning: {data}")
         await self._call_event_handler("on_dialout_warning", data)
 
     async def _on_participant_joined(self, participant):
@@ -2738,6 +2747,7 @@ class DailyTransport(BaseTransport):
 
     async def _on_participant_updated(self, participant):
         """Handle participant updated events."""
+        logger.debug(f"{self} participant updated: {participant}")
         await self._call_event_handler("on_participant_updated", participant)
 
     async def _on_transcription_message(self, message: Mapping[str, Any]) -> None:
@@ -2778,20 +2788,25 @@ class DailyTransport(BaseTransport):
 
     async def _on_transcription_stopped(self, stopped_by, stopped_by_error):
         """Handle transcription stopped events."""
+        logger.debug(f"{self} transcription stopped by: {stopped_by} (error: {stopped_by_error})")
         await self._call_event_handler("on_transcription_stopped", stopped_by, stopped_by_error)
 
     async def _on_transcription_error(self, message):
         """Handle transcription error events."""
+        logger.error(f"{self} transcription error: {message}")
         await self._call_event_handler("on_transcription_error", message)
 
     async def _on_recording_started(self, status):
         """Handle recording started events."""
+        logger.debug(f"{self} recording started: {status}")
         await self._call_event_handler("on_recording_started", status)
 
     async def _on_recording_stopped(self, stream_id):
         """Handle recording stopped events."""
+        logger.debug(f"{self} recording stopped (id: {stream_id})")
         await self._call_event_handler("on_recording_stopped", stream_id)
 
     async def _on_recording_error(self, stream_id, message):
         """Handle recording error events."""
+        logger.error(f"{self} recording error (id: {stream_id}): {message}")
         await self._call_event_handler("on_recording_error", stream_id, message)


### PR DESCRIPTION
## Summary

- Add logging to Daily transport dial-in/dial-out, participant, transcription, and recording event handlers using appropriate log levels (`debug` for normal events, `warning` for warnings, `error` for errors)
- Move transcription error log from `DailyTransportClient.on_transcription_error()` to `DailyTransport._on_transcription_error()` to keep logging consistent at the transport level

## Testing

- Verify dial-in/dial-out events are logged at appropriate levels during a call
- Verify transcription error is logged once (at transport level, not client level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)