### PR TITLE
forward timeout_secs in LLMSwitcher register methods

### DIFF
--- a/changelog/4037.fixed.md
+++ b/changelog/4037.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `LLMSwitcher.register_function()` and `register_direct_function()` not accepting or forwarding the `timeout_secs` parameter.

--- a/src/pipecat/pipeline/llm_switcher.py
+++ b/src/pipecat/pipeline/llm_switcher.py
@@ -80,6 +80,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
         start_callback=None,
         *,
         cancel_on_interruption: bool = True,
+        timeout_secs: Optional[float] = None,
     ):
         """Register a function handler for LLM function calls, on all LLMs, active or not.
 
@@ -96,6 +97,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
 
             cancel_on_interruption: Whether to cancel this function call when an
                 interruption occurs. Defaults to True.
+            timeout_secs: Optional timeout in seconds for the function call.
         """
         for llm in self.llms:
             llm.register_function(
@@ -103,6 +105,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
                 handler=handler,
                 start_callback=start_callback,
                 cancel_on_interruption=cancel_on_interruption,
+                timeout_secs=timeout_secs,
             )
 
     def register_direct_function(
@@ -110,6 +113,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
         handler: DirectFunction,
         *,
         cancel_on_interruption: bool = True,
+        timeout_secs: Optional[float] = None,
     ):
         """Register a direct function handler for LLM function calls, on all LLMs, active or not.
 
@@ -117,9 +121,11 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
             handler: The direct function to register. Must follow DirectFunction protocol.
             cancel_on_interruption: Whether to cancel this function call when an
                 interruption occurs. Defaults to True.
+            timeout_secs: Optional timeout in seconds for the function call.
         """
         for llm in self.llms:
             llm.register_direct_function(
                 handler=handler,
                 cancel_on_interruption=cancel_on_interruption,
+                timeout_secs=timeout_secs,
             )


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #4032 

`LLMSwitcher.register_function()` and `register_direct_function()` were missing the `timeout_secs` parameter that `LLMService` already supports. Calling either method with `timeout_secs` raised a `TypeError`.

Added `timeout_secs: Optional[float] = None` to both methods and forward it to the underlying LLM instances.