### PR TITLE
Deprecate LocalSmartTurnAnalyzerV2 and LocalCoreMLSmartTurnAnalyzer

### DIFF
--- a/changelog/4012.deprecated.md
+++ b/changelog/4012.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated `LocalSmartTurnAnalyzerV2` and `LocalCoreMLSmartTurnAnalyzer`. Use `LocalSmartTurnAnalyzerV3` instead. Instantiating these analyzers will now emit a `DeprecationWarning`.

--- a/src/pipecat/audio/turn/smart_turn/local_coreml_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/local_coreml_smart_turn.py
@@ -10,6 +10,7 @@ This module provides a smart turn analyzer that uses CoreML models for
 local end-of-turn detection without requiring network connectivity.
 """
 
+import warnings
 from typing import Any, Dict
 
 import numpy as np
@@ -35,6 +36,10 @@ class LocalCoreMLSmartTurnAnalyzer(BaseSmartTurn):
     Provides end-of-turn detection using locally-stored CoreML models,
     enabling offline operation without network dependencies. Optimized
     for Apple Silicon and other CoreML-compatible hardware.
+
+    .. deprecated:: 0.0.106
+        LocalCoreMLSmartTurnAnalyzer is deprecated and will be removed in a future version.
+        Use LocalSmartTurnAnalyzerV3 instead.
     """
 
     def __init__(self, *, smart_turn_model_path: str, **kwargs):
@@ -49,6 +54,15 @@ class LocalCoreMLSmartTurnAnalyzer(BaseSmartTurn):
             Exception: If smart_turn_model_path is not provided or model loading fails.
         """
         super().__init__(**kwargs)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "LocalCoreMLSmartTurnAnalyzer is deprecated and will be removed in a future "
+                "version. Use LocalSmartTurnAnalyzerV3 instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if not smart_turn_model_path:
             logger.error("smart_turn_model_path is not set.")

--- a/src/pipecat/audio/turn/smart_turn/local_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/local_smart_turn.py
@@ -36,7 +36,7 @@ class LocalSmartTurnAnalyzer(BaseSmartTurn):
     enabling offline operation without network dependencies. Uses
     Wav2Vec2-BERT architecture for audio sequence classification.
 
-    .. deprecated:: 0.98.0
+    .. deprecated:: 0.0.98
         LocalSmartTurnAnalyzer is deprecated and will be removed in a future version.
         Use LocalSmartTurnAnalyzerV3 instead.
     """

--- a/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
+++ b/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
@@ -10,6 +10,7 @@ This module provides a smart turn analyzer that uses PyTorch models for
 local end-of-turn detection without requiring network connectivity.
 """
 
+import warnings
 from typing import Any, Dict
 
 import numpy as np
@@ -41,6 +42,10 @@ class LocalSmartTurnAnalyzerV2(BaseSmartTurn):
     Provides end-of-turn detection using locally-stored PyTorch models,
     enabling offline operation without network dependencies. Uses
     Wav2Vec2 architecture for audio sequence classification.
+
+    .. deprecated:: 0.0.106
+        LocalSmartTurnAnalyzerV2 is deprecated and will be removed in a future version.
+        Use LocalSmartTurnAnalyzerV3 instead.
     """
 
     def __init__(self, *, smart_turn_model_path: str, **kwargs):
@@ -52,6 +57,15 @@ class LocalSmartTurnAnalyzerV2(BaseSmartTurn):
             **kwargs: Additional arguments passed to BaseSmartTurn.
         """
         super().__init__(**kwargs)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "LocalSmartTurnAnalyzerV2 is deprecated and will be removed in a future version. "
+                "Use LocalSmartTurnAnalyzerV3 instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if not smart_turn_model_path:
             # Define the path to the pretrained model on Hugging Face


### PR DESCRIPTION
## Summary

- Deprecated `LocalSmartTurnAnalyzerV2` and `LocalCoreMLSmartTurnAnalyzer` in favor of `LocalSmartTurnAnalyzerV3`
- Instantiating either analyzer now emits a `DeprecationWarning` at runtime
- Added `.. deprecated::` docstring notices for documentation
- Fixed version number in existing `LocalSmartTurnAnalyzer` deprecation notice (`0.98.0` → `0.0.98`)

## Testing

- Verify deprecation warnings are emitted when instantiating `LocalSmartTurnAnalyzerV2`
- Verify deprecation warnings are emitted when instantiating `LocalCoreMLSmartTurnAnalyzer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)