### PR TITLE
Fix Daily transport log level and eval script import

### DIFF
--- a/scripts/evals/eval.py
+++ b/scripts/evals/eval.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
 import aiofiles
-from deepgram import LiveOptions
 from loguru import logger
 from PIL.ImageFile import ImageFile
 from utils import (
@@ -50,7 +49,7 @@ from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.runner.types import RunnerArguments
 from pipecat.services.cartesia.tts import CartesiaTTSService
-from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.deepgram.stt import DeepgramSTTService, LiveOptions
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.daily.transport import DailyParams, DailyTransport

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -2747,7 +2747,7 @@ class DailyTransport(BaseTransport):
 
     async def _on_participant_updated(self, participant):
         """Handle participant updated events."""
-        logger.debug(f"{self} participant updated: {participant}")
+        logger.trace(f"{self} participant updated: {participant}")
         await self._call_event_handler("on_participant_updated", participant)
 
     async def _on_transcription_message(self, message: Mapping[str, Any]) -> None:


### PR DESCRIPTION
## Summary

- Changed `participant_updated` log level from `debug` to `trace` in Daily transport (too noisy at debug level)
- Fixed `LiveOptions` import in eval script to use the re-export from `pipecat.services.deepgram.stt` instead of importing directly from `deepgram`