### PR TITLE
Tiny bit more rtvi cleanup

### DIFF
--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -57,7 +57,6 @@ class RTVIProcessor(FrameProcessor):
         """Initialize the RTVI processor.
 
         Args:
-            config: Initial RTVI configuration.
             transport: Transport layer for communication.
             **kwargs: Additional arguments passed to parent class.
         """
@@ -66,9 +65,8 @@ class RTVIProcessor(FrameProcessor):
         self._bot_ready = False
         self._client_ready = False
         self._client_ready_id = ""
-        # Default to 0.3.0 which is the last version before actually having a
-        # "client-version".
-        self._client_version = [0, 3, 0]
+        # Default to 0.0.0 to indicate unknown version.
+        self._client_version = [0, 0, 0]
         self._llm_skip_tts: bool = False  # Keep in sync with llm_service.py's configuration.
 
         # A task to process incoming transport messages.
@@ -273,9 +271,6 @@ class RTVIProcessor(FrameProcessor):
                     try:
                         data = RTVI.ClientReadyData.model_validate(message.data)
                     except ValidationError:
-                        # Not all clients have been updated to RTVI 1.0.0.
-                        # For now, that's okay, we just log their info as unknown.
-                        data = None
                         pass
                     await self._handle_client_ready(message.id, data)
                 case "disconnect-bot":
@@ -306,12 +301,23 @@ class RTVIProcessor(FrameProcessor):
         """Handle the client-ready message from the client."""
         version = data.version if data else None
         logger.debug(f"Received client-ready: version {version}")
+        version_error = None
         if version:
             try:
                 self._client_version = [int(v) for v in version.split(".")]
+                protocol_major = int(RTVI.PROTOCOL_VERSION.split(".")[0])
+                if self._client_version[0] != protocol_major:
+                    version_error = f"RTVI version {version} is not compatible with server protocol {RTVI.PROTOCOL_VERSION}."
             except ValueError:
-                logger.warning(f"Invalid client version format: {version}")
+                version_error = f"Invalid client version format ({version})."
+        else:
+            version_error = "Client version unknown."
         about = data.about if data else {"library": "unknown"}
+        if version_error:
+            version_error += " Compatibility issues may occur."
+            logger.warning(version_error)
+            await self._send_error_response(request_id, version_error)
+
         logger.debug(f"Client Details: {about}")
         if self._input_transport:
             await self._input_transport.start_audio_in_streaming()
@@ -413,7 +419,3 @@ class RTVIProcessor(FrameProcessor):
         """Send an error response message."""
         message = RTVI.ErrorResponse(id=id, data=RTVI.ErrorResponseData(error=error))
         await self.push_transport_message(message)
-
-    def _action_id(self, service: str, action: str) -> str:
-        """Generate an action ID from service and action names."""
-        return f"{service}:{action}"

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -304,7 +304,10 @@ class RTVIProcessor(FrameProcessor):
         version_error = None
         if version:
             try:
-                self._client_version = [int(v) for v in version.split(".")]
+                parts = [int(v) for v in version.split(".")]
+                if len(parts) != 3:
+                    raise ValueError
+                self._client_version = parts
                 protocol_major = int(RTVI.PROTOCOL_VERSION.split(".")[0])
                 if self._client_version[0] != protocol_major:
                     version_error = f"RTVI version {version} is not compatible with server protocol {RTVI.PROTOCOL_VERSION}."

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -268,10 +268,19 @@ class RTVIProcessor(FrameProcessor):
             match message.type:
                 case "client-ready":
                     data = None
-                    try:
-                        data = RTVI.ClientReadyData.model_validate(message.data)
-                    except ValidationError:
-                        pass
+                    raw = message.data or {}
+                    version = raw.get("version")
+                    if isinstance(version, str):
+                        about = RTVI.AboutClientData(library="unknown")
+                        about_raw = raw.get("about")
+                        if about_raw is not None:
+                            try:
+                                about = RTVI.AboutClientData.model_validate(about_raw)
+                            except ValidationError:
+                                logger.warning(
+                                    "Invalid 'about' data in client-ready message, ignoring."
+                                )
+                        data = RTVI.ClientReadyData(version=version, about=about)
                     await self._handle_client_ready(message.id, data)
                 case "disconnect-bot":
                     await self.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -5,7 +5,7 @@
 #
 
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pipecat.processors.frameworks.rtvi.models as RTVI
 from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import pipecat.processors.frameworks.rtvi.models as RTVI
+from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
+
+
+class TestRTVIClientReadyVersionHandling(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.processor = RTVIProcessor()
+
+    async def asyncTearDown(self):
+        await self.processor.cleanup()
+
+    async def _call_handle_client_ready(self, data):
+        """Helper to call _handle_client_ready with a mocked _send_error_response."""
+        self.processor._send_error_response = AsyncMock()
+        self.processor._input_transport = None
+        self.processor.set_client_ready = AsyncMock()
+        await self.processor._handle_client_ready("req-1", data)
+
+    async def test_valid_version_1_0_0_sends_no_error(self):
+        data = RTVI.ClientReadyData(
+            version="1.0.0",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor._send_error_response.assert_not_called()
+        self.assertEqual(self.processor._client_version, [1, 0, 0])
+
+    async def test_valid_version_1_2_0_sends_no_error(self):
+        data = RTVI.ClientReadyData(
+            version="1.2.0",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor._send_error_response.assert_not_called()
+        self.assertEqual(self.processor._client_version, [1, 2, 0])
+
+    async def test_version_below_1_0_0_sends_error(self):
+        data = RTVI.ClientReadyData(
+            version="0.3.0",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor._send_error_response.assert_called_once()
+        error_msg = self.processor._send_error_response.call_args[0][1]
+        self.assertIn("0.3.0", error_msg)
+        self.assertIn("not compatible", error_msg)
+
+    async def test_version_above_protocol_major_sends_error(self):
+        data = RTVI.ClientReadyData(
+            version="2.3.1",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor._send_error_response.assert_called_once()
+        error_msg = self.processor._send_error_response.call_args[0][1]
+        self.assertIn("2.3.1", error_msg)
+        self.assertIn("not compatible", error_msg)
+
+    async def test_no_version_sends_error(self):
+        """Client sends no data (data=None)."""
+        await self._call_handle_client_ready(None)
+        self.processor._send_error_response.assert_called_once()
+        error_msg = self.processor._send_error_response.call_args[0][1]
+        self.assertIn("unknown", error_msg)
+
+    async def test_invalid_version_format_sends_error(self):
+        data = RTVI.ClientReadyData(
+            version="not-a-version",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor._send_error_response.assert_called_once()
+        error_msg = self.processor._send_error_response.call_args[0][1]
+        self.assertIn("Invalid client version format", error_msg)
+        self.assertIn("not-a-version", error_msg)
+
+    async def test_error_message_includes_compatibility_warning(self):
+        """All version errors should append the compatibility warning."""
+        for version in ["0.9.9", "2.0.0"]:
+            with self.subTest(version=version):
+                data = RTVI.ClientReadyData(
+                    version=version,
+                    about=RTVI.AboutClientData(library="test-client"),
+                )
+                await self._call_handle_client_ready(data)
+                error_msg = self.processor._send_error_response.call_args[0][1]
+                self.assertIn("Compatibility issues may occur", error_msg)
+
+    async def test_client_ready_is_set_even_on_version_error(self):
+        """Client-ready state should be set regardless of version errors."""
+        data = RTVI.ClientReadyData(
+            version="0.3.0",
+            about=RTVI.AboutClientData(library="test-client"),
+        )
+        await self._call_handle_client_ready(data)
+        self.processor.set_client_ready.assert_called_once()
+
+    async def test_client_ready_is_set_when_no_data(self):
+        await self._call_handle_client_ready(None)
+        self.processor.set_client_ready.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -73,15 +73,18 @@ class TestRTVIClientReadyVersionHandling(unittest.IsolatedAsyncioTestCase):
         self.assertIn("unknown", error_msg)
 
     async def test_invalid_version_format_sends_error(self):
-        data = RTVI.ClientReadyData(
-            version="not-a-version",
-            about=RTVI.AboutClientData(library="test-client"),
-        )
-        await self._call_handle_client_ready(data)
-        self.processor._send_error_response.assert_called_once()
-        error_msg = self.processor._send_error_response.call_args[0][1]
-        self.assertIn("Invalid client version format", error_msg)
-        self.assertIn("not-a-version", error_msg)
+        bad_versions = ["not-a-version", "123", "1.2.3.0", "junk", "1.2"]
+        for version in bad_versions:
+            with self.subTest(version=version):
+                data = RTVI.ClientReadyData(
+                    version=version,
+                    about=RTVI.AboutClientData(library="test-client"),
+                )
+                await self._call_handle_client_ready(data)
+                self.processor._send_error_response.assert_called_once()
+                error_msg = self.processor._send_error_response.call_args[0][1]
+                self.assertIn("Invalid client version format", error_msg)
+                self.assertIn(version, error_msg)
 
     async def test_error_message_includes_compatibility_warning(self):
         """All version errors should append the compatibility warning."""


### PR DESCRIPTION
Now with the deprecated RTVI protocol removed, we require the client's protocol to match.

i didn't go as far as brutally enforcing a valid version and ending the connection if the version doesn't match, but this will at least warn the client if its missing the version, has an incompatible version, or formatted the version incorrectly. (and a valid version is "1.X.Y", where X and Y must be a number)