### PR TITLE
Fix UTF-8 decode error in Inworld TTS streaming response

### DIFF
--- a/changelog/4202.fixed.md
+++ b/changelog/4202.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InworldHttpTTSService` streaming responses crashing with `UnicodeDecodeError` when multi-byte UTF-8 characters were split across chunk boundaries. This caused TTS audio to cut off mid-sentence intermittently.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -387,16 +387,16 @@ class InworldHttpTTSService(TTSService):
         Yields:
             An asynchronous generator of frames.
         """
-        buffer = ""
+        buffer = b""
         # Track the duration of this utterance based on the last word's end time
         utterance_duration = 0.0
 
-        async for chunk in response.content.iter_chunked(1024):
-            buffer += chunk.decode("utf-8")
+        async for chunk in response.content.iter_any():
+            buffer += chunk
 
-            while "\n" in buffer:
-                line, buffer = buffer.split("\n", 1)
-                line_str = line.strip()
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                line_str = line.decode("utf-8").strip()
 
                 if not line_str:
                     continue


### PR DESCRIPTION
## Summary
- Fix crash in `InworldHttpTTSService` streaming where multi-byte UTF-8 characters split across chunk boundaries caused `UnicodeDecodeError`
- Buffer raw bytes and decode only after splitting on newline boundaries

## Test plan
- [x] Tested Inworld HTTP TTS with streaming enabled
- [x] Tested Inworld HTTP TTS with streaming disabled (non-streaming path unaffected)

Fixes #3538

🤖 Generated with [Claude Code](https://claude.com/claude-code)