### PR TITLE
Update AssemblyAI turn detection example to use keyterms_prompt

### DIFF
--- a/changelog/3929.other.md
+++ b/changelog/3929.other.md
@@ -1,0 +1,1 @@
+- Updated AssemblyAI turn detection example to use `keyterms_prompt` list format instead of `prompt` string for improved clarity.

--- a/examples/foundational/07o-interruptible-assemblyai-turn-detection.py
+++ b/examples/foundational/07o-interruptible-assemblyai-turn-detection.py
@@ -100,7 +100,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             # min_turn_silence=100,  # Default
             # max_turn_silence=1000,  # Default
             # Optional: Boost accuracy for specific names/terms
-            # prompt="Names: Xiomara, Saoirse, Krzystof. Technical terms: API, OAuth.",
+            # keyterms_prompt=["Xiomara", "Saoirse", "Krzystof", "API", "OAuth"],
             # Optional: Enable speaker diarization
             # speaker_labels=True,
         ),


### PR DESCRIPTION
Change the commented example from prompt string format to keyterms_prompt list format for better clarity and consistency with API best practices.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.