### PR TITLE
Improve interruption recovery and MCP tool errors

### DIFF
--- a/changelog/4303.fixed.md
+++ b/changelog/4303.fixed.md
@@ -1,0 +1,1 @@
+- Fixed tool-call recovery by clearing stale assistant-side tool state on interruption and returning the original MCP tool error message instead of a generic fallback.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -897,6 +897,8 @@ class LLMAssistantAggregator(LLMContextAggregator):
         """Reset the aggregation state."""
         await super().reset()
         await self._reset_thought_aggregation()  # Just to be safe
+        self._function_calls_in_progress = {}
+        self._function_calls_image_results = {}
         self._push_context_on_bot_stopped_speaking = False
 
     async def _reset_thought_aggregation(self):

--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -242,6 +242,8 @@ class MCPClient(BaseObject):
         except Exception as e:
             error_msg = f"Error calling mcp tool {function_name}: {str(e)}"
             logger.error(error_msg)
+            await result_callback(error_msg)
+            return
 
         response = ""
         if results:

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -867,6 +867,30 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(stop_messages[1].interrupted)
         self.assertEqual(stop_messages[1].content, "Hello there!")
 
+    async def test_interruption_clears_stale_function_call_state(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        await run_test(
+            aggregator,
+            frames_to_send=[
+                FunctionCallsStartedFrame(
+                    function_calls=[
+                        FunctionCallFromLLM(
+                            function_name="missing_tool",
+                            tool_call_id="call_1",
+                            arguments={},
+                            context=None,
+                        )
+                    ]
+                ),
+                InterruptionFrame(),
+            ],
+            expected_down_frames=[InterruptionFrame],
+        )
+
+        self.assertFalse(aggregator.has_function_calls_in_progress)
+
     async def test_function_call(self):
         context = LLMContext()
         aggregator = LLMAssistantAggregator(context)

--- a/tests/test_mcp_service.py
+++ b/tests/test_mcp_service.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from types import SimpleNamespace
+
+from pipecat.services.mcp_service import MCPClient
+
+
+class FailingSession:
+    async def call_tool(self, function_name, arguments=None):
+        raise RuntimeError("upstream unavailable")
+
+
+class TestMCPService(unittest.IsolatedAsyncioTestCase):
+    async def test_call_tool_returns_original_error_message_on_exception(self):
+        captured_results = []
+
+        async def result_callback(result):
+            captured_results.append(result)
+
+        fake_client = SimpleNamespace(_tools_output_filters={})
+
+        await MCPClient._call_tool(
+            fake_client,
+            FailingSession(),
+            "demo_tool",
+            {},
+            result_callback,
+        )
+
+        self.assertEqual(
+            captured_results,
+            ["Error calling mcp tool demo_tool: upstream unavailable"],
+        )


### PR DESCRIPTION
## Summary
Fixes two recovery-path problems around tool calls.

Before this change:
- interruption could leave stale assistant-side tool-call state behind
- MCP failures could lose the real error and return only a generic message

After this change:
- interruption/reset clears stale assistant-local tool-call tracking
- MCP failures return the real error message through the tool result path

## Examples
If a bad tool call leaves stale `tool still running` state behind:
- before: interrupting the conversation may still leave that stale state in memory
- after: interruption clears it

If an MCP tool fails with `upstream unavailable`:
- before: the model gets `Sorry, could not call the mcp tool`
- after: the model gets `Error calling mcp tool demo_tool: upstream unavailable`

## Testing
- `uv run pytest tests/test_context_aggregators_universal.py tests/test_mcp_service.py tests/test_llm_service.py tests/test_user_mute_strategy.py tests/test_user_idle_controller.py`

Closes #4302
