### PR TITLE
Silence krisp_audio import logs on auto-import

### DIFF
--- a/src/pipecat/audio/krisp_instance.py
+++ b/src/pipecat/audio/krisp_instance.py
@@ -15,9 +15,11 @@ from loguru import logger
 try:
     import krisp_audio
 except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error("In order to use the Krisp instance, you need to install krisp_audio.")
-    raise ImportError(f"Missing module: {e}") from e
+    raise ImportError(
+        "krisp_audio is required for Krisp audio features. "
+        "Install it to use KrispVivaFilter, KrispVivaVadAnalyzer, "
+        "KrispVivaTurn, or KrispVivaIPUserTurnStartStrategy."
+    ) from e
 
 
 # Mapping of sample rates (Hz) to Krisp SDK SamplingRate enums


### PR DESCRIPTION
Because of the Krisp import in the turn.user_start module, we were seeing ERRORs. This resolves and relies on ImportError. @filipi87 I think this is a viable solution, but open to other ideas.

## Summary

- `pipecat.audio.krisp_instance` emitted two import-time `ERROR` log lines whenever `krisp_audio` wasn't installed. These fired for every bot that didn't use Krisp, because `pipecat.turns.user_start` transitively imports `krisp_viva_ip_user_turn_start_strategy`, which top-level-imports `krisp_instance`.
- Dropped the `logger.error` calls and rewrote the raised `ImportError` so direct importers of `KrispVivaFilter`, `KrispVivaVadAnalyzer`, `KrispVivaTurn`, or `KrispVivaIPUserTurnStartStrategy` still get a clear install hint, while transitive imports stay quiet (the existing `except ImportError` in `user_start/__init__.py` swallows the exception).

## Testing

- `uv run python -c "import pipecat.turns.user_start"` — banner only, no Krisp errors.
- `uv run python -c "from pipecat.audio.filters.krisp_viva_filter import KrispVivaFilter"` — raises `ImportError: krisp_audio is required for Krisp audio features. Install it to use KrispVivaFilter, KrispVivaVadAnalyzer, KrispVivaTurn, or KrispVivaIPUserTurnStartStrategy.`
- `uv run examples/voice/voice-elevenlabs.py` — no spurious Krisp error lines on startup.