### PR TITLE
Downgrade unrecognized language string log from warning to debug

### DIFF
--- a/changelog/4137.changed.md
+++ b/changelog/4137.changed.md
@@ -1,0 +1,1 @@
+- Unrecognized language strings (e.g. Deepgram's `"multi"`) no longer produce a warning at startup. The log message has been downgraded to debug level since these are valid service-specific values that are passed through correctly.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -132,7 +132,7 @@ class STTService(AIService):
             try:
                 self._settings.language = Language(self._settings.language)
             except ValueError:
-                logger.warning(
+                logger.debug(
                     f"Language string '{self._settings.language}' is not a recognized "
                     f"Language code. It will be passed to the service as-is."
                 )
@@ -316,7 +316,7 @@ class STTService(AIService):
             try:
                 delta.language = Language(delta.language)
             except ValueError:
-                logger.warning(
+                logger.debug(
                     f"Language string '{delta.language}' is not a recognized "
                     f"Language code. It will be passed to the service as-is."
                 )

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -257,7 +257,7 @@ class TTSService(AIService):
             try:
                 self._settings.language = Language(self._settings.language)
             except ValueError:
-                logger.warning(
+                logger.debug(
                     f"Language string '{self._settings.language}' is not a recognized "
                     f"Language code. It will be passed to the service as-is."
                 )
@@ -622,7 +622,7 @@ class TTSService(AIService):
             try:
                 delta.language = Language(delta.language)
             except ValueError:
-                logger.warning(
+                logger.debug(
                     f"Language string '{delta.language}' is not a recognized "
                     f"Language code. It will be passed to the service as-is."
                 )

--- a/tests/test_service_language.py
+++ b/tests/test_service_language.py
@@ -102,12 +102,12 @@ class TestTTSLanguageInit:
         assert svc._settings.language == "en"
 
     def test_raw_string_unrecognized(self):
-        """Unrecognized raw string logs a warning and is passed through as-is."""
+        """Unrecognized raw string logs a debug message and is passed through as-is."""
         with patch("pipecat.services.tts_service.logger") as mock_logger:
             svc = _TestTTSService(settings=_TestTTSService.Settings(language="klingon"))
             assert svc._settings.language == "klingon"
-            mock_logger.warning.assert_called_once()
-            assert "klingon" in mock_logger.warning.call_args[0][0]
+            mock_logger.debug.assert_called_once()
+            assert "klingon" in mock_logger.debug.call_args[0][0]
 
     def test_language_none(self):
         """None language is left as None."""
@@ -144,12 +144,12 @@ class TestSTTLanguageInit:
         assert svc._settings.language == "de"
 
     def test_raw_string_unrecognized(self):
-        """Unrecognized raw string logs a warning and is passed through as-is."""
+        """Unrecognized raw string logs a debug message and is passed through as-is."""
         with patch("pipecat.services.stt_service.logger") as mock_logger:
             svc = _TestSTTService(settings=_TestSTTService.Settings(language="klingon"))
             assert svc._settings.language == "klingon"
-            mock_logger.warning.assert_called_once()
-            assert "klingon" in mock_logger.warning.call_args[0][0]
+            mock_logger.debug.assert_called_once()
+            assert "klingon" in mock_logger.debug.call_args[0][0]
 
     def test_language_none(self):
         """None language is left as None."""
@@ -195,13 +195,13 @@ class TestTTSLanguageUpdate:
 
     @pytest.mark.asyncio
     async def test_update_raw_string_unrecognized(self):
-        """Updating with unrecognized string logs warning and passes through."""
+        """Updating with unrecognized string logs debug message and passes through."""
         svc = _TestTTSService(settings=_TestTTSService.Settings(language=None))
         with patch("pipecat.services.tts_service.logger") as mock_logger:
             await svc._update_settings(_TestTTSService.Settings(language="klingon"))
             assert svc._settings.language == "klingon"
-            mock_logger.warning.assert_called_once()
-            assert "klingon" in mock_logger.warning.call_args[0][0]
+            mock_logger.debug.assert_called_once()
+            assert "klingon" in mock_logger.debug.call_args[0][0]
 
 
 # ---------------------------------------------------------------------------
@@ -242,10 +242,10 @@ class TestSTTLanguageUpdate:
 
     @pytest.mark.asyncio
     async def test_update_raw_string_unrecognized(self):
-        """Updating with unrecognized string logs warning and passes through."""
+        """Updating with unrecognized string logs debug message and passes through."""
         svc = _TestSTTService(settings=_TestSTTService.Settings(language=None))
         with patch("pipecat.services.stt_service.logger") as mock_logger:
             await svc._update_settings(_TestSTTService.Settings(language="klingon"))
             assert svc._settings.language == "klingon"
-            mock_logger.warning.assert_called_once()
-            assert "klingon" in mock_logger.warning.call_args[0][0]
+            mock_logger.debug.assert_called_once()
+            assert "klingon" in mock_logger.debug.call_args[0][0]


### PR DESCRIPTION
## Summary

- Downgraded the "not a recognized Language code" log message from `warning` to `debug` in both `STTService` and `TTSService`
- Service-specific language strings like Deepgram's `"multi"` are valid pass-through values that work correctly, so the warning was unnecessarily alarming

## Fixes

- Fixes #4134