### PR TITLE
Treat conversation_already_has_active_response as non-fatal in Realtime API

### DIFF
--- a/changelog/3960.fixed.md
+++ b/changelog/3960.fixed.md
@@ -1,0 +1,1 @@
+- Fixed OpenAI Realtime, OpenAI Realtime Beta, and Grok realtime services treating `conversation_already_has_active_response` as a fatal error. These services now log it as a non-fatal debug event when a response is already in progress.

--- a/src/pipecat/services/grok/realtime/llm.py
+++ b/src/pipecat/services/grok/realtime/llm.py
@@ -676,7 +676,10 @@ class GrokRealtimeLLMService(LLMService):
             elif evt.type == "response.function_call_arguments.done":
                 await self._handle_evt_function_call_arguments_done(evt)
             elif evt.type == "error":
-                if evt.error.code == "response_cancel_not_active":
+                if evt.error.code in (
+                    "response_cancel_not_active",
+                    "conversation_already_has_active_response",
+                ):
                     logger.debug(f"{self} {evt.error.message}")
                 else:
                     await self._handle_evt_error(evt)

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -747,7 +747,10 @@ class OpenAIRealtimeLLMService(LLMService):
                 await self._handle_evt_function_call_arguments_done(evt)
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
-                    if evt.error.code == "response_cancel_not_active":
+                    if evt.error.code in (
+                        "response_cancel_not_active",
+                        "conversation_already_has_active_response",
+                    ):
                         logger.debug(f"{self} {evt.error.message}")
                     else:
                         await self._handle_evt_error(evt)

--- a/src/pipecat/services/openai_realtime_beta/openai.py
+++ b/src/pipecat/services/openai_realtime_beta/openai.py
@@ -555,7 +555,10 @@ class OpenAIRealtimeBetaLLMService(LLMService):
                 await self._handle_evt_audio_transcript_delta(evt)
             elif evt.type == "error":
                 if not await self._maybe_handle_evt_retrieve_conversation_item_error(evt):
-                    if evt.error.code == "response_cancel_not_active":
+                    if evt.error.code in (
+                        "response_cancel_not_active",
+                        "conversation_already_has_active_response",
+                    ):
                         logger.debug(f"{self} {evt.error.message}")
                     else:
                         await self._handle_evt_error(evt)


### PR DESCRIPTION
## Summary

-  After sending a function call result via conversation.item.create, the Realtime API sometimes auto-creates a response before pipecat sends response.create, producing a conversation_already_has_active_response error
-  This error is harmless (the model is already responding), but it's currently treated as fatal — killing the WebSocket connection and ending the call
-  Fix: handle it the same way as the existing response_cancel_not_active — log at debug level and continue
-  Applied to all three Realtime API services: OpenAI, Grok, and OpenAI Realtime Beta

## How to reproduce

1.   Set up a Realtime API voice bot with function calling (tools)
2.  Trigger a tool call that takes more than a few hundred milliseconds
3.  The response.create sent by pipecat after the tool result races with the API's auto-created response
4.  Connection dies with conversation_already_has_active_response followed by a keepalive ping timeout