### PR TITLE
Yield after create_task to ensure timer tasks are scheduled

### DIFF
--- a/changelog/4183.fixed.md
+++ b/changelog/4183.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a timing issue where turn detection timer tasks (idle controller, speech timeout, turn analyzer, and turn completion) could miss their first tick because the newly created asyncio task was not yet scheduled when the caller continued.

--- a/src/pipecat/turns/user_idle_controller.py
+++ b/src/pipecat/turns/user_idle_controller.py
@@ -143,6 +143,8 @@ class UserIdleController(BaseObject):
             self._idle_timer_expired(),
             f"{self}::idle_timer",
         )
+        # Make sure the task is scheduled.
+        await asyncio.sleep(0)
 
     async def _cancel_idle_timer(self):
         """Cancel the idle timer if running."""

--- a/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
@@ -153,6 +153,8 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._timeout_task = self.task_manager.create_task(
             self._timeout_handler(timeout), f"{self}::_timeout_handler"
         )
+        # Make sure the task is scheduled.
+        await asyncio.sleep(0)
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
@@ -174,6 +176,8 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
             self._timeout_task = self.task_manager.create_task(
                 self._timeout_handler(timeout), f"{self}::_timeout_handler"
             )
+            # Make sure the task is scheduled.
+            await asyncio.sleep(0)
 
     def _calculate_timeout(self) -> float:
         """Calculate the timeout value based on current state.

--- a/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
@@ -193,6 +193,8 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._timeout_task = self.task_manager.create_task(
             self._timeout_handler(timeout), f"{self}::_timeout_handler"
         )
+        # Make sure the task is scheduled.
+        await asyncio.sleep(0)
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
@@ -217,6 +219,8 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
             self._timeout_task = self.task_manager.create_task(
                 self._timeout_handler(timeout), f"{self}::_timeout_handler"
             )
+            # Make sure the task is scheduled.
+            await asyncio.sleep(0)
 
     async def _handle_prediction_result(self, result: Optional[MetricsData]):
         """Handle a prediction result event from the turn analyzer."""

--- a/src/pipecat/turns/user_turn_completion_mixin.py
+++ b/src/pipecat/turns/user_turn_completion_mixin.py
@@ -254,6 +254,8 @@ class UserTurnCompletionLLMServiceMixin:
             self._incomplete_timeout_handler(incomplete_type, timeout),
             f"_incomplete_timeout_{incomplete_type}",
         )
+        # Make sure the task is scheduled.
+        await asyncio.sleep(0)
 
     async def _cancel_incomplete_timeout(self):
         """Cancel any pending incomplete timeout task."""


### PR DESCRIPTION
## Summary

- Fixed a timing issue where turn detection timer tasks could miss their first tick because the newly created asyncio task had not yet been scheduled when the caller continued
- Affected components: `UserIdleController`, `SpeechTimeoutUserTurnStopStrategy`, `TurnAnalyzerUserTurnStopStrategy`, and `UserTurnCompletionLLMServiceMixin`
- Each `create_task()` call is now followed by `await asyncio.sleep(0)` to yield to the event loop and ensure the timer task is scheduled before proceeding

## Testing

- [x] Verify turn detection timing is consistent in voice conversations
- [x] Test idle controller, speech timeout, and turn analyzer strategies
