### PR TITLE
fix(lemonslice): add missing on_dtmf_event callback in DailyCallbacks construction

### DIFF
--- a/changelog/4161.fixed.md
+++ b/changelog/4161.fixed.md
@@ -1,0 +1,1 @@
+- Added missing `on_dtmf_event` callback to `LemonSliceTransportClient.setup()` `DailyCallbacks` construction, fixing a `ValidationError` at pipeline setup time.

--- a/changelog/XXXX.fixed.md
+++ b/changelog/XXXX.fixed.md
@@ -1,1 +1,0 @@
-Added missing `on_dtmf_event` callback to `LemonSliceTransportClient.setup()` `DailyCallbacks` construction, fixing a `ValidationError` at pipeline setup time.

--- a/changelog/XXXX.fixed.md
+++ b/changelog/XXXX.fixed.md
@@ -1,0 +1,1 @@
+Added missing `on_dtmf_event` callback to `LemonSliceTransportClient.setup()` `DailyCallbacks` construction, fixing a `ValidationError` at pipeline setup time.

--- a/src/pipecat/transports/lemonslice/transport.py
+++ b/src/pipecat/transports/lemonslice/transport.py
@@ -181,6 +181,7 @@ class LemonSliceTransportClient:
                 on_dialout_stopped=partial(self._on_handle_callback, "on_dialout_stopped"),
                 on_dialout_error=partial(self._on_handle_callback, "on_dialout_error"),
                 on_dialout_warning=partial(self._on_handle_callback, "on_dialout_warning"),
+                on_dtmf_event=partial(self._on_handle_callback, "on_dtmf_event"),
                 on_participant_joined=self._callbacks.on_participant_joined,
                 on_participant_left=self._callbacks.on_participant_left,
                 on_participant_updated=partial(self._on_handle_callback, "on_participant_updated"),


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes issue: https://github.com/pipecat-ai/pipecat/issues/4160

DailyCallbacks added a required on_dtmf_event field in PR #4047. PR #4079 fixed this for TavusTransportClient but
LemonSliceTransportClient.setup() was not updated, causing a pydantic ValidationError at pipeline setup time.
