### PR TITLE
support tool_choice in Gemini adapter for non-live API

### DIFF
--- a/changelog/4039.added.md
+++ b/changelog/4039.added.md
@@ -1,0 +1,1 @@
+- Added `tool_choice` support to `GeminiLLMAdapter`, converting `LLMContext.tool_choice` to Gemini's `ToolConfig`/`FunctionCallingConfig` format for `GoogleLLMService` and `GoogleVertexLLMService`.

--- a/src/pipecat/adapters/services/gemini_adapter.py
+++ b/src/pipecat/adapters/services/gemini_adapter.py
@@ -19,12 +19,22 @@ from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.processors.aggregators.llm_context import (
     LLMContext,
     LLMContextMessage,
+    LLMContextToolChoice,
     LLMSpecificMessage,
     LLMStandardMessage,
 )
 
 try:
-    from google.genai.types import Blob, Content, FileData, FunctionCall, FunctionResponse, Part
+    from google.genai.types import (
+        Blob,
+        Content,
+        FileData,
+        FunctionCall,
+        FunctionCallingConfig,
+        FunctionResponse,
+        Part,
+        ToolConfig,
+    )
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error("In order to use Google AI, you need to `pip install pipecat-ai[google]`.")
@@ -37,6 +47,7 @@ class GeminiLLMInvocationParams(TypedDict):
     system_instruction: Optional[str]
     messages: List[Content]
     tools: List[Any] | NotGiven
+    tool_config: Optional[ToolConfig]
 
 
 class GeminiLLMAdapter(BaseLLMAdapter[GeminiLLMInvocationParams]):
@@ -68,7 +79,37 @@ class GeminiLLMAdapter(BaseLLMAdapter[GeminiLLMInvocationParams]):
             "messages": messages.messages,
             # NOTE: LLMContext's tools are guaranteed to be a ToolsSchema (or NOT_GIVEN)
             "tools": self.from_standard_tools(context.tools),
+            "tool_config": self._from_standard_tool_choice(context.tool_choice),
         }
+
+    def _from_standard_tool_choice(
+        self, tool_choice: LLMContextToolChoice | NotGiven
+    ) -> Optional[ToolConfig]:
+        """Convert standard tool_choice to Gemini's ToolConfig format.
+
+        Args:
+            tool_choice: The tool choice from the universal LLM context.
+
+        Returns:
+            ToolConfig for Gemini's API, or None if not applicable.
+        """
+        if isinstance(tool_choice, NotGiven):
+            return None
+        if isinstance(tool_choice, str):
+            mode_map = {"auto": "AUTO", "required": "ANY", "none": "NONE"}
+            mode = mode_map.get(tool_choice)
+            if mode:
+                return ToolConfig(function_calling_config=FunctionCallingConfig(mode=mode))
+            return None
+        if isinstance(tool_choice, dict):
+            func_name = tool_choice.get("function", {}).get("name")
+            if func_name:
+                return ToolConfig(
+                    function_calling_config=FunctionCallingConfig(
+                        mode="ANY", allowed_function_names=[func_name]
+                    )
+                )
+        return None
 
     def to_provider_tools_format(self, tools_schema: ToolsSchema) -> List[Dict[str, Any]]:
         """Convert tool schemas to Gemini's function-calling format.

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -904,17 +904,22 @@ class GoogleLLMService(LLMService):
         messages = []
         system = []
         tools = []
+        tool_config = None
         if isinstance(context, LLMContext):
             adapter = self.get_llm_adapter()
             params: GeminiLLMInvocationParams = adapter.get_llm_invocation_params(context)
             messages = params["messages"]
             system = params["system_instruction"]
             tools = params["tools"]
+            tool_config = params.get("tool_config")
         else:
             context = GoogleLLMContext.upgrade_to_google(context)
             messages = context.messages
             system = getattr(context, "system_message", None)
             tools = context.tools or []
+
+        if tool_config is None:
+            tool_config = self._tool_config
 
         # Override system instruction if provided
         if system_instruction is not None:
@@ -927,7 +932,7 @@ class GoogleLLMService(LLMService):
 
         # Build generation config using the same method as streaming
         generation_params = self._build_generation_params(
-            system_instruction=system, tools=tools if tools else None
+            system_instruction=system, tools=tools if tools else None, tool_config=tool_config
         )
 
         # Override max_output_tokens if provided
@@ -1030,8 +1035,8 @@ class GoogleLLMService(LLMService):
             tools = params_from_context["tools"]
         elif self._tools:
             tools = self._tools
-        tool_config = None
-        if self._tool_config:
+        tool_config = params_from_context.get("tool_config")
+        if tool_config is None:
             tool_config = self._tool_config
 
         # Build generation parameters
@@ -1064,6 +1069,7 @@ class GoogleLLMService(LLMService):
             messages=context.messages,
             system_instruction=context.system_message,
             tools=context.tools,
+            tool_config=None,
         )
 
         return await self._stream_content(params)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3994

#### Change : 
Added `tool_choice` support to `GeminiLLMAdapter`, converting `LLMContext.tool_choice` to Gemini's `ToolConfig`/`FunctionCallingConfig` format for `GoogleLLMService` and `GoogleVertexLLMService`

Note : Google's Live API doesn't support `tool_config` ([upstream issue](https://github.com/googleapis/python-genai/issues/468)).