### PR TITLE
enable pause_frame_processing for CartesiaTTSService

### DIFF
--- a/changelog/4101.fixed.md
+++ b/changelog/4101.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `CartesiaTTSService` allowing downstream frames to execute before audio playback completes by enabling `pause_frame_processing`.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -334,7 +334,7 @@ class CartesiaTTSService(WebsocketTTSService):
             text_aggregation_mode=text_aggregation_mode,
             aggregate_sentences=aggregate_sentences,
             push_text_frames=False,
-            pause_frame_processing=False,
+            pause_frame_processing=True,
             sample_rate=sample_rate,
             push_start_frame=True,
             text_aggregator=text_aggregator,


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #4038 

**Change** : Enabled `pause_frame_processing` for `CartesiaTTSService` so downstream frames wait until audio playback completes before reaching the pipeline sink.