### PR TITLE
Fix Azure STT SpeechConfig with private endpoint

### DIFF
--- a/changelog/3967.fixed.md
+++ b/changelog/3967.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AzureSTTService` failing to initialize when `private_endpoint` is provided. The Azure Speech SDK's `SpeechConfig` does not accept both `region` and `endpoint` simultaneously, so they are now passed conditionally.

--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -94,7 +94,7 @@ class AzureSTTService(STTService):
 
             sample_rate: Audio sample rate in Hz. If None, uses service default.
             private_endpoint: Private endpoint for STT behind firewall.
-                See https://docs.azure.cn/en-us/ai-services/speech-service/speech-services-private-link?tabs=portal
+                See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-services-private-link?tabs=portal
             endpoint_id: Custom model endpoint id.
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.
@@ -126,13 +126,21 @@ class AzureSTTService(STTService):
             **kwargs,
         )
 
-        self._speech_config = SpeechConfig(
-            subscription=api_key,
-            region=region,
-            speech_recognition_language=default_settings.language
+        speech_config_kwargs: dict[str, Any] = {
+            "subscription": api_key,
+            "speech_recognition_language": default_settings.language
             or language_to_azure_language(Language.EN_US),
-            endpoint=private_endpoint,
-        )
+        }
+        if private_endpoint:
+            if region:
+                logger.warning(
+                    "Both 'region' and 'private_endpoint' provided; 'region' will be ignored."
+                )
+            speech_config_kwargs["endpoint"] = private_endpoint
+        else:
+            speech_config_kwargs["region"] = region
+
+        self._speech_config = SpeechConfig(**speech_config_kwargs)
 
         if endpoint_id:
             self._speech_config.endpoint_id = endpoint_id


### PR DESCRIPTION
## Summary
- Fix `SpeechConfig` initialization failing when `private_endpoint` is provided
- `region` and `endpoint` are mutually exclusive in the Azure Speech SDK — passing both raises `ValueError`
- Now conditionally passes either `endpoint` (private endpoint) or `region` (standard), never both

## Test plan
- [x] Verify Azure STT works without `private_endpoint` (standard `region`-based config)
- [x] Verify Azure STT works with `private_endpoint` URL (e.g., `wss://my-custom.cognitiveservices.azure.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)