### PR TITLE
Warn when both system_instruction and context system message are set

### DIFF
--- a/changelog/3932.added.md
+++ b/changelog/3932.added.md
@@ -1,0 +1,1 @@
+- LLM services (`BaseOpenAILLMService`, `AnthropicLLMService`, `AWSBedrockLLMService`) now log a warning when both `system_instruction` and a system message in the context are set. The constructor's `system_instruction` takes precedence.

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -403,6 +403,11 @@ class AnthropicLLMService(LLMService):
                 context, enable_prompt_caching=self._settings.enable_prompt_caching
             )
             if self._system_instruction:
+                if params["system"] is not NOT_GIVEN:
+                    logger.warning(
+                        f"{self}: Both system_instruction and a system message in context are"
+                        " set. Using system_instruction."
+                    )
                 params["system"] = self._system_instruction
             return params
 

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -1025,6 +1025,11 @@ class AWSBedrockLLMService(LLMService):
             adapter: AWSBedrockLLMAdapter = self.get_llm_adapter()
             params: AWSBedrockLLMInvocationParams = adapter.get_llm_invocation_params(context)
             if self._system_instruction:
+                if params["system"]:
+                    logger.warning(
+                        f"{self}: Both system_instruction and a system message in context are"
+                        " set. Using system_instruction."
+                    )
                 params["system"] = [{"text": self._system_instruction}]
             return params
 

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -292,9 +292,14 @@ class BaseOpenAILLMService(LLMService):
 
         params.update(self._settings.extra)
 
-        # Prepend system instruction if set
+        # Prepend system instruction from constructor, replacing any context system message
         if self._system_instruction:
             messages = params.get("messages", [])
+            if messages and messages[0].get("role") == "system":
+                logger.warning(
+                    f"{self}: Both system_instruction and a system message in context are set."
+                    " Using system_instruction."
+                )
             params["messages"] = [
                 {"role": "system", "content": self._system_instruction}
             ] + messages


### PR DESCRIPTION
## Summary

- Added warnings in `BaseOpenAILLMService`, `AnthropicLLMService`, and `AWSBedrockLLMService` when both `system_instruction` and a system message in the context are set. The constructor's `system_instruction` always takes precedence.