### PR TITLE
Update Fish Audio default model from s1 to s2-pro

### DIFF
--- a/changelog/3973.changed.md
+++ b/changelog/3973.changed.md
@@ -1,0 +1,1 @@
+- Updated `FishAudioTTSService` default model from `s1` to `s2-pro`, matching Fish Audio's latest recommended model for improved quality and speed.

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -172,7 +172,7 @@ class FishAudioTTSService(InterruptibleTTSService):
 
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = FishAudioTTSSettings(
-            model="s1",
+            model="s2-pro",
             voice=None,
             language=None,
             latency="balanced",


### PR DESCRIPTION
## Summary
- Update the default TTS model for `FishAudioTTSService` from `s1` to `s2-pro`, aligning with Fish Audio's latest recommended model.

## Test plan
- [x] Verify Fish Audio TTS works with default settings (no explicit model_id)
- [x] Verify explicit model_id override still works


🤖 Generated with [Claude Code](https://claude.com/claude-code)