### PR TITLE
Fix Sarvam examples to use 'user' role instead of 'developer'

### DIFF
--- a/examples/foundational/07z-interruptible-sarvam-http.py
+++ b/examples/foundational/07z-interruptible-sarvam-http.py
@@ -111,7 +111,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             logger.info(f"Client connected")
             # Kick off the conversation.
             context.add_message(
-                {"role": "developer", "content": "Please introduce yourself to the user."}
+                {"role": "user", "content": "Please introduce yourself to the user."}
             )
             await task.queue_frames([LLMRunFrame()])
 

--- a/examples/foundational/07z-interruptible-sarvam.py
+++ b/examples/foundational/07z-interruptible-sarvam.py
@@ -104,9 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        context.add_message(
-            {"role": "developer", "content": "Please introduce yourself to the user."}
-        )
+        context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
 
         # Optionally, you can wait for 30 seconds and then change the voice.


### PR DESCRIPTION
## Summary

- Fix Sarvam example bots to use `user` role instead of `developer` for the initial conversation prompt
- Sarvam uses the OpenAI-compatible API but does not support the `developer` role, causing errors

This is a temporary fix until we add an adapter.

## Test plan

- [ ] Run Sarvam examples and verify they start without errors
