### PR TITLE
Change GrokLLMService default model to grok-3

### DIFF
--- a/changelog/4209.changed.md
+++ b/changelog/4209.changed.md
@@ -1,0 +1,1 @@
+- Changed `GrokLLMService` default model from `grok-3-beta` to `grok-3`, now that the model is generally available.

--- a/src/pipecat/services/xai/llm.py
+++ b/src/pipecat/services/xai/llm.py
@@ -102,7 +102,7 @@ class GrokLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Grok's API.
             base_url: The base URL for Grok API. Defaults to "https://api.x.ai/v1".
-            model: The model identifier to use. Defaults to "grok-3-beta".
+            model: The model identifier to use. Defaults to "grok-3".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=GrokLLMService.Settings(model=...)`` instead.
@@ -112,7 +112,9 @@ class GrokLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="grok-3-beta")
+        default_settings = self.Settings(
+            model="grok-3",
+        )
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:


### PR DESCRIPTION
## Summary
- Updates the default model for `GrokLLMService` from `grok-3-beta` to `grok-3` now that the model is generally available

## Test plan
- [x] Verify `GrokLLMService()` uses `grok-3` as the default model
- [x] Verify explicit model override still works via `settings` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)