### PR TITLE
Fixed TTS context not being appended to the assistant message history

### DIFF
--- a/changelog/3936.fixed.md
+++ b/changelog/3936.fixed.md
@@ -1,1 +1,1 @@
-- Fixed `TTSService` to push `LLMAssistantPushAggregationFrame` when the base class is responsible for pushing `TTSStoppedFrame`.
+- Fixed TTS context not being appended to the assistant message history when using `TTSSpeakFrame` with `append_to_context=True` with some TTS providers.

--- a/changelog/3936.fixed.md
+++ b/changelog/3936.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TTSService` to push `LLMAssistantPushAggregationFrame` when the base class is responsible for pushing `TTSStoppedFrame`.

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -17,6 +17,7 @@ from loguru import logger
 from pipecat.frames.frames import (
     ErrorFrame,
     Frame,
+    TTSStoppedFrame,
 )
 from pipecat.services.settings import TTSSettings, _warn_deprecated_param
 from pipecat.services.tts_service import TTSService
@@ -287,6 +288,7 @@ class PiperHttpTTSService(TTSService):
                     yield ErrorFrame(
                         error=f"Error getting audio (status: {response.status}, error: {error})"
                     )
+                    yield TTSStoppedFrame(context_id=context_id)
                     return
 
                 await self.start_tts_usage_metrics(text)

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -768,6 +768,8 @@ class TTSService(AIService):
         # Clean up context when we see TTSStoppedFrame
         if isinstance(frame, TTSStoppedFrame) and frame.context_id:
             if frame.context_id in self._tts_contexts:
+                if self._tts_contexts[frame.context_id].push_assistant_aggregation:
+                    await self.push_frame(LLMAssistantPushAggregationFrame())
                 logger.debug(f"{self} cleaning up TTS context {frame.context_id}")
                 del self._tts_contexts[frame.context_id]
 
@@ -1009,14 +1011,8 @@ class TTSService(AIService):
             # For services using the audio context we are appending to the context, so it preserves the ordering.
             if self.audio_context_available(context_id):
                 await self.append_to_audio_context(context_id, frame)
-                if push_assistant_aggregation:
-                    await self.append_to_audio_context(
-                        context_id, LLMAssistantPushAggregationFrame()
-                    )
             else:
                 await self.push_frame(frame)
-                if push_assistant_aggregation:
-                    await self.push_frame(LLMAssistantPushAggregationFrame())
 
     async def tts_process_generator(
         self, context_id: str, generator: AsyncGenerator[Frame | None, None]
@@ -1047,18 +1043,20 @@ class TTSService(AIService):
 
     async def _stop_frame_handler(self):
         has_started = False
+        context_id = None
         while True:
             try:
                 frame = await asyncio.wait_for(
                     self._stop_frame_queue.get(), timeout=self._stop_frame_timeout_s
                 )
+                context_id = frame.context_id
                 if isinstance(frame, TTSStartedFrame):
                     has_started = True
                 elif isinstance(frame, (TTSStoppedFrame, InterruptionFrame)):
                     has_started = False
             except asyncio.TimeoutError:
                 if has_started:
-                    await self.push_frame(TTSStoppedFrame())
+                    await self.push_frame(TTSStoppedFrame(context_id=context_id))
                     has_started = False
 
     #
@@ -1142,9 +1140,6 @@ class TTSService(AIService):
                 frame.pts = self._word_last_pts
                 frame.context_id = context_id
                 await self.push_frame(frame)
-                if context_id in self._tts_contexts:
-                    if self._tts_contexts[context_id].push_assistant_aggregation:
-                        await self.push_frame(LLMAssistantPushAggregationFrame())
             else:
                 ts_ns = seconds_to_nanoseconds(timestamp)
                 if self._initial_word_timestamp == -1:

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1038,7 +1038,9 @@ class TTSService(AIService):
         async for frame in generator:
             if frame:
                 await self.append_to_audio_context(context_id, frame)
-                is_yielding_frames = True
+                if isinstance(frame, TTSAudioRawFrame):
+                    is_yielding_frames = True
+
         self._is_yielding_frames_synchronously = is_yielding_frames
 
     async def _stop_frame_handler(self):

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1049,8 +1049,8 @@ class TTSService(AIService):
                 frame = await asyncio.wait_for(
                     self._stop_frame_queue.get(), timeout=self._stop_frame_timeout_s
                 )
-                context_id = frame.context_id
                 if isinstance(frame, TTSStartedFrame):
+                    context_id = frame.context_id
                     has_started = True
                 elif isinstance(frame, (TTSStoppedFrame, InterruptionFrame)):
                     has_started = False

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -136,7 +136,7 @@ async def test_run_piper_tts_error(aiohttp_client):
             TTSSpeakFrame(text="Error case.", append_to_context=False),
         ]
 
-        expected_down_frames = [AggregatedTextFrame, TTSStartedFrame, TTSTextFrame, TTSStoppedFrame]
+        expected_down_frames = [AggregatedTextFrame, TTSStartedFrame, TTSStoppedFrame, TTSTextFrame]
 
         expected_up_frames = [ErrorFrame]
 


### PR DESCRIPTION
## Summary

- Fixed TTSService to push LLMAssistantPushAggregationFrame at the correct point: when TTSStoppedFrame is processed  and the TTS context is cleaned up, rather than after each TTSAudioRawFrame                                           
- Fixed _stop_frame_handler to track context_id from TTSStartedFrame so that timeout-triggered TTSStoppedFrame frames carry the correct context ID — enabling the aggregation push to work correctly in that path                         
- Consolidated LLMAssistantPushAggregationFrame emission from multiple locations into a single canonical place (_process_tts_stopped_frame), removing duplicate pushes from _tts_audio_queue_handler and tts_process_generator
- Fixed is_yielding_frames to only be set to True when a TTSAudioRawFrame is received (not for any frame type)