### PR TITLE
fix(inworld): close context at end of turn instead of relying on idle timeout

### DIFF
--- a/changelog/4028.changed.md
+++ b/changelog/4028.changed.md
@@ -1,0 +1,1 @@
+- Modeified `InworldTTSService` to close context at end of turn instead of relying on idle timeout

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -774,12 +774,18 @@ class InworldTTSService(WebsocketTTSService):
         self._cumulative_time = 0.0
         self._generation_end_time = 0.0
 
+    async def on_turn_context_completed(self):
+        """Close the server-side context at end of turn.
+
+        Sends close_context so contextClosed arrives immediately after the
+        last audio byte.
+        """
+        ctx_id = self._turn_context_id
+        await super().on_turn_context_completed()
+        await self._close_context(ctx_id)
+
     async def on_audio_context_interrupted(self, context_id: str):
         """Callback invoked when an audio context has been interrupted."""
-        await self._close_context(context_id)
-
-    async def on_audio_context_completed(self, context_id: str):
-        """Callback invoked when an audio context has been completed."""
         await self._close_context(context_id)
 
     def _get_websocket(self):


### PR DESCRIPTION
The Inworld WS TTS plugin previously relied on the base TTS service's 3-second AUDIO_CONTEXT_TIMEOUT to detect when audio was done, then sent close_context in on_audio_context_completed. This added unnecessary latency before TTSStoppedFrame was emitted.  This also reduces concurrent contexts by closing contexts as soon as they are not needed anymore

The original implementation likely borrowed this idea from the 11labs' impelementation. But it's likely better to mirror the Cartesia plugin pattern where on_audio_context_completed is a no-op because the server signals completion directly.

Now close_context is sent in on_turn_context_completed (right after flush_context), so the server responds with contextClosed immediately after the last audio byte. The existing receive handler already calls remove_audio_context on contextClosed, which exits the audio context handler cleanly.
