### PR TITLE
Add parallel content filter example

### DIFF
--- a/examples/foundational/57-parallel-content-filter.py
+++ b/examples/foundational/57-parallel-content-filter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024–2025, Daily
+# Copyright (c) 2024–2026, Daily
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #


### PR DESCRIPTION
## Summary
- Adds `57-parallel-content-filter.py`, a new foundational example demonstrating how to run a content filter concurrently with LLM text generation using `ParallelPipeline`
- The content filter emits signal frames (`ContentApprovedFrame`/`ContentRejectedFrame`) while the LLM generates text in a parallel branch
- A `ContentFilterGate` processor after the `ParallelPipeline` blocks output until the filter decides — approved text passes to TTS, rejected text is discarded and a canned rejection message is spoken instead

## Test plan
- [x] Run the example and verify the bot introduces itself on connect
- [x] Say something without filtered words (apple, banana, car) and verify normal LLM response
- [x] Say something containing a filtered word and verify the rejection message is spoken
- [ ] Verify interruptions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)