### PR TITLE
Ignore Gemini VAD interrupts when VAD is disabled

### DIFF
--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -828,7 +828,6 @@ class GeminiLiveLLMService(LLMService):
             if self._settings.language
             else "en-US"
         )
-        self._vad_params = self._settings.vad
 
         # Reconnection tracking
         self._consecutive_failures = 0
@@ -1371,8 +1370,13 @@ class GeminiLiveLLMService(LLMService):
                             # track turns, such as local Silero VAD in
                             # combination with the context aggregator default
                             # turn strategies.
-                            logger.debug("Gemini VAD: interrupted signal received")
-                            await self.broadcast_interruption()
+                            if self._settings.vad and self._settings.vad.disabled:
+                                logger.debug(
+                                    "Gemini VAD: interrupted signal received (ignored, VAD disabled)"
+                                )
+                            else:
+                                logger.debug("Gemini VAD: interrupted signal received")
+                                await self.broadcast_interruption()
                         elif message.server_content and message.server_content.model_turn:
                             await self._handle_msg_model_turn(message)
                         elif message.server_content and message.server_content.turn_complete:


### PR DESCRIPTION
## Summary

- When `GeminiVADParams(disabled=True)` is set, suppress server-side VAD interrupt signals instead of broadcasting them
- Logs ignored interrupts at debug level for visibility
- Fixes bot interrupting users despite VAD being explicitly disabled

## Context

We received a support report from a Pipecat Cloud user whose bot was aggressively interrupting users mid-sentence. After investigating their OpenSearch logs across 3 sessions, we found that `Gemini VAD: interrupted signal received` was firing **10+ times per user turn** even with `GeminiVADParams(disabled=True)`.

The `disabled` flag is correctly transmitted to Google's Gemini API via `AutomaticActivityDetection(disabled=True)`, but the API still sends `interrupted` signals. Without a local guard, Pipecat unconditionally broadcasts these interrupts, making it impossible for developers to disable server-side VAD.

### Log evidence (session `8a31d681`):
```
00:14:34 Gemini VAD: interrupted signal received  ← disabled=True!
00:14:35 Gemini VAD: interrupted signal received
00:14:38 Gemini VAD: interrupted signal received
00:14:41 Gemini VAD: interrupted signal received
00:14:50 Gemini VAD: interrupted signal received
...10+ more during a single user turn
```

## Test plan

- [ ] Verify `GeminiVADParams(disabled=True)` no longer broadcasts interrupts
- [ ] Verify `GeminiVADParams(disabled=False)` still broadcasts interrupts normally
- [ ] Verify default `GeminiVADParams()` (disabled=None) still broadcasts interrupts normally
- [ ] Verify debug log shows "ignored, VAD disabled" message when interrupts are suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)