### PR TITLE
Enable direct mode for filter processors

### DIFF
--- a/changelog/4129.performance.md
+++ b/changelog/4129.performance.md
@@ -1,0 +1,1 @@
+- `FrameFilter`, `IdentityFilter`, and `NullFilter` now use direct mode for lower-latency synchronous frame processing, bypassing the async queue.

--- a/src/pipecat/processors/filters/frame_filter.py
+++ b/src/pipecat/processors/filters/frame_filter.py
@@ -20,15 +20,16 @@ class FrameFilter(FrameProcessor):
     automatically allowed to pass through to maintain pipeline integrity.
     """
 
-    def __init__(self, types: Tuple[Type[Frame], ...]):
+    def __init__(self, types: Tuple[Type[Frame], ...], **kwargs):
         """Initialize the frame filter.
 
         Args:
             types: Tuple of frame types that should be allowed to pass through
                    the filter. All other frame types (except SystemFrame and
                    EndFrame) will be blocked.
+            **kwargs: Additional arguments passed to the parent FrameProcessor.
         """
-        super().__init__()
+        super().__init__(enable_direct_mode=True, **kwargs)
         self._types = types
 
     #

--- a/src/pipecat/processors/filters/identity_filter.py
+++ b/src/pipecat/processors/filters/identity_filter.py
@@ -28,7 +28,7 @@ class IdentityFilter(FrameProcessor):
         Args:
             **kwargs: Additional arguments passed to the parent FrameProcessor.
         """
-        super().__init__(**kwargs)
+        super().__init__(enable_direct_mode=True, **kwargs)
 
     #
     # Frame processor

--- a/src/pipecat/processors/filters/null_filter.py
+++ b/src/pipecat/processors/filters/null_filter.py
@@ -29,7 +29,7 @@ class NullFilter(FrameProcessor):
         Args:
             **kwargs: Additional arguments passed to parent FrameProcessor.
         """
-        super().__init__(**kwargs)
+        super().__init__(enable_direct_mode=True, **kwargs)
 
     #
     # Frame processor


### PR DESCRIPTION
## Summary

- Enable direct mode on `FrameFilter`, `IdentityFilter`, and `NullFilter` so they bypass the async queue and process frames synchronously, reducing latency for simple pass-through/block operations
- Also forward `**kwargs` to parent `FrameProcessor` in `FrameFilter` for consistency with the other filters

## Testing

- `uv run pytest tests/` — verify no regressions in existing filter tests
- Verify filters still correctly pass/block frames in a pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)