### PR TITLE
Silence pyright diagnostics for unchecked modules in IDE

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -17,5 +17,20 @@
     "**/*_pb2.py",
     "**/__pycache__"
   ],
+  "ignore": [
+    "src/pipecat/adapters",
+    "src/pipecat/audio",
+    "src/pipecat/processors",
+    "src/pipecat/serializers",
+    "src/pipecat/services",
+    "src/pipecat/sync",
+    "src/pipecat/tests",
+    "src/pipecat/transports",
+    "src/pipecat/utils",
+    "tests",
+    "examples",
+    "scripts",
+    "docs"
+  ],
   "reportMissingImports": false
 }


### PR DESCRIPTION
We have to proactively ignore the modules that aren't pyright compliant to silence errors in IDEs, like VSCode. As we add support, we'll both add those modules to the include list and remove from the ignore list.