### PR TITLE
AudioBufferProcessor: expose recording_start_time for pipeline-clock alignment

### DIFF
--- a/changelog/4353.added.md
+++ b/changelog/4353.added.md
@@ -1,0 +1,1 @@
+- Added `AudioBufferProcessor.recording_start_time` property that exposes the pipeline-clock time (in nanoseconds) captured the moment `start_recording()` is called. Lets downstream consumers align pipeline-clock events (word PTS, turn-boundary events, etc.) to the recorded audio's `t=0` without reconstructing the anchor externally.

--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -85,6 +85,7 @@ class AudioBufferProcessor(FrameProcessor):
         self._bot_turn_audio_buffer = bytearray()
 
         self._recording = False
+        self._recording_start_time: int | None = None
 
         self._input_resampler = create_stream_resampler()
         self._output_resampler = create_stream_resampler()
@@ -111,6 +112,20 @@ class AudioBufferProcessor(FrameProcessor):
             Number of channels (1 for mono, 2 for stereo).
         """
         return self._num_channels
+
+    @property
+    def recording_start_time(self) -> int | None:
+        """Pipeline-clock time at which the current recording started.
+
+        Captured from the processor's clock the moment ``start_recording()`` is
+        called, so downstream consumers can align other pipeline-clock events
+        (e.g. word PTS, turn-boundary events) to the recorded audio's t=0.
+
+        Returns:
+            The recording start time in nanoseconds, or ``None`` if recording
+            has not been started yet (or has been stopped).
+        """
+        return self._recording_start_time
 
     def has_audio(self) -> bool:
         """Check if either user or bot audio buffers contain data.
@@ -143,19 +158,25 @@ class AudioBufferProcessor(FrameProcessor):
     async def start_recording(self):
         """Start recording audio from both user and bot.
 
-        Initializes recording state and resets audio buffers.
+        Initializes recording state, resets audio buffers, and captures the
+        pipeline-clock time at which recording begins (exposed via the
+        ``recording_start_time`` property).
         """
         self._recording = True
+        self._recording_start_time = self._clock.get_time() if self._clock else None
         self._reset_recording()
 
     async def stop_recording(self):
         """Stop recording and trigger final audio data handlers.
 
         Calls audio handlers with any remaining buffered audio before stopping.
+        ``recording_start_time`` is cleared so a subsequent ``start_recording()``
+        call captures a fresh anchor.
         """
         await self._call_on_audio_data_handler()
         self._reset_recording()
         self._recording = False
+        self._recording_start_time = None
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process incoming audio frames and manage audio buffers.

--- a/tests/test_audio_buffer_processor.py
+++ b/tests/test_audio_buffer_processor.py
@@ -30,12 +30,14 @@ class _PassthroughResampler:
         return audio
 
 
-async def _make_processor(*, buffer_size: int = 0) -> AudioBufferProcessor:
-    """Create and start a processor ready to record.
+async def _setup_processor(*, buffer_size: int = 0) -> AudioBufferProcessor:
+    """Create and initialise a processor without starting recording.
 
     Calls setup() and sends a StartFrame through the public process_frame path so that
     the processor is fully initialised (task manager set, sample rate configured,
-    __started flag set) without needing a full pipeline.
+    __started flag set) without needing a full pipeline. The clock is explicitly
+    started so tests exercising pipeline-clock values (e.g. ``recording_start_time``)
+    observe realistic non-zero timestamps.
     """
     processor = AudioBufferProcessor(sample_rate=16000, num_channels=2, buffer_size=buffer_size)
     processor._input_resampler = _PassthroughResampler()
@@ -44,11 +46,22 @@ async def _make_processor(*, buffer_size: int = 0) -> AudioBufferProcessor:
     loop = asyncio.get_event_loop()
     task_manager = TaskManager()
     task_manager.setup(TaskManagerParams(loop=loop))
-    await processor.setup(FrameProcessorSetup(clock=SystemClock(), task_manager=task_manager))
+    clock = SystemClock()
+    clock.start()
+    await processor.setup(FrameProcessorSetup(clock=clock, task_manager=task_manager))
 
     await processor.process_frame(
         StartFrame(audio_out_sample_rate=16000), FrameDirection.DOWNSTREAM
     )
+    # Yield once so the processor's input-frame task actually starts running before
+    # any test tears it down; avoids spurious "coroutine was never awaited" warnings.
+    await asyncio.sleep(0)
+    return processor
+
+
+async def _make_processor(*, buffer_size: int = 0) -> AudioBufferProcessor:
+    """Create a processor and start recording, ready for audio frames."""
+    processor = await _setup_processor(buffer_size=buffer_size)
     await processor.start_recording()
     return processor
 
@@ -322,6 +335,69 @@ class TestSilenceInjectionGuards(unittest.IsolatedAsyncioTestCase):
         await p.cleanup()
 
         self.assertEqual(user_track[:8], b"\x00" * 8)
+
+
+class TestRecordingStartTime(unittest.IsolatedAsyncioTestCase):
+    """Tests for the ``recording_start_time`` property.
+
+    The property exposes the pipeline-clock time (in nanoseconds) at which the
+    current recording started, letting downstream consumers align pipeline-clock
+    events to the recorded audio's t=0.
+    """
+
+    async def test_recording_start_time_is_none_before_start(self):
+        """Before ``start_recording()`` is ever called, the property is ``None``."""
+        p = await _setup_processor()
+        try:
+            self.assertIsNone(p.recording_start_time)
+        finally:
+            await p.cleanup()
+
+    async def test_recording_start_time_captured_on_start(self):
+        """``start_recording()`` captures the current pipeline-clock time."""
+        p = await _setup_processor()
+        try:
+            self.assertIsNone(p.recording_start_time)
+            await p.start_recording()
+            anchor = p.recording_start_time
+            self.assertIsNotNone(anchor)
+            self.assertIsInstance(anchor, int)
+            self.assertGreater(anchor, 0)
+        finally:
+            await p.stop_recording()
+            await p.cleanup()
+
+    async def test_recording_start_time_cleared_on_stop(self):
+        """``stop_recording()`` clears the anchor back to ``None``."""
+        p = await _setup_processor()
+        try:
+            await p.start_recording()
+            self.assertIsNotNone(p.recording_start_time)
+            await p.stop_recording()
+            self.assertIsNone(p.recording_start_time)
+        finally:
+            await p.cleanup()
+
+    async def test_recording_start_time_refreshed_on_restart(self):
+        """A second ``start_recording()`` captures a fresh, later anchor."""
+        p = await _setup_processor()
+        try:
+            await p.start_recording()
+            first = p.recording_start_time
+            self.assertIsNotNone(first)
+
+            await p.stop_recording()
+            # Allow the monotonic clock to advance so the second anchor is strictly
+            # greater than the first; ~1 ms is plenty for nanosecond resolution.
+            await asyncio.sleep(0.001)
+
+            await p.start_recording()
+            second = p.recording_start_time
+            self.assertIsNotNone(second)
+            self.assertGreater(second, first)
+        finally:
+            await p.stop_recording()
+            await p.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`AudioBufferProcessor` records audio on the pipeline clock, but downstream consumers have no way to read the anchor timestamp that maps the recorded audio's `t=0` to the pipeline clock. Callers have to capture it externally by reading `pipeline_task.get_clock().get_time()` right after calling `audiobuffer.start_recording()` from application code, which is fragile (the two timestamps are never the same instant) and duplicated across every consumer that needs to align pipeline-clock events (word-level PTS, turn-boundary events, custom frame metadata, etc.) to the recorded audio.

## Fix

Expose the anchor directly on the processor:

- `start_recording()` now captures `self._clock.get_time()`, the same pattern `FrameProcessor` already uses to stamp PTS on pushed frames.
- `stop_recording()` clears the anchor to `None` **after** the final `on_audio_data` flush, so handlers fired during the flush can still read the value.
- New read-only `recording_start_time` property returns the captured nanoseconds, or `None` when not recording.

Additive and backward-compatible: no existing behaviour changes, `start_recording()` / `stop_recording()` signatures are unchanged, and all 6 existing `AudioBufferProcessor` tests pass without modification.

## Testing

```bash
uv run ruff check . && uv run ruff format --check .         # clean
uv run pyright src/pipecat/processors/audio/audio_buffer_processor.py  # 0 errors, 0 warnings
uv run pytest tests/test_audio_buffer_processor.py          # 10 passed (6 existing + 4 new)
uv run pytest tests/                                         # 1195 passed, 4 skipped
```

### New tests (`TestRecordingStartTime`)

- `test_recording_start_time_is_none_before_start`: property is `None` before the first `start_recording()`.
- `test_recording_start_time_captured_on_start`: `start_recording()` captures a positive pipeline-clock value.
- `test_recording_start_time_cleared_on_stop`: `stop_recording()` clears the anchor back to `None`.
- `test_recording_start_time_refreshed_on_restart`: a second `start_recording()` after a stop captures a fresh, strictly-later anchor.

## Changelog

`changelog/4353.added.md`.