### PR TITLE
fix llm_context_summarizer picking up mid conversation sys-messages

### DIFF
--- a/changelog/4286.fixed.md
+++ b/changelog/4286.fixed.md
@@ -1,0 +1,1 @@
+- Fixed context summarization failing with "No messages to summarize" when mid-conversation system messages (e.g. idle-user prompts) were present in the context. Only the initial system message at index 0 is now treated as the system prompt to preserve.

--- a/changelog/4286.fixed.md
+++ b/changelog/4286.fixed.md
@@ -1,1 +1,0 @@
-- Fixed context summarization failing with "No messages to summarize" when mid-conversation system messages (e.g. idle-user prompts) were present in the context. Only the initial system message at index 0 is now treated as the system prompt to preserve.

--- a/changelog/4289.fixed.md
+++ b/changelog/4289.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `LLMContextSummarizer` scanning all messages for the system prompt instead of only checking `messages[0]`. Mid-conversation system messages (e.g. idle-user prompts) are now correctly treated as regular context.

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -429,17 +429,16 @@ class LLMContextSummarizer(BaseObject):
         config = self._auto_config.summary_config
         messages = self._context.messages
 
-        # Find the first system message to preserve. LLMSpecificMessage instances are excluded
-        # because they are not dict-like and never represent a system message; they hold
-        # service-specific metadata (e.g. thinking blocks) that is always paired with a
-        # standard message.
-        first_system_msg = next(
-            (
-                msg
-                for msg in messages
-                if not isinstance(msg, LLMSpecificMessage) and msg.get("role") == "system"
-            ),
-            None,
+        # Only preserve the initial system message (index 0). Mid-conversation
+        # system messages are regular context, not the system prompt.
+        first_system_msg = (
+            messages[0]
+            if (
+                messages
+                and not isinstance(messages[0], LLMSpecificMessage)
+                and messages[0].get("role") == "system"
+            )
+            else None
         )
 
         # Get recent messages to keep

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -505,7 +505,7 @@ class LLMContextSummarizationUtil:
         """Determine which messages should be included in summarization.
 
         Intelligently selects messages for summarization while preserving:
-        - The first system message (defines assistant behavior)
+        - The initial system message at index 0, if present (defines assistant behavior)
         - The last N messages (maintains immediate conversation context)
         - Incomplete function call sequences (preserves tool interaction integrity)
 
@@ -522,17 +522,17 @@ class LLMContextSummarizationUtil:
         if len(messages) <= min_messages_to_keep:
             return LLMMessagesToSummarize(messages=[], last_summarized_index=-1)
 
-        # Find first system message index. LLMSpecificMessage instances are excluded because
-        # they are not dict-like and never represent a system message; they hold
-        # service-specific metadata (e.g. thinking blocks) that is always paired with a
-        # standard message.
-        first_system_index = next(
-            (
-                i
-                for i, msg in enumerate(messages)
-                if not isinstance(msg, LLMSpecificMessage) and msg.get("role") == "system"
-            ),
-            -1,
+        # Only treat the very first message as the system prompt to preserve.
+        # System messages injected mid-conversation (e.g. idle-user prompts) are
+        # regular context that should be eligible for summarization.
+        first_system_index = (
+            0
+            if (
+                messages
+                and not isinstance(messages[0], LLMSpecificMessage)
+                and messages[0].get("role") == "system"
+            )
+            else -1
         )
 
         # Messages to summarize are between first system and recent messages

--- a/tests/test_context_summarization.py
+++ b/tests/test_context_summarization.py
@@ -121,6 +121,62 @@ class TestContextSummarizationMixin(unittest.TestCase):
         self.assertEqual(len(result.messages), 3)
         self.assertEqual(result.last_summarized_index, 2)
 
+    def test_get_messages_to_summarize_mid_conversation_system(self):
+        """Test that mid-conversation system messages are summarized, not treated as system prompt."""
+        context = LLMContext()
+
+        # No system message at index 0
+        context.add_message({"role": "assistant", "content": "Hello, how can I help?"})
+        context.add_message({"role": "user", "content": "I need help"})
+        context.add_message({"role": "assistant", "content": "Sure thing"})
+        context.add_message({"role": "user", "content": "Thanks"})
+        context.add_message({"role": "assistant", "content": "You're welcome"})
+        # Mid-conversation system message (e.g. idle-user prompt)
+        context.add_message(
+            {"role": "system", "content": "The user has been quiet. Ask if they're still there."}
+        )
+        context.add_message({"role": "assistant", "content": "Are you still there?"})
+        context.add_message({"role": "user", "content": "Yes"})
+
+        # Keep last 2 messages
+        result = LLMContextSummarizationUtil.get_messages_to_summarize(context, 2)
+
+        # Should summarize indices 0-5 (everything except last 2)
+        self.assertEqual(len(result.messages), 6)
+        self.assertEqual(result.last_summarized_index, 5)
+        # The mid-conversation system message should be included in messages to summarize
+        system_msgs = [m for m in result.messages if m.get("role") == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertIn("quiet", system_msgs[0]["content"])
+
+    def test_get_messages_to_summarize_system_at_zero_and_mid_conversation(self):
+        """Test system prompt at index 0 with a mid-conversation system message."""
+        context = LLMContext()
+
+        # System prompt at index 0
+        context.add_message({"role": "system", "content": "You are a helpful assistant"})
+        context.add_message({"role": "user", "content": "Message 1"})
+        context.add_message({"role": "assistant", "content": "Response 1"})
+        context.add_message({"role": "user", "content": "Message 2"})
+        context.add_message({"role": "assistant", "content": "Response 2"})
+        # Mid-conversation system message (e.g. idle-user prompt)
+        context.add_message(
+            {"role": "system", "content": "The user has been quiet. Ask if they're still there."}
+        )
+        context.add_message({"role": "assistant", "content": "Are you still there?"})
+        context.add_message({"role": "user", "content": "Yes"})
+
+        # Keep last 2 messages
+        result = LLMContextSummarizationUtil.get_messages_to_summarize(context, 2)
+
+        # Should summarize indices 1-5 (skip system at 0, keep last 2)
+        self.assertEqual(len(result.messages), 5)
+        self.assertEqual(result.last_summarized_index, 5)
+        # The mid-conversation system message should be in the summarizable range
+        system_msgs = [m for m in result.messages if m.get("role") == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertIn("quiet", system_msgs[0]["content"])
+
     def test_get_messages_to_summarize_insufficient(self):
         """Test when there aren't enough messages to summarize."""
         context = LLMContext()

--- a/tests/test_llm_context_summarizer.py
+++ b/tests/test_llm_context_summarizer.py
@@ -213,6 +213,53 @@ class TestLLMContextSummarizer(unittest.IsolatedAsyncioTestCase):
 
         await summarizer.cleanup()
 
+    async def test_apply_summary_ignores_mid_conversation_system_message(self):
+        """Test that _apply_summary only preserves system message at index 0."""
+        # Replace context with one that has no system message at index 0
+        self.context.set_messages([])
+        self.context.add_message({"role": "assistant", "content": "Hello"})
+        self.context.add_message({"role": "user", "content": "Hi"})
+        self.context.add_message({"role": "assistant", "content": "How can I help?"})
+        self.context.add_message({"role": "system", "content": "The user has been quiet."})
+        self.context.add_message({"role": "assistant", "content": "Still there?"})
+        self.context.add_message({"role": "user", "content": "Yes"})
+
+        config = LLMAutoContextSummarizationConfig(
+            max_context_tokens=50,
+            summary_config=LLMContextSummaryConfig(min_messages_after_summary=2),
+        )
+
+        summarizer = LLMContextSummarizer(context=self.context, config=config)
+        await summarizer.setup(self.task_manager)
+
+        request_frame = None
+
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal request_frame
+            request_frame = frame
+
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+        self.assertIsNotNone(request_frame)
+
+        # Simulate summary result covering indices 0-3
+        summary_result = LLMContextSummaryResultFrame(
+            request_id=request_frame.request_id,
+            summary="User greeted assistant and went idle.",
+            last_summarized_index=3,
+            error=None,
+        )
+
+        await summarizer.process_frame(summary_result)
+
+        # Context should be: [summary_message] + [2 recent messages] = 3
+        # The mid-conversation system message should NOT be preserved as a system prompt
+        self.assertEqual(len(self.context.messages), 3)
+        self.assertNotEqual(self.context.messages[0].get("role"), "system")
+        self.assertIn("Conversation summary:", self.context.messages[0].get("content", ""))
+
+        await summarizer.cleanup()
+
     async def test_interruption_cancels_summarization(self):
         """Test that an interruption cancels pending summarization."""
         config = LLMAutoContextSummarizationConfig(max_context_tokens=50)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #4286 

The summarizer scanned all messages for the first `system` role & treated it as the system prompt to preserve. When features like idle-user detection injected system messages mid-conversation, the summarizer mistakenly anchored to those - leaving zero messages eligible for summarization & throwing "No messages to summarize".

Now only `messages[0]` is checked. Mid-conversation system messages are treated as regular context.
