### PR TITLE
test: reproduce ElevenLabs 5-context limit bug (#4132)

### DIFF
--- a/tests/test_elevenlabs_context_limit_repro.py
+++ b/tests/test_elevenlabs_context_limit_repro.py
@@ -4,25 +4,22 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Reproduction test for ElevenLabs TTS 5-context limit bug.
+"""Reproduction test for ElevenLabs TTS 5-context-per-connection limit bug.
 
-The bug: ElevenLabsTTSService._close_context() sends close_context:True over
-the WebSocket fire-and-forget, without waiting for server acknowledgment.
-During rapid user interruptions, new contexts are created before old ones are
-fully closed server-side, eventually exceeding the 5-context limit and causing
-a 1008 (policy violation) disconnect from the ElevenLabs server.
+Bug: ElevenLabsTTSService._close_context() sends close_context:True over the
+WebSocket fire-and-forget.  During rapid user interruptions the bot creates new
+contexts faster than ElevenLabs releases old ones, eventually exceeding the
+5-context limit and receiving a 1008 (policy violation) disconnect.  After that
+the bot goes silent — no more TTS audio is produced.
 
-This test uses a mock WebSocket server that faithfully models the ElevenLabs
-server behavior:
-  - Tracks open contexts with a configurable limit (MAX_CONTEXTS = 5).
-  - Delays processing of close_context requests (simulating server-side async cleanup).
-  - Sends a 1008 close frame when a 6th context is opened.
-
-The test directly drives the ElevenLabsTTSService methods that create and close
-contexts over the WebSocket, reproducing the exact race condition.
+This test drives the real ElevenLabsTTSService through a pipecat Pipeline,
+alternating between TTS generation and InterruptionFrame, against a mock
+WebSocket server that enforces the 5-context limit with realistic cleanup
+delay.
 """
 
 import asyncio
+import base64
 import json
 import unittest
 from typing import Any, List, Set
@@ -31,96 +28,112 @@ import websockets
 from websockets.asyncio.server import serve as websocket_serve
 from websockets.frames import CloseCode
 
+from pipecat.frames.frames import (
+    EndFrame,
+    ErrorFrame,
+    Frame,
+    InterruptionFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    StartFrame,
+    TextFrame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.elevenlabs.tts import ElevenLabsTTSService, ElevenLabsTTSSettings
+
+# ---------------------------------------------------------------------------
+# Mock ElevenLabs WebSocket server
+# ---------------------------------------------------------------------------
+
 MAX_CONTEXTS = 5
-CLOSE_DELAY_S = 0.3  # Simulated server-side cleanup delay
+CLOSE_DELAY_S = 1.0  # Simulated server-side cleanup latency (real ElevenLabs can be slow)
+_FAKE_AUDIO = base64.b64encode(b"\x00\x01" * 160).decode("ascii")
 
 
 class MockElevenLabsServer:
-    """Mock ElevenLabs WebSocket server that enforces context limits.
+    """Mock server that enforces the ElevenLabs 5-context limit.
 
-    When a client sends a text message with a new context_id, the server
-    tracks it as open.  When the client sends close_context, the server
-    delays the actual cleanup (simulating real ElevenLabs behavior).
-    If the number of simultaneously open contexts exceeds MAX_CONTEXTS,
-    the server closes the connection with 1008 Policy Violation.
+    Accepts text messages (opens context), close_context messages (delayed
+    cleanup), and disconnects with 1008 when more than MAX_CONTEXTS are
+    simultaneously open — matching real ElevenLabs behavior.
     """
 
     def __init__(self) -> None:
         self.open_contexts: Set[str] = set()
-        self.close_requests_received: List[str] = []
+        self.close_requests: List[str] = []
         self.policy_violation_sent = False
-        self.connections_made = 0
         self.peak_open_contexts = 0
         self._server: Any = None
         self.port: int = 0
         self._pending_closes: List[asyncio.Task[None]] = []
 
     async def _delayed_close(self, context_id: str) -> None:
-        """Simulate server-side async cleanup that takes time."""
         await asyncio.sleep(CLOSE_DELAY_S)
         self.open_contexts.discard(context_id)
 
     async def handler(self, websocket: Any) -> None:
-        self.connections_made += 1
         try:
             async for message in websocket:
                 data = json.loads(message)
                 context_id = data.get("context_id", "")
 
-                # Handle close_context request
                 if data.get("close_context"):
-                    self.close_requests_received.append(context_id)
-                    # Start delayed cleanup -- the context remains "open"
-                    # from the server's perspective during the delay
+                    self.close_requests.append(context_id)
                     task = asyncio.create_task(self._delayed_close(context_id))
                     self._pending_closes.append(task)
-                    # Send isFinal after a small delay (like real server)
-                    await asyncio.sleep(0.01)
+                    await asyncio.sleep(0.005)
                     try:
                         await websocket.send(json.dumps({"contextId": context_id, "isFinal": True}))
                     except websockets.exceptions.ConnectionClosed:
                         pass
                     continue
 
-                # Handle close_socket
                 if data.get("close_socket"):
                     await websocket.close()
                     return
 
-                # Any message with text + context_id opens/uses a context
-                if "text" in data and context_id:
-                    if context_id not in self.open_contexts:
-                        # New context being opened -- check limit
-                        if len(self.open_contexts) >= MAX_CONTEXTS:
-                            self.policy_violation_sent = True
-                            await websocket.close(
-                                CloseCode.POLICY_VIOLATION,
-                                f"Too many contexts: {len(self.open_contexts) + 1} > {MAX_CONTEXTS}",
-                            )
-                            return
-                        self.open_contexts.add(context_id)
-                        self.peak_open_contexts = max(
-                            self.peak_open_contexts, len(self.open_contexts)
-                        )
+                if data.get("flush"):
+                    continue
 
-                    # Send back a small audio response
-                    try:
-                        await websocket.send(
-                            json.dumps(
-                                {
-                                    "contextId": context_id,
-                                    "audio": "AAAA",
-                                    "alignment": {
-                                        "chars": ["h"],
-                                        "charStartTimesMs": [0],
-                                        "charDurationsMs": [100],
-                                    },
-                                }
-                            )
-                        )
-                    except websockets.exceptions.ConnectionClosed:
-                        pass
+                text = data.get("text", "")
+                if not text.strip() or not context_id:
+                    continue
 
+                # New context — enforce the limit
+                if context_id not in self.open_contexts:
+                    if len(self.open_contexts) >= MAX_CONTEXTS:
+                        self.policy_violation_sent = True
+                        await websocket.close(
+                            CloseCode.POLICY_VIOLATION,
+                            f"Max contexts exceeded: {len(self.open_contexts) + 1} > {MAX_CONTEXTS}",
+                        )
+                        return
+                    self.open_contexts.add(context_id)
+                    self.peak_open_contexts = max(self.peak_open_contexts, len(self.open_contexts))
+
+                # Respond with audio + alignment
+                try:
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "contextId": context_id,
+                                "audio": _FAKE_AUDIO,
+                                "alignment": {
+                                    "chars": list(text[:5]),
+                                    "charStartTimesMs": list(range(0, len(text[:5]) * 20, 20)),
+                                    "charDurationsMs": [20] * len(text[:5]),
+                                },
+                            }
+                        )
+                    )
+                except websockets.exceptions.ConnectionClosed:
+                    pass
         except websockets.exceptions.ConnectionClosed:
             pass
 
@@ -129,7 +142,6 @@ class MockElevenLabsServer:
         self.port = self._server.sockets[0].getsockname()[1]
 
     async def stop(self) -> None:
-        # Cancel pending delayed closes
         for task in self._pending_closes:
             task.cancel()
         if self._server:
@@ -137,226 +149,148 @@ class MockElevenLabsServer:
             await self._server.wait_closed()
 
 
-class TestElevenLabsContextLimitBug(unittest.IsolatedAsyncioTestCase):
-    """Reproduce the fire-and-forget close_context bug.
+# ---------------------------------------------------------------------------
+# ElevenLabs subclass wired to mock server
+# ---------------------------------------------------------------------------
 
-    This test PASSES when the bug is present, demonstrating that the
-    current _close_context implementation does not wait for server-side
-    acknowledgment, allowing context accumulation beyond the limit.
+
+class MockedElevenLabsTTSService(ElevenLabsTTSService):
+    """ElevenLabsTTSService pointed at a local mock WebSocket server."""
+
+    def __init__(self, server_port: int, **kwargs: Any) -> None:
+        super().__init__(
+            api_key="test-key",
+            url=f"ws://127.0.0.1:{server_port}",
+            settings=ElevenLabsTTSSettings(
+                voice="test-voice",
+                model="eleven_flash_v2_5",
+            ),
+            **kwargs,
+        )
+        self._pause_frame_processing = False
+        self._stop_frame_timeout_s = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Frame collector
+# ---------------------------------------------------------------------------
+
+
+class FrameCollector(FrameProcessor):
+    """Collects TTS and error frames for test assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.frames: List[Frame] = []
+        self.errors: List[ErrorFrame] = []
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, ErrorFrame):
+            self.errors.append(frame)
+        if isinstance(frame, (TTSStartedFrame, TTSAudioRawFrame, TTSStoppedFrame, ErrorFrame)):
+            self.frames.append(frame)
+        await self.push_frame(frame, direction)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestElevenLabsContextLimitInPipeline(unittest.IsolatedAsyncioTestCase):
+    """Reproduce the 5-context limit bug using the real ElevenLabsTTSService
+    in a pipecat pipeline with InterruptionFrames.
     """
 
-    async def test_rapid_close_and_reopen_exceeds_context_limit(self) -> None:
-        """Directly simulate the _close_context fire-and-forget race.
+    async def test_rapid_interruptions_trigger_1008_and_silence(self) -> None:
+        """Rapid interruptions during TTS exhaust the context limit.
 
-        Reproduces the exact sequence:
-        1. Client opens context via text message
-        2. Client sends close_context (fire-and-forget, no await on server ack)
-        3. Client immediately opens a new context
-        4. Server has not yet freed the old context
-        5. After enough cycles, server sees >5 open contexts -> 1008
-
-        This mirrors what happens during rapid InterruptionFrame handling:
-        _handle_interruption calls on_audio_context_interrupted which calls
-        _close_context, then immediately a new audio context task creates
-        a new context via run_tts.
+        Simulates a fast conversation: each turn the LLM produces text (via
+        LLMFullResponseStartFrame → TextFrame → LLMFullResponseEndFrame),
+        then the user interrupts (InterruptionFrame).  _close_context sends
+        close_context fire-and-forget, but the mock server delays cleanup.
+        After enough turns, contexts accumulate past 5 → 1008 disconnect
+        → bot goes silent (no more TTSAudioRawFrames).
         """
         server = MockElevenLabsServer()
         await server.start()
 
-        policy_violation_received = False
-        contexts_created = 0
+        tts = MockedElevenLabsTTSService(server.port)
+        collector = FrameCollector()
+        pipeline = Pipeline([tts, collector])
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(enable_metrics=False),
+            cancel_on_idle_timeout=False,
+            enable_rtvi=False,
+        )
+        runner = PipelineRunner()
+
+        audio_per_turn: List[int] = []
+
+        async def drive() -> None:
+            await task.queue_frame(StartFrame())
+            await asyncio.sleep(0.1)
+
+            for turn in range(10):
+                collector.frames.clear()
+
+                # -- LLM produces a response --
+                await task.queue_frame(LLMFullResponseStartFrame())
+                await task.queue_frame(TextFrame(f"Turn {turn} response."))
+                await task.queue_frame(LLMFullResponseEndFrame())
+                await asyncio.sleep(0.15)
+
+                # Count audio frames produced this turn
+                audio_count = sum(1 for f in collector.frames if isinstance(f, TTSAudioRawFrame))
+                audio_per_turn.append(audio_count)
+
+                # -- User interrupts mid-speech --
+                await tts.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+                # Brief pause — not enough for server-side cleanup
+                await asyncio.sleep(0.03)
+
+            await task.queue_frame(EndFrame())
 
         try:
-            ws_url = f"ws://127.0.0.1:{server.port}"
-            ws = await websockets.connect(ws_url)
-
-            try:
-                # Simulate rapid context create -> close -> create cycles
-                # This is exactly what ElevenLabsTTSService does:
-                #   run_tts creates context by sending text with context_id
-                #   _close_context sends close_context:True fire-and-forget
-                #   Next run_tts immediately creates a new context
-                for i in range(8):
-                    context_id = f"ctx-{i}"
-
-                    # 1. Create context (what run_tts does)
-                    await ws.send(
-                        json.dumps(
-                            {
-                                "text": " ",
-                                "context_id": context_id,
-                            }
-                        )
-                    )
-                    contexts_created += 1
-
-                    # Read back the audio response
-                    try:
-                        msg = await asyncio.wait_for(ws.recv(), timeout=1.0)
-                    except (
-                        asyncio.TimeoutError,
-                        websockets.exceptions.ConnectionClosed,
-                    ) as e:
-                        if isinstance(e, websockets.exceptions.ConnectionClosed):
-                            # Check if this was a 1008 policy violation
-                            if ws.close_code == 1008:
-                                policy_violation_received = True
-                        break
-
-                    # Send some text (what run_tts does for the actual text)
-                    try:
-                        await ws.send(
-                            json.dumps(
-                                {
-                                    "text": f"Hello world {i}",
-                                    "context_id": context_id,
-                                }
-                            )
-                        )
-                    except websockets.exceptions.ConnectionClosed:
-                        if ws.close_code == 1008:
-                            policy_violation_received = True
-                        break
-
-                    # Read audio response
-                    try:
-                        msg = await asyncio.wait_for(ws.recv(), timeout=1.0)
-                    except (
-                        asyncio.TimeoutError,
-                        websockets.exceptions.ConnectionClosed,
-                    ) as e:
-                        if isinstance(e, websockets.exceptions.ConnectionClosed):
-                            if ws.close_code == 1008:
-                                policy_violation_received = True
-                        break
-
-                    # 2. Close context -- fire-and-forget (what _close_context does)
-                    # Note: we do NOT wait for the server's isFinal response,
-                    # just like ElevenLabsTTSService._close_context doesn't.
-                    try:
-                        await ws.send(
-                            json.dumps(
-                                {
-                                    "context_id": context_id,
-                                    "close_context": True,
-                                }
-                            )
-                        )
-                    except websockets.exceptions.ConnectionClosed:
-                        if ws.close_code == 1008:
-                            policy_violation_received = True
-                        break
-
-                    # 3. Do NOT wait for the server to process the close.
-                    # This is the bug -- we immediately loop and create
-                    # the next context while the old one is still "open"
-                    # on the server side.
-
-                    # Tiny yield to let asyncio process, but NOT enough time
-                    # for the server's CLOSE_DELAY_S to complete
-                    await asyncio.sleep(0.02)
-
-            except websockets.exceptions.ConnectionClosed:
-                if ws.close_code == 1008:
-                    policy_violation_received = True
-            finally:
-                try:
-                    await ws.close()
-                except Exception:
-                    pass
-
+            async with asyncio.timeout(15):
+                await asyncio.gather(runner.run(task), drive())
         finally:
             await server.stop()
 
-        # The bug manifests as a 1008 policy violation because:
-        # - We created contexts faster than the server could close them
-        # - _close_context is fire-and-forget (no ack wait)
-        # - After 5+ contexts accumulate server-side, the server disconnects
+        # 1. Server hit the 5-context limit
         self.assertTrue(
             server.policy_violation_sent,
-            f"Expected server to send 1008 policy violation. "
-            f"Contexts created: {contexts_created}, "
+            f"Expected 1008 policy violation. "
             f"Peak open: {server.peak_open_contexts}, "
-            f"Close requests: {len(server.close_requests_received)}. "
-            f"The fire-and-forget close_context bug was not triggered -- "
-            f"either the server closed contexts too fast or not enough cycles ran.",
+            f"Close requests: {len(server.close_requests)}.",
         )
-        self.assertTrue(
-            policy_violation_received,
-            "Client should have received the 1008 close code.",
-        )
-        # Verify we actually sent close requests (proving we tried to close)
+
+        # 2. _close_context did send close requests (it tried)
         self.assertGreater(
-            len(server.close_requests_received),
+            len(server.close_requests),
             0,
-            "At least one close_context request should have been sent.",
-        )
-        # The peak should exceed the limit -- this is the smoking gun
-        self.assertGreaterEqual(
-            server.peak_open_contexts,
-            MAX_CONTEXTS,
-            f"Peak open contexts ({server.peak_open_contexts}) should reach "
-            f"the limit ({MAX_CONTEXTS}) to trigger the policy violation.",
+            "close_context messages should have been sent.",
         )
 
-    async def test_waiting_for_close_ack_avoids_limit(self) -> None:
-        """Show that waiting for isFinal before opening a new context is safe.
-
-        This is the counterpart to the bug test above.  If _close_context
-        waited for the server's isFinal acknowledgment before returning,
-        contexts would never accumulate beyond 1 and the 1008 would never
-        be triggered.
-
-        This test should ALWAYS pass -- it shows the correct behavior.
-        """
-        server = MockElevenLabsServer()
-        await server.start()
-
-        try:
-            ws_url = f"ws://127.0.0.1:{server.port}"
-            ws = await websockets.connect(ws_url)
-
-            try:
-                for i in range(8):
-                    context_id = f"ctx-{i}"
-
-                    # Create context
-                    await ws.send(json.dumps({"text": " ", "context_id": context_id}))
-                    msg = await asyncio.wait_for(ws.recv(), timeout=1.0)
-
-                    # Send text
-                    await ws.send(json.dumps({"text": f"Hello {i}", "context_id": context_id}))
-                    msg = await asyncio.wait_for(ws.recv(), timeout=1.0)
-
-                    # Close context
-                    await ws.send(json.dumps({"context_id": context_id, "close_context": True}))
-
-                    # THE FIX: wait for isFinal acknowledgment before proceeding
-                    ack = await asyncio.wait_for(ws.recv(), timeout=2.0)
-                    ack_data = json.loads(ack)
-                    self.assertTrue(ack_data.get("isFinal"))
-
-                    # Also wait for the server-side cleanup to complete
-                    await asyncio.sleep(CLOSE_DELAY_S + 0.05)
-
-            finally:
-                try:
-                    await ws.close()
-                except Exception:
-                    pass
-
-        finally:
-            await server.stop()
-
-        # With proper close acknowledgment, we should never hit the limit
-        self.assertFalse(
-            server.policy_violation_sent,
-            "No policy violation should occur when waiting for close ack.",
+        # 3. Some turns produced audio, proving TTS worked initially
+        turns_with_audio = sum(1 for c in audio_per_turn if c > 0)
+        self.assertGreater(
+            turns_with_audio,
+            0,
+            "TTS should produce audio for at least some turns.",
         )
-        self.assertLessEqual(
-            server.peak_open_contexts,
-            1,
-            "At most 1 context should be open at a time when waiting for ack.",
+
+        # 4. Some turns produced NO audio — the user-facing bug.
+        #    The 1008 disconnect causes the bot to drop audio for one
+        #    or more turns until the reconnect succeeds.
+        silent_turns = [i for i, c in enumerate(audio_per_turn) if c == 0]
+        self.assertGreater(
+            len(silent_turns),
+            0,
+            f"Expected some turns with no audio (bot goes silent after 1008). "
+            f"Audio per turn: {audio_per_turn}.",
         )
 
 


### PR DESCRIPTION
## Summary

Reproduction test for #4132 — ElevenLabs TTS `_close_context()` is fire-and-forget, causing 1008 policy violation during rapid interruptions.

## How it works

Drives the **real `ElevenLabsTTSService`** through a pipecat `Pipeline` with `PipelineTask`, alternating between LLM response frames and `InterruptionFrame`, against a mock WebSocket server that enforces the 5-context limit with realistic cleanup delay.

### Mock server behavior
- Tracks open contexts (max 5)
- `close_context` requests trigger delayed cleanup (1s) — simulating real ElevenLabs async processing
- Sends 1008 (policy violation) when a 6th context is opened

### What the test proves

1. **Server sends 1008** — contexts accumulate past the 5-context limit
2. **`_close_context` was called** — fire-and-forget close requests were sent
3. **TTS works initially** — audio frames produced before the disconnect
4. **Bot goes silent** — some turns produce zero audio after the 1008 (the user-facing bug)

This PR is just the repro test — feel free to close after confirming the bug.