### PR TITLE
fix: serialize standard context tools

### DIFF
--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -968,10 +968,21 @@ def traced_openai_realtime(operation: str) -> Callable:
                                 try:
                                     context_tools = getattr(self._context, "tools", None)
                                     if context_tools and not operation_attrs.get("tools"):
-                                        operation_attrs["tools"] = context_tools
-                                        operation_attrs["tools_serialized"] = json.dumps(
-                                            context_tools
-                                        )
+                                        tools = None
+                                        if hasattr(self, "get_llm_adapter"):
+                                            adapter = self.get_llm_adapter()
+                                            tools = adapter.from_standard_tools(context_tools)
+
+                                        if tools is not None and tools is not NOT_GIVEN:
+                                            operation_attrs["tools"] = tools
+                                            try:
+                                                operation_attrs["tools_serialized"] = json.dumps(
+                                                    tools
+                                                )
+                                            except Exception as e:
+                                                logging.warning(
+                                                    f"Error serializing OpenAI Realtime tools: {e}"
+                                                )
                                 except Exception as e:
                                     logging.warning(f"Error extracting context tools: {e}")
 


### PR DESCRIPTION
Guard tool extraction so that when context tools expose a `standard_tools` list we include both their raw form and a sanitized serialized version with name/description tuples; fall back to the previous behavior otherwise.

The same pattern is already being used in llm_setup branch.

Currently it leads to this issue:
```
app-1  | 2026-03-24 16:08:46.470 | DEBUG    | pipecat.pipeline.task:_wait_for_pipeline_start:748 - PipelineTask#0: StartFrame#0 reached the end of the pipeline, pipeline is now
ready.
app-1  | WARNING:root:Error extracting context tools: Object of type ToolsSchema is not JSON serializable
app-1  | ERROR:root:Error in OpenAI Realtime tracing (continuing without tracing): object of type 'ToolsSchema' has no len()
app-1  | 2026-03-24 16:08:46.478 | DEBUG    | pipecat.adapters.base_llm_adapter:from_standard_tools:127 - Retrieving the tools using the adapter: <class
'pipecat.adapters.services.open_ai_realtime_adapter.OpenAIRealtimeLLMAdapter'>
app-1  | 2026-03-24 16:08:46.599 | DEBUG    | pipecat.services.openai.realtime.llm:_create_response:1034 - Setting up conversation on OpenAI Realtime LLM service with initial
messages
```