### PR TITLE
Fix audio transcript check in base_llm.py

### DIFF
--- a/changelog/4152.fixed.md
+++ b/changelog/4152.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a crash in OpenAI LLM processing when the provider returns `chunk.choices[0].delta.audio = None`, which caused `'NoneType' object has no attribute 'get'` errors during audio transcript handling.

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -545,7 +545,7 @@ class BaseOpenAILLMService(LLMService):
 
                 # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
                 # we need to get LLMTextFrame for the transcript
-                elif hasattr(chunk.choices[0].delta, "audio") and chunk.choices[0].delta.audio.get(
+                elif hasattr(chunk.choices[0].delta, "audio") and chunk.choices[0].delta.audio and chunk.choices[0].delta.audio.get(
                     "transcript"
                 ):
                     await self.push_frame(LLMTextFrame(chunk.choices[0].delta.audio["transcript"]))

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -545,8 +545,10 @@ class BaseOpenAILLMService(LLMService):
 
                 # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
                 # we need to get LLMTextFrame for the transcript
-                elif hasattr(chunk.choices[0].delta, "audio") and chunk.choices[0].delta.audio and chunk.choices[0].delta.audio.get(
-                    "transcript"
+                elif (
+                    hasattr(chunk.choices[0].delta, "audio")
+                    and chunk.choices[0].delta.audio
+                    and chunk.choices[0].delta.audio.get("transcript")
                 ):
                     await self.push_frame(LLMTextFrame(chunk.choices[0].delta.audio["transcript"]))
 


### PR DESCRIPTION
In some cases the openai provider could answer with a `chunk.choices[0].delta.audio = None`, so the process context fails with error:
```
pipecat/services/openai/base_llm.py:552): Error during completion: 'NoneType' object has no attribute 'get'
```