### PR TITLE
Fix: Restore default model to gpt-4.1 for OpenAI, Azure

### DIFF
--- a/changelog/4000.fixed.md
+++ b/changelog/4000.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where the default model for `OpenAILLMService` and `AzureLLMService` was mistakenly reverted to `gpt-4o`. The defaults are now restored to `gpt-4.1`.

--- a/examples/foundational/04a-transports-daily.py
+++ b/examples/foundational/04a-transports-daily.py
@@ -58,7 +58,6 @@ async def main():
         llm = OpenAILLMService(
             api_key=os.getenv("OPENAI_API_KEY"),
             settings=OpenAILLMService.Settings(
-                model="gpt-4o",
                 system_instruction="You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. Your output will be spoken aloud, so avoid special characters that can't easily be spoken, such as emojis or bullet points. Respond to what the user said in a creative and helpful way.",
             ),
         )

--- a/examples/foundational/14v-function-calling-openai.py
+++ b/examples/foundational/14v-function-calling-openai.py
@@ -79,7 +79,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         instructions="Please speak clearly and at a moderate pace.",
     )
 
-    # model choices: gpt-4o, gpt-4.1, etc.
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
         settings=OpenAILLMService.Settings(

--- a/examples/foundational/27-simli-layer.py
+++ b/examples/foundational/27-simli-layer.py
@@ -73,7 +73,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
         settings=OpenAILLMService.Settings(
-            model="gpt-4o-mini",
             system_instruction="You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way. Your output will be spoken aloud, so avoid special characters that can't easily be spoken, such as emojis or bullet points. Respond to what the user said in a creative and helpful way.",
         ),
     )

--- a/examples/foundational/35-pattern-pair-voice-switching.py
+++ b/examples/foundational/35-pattern-pair-voice-switching.py
@@ -24,7 +24,7 @@ The PatternPairAggregator:
     - Returns processed text at sentence boundaries
 
 Requirements:
-    - OpenAI API key (for GPT-4o)
+    - OpenAI API key
     - Cartesia API key (for text-to-speech)
     - Daily API key (for video/audio transport)
 

--- a/examples/foundational/37-mem0.py
+++ b/examples/foundational/37-mem0.py
@@ -24,7 +24,7 @@ Example usage (run from pipecat root directory):
     $ python examples/foundational/37-mem0.py
 
 Requirements:
-    - OpenAI API key (for GPT-4o-mini)
+    - OpenAI API key
     - ElevenLabs API key (for text-to-speech)
     - Daily API key (for video/audio transport)
     - Mem0 API key (for cloud-based memory storage)
@@ -226,7 +226,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
         settings=OpenAILLMService.Settings(
-            model="gpt-4o-mini",
             system_instruction="""You are a personal assistant. You can remember things about the person you are talking to.
                         Some Guidelines:
                         - Make sure your responses are friendly yet short and concise.

--- a/src/pipecat/services/azure/llm.py
+++ b/src/pipecat/services/azure/llm.py
@@ -47,7 +47,7 @@ class AzureLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Azure OpenAI.
             endpoint: The Azure endpoint URL.
-            model: The model identifier to use. Defaults to "gpt-4o".
+            model: The model identifier to use. Defaults to "gpt-4.1".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=AzureLLMService.Settings(model=...)`` instead.
@@ -58,7 +58,7 @@ class AzureLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="gpt-4o")
+        default_settings = self.Settings(model="gpt-4.1")
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -151,7 +151,7 @@ class BaseOpenAILLMService(LLMService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="gpt-4o",
+            model="gpt-4.1",
             system_instruction=None,
             frequency_penalty=NOT_GIVEN,
             presence_penalty=NOT_GIVEN,


### PR DESCRIPTION
## Summary
- Restored the default model for `OpenAILLMService` and `AzureLLMService` to `gpt-4.1`
- Remove hardcoded `gpt-4o` / `gpt-4o-mini` model references from examples so they use the new default

## Test plan
- [x] Verify `OpenAILLMService` defaults to `gpt-4.1` when no model is specified
- [x] Verify `AzureLLMService` defaults to `gpt-4.1` when no model is specified
- [x] Run affected examples to confirm they work with the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)