### PR TITLE
enable_dialout should not depend on sip_caller_phone being set

### DIFF
--- a/src/pipecat/runner/daily.py
+++ b/src/pipecat/runner/daily.py
@@ -225,6 +225,9 @@ async def configure(
         if room_geo:
             room_properties.geo = room_geo
 
+        if enable_dialout:
+            room_properties.enable_dialout = True
+
         # Add SIP configuration if enabled
         if sip_enabled:
             sip_params = DailyRoomSipParams(
@@ -236,7 +239,6 @@ async def configure(
                 provider=sip_provider,
             )
             room_properties.sip = sip_params
-            room_properties.enable_dialout = enable_dialout
             room_properties.start_video_off = not sip_enable_video  # Voice-only by default
 
     # Create room parameters

--- a/src/pipecat/runner/daily.py
+++ b/src/pipecat/runner/daily.py
@@ -207,7 +207,7 @@ async def configure(
         return DailyRoomConfig(room_url=room_url, token=token)
 
     # Create a new room
-    room_prefix = "pipecat-sip" if (sip_enabled or enable_dialout) else "pipecat"
+    room_prefix = "pipecat-telephony" if (sip_enabled or enable_dialout) else "pipecat"
     room_name = f"{room_prefix}-{uuid.uuid4().hex[:8]}"
     logger.info(f"Creating new Daily room: {room_name}")
 

--- a/src/pipecat/runner/daily.py
+++ b/src/pipecat/runner/daily.py
@@ -207,7 +207,7 @@ async def configure(
         return DailyRoomConfig(room_url=room_url, token=token)
 
     # Create a new room
-    room_prefix = "pipecat-sip" if sip_enabled else "pipecat"
+    room_prefix = "pipecat-sip" if (sip_enabled or enable_dialout) else "pipecat"
     room_name = f"{room_prefix}-{uuid.uuid4().hex[:8]}"
     logger.info(f"Creating new Daily room: {room_name}")
 


### PR DESCRIPTION
Decouple `enable_dialout` from SIP dial-in configuration in `configure()` and allowing dial-out without needing to create a SIP dial-in