### PR TITLE
Fix Gemini Live session resumption hanging after reconnect

### DIFF
--- a/changelog/4242.fixed.md
+++ b/changelog/4242.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Gemini Live bot hanging after a session resumption reconnect. Audio, video, and text input were silently dropped after reconnecting because the internal `_ready_for_realtime_input` flag was not being reset.

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1355,14 +1355,28 @@ class GeminiLiveLLMService(LLMService):
     async def _handle_session_ready(self, session: AsyncSession):
         """Handle the session being ready."""
         self._session = session
-        # If we were just waititng for the session to be ready to run the LLM,
-        # do that now.
         if self._run_llm_when_session_ready:
+            # Initial connection: context arrived before session was ready.
             self._run_llm_when_session_ready = False
             await self._create_initial_response()
-        elif self._context:
-            # Reconnect case: context already exists, no need for _create_initial_response
+        elif self._session_resumption_handle:
+            # Reconnect with session resumption: the server will restore
+            # session state, so we can accept realtime input right away.
             self._ready_for_realtime_input = True
+        elif self._context:
+            # Reconnect without session resumption (e.g. error occurred
+            # before server sent a resumption handle).
+            # TODO: ideally we'd re-send conversation history here via
+            # _create_initial_response(), but that currently doesn't handle
+            # the reconnect case properly. This should be very rare — the
+            # connection would have to drop before we've received our first
+            # session_resumption_handle from the server.
+            self._ready_for_realtime_input = True
+        else:
+            # Initial connection: session is ready before context has
+            # arrived. Nothing to do — _handle_context will call
+            # _create_initial_response when the context arrives.
+            pass
 
     async def _handle_msg_model_turn(self, msg: LiveServerMessage):
         """Handle the model turn message."""

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1360,6 +1360,9 @@ class GeminiLiveLLMService(LLMService):
         if self._run_llm_when_session_ready:
             self._run_llm_when_session_ready = False
             await self._create_initial_response()
+        elif self._context:
+            # Reconnect case: context already exists, no need for _create_initial_response
+            self._ready_for_realtime_input = True
 
     async def _handle_msg_model_turn(self, msg: LiveServerMessage):
         """Handle the model turn message."""


### PR DESCRIPTION
## Summary

- Fixed Gemini Live bot hanging after session resumption reconnect
- After reconnect, `_ready_for_realtime_input` was never set back to `True`, causing all audio/video/text input to be silently dropped
- Root cause: `_disconnect()` resets `_ready_for_realtime_input = False`, but on reconnect nobody set it back — `_create_initial_response()` (which normally sets the flag) is only called on initial connection
- Fix: in `_handle_session_ready`, detect reconnects via `_session_resumption_handle` (primary) or existing `_context` (fallback), and set the flag directly

## Testing

- Tested with simulated disconnect across multiple Pipecat versions (v0.0.96 through main) to bisect the regression
- Confirmed bug reproduces on v0.0.108+ (when `_ready_for_realtime_input` was introduced)
- Confirmed fix works with both session-resumption and non-resumption reconnect paths
- Verified initial connection (non-reconnect) still works correctly