### PR TITLE
 Fix Inworld TTS word timestamps dropping punctuation from assistant context

### DIFF
--- a/changelog/4261.fixed.md
+++ b/changelog/4261.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InworldTTSService` word timestamps returning bare words without punctuation, causing the assistant context to lose punctuation and the LLM to imitate that style on subsequent turns.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -16,6 +16,7 @@ Inworld’s text-to-speech (TTS) models offer ultra-realistic, context-aware spe
 import asyncio
 import base64
 import json
+import re
 import uuid
 from dataclasses import dataclass, field
 from typing import (
@@ -39,6 +40,12 @@ from loguru import logger
 from pipecat import version as pipecat_version
 
 USER_AGENT = f"pipecat/{pipecat_version()}"
+
+# Regex for stripping all non-word characters when comparing aligned words to
+# original text. Apostrophes (straight and curly) are also stripped so that
+# contractions like "don't" and "don\u2019t" compare as equal.
+_PUNCT_RE = re.compile(r"[^\w]")
+
 from pydantic import BaseModel
 
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
@@ -94,6 +101,48 @@ class InworldTTSSettings(TTSSettings):
         if isinstance(nested, dict):
             flat.setdefault("speaking_rate", nested.get("speakingRate"))
         return super().from_mapping(flat)
+
+
+def _restore_punctuation(
+    aligned_words: List[str],
+    original_tokens: List[str],
+    start_idx: int = 0,
+) -> Tuple[List[str], int]:
+    """Map aligned words back to original text tokens to restore punctuation.
+
+    Inworld's word alignment returns tokens with inconsistent punctuation
+    (varies by model and word position). This maps each aligned word to its
+    corresponding original whitespace-delimited token by comparing stripped
+    forms, then returns the original token which carries canonical punctuation.
+
+    Falls back to the bare aligned word when no match is found (e.g. number
+    expansion, hyphenated word splits).
+
+    Args:
+        aligned_words: Words from Inworld's wordAlignment response.
+        original_tokens: The original text split by whitespace.
+        start_idx: Cursor position in original_tokens to resume from.
+
+    Returns:
+        Tuple of (restored_words, new_cursor_position).
+    """
+    result: List[str] = []
+    idx = start_idx
+    for word in aligned_words:
+        stripped_word = _PUNCT_RE.sub("", word).lower()
+        matched = False
+        # Lookahead of 5 handles occasional non-spoken tokens (emojis,
+        # symbols) between spoken words without scanning the full list.
+        for j in range(idx, min(idx + 5, len(original_tokens))):
+            stripped_orig = _PUNCT_RE.sub("", original_tokens[j]).lower()
+            if stripped_orig == stripped_word:
+                result.append(original_tokens[j])
+                idx = j + 1
+                matched = True
+                break
+        if not matched:
+            result.append(word)
+    return result, idx
 
 
 class InworldHttpTTSService(TTSService):
@@ -219,6 +268,8 @@ class InworldHttpTTSService(TTSService):
 
         self._cumulative_time = 0.0
         self._current_run_had_timestamps = False
+        self._current_original_tokens: List[str] = []
+        self._current_restore_idx: int = 0
 
         # Init-only config (not runtime-updatable).
         self._audio_encoding = encoding
@@ -278,7 +329,10 @@ class InworldHttpTTSService(TTSService):
         end_times = alignment.get("wordEndTimeSeconds", [])
 
         if words and start_times and len(words) == len(start_times):
-            for i, word in enumerate(words):
+            restored, self._current_restore_idx = _restore_punctuation(
+                words, self._current_original_tokens, self._current_restore_idx
+            )
+            for i, word in enumerate(restored):
                 word_start = self._cumulative_time + start_times[i]
                 word_times.append((word, word_start))
 
@@ -302,6 +356,8 @@ class InworldHttpTTSService(TTSService):
         logger.debug(f"{self}: Generating TTS [{text}] (streaming={self._streaming})")
 
         self._current_run_had_timestamps = False
+        self._current_original_tokens = text.split()
+        self._current_restore_idx = 0
 
         audio_config = {
             "audioEncoding": self._audio_encoding,
@@ -686,6 +742,7 @@ class InworldTTSService(WebsocketTTSService):
         # portion that was spoken.
         self._context_texts: Dict[str, str] = {}
         self._contexts_with_timestamps: Set[str] = set()
+        self._context_text_word_idx: Dict[str, int] = {}
 
         # Init-only config (not runtime-updatable).
         self._audio_encoding = encoding
@@ -758,7 +815,9 @@ class InworldTTSService(WebsocketTTSService):
         except Exception as e:
             logger.warning(f"{self}: Failed to pre-open context: {e}")
 
-    def _calculate_word_times(self, timestamp_info: Dict[str, Any]) -> List[Tuple[str, float]]:
+    def _calculate_word_times(
+        self, timestamp_info: Dict[str, Any], context_id: Optional[str] = None
+    ) -> List[Tuple[str, float]]:
         """Calculate word timestamps from Inworld WebSocket API response.
 
         Adds cumulative time offset to maintain monotonically increasing timestamps
@@ -767,6 +826,7 @@ class InworldTTSService(WebsocketTTSService):
 
         Args:
             timestamp_info: The timestamp information from Inworld API.
+            context_id: Optional context ID for punctuation restoration.
 
         Returns:
             List of (word, timestamp) tuples with cumulative offset applied.
@@ -779,7 +839,13 @@ class InworldTTSService(WebsocketTTSService):
         end_times = alignment.get("wordEndTimeSeconds", [])
 
         if words and start_times and len(words) == len(start_times):
-            for i, word in enumerate(words):
+            original_text = self._context_texts.get(context_id, "") if context_id else ""
+            original_tokens = original_text.split()
+            start_idx = self._context_text_word_idx.get(context_id, 0) if context_id else 0
+            restored, new_idx = _restore_punctuation(words, original_tokens, start_idx)
+            if context_id:
+                self._context_text_word_idx[context_id] = new_idx
+            for i, word in enumerate(restored):
                 word_start = self._cumulative_time + start_times[i]
                 word_times.append((word, word_start))
 
@@ -834,6 +900,7 @@ class InworldTTSService(WebsocketTTSService):
         had_timestamps = context_id in self._contexts_with_timestamps
         text = self._context_texts.pop(context_id, "").strip()
         self._contexts_with_timestamps.discard(context_id)
+        self._context_text_word_idx.pop(context_id, None)
         if had_timestamps or not text:
             return
         logger.debug(f"{self}: No timestamps for context {context_id}, pushing fallback: [{text}]")
@@ -952,6 +1019,7 @@ class InworldTTSService(WebsocketTTSService):
             self._reset_generation_timing()
             self._context_texts.clear()
             self._contexts_with_timestamps.clear()
+            self._context_text_word_idx.clear()
             await self._call_event_handler("on_disconnected")
 
     async def _receive_messages(self):
@@ -1015,7 +1083,7 @@ class InworldTTSService(WebsocketTTSService):
             # timestampInfo is inside audioChunk
             timestamp_info = audio_chunk.get("timestampInfo")
             if timestamp_info:
-                word_times = self._calculate_word_times(timestamp_info)
+                word_times = self._calculate_word_times(timestamp_info, ctx_id)
                 if word_times:
                     if ctx_id:
                         self._contexts_with_timestamps.add(ctx_id)

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -41,9 +41,7 @@ from pipecat import version as pipecat_version
 
 USER_AGENT = f"pipecat/{pipecat_version()}"
 
-# Regex for stripping all non-word characters when comparing aligned words to
-# original text. Apostrophes (straight and curly) are also stripped so that
-# contractions like "don't" and "don\u2019t" compare as equal.
+# Strips non-word chars for punctuation-insensitive word comparison.
 _PUNCT_RE = re.compile(r"[^\w]")
 
 from pydantic import BaseModel

--- a/tests/test_inworld_tts.py
+++ b/tests/test_inworld_tts.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Inworld TTS punctuation restoration logic."""
+
+import unittest
+
+from pipecat.services.inworld.tts import _restore_punctuation
+
+
+class TestRestorePunctuation(unittest.TestCase):
+    def test_basic_punctuation_restoration(self):
+        """Bare aligned words are mapped back to punctuated originals."""
+        aligned = ["Hello", "how", "are", "you"]
+        original = ["Hello,", "how", "are", "you?"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["Hello,", "how", "are", "you?"])
+        self.assertEqual(idx, 4)
+
+    def test_partial_punctuation_from_api(self):
+        """When the API includes some punctuation, the original token is still preferred."""
+        aligned = ["Hello,", "world"]
+        original = ["Hello,", "world!"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["Hello,", "world!"])
+        self.assertEqual(idx, 2)
+
+    def test_contractions(self):
+        """Contractions with straight apostrophes match correctly."""
+        aligned = ["don't", "worry"]
+        original = ["don't,", "worry."]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["don't,", "worry."])
+        self.assertEqual(idx, 2)
+
+    def test_curly_apostrophe(self):
+        """Contractions with curly apostrophes (U+2019) match straight ones."""
+        aligned = ["don\u2019t"]
+        original = ["don\u2019t,"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["don\u2019t,"])
+        self.assertEqual(idx, 1)
+
+    def test_cross_apostrophe_matching(self):
+        """Straight apostrophe in aligned matches curly apostrophe in original."""
+        aligned = ["don't"]
+        original = ["don\u2019t,"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["don\u2019t,"])
+        self.assertEqual(idx, 1)
+
+    def test_number_expansion_fallback(self):
+        """TTS-expanded numbers fall back to bare aligned words."""
+        aligned = ["one", "hundred"]
+        original = ["100"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["one", "hundred"])
+        self.assertEqual(idx, 0)
+
+    def test_hyphenated_word_fallback(self):
+        """Hyphenated words split by TTS fall back gracefully."""
+        aligned = ["mother", "in", "law"]
+        original = ["mother-in-law"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["mother", "in", "law"])
+        self.assertEqual(idx, 0)
+
+    def test_repeated_words(self):
+        """Repeated words are matched sequentially via cursor advancement."""
+        aligned = ["the", "cat", "and", "the", "dog"]
+        original = ["the", "cat", "and", "the", "dog."]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["the", "cat", "and", "the", "dog."])
+        self.assertEqual(idx, 5)
+
+    def test_empty_aligned_words(self):
+        """Empty aligned words returns empty list."""
+        result, idx = _restore_punctuation([], ["Hello,", "world!"])
+        self.assertEqual(result, [])
+        self.assertEqual(idx, 0)
+
+    def test_empty_original_tokens(self):
+        """Empty original tokens causes all words to fall back."""
+        aligned = ["Hello", "world"]
+        result, idx = _restore_punctuation(aligned, [])
+        self.assertEqual(result, ["Hello", "world"])
+        self.assertEqual(idx, 0)
+
+    def test_cursor_continuity_across_calls(self):
+        """Simulates multiple chunks within one context — cursor resumes."""
+        original = ["Hello,", "how", "are", "you?", "I'm", "fine."]
+
+        # First chunk
+        result1, idx = _restore_punctuation(["Hello", "how"], original, start_idx=0)
+        self.assertEqual(result1, ["Hello,", "how"])
+        self.assertEqual(idx, 2)
+
+        # Second chunk — cursor resumes from idx=2
+        result2, idx = _restore_punctuation(["are", "you"], original, start_idx=idx)
+        self.assertEqual(result2, ["are", "you?"])
+        self.assertEqual(idx, 4)
+
+    def test_case_insensitive_matching(self):
+        """Matching is case-insensitive to handle capitalization differences."""
+        aligned = ["hello"]
+        original = ["Hello,"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["Hello,"])
+        self.assertEqual(idx, 1)
+
+    def test_punctuation_only_text(self):
+        """Aligned word of pure punctuation doesn't match anything, falls back."""
+        aligned = ["..."]
+        original = ["Hello,"]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(result, ["..."])
+        self.assertEqual(idx, 0)
+
+    def test_multi_sentence(self):
+        """Full multi-sentence restoration works end-to-end."""
+        aligned = ["Hey", "welcome", "back", "It's", "good", "to", "have", "you", "again"]
+        original = ["Hey,", "welcome", "back!", "It's", "good", "to", "have", "you", "again."]
+        result, idx = _restore_punctuation(aligned, original)
+        self.assertEqual(
+            result,
+            ["Hey,", "welcome", "back!", "It's", "good", "to", "have", "you", "again."],
+        )
+        self.assertEqual(idx, 9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #4261 

**Issue :** Inworld's word alignment API returns bare words, these become assistant context via TTSTextFrame, so the LLM sees unpunctuated history and imitates that style   
                                                                     
**Fix :** Added `_restore_punctuation()` to map aligned words back to original text tokens, recovering punctuation. Falls back to bare word on mismatch. Applied to both HTTP and WebSocket services                                                                                   
                                                