### PR TITLE
Fix TTS flush creating phantom contexts on ElevenLabs

### DIFF
--- a/changelog/4126.fixed.md
+++ b/changelog/4126.fixed.md
@@ -1,0 +1,1 @@
+- Fixed ElevenLabs WebSocket disconnections (1008 "Maximum simultaneous contexts exceeded") caused by rapid user interruptions. When interruptions arrived before any TTS text was generated, phantom contexts were created on the ElevenLabs server that were never closed, eventually exceeding the 5-context limit.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -682,7 +682,12 @@ class TTSService(AIService):
             await self.remove_audio_context(self._turn_context_id)
 
         # Flush any pending audio so the TTS service closes the current context.
-        await self.flush_audio(context_id=self._turn_context_id)
+        # Only flush if the context was actually opened (text reached run_tts).
+        # When an interruption arrives before any text flows, the turn context ID
+        # exists but was never registered via create_audio_context, so flushing
+        # would send a message for a context the provider never opened.
+        if self._turn_context_id and self.audio_context_available(self._turn_context_id):
+            await self.flush_audio(context_id=self._turn_context_id)
 
         # Reset the turn context ID
         self._turn_context_id = None


### PR DESCRIPTION
## Summary

- Fixed ElevenLabs WebSocket 1008 policy violation ("Maximum simultaneous contexts exceeded") caused by rapid user interruptions
- When an interruption arrives before any LLM text reaches `run_tts`, the turn context ID exists but was never registered via `create_audio_context`. The subsequent `LLMFullResponseEndFrame` triggers `on_turn_context_completed` → `flush_audio`, which sends a `{"context_id": "<uuid>", "flush": true}` message to ElevenLabs for a context it has never seen. ElevenLabs implicitly creates a server-side context for each such flush, and since no `close_context` is ever sent, they accumulate until the 5-context limit is exceeded.
- The fix guards `flush_audio` in base `TTSService.on_turn_context_completed` with `audio_context_available` so it only fires when text actually reached the TTS provider and the context was opened

## Testing

- Connect to an ElevenLabs-backed voice agent and rapidly interrupt (speak over the bot) 10-20 times in quick succession
- Previously this would cause a 1008 WebSocket disconnection; with the fix the connection remains stable

## Fixes

- Fixes #4114

🤖 Generated with [Claude Code](https://claude.com/claude-code)