### PR TITLE
fix(livekit): clear AudioSource buffer on interruption

### DIFF
--- a/changelog/4151.fixed.md
+++ b/changelog/4151.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `LiveKitOutputTransport` not clearing the `rtc.AudioSource` internal buffer on interruption, causing the bot to continue speaking for several seconds after being interrupted.

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -27,7 +27,9 @@ from pipecat.frames.frames import (
     CancelFrame,
     ClientConnectedFrame,
     EndFrame,
+    Frame,
     ImageRawFrame,
+    InterruptionFrame,
     OutputAudioRawFrame,
     OutputDTMFFrame,
     OutputDTMFUrgentFrame,
@@ -879,6 +881,21 @@ class LiveKitOutputTransport(BaseOutputTransport):
         """
         await super().cancel(frame)
         await self._client.disconnect()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process frames, clearing the LiveKit AudioSource buffer on interruption.
+
+        When an InterruptionFrame arrives, any audio already submitted to the
+        LiveKit AudioSource (but not yet played out) is cleared immediately so
+        the bot stops speaking without delay.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame flow in the pipeline.
+        """
+        await super().process_frame(frame, direction)
+        if isinstance(frame, InterruptionFrame) and self._client._audio_source is not None:
+            self._client._audio_source.clear_queue()
 
     async def setup(self, setup: FrameProcessorSetup):
         """Setup the output transport with shared client setup.


### PR DESCRIPTION
## Summary

- When an `InterruptionFrame` arrives, Pipecat cancels its Python-side audio task but frames already submitted to LiveKit's `rtc.AudioSource` via `capture_frame()` remain in its internal buffer and continue playing — causing the bot to keep speaking for several seconds (up to minutes if the TTS had streamed far ahead) after being interrupted
- Fix overrides `process_frame` in `LiveKitOutputTransport` to call `audio_source.clear_queue()` on `InterruptionFrame`, immediately flushing the buffered audio

## Test plan

- [ ] Start a LiveKit voice session with a verbose bot response
- [ ] Interrupt the bot mid-speech — bot should stop speaking immediately
- [ ] Confirm normal conversation flow continues after interruption