### PR TITLE
fix(openai): handle tool calls with empty/null arguments

### DIFF
--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -532,7 +532,7 @@ class BaseOpenAILLMService(LLMService):
                     tool_call = chunk.choices[0].delta.tool_calls[0]
                     if tool_call.index != func_idx:
                         functions_list.append(function_name)
-                        arguments_list.append(arguments)
+                        arguments_list.append(arguments or "{}")
                         tool_id_list.append(tool_call_id)
                         function_name = ""
                         arguments = ""
@@ -558,10 +558,10 @@ class BaseOpenAILLMService(LLMService):
         # a registered handler. If so, run the registered callback, save the result to
         # the context, and re-prompt to get a chat answer. If we don't have a registered
         # handler, raise an exception.
-        if function_name and arguments:
+        if function_name:
             # added to the list as last function name and arguments not added to the list
             functions_list.append(function_name)
-            arguments_list.append(arguments)
+            arguments_list.append(arguments or "{}")
             tool_id_list.append(tool_call_id)
 
             function_calls = []


### PR DESCRIPTION
Fixes #4059

## Problem

When an LLM returns a streaming tool call with no arguments (`arguments=null` in the delta chunks), the tool call is silently dropped. This affects all OpenAI-compatible providers that don't send `arguments: "{}"` for parameterless tools, including vLLM (with Qwen, Llama, Mistral), Ollama, and others.

**Root cause in `BaseOpenAILLMService._process_context`:**

1. `tool_call.function.arguments` is `None` → nothing accumulated → `arguments` stays `""`
2. `if function_name and arguments:` → `""` is falsy → tool call execution skipped entirely
3. No error or warning logged — completely silent failure

OpenAI masks this because it always sends `arguments: "{}"` even for tools with zero parameters.

## Fix

Three lines changed:

- **Line 535**: `arguments_list.append(arguments)` → `arguments_list.append(arguments or "{}")` (intermediate tool calls in multi-tool responses)
- **Line 561**: `if function_name and arguments:` → `if function_name:` (final tool call check)
- **Line 564**: `arguments_list.append(arguments)` → `arguments_list.append(arguments or "{}")` (final tool call append)

Empty arguments default to `"{}"` so `json.loads` produces `{}`. No behavior change for OpenAI or any provider that already sends `"{}"`.

## Testing

Verified with vLLM serving `Qwen3-VL-235B` with `--enable-auto-tool-choice --tool-call-parser hermes`. Before this fix, `end_call` tool calls were silently dropped. After, they execute correctly with empty arguments.