### PR TITLE
PipelineRunner: make _gc_collect async    

### DIFF
--- a/changelog/4255.fixed.md
+++ b/changelog/4255.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `PipelineRunner._gc_collect()` blocking the event loop by running `gc.collect()` synchronously. Now offloaded via `asyncio.to_thread` to avoid stalling concurrent pipeline tasks.

--- a/src/pipecat/pipeline/runner.py
+++ b/src/pipecat/pipeline/runner.py
@@ -90,7 +90,7 @@ class PipelineRunner(BaseObject):
             await self._sig_task
 
         if self._force_gc:
-            self._gc_collect()
+            await self._gc_collect()
 
         logger.debug(f"Runner {self} finished running {task}")
 
@@ -136,8 +136,8 @@ class PipelineRunner(BaseObject):
         logger.warning(f"Interruption detected. Cancelling runner {self}")
         await self.cancel()
 
-    def _gc_collect(self):
+    async def _gc_collect(self):
         """Force garbage collection and log results."""
-        collected = gc.collect()
+        collected = await asyncio.to_thread(gc.collect)
         logger.debug(f"Garbage collector: collected {collected} objects.")
         logger.debug(f"Garbage collector: uncollectable objects {gc.garbage}")


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #3056 

**Issue :** `_gc_collect()` calls `gc.collect()` synchronously inside an async method, blocking the event loop. This prevents I/O polling & audio frame delivery for concurrent pipeline tasks.

**Change :** Wrapped `gc.collect()` in `asyncio.to_thread`