### PR TITLE
Fix ElevenLabs TTS boolean params and add missing features

### DIFF
--- a/changelog/4293.added.2.md
+++ b/changelog/4293.added.2.md
@@ -1,0 +1,1 @@
+- Added `pcm_32000` and `pcm_48000` sample rate support to ElevenLabs TTS services.

--- a/changelog/4293.added.md
+++ b/changelog/4293.added.md
@@ -1,0 +1,1 @@
+- Added `enable_logging` parameter to `ElevenLabsHttpTTSService`. Set to `False` to enable zero retention mode (enterprise only).

--- a/changelog/4293.fixed.md
+++ b/changelog/4293.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ElevenLabsTTSService` ignoring `enable_logging=False` and `enable_ssml_parsing=False`. The truthy check treated `False` the same as `None` (both skipped), and Python's `str(False)` produced `"False"` instead of the lowercase `"false"` expected by the API.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -673,11 +673,11 @@ class ElevenLabsTTSService(WebsocketTTSService):
             output_format = self._output_format
             url = f"{self._url}/v1/text-to-speech/{voice_id}/multi-stream-input?model_id={model}&output_format={output_format}&auto_mode={str(self._auto_mode).lower()}"
 
-            if self._enable_ssml_parsing:
-                url += f"&enable_ssml_parsing={self._enable_ssml_parsing}"
+            if self._enable_ssml_parsing is not None:
+                url += f"&enable_ssml_parsing={str(self._enable_ssml_parsing).lower()}"
 
-            if self._enable_logging:
-                url += f"&enable_logging={self._enable_logging}"
+            if self._enable_logging is not None:
+                url += f"&enable_logging={str(self._enable_logging).lower()}"
 
             if self._settings.apply_text_normalization is not None:
                 url += f"&apply_text_normalization={self._settings.apply_text_normalization}"
@@ -952,6 +952,7 @@ class ElevenLabsHttpTTSService(TTSService):
         model: Optional[str] = None,
         base_url: str = "https://api.elevenlabs.io",
         sample_rate: Optional[int] = None,
+        enable_logging: Optional[bool] = None,
         pronunciation_dictionary_locators: Optional[List[PronunciationDictionaryLocator]] = None,
         params: Optional[InputParams] = None,
         settings: Optional[Settings] = None,
@@ -976,6 +977,8 @@ class ElevenLabsHttpTTSService(TTSService):
 
             base_url: Base URL for ElevenLabs HTTP API.
             sample_rate: Audio sample rate. If None, uses default.
+            enable_logging: Whether to enable ElevenLabs server-side logging.
+                Set to False for zero retention mode (enterprise only).
             pronunciation_dictionary_locators: List of pronunciation dictionary
                 locators to use.
             params: Additional input parameters for voice customization.
@@ -1057,6 +1060,7 @@ class ElevenLabsHttpTTSService(TTSService):
         self._api_key = api_key
         self._base_url = base_url
         self._session = aiohttp_session
+        self._enable_logging = enable_logging
 
         self._output_format = ""  # initialized in start()
         self._voice_settings = self._set_voice_settings()
@@ -1262,6 +1266,8 @@ class ElevenLabsHttpTTSService(TTSService):
         }
         if self._settings.optimize_streaming_latency is not None:
             params["optimize_streaming_latency"] = self._settings.optimize_streaming_latency
+        if self._enable_logging is not None:
+            params["enable_logging"] = str(self._enable_logging).lower()
 
         try:
             async with self._session.post(

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -63,8 +63,6 @@ except ModuleNotFoundError as e:
     logger.error("In order to use ElevenLabs, you need to `pip install pipecat-ai[elevenlabs]`.")
     raise Exception(f"Missing module: {e}")
 
-ElevenLabsOutputFormat = Literal["pcm_16000", "pcm_22050", "pcm_24000", "pcm_44100"]
-
 # Models that support language codes
 # The following models are excluded as they don't support language codes:
 # - eleven_flash_v2
@@ -141,8 +139,12 @@ def output_format_from_sample_rate(sample_rate: int) -> str:
             return "pcm_22050"
         case 24000:
             return "pcm_24000"
+        case 32000:
+            return "pcm_32000"
         case 44100:
             return "pcm_44100"
+        case 48000:
+            return "pcm_48000"
     logger.warning(
         f"ElevenLabsTTSService: No output format available for {sample_rate} sample rate"
     )


### PR DESCRIPTION
## Summary

- Fixed `ElevenLabsTTSService` ignoring `enable_logging=False` and `enable_ssml_parsing=False` — the truthy check treated `False` the same as `None`, and `str(False)` produced `"False"` instead of the lowercase `"false"` expected by the API
- Added `enable_logging` parameter to `ElevenLabsHttpTTSService` for zero retention mode (enterprise only)
- Added `pcm_32000` and `pcm_48000` sample rate support to match the ElevenLabs API
- Removed unused `ElevenLabsOutputFormat` type alias

## Testing

- Verify `enable_logging=False` produces `&enable_logging=false` in WebSocket URL
- Verify `enable_ssml_parsing=False` produces `&enable_ssml_parsing=false` in WebSocket URL
- Verify `enable_logging=False` is passed as query param in HTTP service
- Verify 32000 and 48000 sample rates map correctly

## Fixes

- Fixes #4290

🤖 Generated with [Claude Code](https://claude.com/claude-code)