### PR TITLE
fix(anthropic): handle None token counts in usage events

### DIFF
--- a/changelog/4157.fixed.md
+++ b/changelog/4157.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TypeError` in Anthropic LLM service when token usage fields (`input_tokens`, `output_tokens`) are `None` in streaming events. This could cause crashes during normal streaming responses when `RawMessageDeltaEvent` contains `None` token counts.

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -583,20 +583,36 @@ class AnthropicLLMService(LLMService):
                 # data embedded in messages that we do other processing for, above.
                 if hasattr(event, "usage"):
                     prompt_tokens += (
-                        event.usage.input_tokens if hasattr(event.usage, "input_tokens") else 0
+                        event.usage.input_tokens
+                        if (
+                            hasattr(event.usage, "input_tokens")
+                            and event.usage.input_tokens is not None
+                        )
+                        else 0
                     )
                     completion_tokens += (
-                        event.usage.output_tokens if hasattr(event.usage, "output_tokens") else 0
+                        event.usage.output_tokens
+                        if (
+                            hasattr(event.usage, "output_tokens")
+                            and event.usage.output_tokens is not None
+                        )
+                        else 0
                     )
                 elif hasattr(event, "message") and hasattr(event.message, "usage"):
                     prompt_tokens += (
                         event.message.usage.input_tokens
-                        if hasattr(event.message.usage, "input_tokens")
+                        if (
+                            hasattr(event.message.usage, "input_tokens")
+                            and event.message.usage.input_tokens is not None
+                        )
                         else 0
                     )
                     completion_tokens += (
                         event.message.usage.output_tokens
-                        if hasattr(event.message.usage, "output_tokens")
+                        if (
+                            hasattr(event.message.usage, "output_tokens")
+                            and event.message.usage.output_tokens is not None
+                        )
                         else 0
                     )
                     cache_creation_input_tokens += (


### PR DESCRIPTION
## Summary

- Fixed `TypeError` crash in Anthropic LLM service when token usage fields (`input_tokens`, `output_tokens`) are `None` in streaming events
- Anthropic's `RawMessageDeltaEvent` can have `input_tokens=None` in its `MessageDeltaUsage`, causing `int += None` errors when accumulating token counts
- Added `is not None` guards to match the pattern already used for `cache_creation_input_tokens` and `cache_read_input_tokens`

## Fixes

- Fixes #1852