### PR TITLE
Fix an out-of-date comment for accuracy. In the OpenAI LLM service, w…

### DIFF
--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -327,7 +327,7 @@ class BaseOpenAILLMService(LLMService):
 
         params.update(self._settings.extra)
 
-        # Prepend system instruction from constructor, replacing any context system message
+        # Prepend system instruction from constructor
         if self._settings.system_instruction:
             messages = params.get("messages", [])
             if messages and messages[0].get("role") == "system":


### PR DESCRIPTION
…e *don't* replace any context system messages with system instructions from the constructor.