### PR TITLE
fix: handle Claude 4.6+ no-prefill constraint for Anthropic and Bedrock

### DIFF
--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -178,6 +178,27 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
 
         return self.ConvertedMessages(messages=messages, system=system)
 
+    @staticmethod
+    def ensure_last_message_is_user(messages: list[MessageParam]) -> list[MessageParam]:
+        """Ensure the message list does not end with an assistant message.
+
+        Claude 4.6+ models do not support assistant message prefilling — the
+        conversation must end with a user turn.  When the last message has
+        ``role="assistant"``, a minimal user message is appended so that the
+        API request is accepted.
+
+        Args:
+            messages: The converted message list (may be mutated in-place).
+
+        Returns:
+            The same list, possibly with an appended user message.
+        """
+        if messages and messages[-1]["role"] == "assistant":
+            messages.append(
+                {"role": "user", "content": [{"type": "text", "text": "(continue)"}]}
+            )
+        return messages
+
     def _from_universal_context_message(self, message: LLMContextMessage) -> MessageParam:
         if isinstance(message, LLMSpecificMessage):
             return self._from_anthropic_specific_message(message)

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -168,6 +168,25 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
 
         return self.ConvertedMessages(messages=messages, system=system)
 
+    @staticmethod
+    def ensure_last_message_is_user(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Ensure the message list does not end with an assistant message.
+
+        Claude 4.6+ models on Bedrock do not support assistant message
+        prefilling — the conversation must end with a user turn.  When the
+        last message has ``role="assistant"``, a minimal user message is
+        appended so that the Converse API request is accepted.
+
+        Args:
+            messages: The converted message list (may be mutated in-place).
+
+        Returns:
+            The same list, possibly with an appended user message.
+        """
+        if messages and messages[-1]["role"] == "assistant":
+            messages.append({"role": "user", "content": [{"text": "(continue)"}]})
+        return messages
+
     def _from_universal_context_message(self, message: LLMContextMessage) -> dict[str, Any]:
         if isinstance(message, LLMSpecificMessage):
             return copy.deepcopy(message.message)

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -292,6 +292,10 @@ class AnthropicLLMService(LLMService):
         system = invocation_params["system"]
         tools = invocation_params["tools"]
 
+        # Claude 4.6+ rejects requests ending with an assistant message.
+        if self._model_disables_prefill():
+            adapter.ensure_last_message_is_user(messages)
+
         # Build params using the same method as streaming completions
         params = {
             "model": self._settings.model,
@@ -315,6 +319,14 @@ class AnthropicLLMService(LLMService):
 
         return next((block.text for block in response.content if hasattr(block, "text")), None)
 
+    # Claude 4.6+ models do not support assistant message prefilling.
+    _NO_PREFILL_PATTERNS = ("claude-sonnet-4-6", "claude-opus-4-6")
+
+    def _model_disables_prefill(self) -> bool:
+        """Return True if the current model does not support assistant message prefilling."""
+        model = self._settings.model or ""
+        return any(model.startswith(p) for p in self._NO_PREFILL_PATTERNS)
+
     def _get_llm_invocation_params(self, context: LLMContext) -> AnthropicLLMInvocationParams:
         adapter: AnthropicLLMAdapter = self.get_llm_adapter()
         params: AnthropicLLMInvocationParams = adapter.get_llm_invocation_params(
@@ -322,6 +334,9 @@ class AnthropicLLMService(LLMService):
             enable_prompt_caching=self._settings.enable_prompt_caching,
             system_instruction=self._settings.system_instruction,
         )
+        # Claude 4.6+ rejects requests ending with an assistant message.
+        if self._model_disables_prefill():
+            adapter.ensure_last_message_is_user(params["messages"])
         return params
 
     @traced_llm

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -287,6 +287,10 @@ class AWSBedrockLLMService(LLMService):
         messages = params["messages"]
         system = params["system"]  # [{"text": "system message"}] or None
 
+        # Claude 4.6+ rejects requests ending with an assistant message.
+        if self._model_disables_prefill():
+            adapter.ensure_last_message_is_user(messages)
+
         # Prepare request parameters using the same method as streaming
         inference_config = self._build_inference_config()
 
@@ -368,11 +372,27 @@ class AWSBedrockLLMService(LLMService):
             }
         }
 
+    # Claude 4.6+ models do not support assistant message prefilling.
+    _NO_PREFILL_PATTERNS = ("claude-sonnet-4-6", "claude-opus-4-6")
+
+    def _model_disables_prefill(self) -> bool:
+        """Return True if the current model does not support assistant message prefilling.
+
+        Bedrock model identifiers typically look like
+        ``us.anthropic.claude-sonnet-4-6-v1:0`` or
+        ``anthropic.claude-opus-4-6-v1:0``.
+        """
+        model = self._settings.model or ""
+        return any(p in model for p in self._NO_PREFILL_PATTERNS)
+
     def _get_llm_invocation_params(self, context: LLMContext) -> AWSBedrockLLMInvocationParams:
         adapter: AWSBedrockLLMAdapter = self.get_llm_adapter()
         params: AWSBedrockLLMInvocationParams = adapter.get_llm_invocation_params(
             context, system_instruction=self._settings.system_instruction
         )
+        # Claude 4.6+ rejects requests ending with an assistant message.
+        if self._model_disables_prefill():
+            adapter.ensure_last_message_is_user(params["messages"])
         return params
 
     @traced_llm

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -1089,6 +1089,46 @@ class TestAnthropicGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(len(params["messages"]), 1)
         self.assertEqual(params["messages"][0]["role"], "user")
 
+    def test_ensure_last_message_is_user_appends_when_trailing_assistant(self):
+        """Test that ensure_last_message_is_user appends a user message when last message is assistant."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        result = AnthropicLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[-1]["role"], "user")
+        self.assertEqual(result[-1]["content"], [{"type": "text", "text": "(continue)"}])
+
+    def test_ensure_last_message_is_user_noop_when_trailing_user(self):
+        """Test that ensure_last_message_is_user does nothing when last message is already user."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        result = AnthropicLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[-1]["role"], "user")
+        self.assertEqual(result[-1]["content"], "How are you?")
+
+    def test_ensure_last_message_is_user_handles_empty_list(self):
+        """Test that ensure_last_message_is_user handles empty message list."""
+        messages = []
+        result = AnthropicLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 0)
+
+    def test_ensure_last_message_is_user_handles_tool_result_trailing(self):
+        """Test that ensure_last_message_is_user does nothing when last message is a tool_result (user role)."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "get_weather", "input": {}}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "Sunny, 22°C"}]},
+        ]
+        result = AnthropicLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)  # No message appended
+        self.assertEqual(result[-1]["role"], "user")
+
 
 class TestAWSBedrockGetLLMInvocationParams(unittest.TestCase):
     def setUp(self) -> None:
@@ -1417,6 +1457,45 @@ class TestAWSBedrockGetLLMInvocationParams(unittest.TestCase):
         params = self.adapter.get_llm_invocation_params(context)
 
         self.assertEqual(params["messages"][2]["role"], "user")
+
+    def test_ensure_last_message_is_user_appends_when_trailing_assistant(self):
+        """Test that ensure_last_message_is_user appends a user message when last message is assistant."""
+        messages = [
+            {"role": "user", "content": [{"text": "Hello"}]},
+            {"role": "assistant", "content": [{"text": "Hi there!"}]},
+        ]
+        result = AWSBedrockLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[-1]["role"], "user")
+        self.assertEqual(result[-1]["content"], [{"text": "(continue)"}])
+
+    def test_ensure_last_message_is_user_noop_when_trailing_user(self):
+        """Test that ensure_last_message_is_user does nothing when last message is already user."""
+        messages = [
+            {"role": "user", "content": [{"text": "Hello"}]},
+            {"role": "assistant", "content": [{"text": "Hi there!"}]},
+            {"role": "user", "content": [{"text": "How are you?"}]},
+        ]
+        result = AWSBedrockLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[-1]["role"], "user")
+
+    def test_ensure_last_message_is_user_handles_empty_list(self):
+        """Test that ensure_last_message_is_user handles empty message list."""
+        messages = []
+        result = AWSBedrockLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 0)
+
+    def test_ensure_last_message_is_user_handles_tool_result_trailing(self):
+        """Test that ensure_last_message_is_user does nothing when last message is a toolResult (user role)."""
+        messages = [
+            {"role": "user", "content": [{"text": "What's the weather?"}]},
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "get_weather", "input": {}}}]},
+            {"role": "user", "content": [{"toolResult": {"toolUseId": "t1", "content": [{"text": "Sunny, 22°C"}]}}]},
+        ]
+        result = AWSBedrockLLMAdapter.ensure_last_message_is_user(messages)
+        self.assertEqual(len(result), 3)  # No message appended
+        self.assertEqual(result[-1]["role"], "user")
 
 
 class TestPerplexityGetLLMInvocationParams(unittest.TestCase):


### PR DESCRIPTION
## Summary

Claude 4.6+ models (Sonnet and Opus) do not support assistant message prefilling — the API rejects requests where the conversation ends with an assistant turn:

```
Error code: 400 - {"type": "error", "error": {"type": "invalid_request_error",
"message": "This model does not support assistant message prefill.
The conversation must end with a user message."}}
```

This can occur during tool call flows when the model streams text (e.g. "Let me check that...") alongside a `tool_use` block. The streamed text is appended to the context as a trailing assistant message after tool results have been added, causing the next inference request to fail.

## Root Cause

In `_process_context()`, the flow is:
1. LLM streams text + `tool_use` blocks
2. `run_function_calls()` executes tools, adds `assistant(tool_calls)` + `user(tool_result)` to context
3. Tool result triggers re-inference (context pushed upstream)
4. `finally:` block fires `LLMFullResponseEndFrame` → `push_aggregation()` adds streamed text as a trailing `assistant` message

The trailing assistant message from step 4 causes Claude 4.6+ to reject the request.

**Why this is hard to reproduce:** If the model returns a bare tool call with no preamble text, `push_aggregation` has nothing to push — no trailing assistant message, no error. The bug only triggers when the model says something *before* calling the tool.

## Changes

- **Adapters:** Add `ensure_last_message_is_user()` static method to both `AnthropicLLMAdapter` and `AWSBedrockLLMAdapter`. When the message list ends with an assistant turn, a minimal `(continue)` user message is appended.
- **LLM Services:** Add `_model_disables_prefill()` to both `AnthropicLLMService` and `AWSBedrockLLMService` to detect Claude 4.6+ model identifiers. Applied in both `_get_llm_invocation_params()` (streaming) and `run_inference()` (non-streaming) code paths.
- **Tests:** 8 unit tests covering the adapter methods for both providers.

For Bedrock, model ID matching uses `in` instead of `startswith` since Bedrock IDs include region prefixes (e.g. `us.anthropic.claude-sonnet-4-6-v1:0`).

## References

- Similar fix shipped by LiveKit: https://github.com/livekit/agents/pull/4973
- Same issue reported across the ecosystem: langchain, strands-agents, crush, oh-my-openagent, opencode

Fixes #4020