### PR TITLE
Fixed the ordering of `_maybe_pause_frame_processing` call in `TTSService`

### DIFF
--- a/changelog/4071.fixed.md
+++ b/changelog/4071.fixed.md
@@ -1,0 +1,1 @@
+- Fixed audio overlap and potential dropped TTS content when multiple assistant turns occur in quick succession. `TTSService` now flushes remaining text before pausing frame processing on `LLMFullResponseEndFrame`/`EndFrame`, instead of pausing first.

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -5,13 +5,19 @@
 #
 
 
+import asyncio
 import os
 
 from dotenv import load_dotenv
 from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import LLMRunFrame
+from pipecat.frames.frames import (
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMRunFrame,
+    TextFrame,
+)
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -102,6 +108,16 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         # Kick off the conversation.
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
+        # Rapid consecutive assistant turns to try to force the ElevenLabs maximum context limit exceeded error.
+        #for idx in range(1, int(10) + 1):
+        #    await task.queue_frames(
+        #        [
+        #            LLMFullResponseStartFrame(),
+        #            TextFrame(f"✓ [{idx}] test"),
+        #            LLMFullResponseEndFrame(),
+        #        ],
+        #    )
+        #    await asyncio.sleep(0)
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -5,19 +5,13 @@
 #
 
 
-import asyncio
 import os
 
 from dotenv import load_dotenv
 from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import (
-    LLMFullResponseEndFrame,
-    LLMFullResponseStartFrame,
-    LLMRunFrame,
-    TextFrame,
-)
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -108,16 +102,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         # Kick off the conversation.
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
-        # Rapid consecutive assistant turns to try to force the ElevenLabs maximum context limit exceeded error.
-        # for idx in range(1, int(10) + 1):
-        #    await task.queue_frames(
-        #        [
-        #            LLMFullResponseStartFrame(),
-        #            TextFrame(f"✓ [{idx}] test"),
-        #            LLMFullResponseEndFrame(),
-        #        ],
-        #    )
-        #    await asyncio.sleep(0)
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/foundational/07d-interruptible-elevenlabs.py
+++ b/examples/foundational/07d-interruptible-elevenlabs.py
@@ -109,7 +109,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
         # Rapid consecutive assistant turns to try to force the ElevenLabs maximum context limit exceeded error.
-        #for idx in range(1, int(10) + 1):
+        # for idx in range(1, int(10) + 1):
         #    await task.queue_frames(
         #        [
         #            LLMFullResponseStartFrame(),

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -720,17 +720,17 @@ class TTSService(AIService):
             self._turn_context_id = self.create_context_id()
             await self.push_frame(frame, direction)
         elif isinstance(frame, (LLMFullResponseEndFrame, EndFrame)):
-            # We pause processing incoming frames if the LLM response included
-            # text (it might be that it's only a function calling response). We
-            # pause to avoid audio overlapping.
-            await self._maybe_pause_frame_processing()
-
             # Flush any remaining text (including text waiting for lookahead)
             remaining = await self._text_aggregator.flush()
             # Stop the aggregation metric (no-op if already stopped on first sentence).
             await self.stop_text_aggregation_metrics()
             if remaining:
                 await self._push_tts_frames(AggregatedTextFrame(remaining.text, remaining.type))
+
+            # We pause processing incoming frames if the LLM response included
+            # text (it might be that it's only a function calling response). We
+            # pause to avoid audio overlapping.
+            await self._maybe_pause_frame_processing()
 
             # Log accumulated streamed text and emit aggregated usage metric.
             if self._streamed_text:


### PR DESCRIPTION
## Summary
- Fixed the ordering of `_maybe_pause_frame_processing` call in `TTSService`. It now runs after flushing remaining text on `LLMFullResponseEndFrame`/`EndFrame`, not before.                                                                                           
- Previously, frame processing was paused before remaining TTS text was flushed, which could cause audio overlap or dropped content when ElevenLabs (and other TTS services) hit context limits under rapid consecutive turns 

Fixes #4041, #4027 