### PR TITLE
Invoking on_turn_context_created when we receive a TTSSpeakFrame.

### DIFF
--- a/changelog/4013.added.md
+++ b/changelog/4013.added.md
@@ -1,0 +1,1 @@
+- Added `on_turn_context_created(context_id)` hook to `TTSService`. Override this to perform provider-specific setup (e.g. eagerly opening a server-side context) before text starts flowing. Called each time a new turn context ID is created.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -661,7 +661,7 @@ class TTSService(AIService):
 
         Override to perform provider-specific setup (e.g., eagerly opening a
         server-side context) before text starts flowing. This is called from
-        ``process_frame`` when an ``LLMFullResponseStartFrame`` arrives.
+        ``process_frame`` when an ``LLMFullResponseStartFrame`` or ``TTSSpeakFrame`` arrives.
 
         Args:
             context_id: The newly created turn context ID.
@@ -759,6 +759,7 @@ class TTSService(AIService):
             self._turn_context_id = None
             # Creating a new context_id for the TTS request.
             self._turn_context_id = self.create_context_id()
+            await self.on_turn_context_created(self._turn_context_id)
             # If we are not receiving text from the LLM, we can assume that the SpeakFrame should be automatically added to the context
             push_assistant_aggregation = frame.append_to_context and not self._llm_response_started
             # Assumption: text in TTSSpeakFrame does not include inter-frame spaces


### PR DESCRIPTION
This is a follow-up PR, for the changes introduced by Inworld here:
- https://github.com/pipecat-ai/pipecat/pull/4013