### PR TITLE
use audio context hook for InterruptibleTTSService

### DIFF
--- a/changelog/4099.fixed.md
+++ b/changelog/4099.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InterruptibleTTSService` interruption handling by replacing the `_bot_speaking` guard with `on_audio_context_interrupted`, so the websocket is always reconnected when audio is in-transit. Affects Fish Audio, LMNT, Neuphonic, and Sarvam TTS services.

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -362,6 +362,7 @@ class FishAudioTTSService(InterruptibleTTSService):
 
     async def on_audio_context_interrupted(self, context_id: str):
         """Stop all metrics when audio context is interrupted."""
+        await super().on_audio_context_interrupted(context_id)
         await self.stop_all_metrics()
 
     async def _receive_messages(self):

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -31,7 +31,6 @@ from pipecat.audio.utils import create_stream_resampler
 from pipecat.frames.frames import (
     AggregatedTextFrame,
     AggregationType,
-    BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     CancelFrame,
     EndFrame,
@@ -1478,42 +1477,15 @@ class WebsocketTTSService(TTSService, WebsocketService):
 class InterruptibleTTSService(WebsocketTTSService):
     """Websocket-based TTS service that handles interruptions without word timestamps.
 
-    Designed for TTS services that don't support word timestamps. Handles interruptions
-    by reconnecting the websocket when the bot is speaking and gets interrupted.
+    Designed for TTS services that don't support word timestamps or native cancel
+    APIs. Handles interruptions by reconnecting the websocket when an active audio
+    context gets interrupted.
     """
 
-    def __init__(self, **kwargs):
-        """Initialize the Interruptible TTS service.
-
-        Args:
-            **kwargs: Additional arguments passed to the parent WebsocketTTSService.
-        """
-        super().__init__(**kwargs)
-
-        # Indicates if the bot is speaking. If the bot is not speaking we don't
-        # need to reconnect when the user speaks. If the bot is speaking and the
-        # user interrupts we need to reconnect.
-        self._bot_speaking = False
-
-    async def _handle_interruption(self, frame: InterruptionFrame, direction: FrameDirection):
-        await super()._handle_interruption(frame, direction)
-        if self._bot_speaking:
-            await self._disconnect()
-            await self._connect()
-
-    async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Process frames with bot speaking state tracking.
-
-        Args:
-            frame: The frame to process.
-            direction: The direction of frame processing.
-        """
-        await super().process_frame(frame, direction)
-
-        if isinstance(frame, BotStartedSpeakingFrame):
-            self._bot_speaking = True
-        elif isinstance(frame, BotStoppedSpeakingFrame):
-            self._bot_speaking = False
+    async def on_audio_context_interrupted(self, context_id: str):
+        """Disconnect and reconnect the websocket to stop server-side synthesis."""
+        await self._disconnect()
+        await self._connect()
 
 
 class WebsocketWordTTSService(WebsocketTTSService):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #3986 

### Issue :
The `_bot_speaking` guard in `InterruptibleTTSService._handle_interruption()` skips websocket disconnect/reconnect when `BotStartedSpeakingFrame` hasn't reached the TTS processor yet. If a user interrupts while audio is still being synthesized or in-transit, the TTS server keeps streaming stale audio into the next response. 

Note: #4090 partially addressed this by routing audio through append_to_audio_context(), so stale audio is discarded when no active context exists. However, the server still continues synthesizing unused audio (wasted cost/bandwidth), and old audio can leak into the next response once a new audio context becomes active.                                                          
                                                                                                                             
### Approach : 
Replaced the `_bot_speaking` guard with an `on_audio_context_interrupted()` override - the same hook ElevenLabs, Rime, & Deepgram already use. Audio contexts exist from synthesis start to playback end, so this fires exactly when needed & stays silent when the bot is idle (preserving the original optimization against unnecessary reconnects from VAD noise).                 

**Changes** : 
- tts_service.py: removed _bot_speaking, _handle_interruption, process_frame override; added on_audio_context_interrupted with disconnect/reconnect              
- fish/tts.py: added super() call in existing on_audio_context_interrupted override  