### PR TITLE
fix(livekit): remove redundant self arg in on_call_state_updated

### DIFF
--- a/changelog/3959.fixed.md
+++ b/changelog/3959.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `on_call_state_updated` event handler in LiveKit transport receiving incorrect number of arguments due to redundant `self` passed to `_call_event_handler`.

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -1244,7 +1244,7 @@ class LiveKitTransport(BaseTransport):
 
     async def _on_call_state_updated(self, state: str):
         """Handle call state update events."""
-        await self._call_event_handler("on_call_state_updated", self, state)
+        await self._call_event_handler("on_call_state_updated", state)
 
     async def _on_first_participant_joined(self, participant_id: str):
         """Handle first participant joined events."""


### PR DESCRIPTION
## Summary
- `_on_call_state_updated` passes `(self, state)` to `_call_event_handler`, but `_run_handler` already prepends `self` when invoking the handler. This causes event handlers registered via `@transport.event_handler("on_call_state_updated")` to receive 3 positional arguments `(transport, transport, state)` instead of the expected 2 `(transport, state)`, making the event unusable.
- This aligns the behavior with `_on_first_participant_joined`, which correctly passes only `participant_id` without `self`.

## Test plan
- [x] Register an `on_call_state_updated` event handler with signature `(transport, state)` and verify it receives the correct arguments
- [x] Verify SIP call state changes (dialing → active → hangup) are correctly reported