### PR TITLE
feat(assemblyai): add domain parameter for Medical Mode

### DIFF
--- a/changelog/4117.added.md
+++ b/changelog/4117.added.md
@@ -1,0 +1,1 @@
+- Added `domain` parameter to `AssemblyAISTTSettings` for specialized recognition modes such as Medical Mode (`domain="medical-v1"`).

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -101,6 +101,8 @@ class AssemblyAISTTSettings(STTSettings):
         speaker_labels: Enable speaker diarization.
         vad_threshold: VAD confidence threshold (0.0–1.0) for classifying
             audio frames as silence. Only applicable to u3-rt-pro.
+        domain: Optional domain for specialized recognition modes. For example,
+            set to "medical-v1" to enable Medical Mode for healthcare transcription.
     """
 
     formatted_finals: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -118,6 +120,7 @@ class AssemblyAISTTSettings(STTSettings):
     format_turns: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     speaker_labels: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     vad_threshold: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    domain: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class AssemblyAISTTService(WebsocketSTTService):
@@ -204,6 +207,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             format_turns=True,
             speaker_labels=None,
             vad_threshold=None,
+            domain=None,
         )
 
         # 2. Apply direct init arg overrides (deprecated)
@@ -470,6 +474,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             "format_turns": s.format_turns,
             "speaker_labels": s.speaker_labels,
             "vad_threshold": s.vad_threshold,
+            "domain": s.domain,
         }
 
         for k, v in optional_fields.items():


### PR DESCRIPTION
## Summary

- Add `domain` field to `AssemblyAISTTSettings` to support AssemblyAI's streaming API `domain` query parameter
- This enables specialized recognition modes like **Medical Mode** (`medical-v1`) for healthcare transcription
- The parameter is passed as a WebSocket query parameter, consistent with how other optional settings are handled

## Usage

```python
stt = AssemblyAISTTService(
    api_key="...",
    settings=AssemblyAISTTService.Settings(
        domain="medical-v1",
    ),
)
```

## Documentation

AssemblyAI Medical Mode docs: https://assemblyai-preview-9b76d250-9a53-4bf9-b2d8-4af9b3bc1133.docs.buildwithfern.com/docs/streaming/medical-mode

## Test plan

- [ ] Verify `domain` parameter is included in WebSocket URL when set (e.g., `domain=medical-v1`)
- [ ] Verify `domain` parameter is omitted from WebSocket URL when not set (default behavior unchanged)
- [ ] Verify Medical Mode works with supported streaming models (`u3-rt-pro`, `universal-streaming-english`, `universal-streaming-multilingual`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)