### PR TITLE
Fail missing tool calls cleanly

### DIFF
--- a/changelog/4301.fixed.md
+++ b/changelog/4301.fixed.md
@@ -1,0 +1,1 @@
+- Fixed missing tool handlers so unregistered tool calls fail with a normal final tool result instead of leaving tool-call state hanging.

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -725,10 +725,8 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
                 logger.warning(
                     f"{self} is calling '{function_call.function_name}', but it's not registered."
                 )
-                item = FunctionCallRegistryItem(
-                    function_name=function_call.function_name,
-                    handler=self._missing_function_call_handler,
-                    cancel_on_interruption=True,
+                item = self._build_missing_function_call_registry_item(
+                    function_call.function_name
                 )
 
             runner_items.append(
@@ -786,7 +784,21 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
             await self._sequential_runner_queue.put(runner_item)
 
     async def _run_function_call(self, runner_item: FunctionCallRunnerItem):
-        item = runner_item.registry_item
+        # Re-resolve the registry item at execution time. The function may have
+        # been unregistered between queuing and execution, in which case we
+        # fall back to the missing-function handler so the call still terminates
+        # with a normal tool result.
+        if runner_item.function_name in self._functions.keys():
+            item = self._functions[runner_item.function_name]
+        elif None in self._functions.keys():
+            item = self._functions[None]
+        elif runner_item.registry_item.handler is self._missing_function_call_handler:
+            item = runner_item.registry_item
+        else:
+            logger.warning(
+                f"{self} is calling '{runner_item.function_name}', but it was just unregistered."
+            )
+            item = self._build_missing_function_call_registry_item(runner_item.function_name)
 
         logger.debug(
             f"{self} Calling function [{runner_item.function_name}:{runner_item.tool_call_id}] with arguments {runner_item.arguments}"
@@ -892,6 +904,16 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
         finally:
             if timeout_task and not timeout_task.done():
                 await self.cancel_task(timeout_task)
+
+    def _build_missing_function_call_registry_item(
+        self, function_name: str
+    ) -> FunctionCallRegistryItem:
+        """Build a registry item that routes to the missing-function handler."""
+        return FunctionCallRegistryItem(
+            function_name=function_name,
+            handler=self._missing_function_call_handler,
+            cancel_on_interruption=True,
+        )
 
     async def _missing_function_call_handler(self, params: FunctionCallParams):
         """Return a terminal tool result when the LLM calls an unknown function."""

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -725,7 +725,11 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
                 logger.warning(
                     f"{self} is calling '{function_call.function_name}', but it's not registered."
                 )
-                continue
+                item = FunctionCallRegistryItem(
+                    function_name=function_call.function_name,
+                    handler=self._missing_function_call_handler,
+                    cancel_on_interruption=True,
+                )
 
             runner_items.append(
                 FunctionCallRunnerItem(
@@ -782,12 +786,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
             await self._sequential_runner_queue.put(runner_item)
 
     async def _run_function_call(self, runner_item: FunctionCallRunnerItem):
-        if runner_item.function_name in self._functions.keys():
-            item = self._functions[runner_item.function_name]
-        elif None in self._functions.keys():
-            item = self._functions[None]
-        else:
-            return
+        item = runner_item.registry_item
 
         logger.debug(
             f"{self} Calling function [{runner_item.function_name}:{runner_item.tool_call_id}] with arguments {runner_item.arguments}"
@@ -893,6 +892,12 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
         finally:
             if timeout_task and not timeout_task.done():
                 await self.cancel_task(timeout_task)
+
+    async def _missing_function_call_handler(self, params: FunctionCallParams):
+        """Return a terminal tool result when the LLM calls an unknown function."""
+        await params.result_callback(
+            f"Error: function '{params.function_name}' is not registered."
+        )
 
     def _has_async_tools(self) -> bool:
         """Return True if at least one non-builtin async tool is registered."""

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -792,7 +792,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
             item = self._functions[runner_item.function_name]
         elif None in self._functions.keys():
             item = self._functions[None]
-        elif runner_item.registry_item.handler is self._missing_function_call_handler:
+        elif runner_item.registry_item.handler == self._missing_function_call_handler:
             item = runner_item.registry_item
         else:
             logger.warning(

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -725,9 +725,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
                 logger.warning(
                     f"{self} is calling '{function_call.function_name}', but it's not registered."
                 )
-                item = self._build_missing_function_call_registry_item(
-                    function_call.function_name
-                )
+                item = self._build_missing_function_call_registry_item(function_call.function_name)
 
             runner_items.append(
                 FunctionCallRunnerItem(
@@ -917,9 +915,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService):
 
     async def _missing_function_call_handler(self, params: FunctionCallParams):
         """Return a terminal tool result when the LLM calls an unknown function."""
-        await params.result_callback(
-            f"Error: function '{params.function_name}' is not registered."
-        )
+        await params.result_callback(f"Error: function '{params.function_name}' is not registered.")
 
     def _has_async_tools(self) -> bool:
         """Return True if at least one non-builtin async tool is registered."""

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from unittest.mock import AsyncMock
+
+from pipecat.frames.frames import (
+    FunctionCallFromLLM,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    FunctionCallsStartedFrame,
+)
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.services.llm_service import LLMService
+from pipecat.services.settings import LLMSettings
+from pipecat.turns.user_mute.function_call_user_mute_strategy import FunctionCallUserMuteStrategy
+
+
+class MockLLMService(LLMService):
+    """Minimal LLM service for testing function call execution."""
+
+    def __init__(self, **kwargs):
+        settings = LLMSettings(
+            model="test-model",
+            system_instruction=None,
+            temperature=None,
+            max_tokens=None,
+            top_p=None,
+            top_k=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            filter_incomplete_user_turns=None,
+            user_turn_completion_config=None,
+        )
+        super().__init__(settings=settings, **kwargs)
+
+
+class TestLLMService(unittest.IsolatedAsyncioTestCase):
+    async def _run_function_calls_inline(self, service: MockLLMService):
+        async def run_inline(runner_items):
+            for runner_item in runner_items:
+                await service._run_function_call(runner_item)
+
+        service._run_parallel_function_calls = run_inline
+        service._run_sequential_function_calls = run_inline
+
+    async def test_missing_function_call_emits_terminal_result(self):
+        service = MockLLMService()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls(**kwargs))
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="missing_tool",
+                    tool_call_id="call_1",
+                    arguments={"query": "weather"},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        self.assertEqual(
+            [type(frame) for frame in recorded_frames],
+            [
+                FunctionCallsStartedFrame,
+                FunctionCallInProgressFrame,
+                FunctionCallResultFrame,
+            ],
+        )
+        self.assertEqual(recorded_frames[1].function_name, "missing_tool")
+        self.assertEqual(
+            recorded_frames[2].result,
+            "Error: function 'missing_tool' is not registered.",
+        )
+
+    async def test_missing_function_call_allows_user_mute_cleanup(self):
+        service = MockLLMService()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls(**kwargs))
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="missing_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        strategy = FunctionCallUserMuteStrategy()
+        muted = False
+        for frame in recorded_frames:
+            muted = await strategy.process_frame(frame)
+
+        self.assertFalse(muted)

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -85,6 +85,56 @@ class TestLLMService(unittest.IsolatedAsyncioTestCase):
             "Error: function 'missing_tool' is not registered.",
         )
 
+    async def test_function_unregistered_between_queue_and_execute(self):
+        """Function unregistered between queuing and execution still terminates."""
+        service = MockLLMService()
+        service._call_event_handler = AsyncMock()
+
+        async def real_handler(params):
+            await params.result_callback("should not be called")
+
+        service.register_function("doomed_tool", real_handler)
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls(**kwargs))
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        async def run_inline(runner_items):
+            # Simulate the function being unregistered after queuing but before execution.
+            service.unregister_function("doomed_tool")
+            for runner_item in runner_items:
+                await service._run_function_call(runner_item)
+
+        service._run_parallel_function_calls = run_inline
+        service._run_sequential_function_calls = run_inline
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="doomed_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        self.assertEqual(
+            [type(frame) for frame in recorded_frames],
+            [
+                FunctionCallsStartedFrame,
+                FunctionCallInProgressFrame,
+                FunctionCallResultFrame,
+            ],
+        )
+        self.assertEqual(
+            recorded_frames[2].result,
+            "Error: function 'doomed_tool' is not registered.",
+        )
+
     async def test_missing_function_call_allows_user_mute_cleanup(self):
         service = MockLLMService()
         service._call_event_handler = AsyncMock()

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -5,7 +5,7 @@
 #
 
 import unittest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from pipecat.frames.frames import (
     FunctionCallFromLLM,
@@ -60,16 +60,17 @@ class TestLLMService(unittest.IsolatedAsyncioTestCase):
 
         service.broadcast_frame = mock_broadcast_frame
 
-        await service.run_function_calls(
-            [
-                FunctionCallFromLLM(
-                    function_name="missing_tool",
-                    tool_call_id="call_1",
-                    arguments={"query": "weather"},
-                    context=LLMContext(),
-                )
-            ]
-        )
+        with patch("pipecat.services.llm_service.logger") as mock_logger:
+            await service.run_function_calls(
+                [
+                    FunctionCallFromLLM(
+                        function_name="missing_tool",
+                        tool_call_id="call_1",
+                        arguments={"query": "weather"},
+                        context=LLMContext(),
+                    )
+                ]
+            )
 
         self.assertEqual(
             [type(frame) for frame in recorded_frames],
@@ -84,6 +85,12 @@ class TestLLMService(unittest.IsolatedAsyncioTestCase):
             recorded_frames[2].result,
             "Error: function 'missing_tool' is not registered.",
         )
+
+        # Only the queue-time warning should fire; the execution-time
+        # "just unregistered" warning must not double-log.
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        self.assertTrue(any("not registered" in w for w in warnings))
+        self.assertFalse(any("just unregistered" in w for w in warnings))
 
     async def test_function_unregistered_between_queue_and_execute(self):
         """Function unregistered between queuing and execution still terminates."""


### PR DESCRIPTION
## Summary
Fixes missing tool handlers so they fail cleanly instead of leaving tool-call state hanging.

Before this change:
- the model could call an unregistered tool
- Pipecat would log a warning and skip it
- the tool call might never get a normal final result
- the turn could go silent and downstream state could stay stuck

After this change:
- missing tools still produce a normal final tool result
- Pipecat returns a clear error message
- downstream state can clean up normally
- the model can continue the conversation

## Example
If the model calls `lookup_customer` but no handler is registered:

Before:
- Pipecat logs a warning
- no terminal tool result is sent
- parts of the system may still think a tool is running

After:
- Pipecat sends a normal final tool result:
  - `Error: function 'lookup_customer' is not registered.`

## Testing
- `uv run pytest tests/test_llm_service.py tests/test_user_mute_strategy.py tests/test_user_idle_controller.py`

Closes #4300

## Related
Once a tool call starts, it should always reach a terminal state. Several issues have hit variants of this invariant being broken:
- #4165 — orphan function call entries block transitions after interruption
- #3661 — function calls stuck when cancelled before InProgressFrame arrives
- #4260 — TTS queue drops function call frames during interruption, causing permanent silence

This PR closes another gap: when no handler is registered (e.g. model hallucinates a tool name), the call now still gets a proper terminal result.