### PR TITLE
Handle incomplete function call arguments from interrupted LLM streams

### DIFF
--- a/changelog/4203.fixed.md
+++ b/changelog/4203.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a crash (`JSONDecodeError`) when a user interruption occurs while the LLM is streaming function call arguments. Previously, the incomplete JSON arguments were passed directly to `json.loads()`, causing an unhandled exception. Affected services: OpenAI, Google (OpenAI-compatible), and SambaNova.

--- a/src/pipecat/services/google/openai/llm.py
+++ b/src/pipecat/services/google/openai/llm.py
@@ -199,7 +199,11 @@ class GoogleLLMOpenAIBetaService(OpenAILLMService):
                     # which currently results in an empty function name('').
                     continue
 
-                arguments = json.loads(arguments)
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    logger.warning(f"{self}: Failed to parse function call arguments: {arguments}")
+                    continue
 
                 function_calls.append(
                     FunctionCallFromLLM(

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -567,7 +567,11 @@ class BaseOpenAILLMService(LLMService):
             for function_name, arguments, tool_id in zip(
                 functions_list, arguments_list, tool_id_list
             ):
-                arguments = json.loads(arguments)
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    logger.warning(f"{self}: Failed to parse function call arguments: {arguments}")
+                    continue
                 function_calls.append(
                     FunctionCallFromLLM(
                         context=context,

--- a/src/pipecat/services/sambanova/llm.py
+++ b/src/pipecat/services/sambanova/llm.py
@@ -245,7 +245,11 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
                 if len(arguments) < 1:
                     continue
 
-                arguments = json.loads(arguments)
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    logger.warning(f"{self}: Failed to parse function call arguments: {arguments}")
+                    continue
                 function_calls.append(
                     FunctionCallFromLLM(
                         context=context,


### PR DESCRIPTION
## Summary

- Fixed a `JSONDecodeError` crash that occurs when a user interruption causes the LLM chunk stream to exit early while streaming function call arguments
- When arguments are incomplete JSON, the malformed function call is now skipped with a warning log instead of crashing
- Applied the fix to `BaseOpenAILLMService`, `GoogleLLMOpenAIBetaService`, and `SambaNovaLLMService` (the Responses API already had this handling)

## Fixes

- Fixes #2461