### PR TITLE
Stop audio mixer on pipeline cancellation

### DIFF
--- a/changelog/2955.fixed.md
+++ b/changelog/2955.fixed.md
@@ -1,0 +1,1 @@
+- Fixed audio mixer not being stopped on pipeline cancellation, causing 100% CPU usage after call disconnect.

--- a/changelog/2955.fixed.md
+++ b/changelog/2955.fixed.md
@@ -1,1 +1,0 @@
-- Fixed audio mixer not being stopped on pipeline cancellation, causing 100% CPU usage after call disconnect.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -504,6 +504,10 @@ class BaseOutputTransport(FrameProcessor):
             await self._cancel_clock_task()
             await self._cancel_video_task()
 
+            # Stop audio mixer so it doesn't keep generating frames after cancellation.
+            if self._mixer:
+                await self._mixer.stop()
+
         async def handle_interruptions(self, _: InterruptionFrame):
             """Handle interruption events by restarting tasks and clearing buffers.
 


### PR DESCRIPTION
`cancel()` was missing `mixer.stop()` that `stop()` already had - added for consistency and custom mixer implementations.