### PR TITLE
Fix for compatibility with `transformers>=5.0.0`

### DIFF
--- a/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
+++ b/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
@@ -137,7 +137,7 @@ class _Wav2Vec2ForEndpointing(Wav2Vec2PreTrainedModel):
                 if module.bias is not None:
                     module.bias.data.zero_()
 
-        if version.parse(transformers.__version__) >= "5.0.0":
+        if version.parse(transformers.__version__) >= version.parse("5.0.0"):
             self.post_init()
 
     def attention_pool(self, hidden_states, attention_mask):


### PR DESCRIPTION
This PR makes the custom model `_Wav2Vec2ForEndpointing` that's part of `SmartTurn v2` work with Transformers versions >= 5.0.0.

That version introduced a breaking change that requires a `self.post_init()` at the end of `self.__init__()`.

See this issue for more discussions: https://github.com/huggingface/transformers/issues/42832