### PR TITLE
fix: idle processor race condition + context summarization tool call split

### DIFF
--- a/src/pipecat/processors/idle_frame_processor.py
+++ b/src/pipecat/processors/idle_frame_processor.py
@@ -85,7 +85,10 @@ class IdleFrameProcessor(FrameProcessor):
         while True:
             try:
                 await asyncio.wait_for(self._idle_event.wait(), timeout=self._timeout)
-            except asyncio.TimeoutError:
-                await self._callback(self)
-            finally:
+                # Event was set (activity detected) — clear immediately
                 self._idle_event.clear()
+            except asyncio.TimeoutError:
+                # No activity within timeout — trigger callback.
+                # Don't clear the event: if set() was called between the
+                # timeout and now, the next iteration should see it.
+                await self._callback(self)

--- a/src/pipecat/processors/user_idle_processor.py
+++ b/src/pipecat/processors/user_idle_processor.py
@@ -201,9 +201,12 @@ class UserIdleProcessor(FrameProcessor):
         while running:
             try:
                 await asyncio.wait_for(self._idle_event.wait(), timeout=self._timeout)
+                # Event was set (activity detected) — clear immediately
+                self._idle_event.clear()
             except asyncio.TimeoutError:
+                # No activity within timeout — trigger callback.
+                # Don't clear the event: if set() was called between the
+                # timeout and now, the next iteration should see it.
                 if not self._interrupted:
                     self._retry_count += 1
                     running = await self._callback(self, self._retry_count)
-            finally:
-                self._idle_event.clear()

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -504,6 +504,22 @@ class LLMContextSummarizationUtil:
         if summary_start >= summary_end:
             return LLMMessagesToSummarize(messages=[], last_summarized_index=-1)
 
+        # Ensure we don't split a complete tool call sequence at the boundary.
+        # If the first kept message has role "tool", walk summary_end backwards
+        # to include the preceding assistant message with tool_calls.
+        while summary_end > summary_start and summary_end < len(messages):
+            boundary_msg = messages[summary_end]
+            if isinstance(boundary_msg, LLMSpecificMessage):
+                summary_end -= 1
+                continue
+            if isinstance(boundary_msg, dict) and boundary_msg.get("role") == "tool":
+                summary_end -= 1
+            else:
+                break
+
+        if summary_start >= summary_end:
+            return LLMMessagesToSummarize(messages=[], last_summarized_index=-1)
+
         messages_to_summarize = messages[summary_start:summary_end]
         last_summarized_index = summary_end - 1
 


### PR DESCRIPTION
## Summary

- **Idle processor race condition (#3402):** Both `IdleFrameProcessor` and `UserIdleProcessor` use `finally: self._idle_event.clear()` after `asyncio.wait_for()`. If `_idle_event.set()` is called by another coroutine between when the timeout fires and when `clear()` executes, that activity signal is lost. The next iteration waits the full timeout and may falsely trigger the idle callback. Fixed by moving `clear()` into the `try` block (only on successful wait) and removing the `finally` block entirely.

- **Context summarization splits complete tool call sequences (#3832):** `get_messages_to_summarize()` computes a `summary_end` boundary that can fall between an assistant message with `tool_calls` and its corresponding `tool` response. The existing `_get_function_calls_in_progress_index` check only catches **incomplete** sequences (where tool response hasn't arrived). A complete sequence split leaves an orphaned `tool` role message in the kept messages, which OpenAI rejects with HTTP 400. Added a boundary walk-back that moves `summary_end` past any `tool` or `LLMSpecificMessage` messages at the boundary.

## Test plan

- [x] All 42 context summarization tests pass
- [x] Imports verified for both idle processors
- [ ] Verify idle callback doesn't fire falsely when activity occurs during timeout handling
- [ ] Verify context summarization keeps tool call sequences intact when boundary falls mid-sequence

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)