### PR TITLE
Handle falsy final tool results

### DIFF
--- a/changelog/4299.fixed.md
+++ b/changelog/4299.fixed.md
@@ -1,0 +1,1 @@
+- Fixed assistant tool-call handling so final falsy results like `None` and `{}` still trigger LLM follow-up and preserve the real result in context.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1133,8 +1133,9 @@ class LLMAssistantAggregator(LLMContextAggregator):
             # If an image frame has been added to the context, let's run inference.
             run_llm = await self._maybe_append_image_to_context(image_frame)
 
-        # Run inference if the function call result requires it.
-        if frame.result:
+        # Final result frames should be considered completion events even when
+        # the tool returns a falsy payload like None, {}, [], 0, or "".
+        if is_final or frame.result is not None:
             if properties and properties.run_llm is not None:
                 # If the tool call result has a run_llm property, use it.
                 run_llm = properties.run_llm
@@ -1229,7 +1230,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
         is_async = not in_progress_frame.cancel_on_interruption
         del self._function_calls_in_progress[frame.tool_call_id]
 
-        result = json.dumps(frame.result, ensure_ascii=False) if frame.result else "COMPLETED"
+        result = json.dumps(frame.result, ensure_ascii=False)
 
         if is_async:
             # For async function calls inject a developer message so the LLM is

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -893,6 +893,60 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         )
         assert json.loads(context.messages[-1]["content"]) == {"conditions": "Sunny"}
 
+    async def test_function_call_empty_dict_result_triggers_llm_and_preserves_result(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        await run_test(
+            aggregator,
+            frames_to_send=[
+                FunctionCallInProgressFrame(
+                    function_name="get_weather",
+                    tool_call_id="1",
+                    arguments={"location": "Los Angeles"},
+                    cancel_on_interruption=True,
+                ),
+                SleepFrame(),
+                FunctionCallResultFrame(
+                    function_name="get_weather",
+                    tool_call_id="1",
+                    arguments={"location": "Los Angeles"},
+                    result={},
+                ),
+            ],
+            expected_down_frames=[],
+            expected_up_frames=[LLMContextFrame],
+        )
+
+        self.assertEqual(json.loads(context.messages[-1]["content"]), {})
+
+    async def test_function_call_none_result_triggers_llm_and_preserves_result(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        await run_test(
+            aggregator,
+            frames_to_send=[
+                FunctionCallInProgressFrame(
+                    function_name="get_weather",
+                    tool_call_id="1",
+                    arguments={"location": "Los Angeles"},
+                    cancel_on_interruption=True,
+                ),
+                SleepFrame(),
+                FunctionCallResultFrame(
+                    function_name="get_weather",
+                    tool_call_id="1",
+                    arguments={"location": "Los Angeles"},
+                    result=None,
+                ),
+            ],
+            expected_down_frames=[],
+            expected_up_frames=[LLMContextFrame],
+        )
+
+        self.assertIsNone(json.loads(context.messages[-1]["content"]))
+
     async def test_function_call_on_context_updated(self):
         context_updated = False
 


### PR DESCRIPTION
## Summary
Fixes tool calls that finish with empty-looking results such as `None` or `{}`.

Before this change:
- Pipecat could skip the LLM follow-up
- the assistant could stay silent
- the stored tool result could become `"COMPLETED"` instead of the real value

After this change:
- final falsy tool results still count as completed tool calls
- the LLM can run again
- the real result is preserved in context

## Examples
If a weather tool times out and returns `None`:
- before: the user may hear nothing
- after: the model can still respond with something like `Sorry, that tool timed out`

If a tool returns `{}` to mean `no data found`:
- before: context stores `"COMPLETED"`
- after: context stores `{}`

## Testing
- `uv run pytest tests/test_context_aggregators_universal.py`

Closes #4298
