### PR TITLE
fix(stt): clear audio buffer on InterruptionFrame in SegmentedSTTService

### DIFF
--- a/changelog/4155.fixed.md
+++ b/changelog/4155.fixed.md
@@ -1,0 +1,1 @@
+- `SegmentedSTTService`: Clear audio buffer on `InterruptionFrame` to prevent overlap audio from contaminating the next user transcription.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -650,6 +650,8 @@ class SegmentedSTTService(STTService):
             await self._handle_user_started_speaking(frame)
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             await self._handle_user_stopped_speaking(frame)
+        elif isinstance(frame, InterruptionFrame):
+            self._audio_buffer.clear()
 
     async def _handle_user_started_speaking(self, frame: VADUserStartedSpeakingFrame):
         self._user_speaking = True


### PR DESCRIPTION
## Summary

When a user interrupts the bot, `SegmentedSTTService._audio_buffer` is never cleared on `InterruptionFrame`. The buffer accumulates audio from the overlap window — bot still speaking, potential acoustic echo — which then gets appended with the user's speech and sent to the STT API as a single chunk, producing inaccurate transcriptions.

## Fix

Clear `_audio_buffer` on `InterruptionFrame` in `SegmentedSTTService.process_frame()`.

The parent's handler (`STTService`) only resets TTFB metrics and pushes the frame downstream — it never reads the buffer — so this is safe. Any in-flight `run_stt()` from the previous segment completes normally; `LLMUserAggregator` already discards stale post-interruption transcripts.

Affects all services extending `SegmentedSTTService` (OpenAI, Groq/Whisper, Azure, etc.).

## Changes

- `src/pipecat/services/stt_service.py`: Add `InterruptionFrame` handling in `SegmentedSTTService.process_frame()` to clear the audio buffer
- `changelog/4155.fixed.md`: Changelog entry