### PR TITLE
Fix Smallest AI TTS WebSocket endpoint URL and remove unsupported flush

### DIFF
--- a/changelog/4320.fixed.md
+++ b/changelog/4320.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SmallestTTSService` WebSocket endpoint URL to match Smallest AI v4.0.0 API (`wss://waves-api.smallest.ai` → `wss://api.smallest.ai`) and restored keepalive using a silent space message instead of the unsupported flush command.

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -125,8 +125,8 @@ class SmallestTTSService(InterruptibleTTSService):
         *,
         api_key: str,
         base_url: str = "wss://api.smallest.ai",
-        sample_rate: Optional[int] = None,
-        settings: Optional[Settings] = None,
+        sample_rate: int | None = None,
+        settings: Settings | None = None,
         **kwargs,
     ):
         """Initialize the Smallest AI WebSocket TTS service.

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -124,7 +124,7 @@ class SmallestTTSService(InterruptibleTTSService):
         self,
         *,
         api_key: str,
-        base_url: str = "wss://waves-api.smallest.ai",
+        base_url: str = "wss://api.smallest.ai",
         sample_rate: Optional[int] = None,
         settings: Optional[Settings] = None,
         **kwargs,
@@ -216,7 +216,7 @@ class SmallestTTSService(InterruptibleTTSService):
 
     def _build_websocket_url(self) -> str:
         """Build the WebSocket URL from base URL and model."""
-        return f"{self._base_url}/api/v1/{self._settings.model}/get_speech/stream"
+        return f"{self._base_url}/waves/v1/{self._settings.model}/get_speech/stream"
 
     async def start(self, frame: StartFrame):
         """Start the Smallest TTS service.

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -10,7 +10,6 @@ This module provides a WebSocket-based integration with Smallest AI's
 Waves API for real-time text-to-speech synthesis.
 """
 
-import asyncio
 import base64
 import json
 from dataclasses import dataclass, field
@@ -163,7 +162,6 @@ class SmallestTTSService(InterruptibleTTSService):
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._receive_task = None
-        self._keepalive_task = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -272,9 +270,6 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._websocket and not self._receive_task:
             self._receive_task = self.create_task(self._receive_task_handler(self._report_error))
 
-        if self._websocket and not self._keepalive_task:
-            self._keepalive_task = self.create_task(self._keepalive_task_handler())
-
     async def _disconnect(self):
         """Disconnect from Smallest WebSocket and clean up tasks."""
         await super()._disconnect()
@@ -282,10 +277,6 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._receive_task:
             await self.cancel_task(self._receive_task)
             self._receive_task = None
-
-        if self._keepalive_task:
-            await self.cancel_task(self._keepalive_task)
-            self._keepalive_task = None
 
         await self._disconnect_websocket()
 
@@ -340,25 +331,6 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._websocket:
             return self._websocket
         raise Exception("Websocket not connected")
-
-    async def _keepalive_task_handler(self):
-        """Send periodic keepalive messages to prevent idle timeout."""
-        KEEPALIVE_INTERVAL = 30
-        while True:
-            await asyncio.sleep(KEEPALIVE_INTERVAL)
-            await self._send_keepalive()
-
-    async def _send_keepalive(self):
-        """Send a flush message to keep the connection alive."""
-        if self._websocket and self._websocket.state is State.OPEN:
-            msg = {"flush": True}
-            await self._websocket.send(json.dumps(msg))
-
-    async def flush_audio(self, context_id: Optional[str] = None):
-        """Flush any pending audio synthesis."""
-        if not self._websocket or self._websocket.state is State.CLOSED:
-            return
-        await self._get_websocket().send(json.dumps({"flush": True}))
 
     async def _receive_messages(self):
         """Receive and process messages from the Smallest WebSocket API."""

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -172,6 +172,10 @@ class SmallestTTSService(InterruptibleTTSService):
         """
         return True
 
+    async def flush_audio(self, context_id: str | None = None):
+        """Flush any buffered audio data."""
+        pass
+
     def language_to_service_language(self, language: Language) -> str | None:
         """Convert a Language enum to Smallest service language format.
 

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -10,6 +10,7 @@ This module provides a WebSocket-based integration with Smallest AI's
 Waves API for real-time text-to-speech synthesis.
 """
 
+import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator
@@ -163,6 +164,7 @@ class SmallestTTSService(InterruptibleTTSService):
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._receive_task = None
+        self._keepalive_task = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -275,6 +277,9 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._websocket and not self._receive_task:
             self._receive_task = self.create_task(self._receive_task_handler(self._report_error))
 
+        if self._websocket and not self._keepalive_task:
+            self._keepalive_task = self.create_task(self._keepalive_task_handler())
+
     async def _disconnect(self):
         """Disconnect from Smallest WebSocket and clean up tasks."""
         await super()._disconnect()
@@ -282,6 +287,10 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._receive_task:
             await self.cancel_task(self._receive_task)
             self._receive_task = None
+
+        if self._keepalive_task:
+            await self.cancel_task(self._keepalive_task)
+            self._keepalive_task = None
 
         await self._disconnect_websocket()
 
@@ -336,6 +345,23 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._websocket:
             return self._websocket
         raise Exception("Websocket not connected")
+
+    async def _keepalive_task_handler(self):
+        """Send periodic keepalive messages to prevent idle timeout."""
+        KEEPALIVE_INTERVAL = 30
+        while True:
+            await asyncio.sleep(KEEPALIVE_INTERVAL)
+            await self._send_keepalive()
+
+    async def _send_keepalive(self):
+        """Send a silent message to keep the WebSocket connection alive."""
+        if self._websocket and self._websocket.state is State.OPEN:
+            msg = {
+                "text": " ",
+                "voice_id": self._settings.voice,
+                "language": self._settings.language,
+            }
+            await self._websocket.send(json.dumps(msg))
 
     async def _receive_messages(self):
         """Receive and process messages from the Smallest WebSocket API."""

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -173,8 +173,8 @@ class SmallestTTSService(InterruptibleTTSService):
         return True
 
     async def flush_audio(self, context_id: str | None = None):
-        """Flush any buffered audio data."""
-        pass
+        """Flush any pending audio data."""
+        logger.trace(f"{self}: flushing audio")
 
     def language_to_service_language(self, language: Language) -> str | None:
         """Convert a Language enum to Smallest service language format.


### PR DESCRIPTION
## Summary
- Fix WebSocket base URL from `wss://waves-api.smallest.ai` → `wss://api.smallest.ai` and path prefix from `/api/v1/` → `/waves/v1/` to match the [v4.0.0 API docs](https://docs.smallest.ai/waves/v-4-0-0/documentation/text-to-speech-lightning/quickstart)
- Remove `flush_audio`, `_keepalive_task_handler`, and `_send_keepalive` — the Smallest AI WebSocket API does not support the `{"flush": True}` message type

## Test plan
- [ ] Run `examples/voice/voice-smallest.py -t webrtc -v` and verify WebSocket connects without error
- [ ] Confirm no `unknown message status` warnings in logs
- [ ] Confirm TTS audio plays back correctly