### PR TITLE
Make Azure STT region optional when private_endpoint is used

### DIFF
--- a/changelog/3974.changed.md
+++ b/changelog/3974.changed.md
@@ -1,0 +1,1 @@
+- `AzureSTTService` `region` parameter is now optional when `private_endpoint` is provided. A `ValueError` is raised if neither is given, and a warning is logged if both are provided (`private_endpoint` takes priority).

--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -95,7 +95,7 @@ class AzureSTTService(STTService):
 
             sample_rate: Audio sample rate in Hz. If None, uses service default.
             private_endpoint: Private endpoint for STT behind firewall.
-                See https://docs.azure.cn/en-us/ai-services/speech-service/speech-services-private-link?tabs=portal
+                See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-services-private-link?tabs=portal
             endpoint_id: Custom model endpoint id.
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.

--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -73,7 +73,7 @@ class AzureSTTService(STTService):
         self,
         *,
         api_key: str,
-        region: str,
+        region: Optional[str] = None,
         language: Optional[Language] = Language.EN_US,
         sample_rate: Optional[int] = None,
         private_endpoint: Optional[str] = None,
@@ -87,6 +87,7 @@ class AzureSTTService(STTService):
         Args:
             api_key: Azure Cognitive Services subscription key.
             region: Azure region for the Speech service (e.g., 'eastus').
+                Required unless ``private_endpoint`` is provided.
             language: Language for speech recognition. Defaults to English (US).
 
                 .. deprecated:: 0.0.105
@@ -94,7 +95,7 @@ class AzureSTTService(STTService):
 
             sample_rate: Audio sample rate in Hz. If None, uses service default.
             private_endpoint: Private endpoint for STT behind firewall.
-                See https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-services-private-link?tabs=portal
+                See https://docs.azure.cn/en-us/ai-services/speech-service/speech-services-private-link?tabs=portal
             endpoint_id: Custom model endpoint id.
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.
@@ -126,21 +127,29 @@ class AzureSTTService(STTService):
             **kwargs,
         )
 
-        speech_config_kwargs: dict[str, Any] = {
-            "subscription": api_key,
-            "speech_recognition_language": default_settings.language
-            or language_to_azure_language(Language.EN_US),
-        }
+        recognition_language = default_settings.language or language_to_azure_language(
+            Language.EN_US
+        )
+
+        if not region and not private_endpoint:
+            raise ValueError("Either 'region' or 'private_endpoint' must be provided.")
+
         if private_endpoint:
             if region:
                 logger.warning(
                     "Both 'region' and 'private_endpoint' provided; 'region' will be ignored."
                 )
-            speech_config_kwargs["endpoint"] = private_endpoint
+            self._speech_config = SpeechConfig(
+                subscription=api_key,
+                endpoint=private_endpoint,
+                speech_recognition_language=recognition_language,
+            )
         else:
-            speech_config_kwargs["region"] = region
-
-        self._speech_config = SpeechConfig(**speech_config_kwargs)
+            self._speech_config = SpeechConfig(
+                subscription=api_key,
+                region=region,
+                speech_recognition_language=recognition_language,
+            )
 
         if endpoint_id:
             self._speech_config.endpoint_id = endpoint_id


### PR DESCRIPTION
## Summary

- Make `region` parameter optional (`Optional[str] = None`) so users can provide only `private_endpoint`
- Raise `ValueError` if neither `region` nor `private_endpoint` is provided
- Log a warning when both are provided (`private_endpoint` takes priority)

Follow-up to #3967 which fixed the `SpeechConfig` mutual exclusivity bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)