### PR TITLE
Add Rime custom-pronunciations text rewriter to the Rime TTS services

### DIFF
--- a/src/pipecat/services/rime/custom_pronunciations.py
+++ b/src/pipecat/services/rime/custom_pronunciations.py
@@ -1,0 +1,477 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom pronunciations for the Rime TTS plugin.
+
+Rime's Mist-family models (``mistv2``, ``mistv3``) parse ``{phoneme}`` blocks
+inline in the synthesis text: whatever is inside the curly braces is pronounced
+verbatim using Rime's phoneme alphabet, bypassing the grapheme-to-phoneme
+lexicon for that span.
+
+This module provides a ``CustomPronunciations`` object that owns a mapping of
+``{input_text: phonemes}`` pairs, optionally kept in sync with the Rime
+customer API via a background refresh loop. Any number of ``rime.TTS``
+instances can reference the same object; each call to ``tts.synthesize(...)``
+consults ``prons.rewrite(text)`` by reference, so a refresh mid-session is
+picked up by the next utterance with no TTS reconfiguration.
+
+Keys are stored exactly as the API delivers them (no case folding, no
+whitespace stripping). Matching rules are derived from key content:
+
+- Keys containing any uppercase character are matched **case-sensitively**
+  (these are literals; canonical forms are lowercased by the server).
+- All-lowercase keys are matched **case-insensitively** (could be canonicals
+  or lowercase literals — case-insensitive is the safe superset).
+
+Matching uses ``\\w`` lookarounds (``(?<!\\w)...(?!\\w)``) rather than ``\\b``,
+so keys with trailing punctuation (``"Dr."``) and keys with internal spaces
+(``"Lisinopril 10mg"``) both match cleanly.
+
+``{phoneme}`` bracket syntax is Mist-only. Attaching a non-empty pronunciations
+object to a ``rime.TTS(model="arcana")`` logs a warning once per TTS instance
+and suppresses rewriting for that TTS — Arcana would synthesize the brace
+characters literally in the rendered audio, so the plugin sends unrewritten
+text rather than producing broken output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import Mapping
+from typing import Any, Callable
+
+import aiohttp
+from loguru import logger
+
+_DEFAULT_CUSTOMER_API_BASE_URL = "https://users.rime.ai"
+_MIN_REFRESH_INTERVAL = 30.0
+_INITIAL_FETCH_RETRIES = 2
+_INITIAL_FETCH_BACKOFFS = (1.0, 3.0)
+
+
+# ---------------------------------------------------------------------------
+# Response projection
+# ---------------------------------------------------------------------------
+
+
+def _project_response(body: Mapping[str, Any]) -> dict[str, str]:
+    """Project a ``GET /speech-qa/custom-pronunciations`` response into a flat map.
+
+    Expected response shape (API-010)::
+
+        {"default": {"<input_text_or_canonical>": "<pronunciation>", ...},
+         "vocabs": {}}
+
+    Keys and values must both be non-empty strings. ``vocabs`` is read and
+    discarded. Keys are not normalized — they are stored exactly as delivered.
+    """
+    out: dict[str, str] = {}
+    default = body.get("default")
+    if isinstance(default, Mapping):
+        for k, v in default.items():
+            if isinstance(k, str) and isinstance(v, str) and k and v:
+                out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Regex compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_patterns(
+    entries: Mapping[str, str],
+) -> tuple[re.Pattern[str] | None, re.Pattern[str] | None]:
+    """Build two alternation regexes over ``entries.keys()``.
+
+    Returns ``(case_sensitive_pattern, case_insensitive_pattern)``. Keys
+    containing any uppercase character go into the case-sensitive pattern;
+    all-lowercase keys go into the case-insensitive pattern. Within each
+    pattern, keys are sorted descending by length so longer literals match
+    before shorter ones that would shadow them (``"Lisinopril 10mg"`` before
+    ``"Lisinopril"``). Bounds use ``\\w`` lookarounds, not ``\\b``.
+    """
+    cased_keys: list[str] = []
+    lower_keys: list[str] = []
+    for k in entries:
+        (cased_keys if any(c.isupper() for c in k) else lower_keys).append(k)
+
+    def _build(keys: list[str], flags: int) -> re.Pattern[str] | None:
+        if not keys:
+            return None
+        keys_sorted = sorted(keys, key=len, reverse=True)
+        escaped = [re.escape(k) for k in keys_sorted]
+        return re.compile(r"(?<!\w)(" + "|".join(escaped) + r")(?!\w)", flags)
+
+    return _build(cased_keys, 0), _build(lower_keys, re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# CustomPronunciations
+# ---------------------------------------------------------------------------
+
+
+class CustomPronunciations:
+    """A live mapping of ``{input_text: phonemes}`` used at synthesis time.
+
+    Instances are typically produced by :func:`load_custom_pronunciations`,
+    which performs the initial fetch and optionally runs a background refresh
+    loop. The object is safe to share across many ``rime.TTS`` instances:
+    each synth consults ``rewrite(text)`` by reference, so refreshes are
+    picked up by the next utterance without any TTS reconfiguration.
+
+    The object must be closed when no longer needed (``await prons.aclose()``
+    or ``async with prons: ...``). When used inside a LiveKit ``JobContext``,
+    the recommended pattern is ``ctx.add_shutdown_callback(prons.aclose)``.
+    """
+
+    def __init__(self) -> None:
+        # Public attribute initialized to empty; populated by fetch or by the
+        # internal factory used in :func:`load_custom_pronunciations`.
+        self._entries: dict[str, str] = {}
+        self._cs_pattern: re.Pattern[str] | None = None
+        self._ci_pattern: re.Pattern[str] | None = None
+        self._refresh_lock = asyncio.Lock()
+        self._in_flight: asyncio.Task[None] | None = None
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+        # Fetch configuration, set when load_custom_pronunciations builds the
+        # object. Direct construction leaves these as None, which is fine:
+        # rewrite() still works over the empty mapping, and refresh() raises
+        # cleanly if invoked without configuration.
+        self._api_key: str | None = None
+        self._base_url: str = _DEFAULT_CUSTOMER_API_BASE_URL
+        self._http_session: aiohttp.ClientSession | None = None
+        self._refresh_interval: float | None = None
+
+    # ------------------------------------------------------------------
+    # Public read surface
+    # ------------------------------------------------------------------
+
+    @property
+    def entries(self) -> Mapping[str, str]:
+        """Read-only snapshot of the current mapping."""
+        return dict(self._entries)
+
+    def rewrite(self, text: str) -> str:
+        """Wrap every known literal in ``{phonemes}``.
+
+        Pure, synchronous, no IO. Case-sensitive for keys containing any
+        uppercase character; case-insensitive for all-lowercase keys.
+        """
+        cs = self._cs_pattern
+        ci = self._ci_pattern
+        if cs is None and ci is None:
+            return text
+        entries = self._entries
+
+        def _replace(match: re.Match[str]) -> str:
+            key = match.group(0)
+            # Case-sensitive hits: exact lookup.
+            if key in entries:
+                return "{" + entries[key] + "}"
+            # Case-insensitive hits: lookup by lowered form.
+            lowered = key.lower()
+            if lowered in entries:
+                return "{" + entries[lowered] + "}"
+            # Shouldn't happen (both patterns are built from `entries`), but
+            # if it does, leave the span untouched.
+            return key
+
+        if cs is not None:
+            text = cs.sub(_replace, text)
+        if ci is not None:
+            text = ci.sub(_replace, text)
+        return text
+
+    def __call__(self, text: str) -> str:
+        """Alias for :meth:`rewrite`, so instances satisfy ``Callable[[str], str]``."""
+        return self.rewrite(text)
+
+    # ------------------------------------------------------------------
+    # Refresh
+    # ------------------------------------------------------------------
+
+    async def refresh(self) -> None:
+        """Force a fetch now. Coalesces with any in-flight refresh.
+
+        If another ``refresh()`` is already in flight, awaits that one
+        instead of issuing a second request. Safe to call concurrently from
+        many tasks.
+        """
+        if self._closed:
+            return
+        task = self._in_flight
+        if task is not None and not task.done():
+            await asyncio.shield(task)
+            return
+        task = asyncio.create_task(self._fetch_and_swap(), name="rime-prons-refresh-fetch")
+        self._in_flight = task
+        try:
+            await task
+        finally:
+            # Always clear so a future refresh starts a new fetch. If the
+            # task raised, the exception is consumed by the `await` above;
+            # callers waiting on `asyncio.shield(task)` also see it, but
+            # the task's result is consumed by every awaiter, so no
+            # unretrieved-exception warning.
+            self._in_flight = None
+
+    async def _fetch_and_swap(self) -> None:
+        body = await _http_get_pronunciations(
+            api_key=self._api_key,
+            base_url=self._base_url,
+            http_session=self._http_session,
+        )
+        new_entries = _project_response(body)
+        async with self._refresh_lock:
+            cs, ci = _compile_patterns(new_entries)
+            # Atomic swap. Reads don't take the lock; Python reference
+            # assignment is atomic under the GIL, so a concurrent rewrite()
+            # sees either old or new, never a torn state.
+            self._entries = new_entries
+            self._cs_pattern = cs
+            self._ci_pattern = ci
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Cancel the refresh task. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        task = self._refresh_task
+        self._refresh_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def __aenter__(self) -> CustomPronunciations:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    def __del__(self) -> None:
+        # Best-effort warning for leaked refresh loops. We can't await here,
+        # so we can't cancel the task cleanly; just make the mistake noisy.
+        try:
+            if not self._closed and self._refresh_task is not None:
+                logger.warning(
+                    "CustomPronunciations was garbage-collected without aclose(); "
+                    "the refresh loop may leak until event loop shutdown. "
+                    "Call `await prons.aclose()` or use `async with prons:`."
+                )
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+
+async def _http_get_pronunciations(
+    *,
+    api_key: str | None,
+    base_url: str,
+    http_session: aiohttp.ClientSession | None,
+) -> Mapping[str, Any]:
+    """One HTTP GET against ``{base_url}/speech-qa/custom-pronunciations``.
+
+    Raises on HTTP errors and connection errors. Callers decide whether to
+    retry or swallow.
+    """
+    if not api_key:
+        raise ValueError(
+            "Rime API key is required, either as argument or set RIME_API_KEY "
+            "environmental variable"
+        )
+    url = f"{base_url.rstrip('/')}/speech-qa/custom-pronunciations"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    if http_session is not None:
+        async with http_session.get(url, headers=headers) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """Return True for errors worth retrying at initial-fetch time.
+
+    Transient: 5xx responses, timeouts, connection resets. Permanent: 4xx
+    responses (auth, bad request) — those mean config bugs that should
+    surface immediately at app startup.
+    """
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if isinstance(exc, aiohttp.ClientResponseError):
+        return exc.status >= 500
+    if isinstance(exc, aiohttp.ClientConnectionError):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+async def load_custom_pronunciations(
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    refresh_interval: float | None = 300.0,
+    http_session: aiohttp.ClientSession | None = None,
+) -> CustomPronunciations:
+    """Fetch custom pronunciations and return a ready-to-use object.
+
+    Performs the initial fetch before returning. Transient errors (5xx,
+    timeouts, connection resets) are retried twice with 1s/3s backoff;
+    permanent errors (4xx, including auth failures) raise immediately.
+
+    If ``refresh_interval`` is set (default 300s, clamped to a minimum of
+    30s), a background task re-fetches on that interval. Refresh-loop
+    failures are logged and swallowed — the previously loaded mapping stays
+    in effect. Pass ``refresh_interval=None`` for a one-shot snapshot.
+
+    The returned object must be closed when no longer needed::
+
+        async def entrypoint(ctx: JobContext):
+            prons = await rime.load_custom_pronunciations(refresh_interval=300)
+            ctx.add_shutdown_callback(prons.aclose)
+            tts = rime.TTS(model="mistv2", custom_pronunciations=prons)
+    """
+    resolved_key = api_key or os.environ.get("RIME_API_KEY")
+    if not resolved_key:
+        raise ValueError(
+            "Rime API key is required, either as argument or set RIME_API_KEY "
+            "environmental variable"
+        )
+
+    resolved_base = (base_url or _DEFAULT_CUSTOMER_API_BASE_URL).rstrip("/")
+
+    resolved_interval: float | None
+    if refresh_interval is None:
+        resolved_interval = None
+    else:
+        if refresh_interval < _MIN_REFRESH_INTERVAL:
+            logger.warning(
+                "refresh_interval=%s is below the minimum of %ss; clamping.",
+                refresh_interval,
+                _MIN_REFRESH_INTERVAL,
+            )
+            resolved_interval = _MIN_REFRESH_INTERVAL
+        else:
+            resolved_interval = float(refresh_interval)
+
+    prons = CustomPronunciations()
+    prons._api_key = resolved_key
+    prons._base_url = resolved_base
+    prons._http_session = http_session
+    prons._refresh_interval = resolved_interval
+
+    # Initial fetch with limited retry on transient errors.
+    last_exc: BaseException | None = None
+    attempts = _INITIAL_FETCH_RETRIES + 1
+    for attempt in range(attempts):
+        try:
+            await prons._fetch_and_swap()
+            last_exc = None
+            break
+        except BaseException as e:
+            last_exc = e
+            if attempt == attempts - 1 or not _is_transient_error(e):
+                raise
+            backoff = _INITIAL_FETCH_BACKOFFS[min(attempt, len(_INITIAL_FETCH_BACKOFFS) - 1)]
+            logger.warning(
+                "initial custom_pronunciations fetch failed (%s); "
+                "retrying in %ss (attempt %d/%d)",
+                type(e).__name__,
+                backoff,
+                attempt + 1,
+                attempts,
+            )
+            await asyncio.sleep(backoff)
+    if last_exc is not None:
+        raise last_exc
+
+    # Start the refresh loop if requested.
+    if resolved_interval is not None:
+        prons._refresh_task = asyncio.create_task(
+            _refresh_loop(prons, resolved_interval),
+            name="rime-custom-pronunciations-refresh",
+        )
+
+    return prons
+
+
+async def _refresh_loop(prons: CustomPronunciations, interval: float) -> None:
+    """Background refresh task. Logs and swallows all errors but cancellation."""
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            await prons.refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "custom_pronunciations refresh failed; "
+                "keeping previously loaded mapping in effect"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Text-rewriter protocol
+# ---------------------------------------------------------------------------
+
+# A text-rewriter is any callable that takes a string and returns a string.
+# Both `CustomPronunciations` and user-supplied lambdas satisfy this, so the
+# TTS constructor accepts either shape in the `custom_pronunciations=` slot.
+TextRewriter = Callable[[str], str]
+
+
+def _rewriter_is_nonempty(rewriter: TextRewriter | None) -> bool:
+    """Cheap check for "would this rewriter produce any substitutions?"
+
+    For a ``CustomPronunciations`` instance we can inspect its mapping; for
+    arbitrary callables we conservatively answer True (we can't introspect a
+    user function). Used to decide whether Arcana's warn-and-drop applies.
+    """
+    if rewriter is None:
+        return False
+    if isinstance(rewriter, CustomPronunciations):
+        return bool(rewriter._entries)
+    return True
+
+
+__all__ = [
+    "CustomPronunciations",
+    "TextRewriter",
+    "load_custom_pronunciations",
+]

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -14,7 +14,7 @@ import base64
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar, Union
 
 import aiohttp
 from loguru import logger
@@ -30,6 +30,11 @@ from pipecat.frames.frames import (
     TTSStartedFrame,
     TTSStoppedFrame,
 )
+from pipecat.services.rime.custom_pronunciations import (
+    CustomPronunciations,
+    TextRewriter,
+    _rewriter_is_nonempty,
+)
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import (
     InterruptibleTTSService,
@@ -37,6 +42,39 @@ from pipecat.services.tts_service import (
     TTSService,
     WebsocketTTSService,
 )
+
+_ARCANA_SUPPRESSION_WARNING = (
+    "custom_pronunciations are ignored on model='arcana' — Rime's "
+    "{phoneme} bracket syntax is only parsed by Mist models. Switch to a "
+    "Mist model to apply overrides, or construct the service without "
+    "custom_pronunciations=."
+)
+
+
+def _apply_rewriter(
+    rewriter: Union[CustomPronunciations, TextRewriter, None],
+    text: str,
+    model: str | None,
+    arcana_warning_logged: list[bool],
+    service_repr: str,
+) -> str:
+    """Apply a custom-pronunciations rewriter with Arcana warn-and-drop semantics.
+
+    ``arcana_warning_logged`` is a one-element mutable list so callers can
+    observe the flip from ``[False]`` → ``[True]`` after the first warning.
+    """
+    if rewriter is None:
+        return text
+    if model == "arcana" and _rewriter_is_nonempty(rewriter):
+        if not arcana_warning_logged[0]:
+            logger.warning(f"{service_repr}: {_ARCANA_SUPPRESSION_WARNING}")
+            arcana_warning_logged[0] = True
+        return text
+    try:
+        return rewriter(text)
+    except Exception as e:
+        logger.error(f"{service_repr}: custom_pronunciations rewriter raised: {e}")
+        return text
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.text.skip_tags_aggregator import SkipTagsAggregator
 from pipecat.utils.tracing.service_decorators import traced_tts
@@ -178,6 +216,7 @@ class RimeTTSService(WebsocketTTSService):
         settings: Settings | None = None,
         text_aggregation_mode: TextAggregationMode | None = None,
         aggregate_sentences: bool | None = None,
+        custom_pronunciations: Union[CustomPronunciations, TextRewriter, None] = None,
         **kwargs,
     ):
         """Initialize Rime TTS service.
@@ -208,6 +247,13 @@ class RimeTTSService(WebsocketTTSService):
 
                 .. deprecated:: 0.0.104
                     Use ``text_aggregation_mode`` instead.
+
+            custom_pronunciations: Optional rewriter applied to every outgoing
+                TTS request. Accepts a :class:`CustomPronunciations` instance
+                from :func:`load_custom_pronunciations` (managed + refreshable)
+                or any ``Callable[[str], str]`` for local-only rewriting. On
+                Arcana the rewriter is skipped and a one-time warning is
+                logged, since Arcana does not parse ``{phoneme}`` brackets.
 
             **kwargs: Additional arguments passed to parent class.
         """
@@ -293,6 +339,23 @@ class RimeTTSService(WebsocketTTSService):
         self._receive_task = None
         self._cumulative_time = 0  # Accumulates time across messages
         self._extra_msg_fields = {}  # Extra fields for next message
+
+        # Custom-pronunciations state. The Arcana-warning flag is a one-element
+        # list so the module-level _apply_rewriter helper can flip it in place.
+        self._custom_pronunciations = custom_pronunciations
+        self._arcana_warning_logged: list[bool] = [False]
+
+    def set_custom_pronunciations(
+        self, rewriter: Union[CustomPronunciations, TextRewriter, None]
+    ) -> None:
+        """Swap the custom-pronunciations rewriter at runtime.
+
+        The Arcana warn-once flag persists across swaps: once the service has
+        warned about Arcana+rewriter for this instance, it does not warn again.
+        Lifecycle of a :class:`CustomPronunciations` passed here is owned by
+        the caller — the service does not close it.
+        """
+        self._custom_pronunciations = rewriter
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -613,6 +676,13 @@ class RimeTTSService(WebsocketTTSService):
         Yields:
             Frame: Audio frames containing the synthesized speech.
         """
+        text = _apply_rewriter(
+            self._custom_pronunciations,
+            text,
+            self._settings.model,
+            self._arcana_warning_logged,
+            str(self),
+        )
         logger.debug(f"{self}: Generating TTS [{text}]")
         try:
             if not self._websocket or self._websocket.state is State.CLOSED:
@@ -681,6 +751,7 @@ class RimeHttpTTSService(TTSService):
         sample_rate: int | None = None,
         params: InputParams | None = None,
         settings: Settings | None = None,
+        custom_pronunciations: Union[CustomPronunciations, TextRewriter, None] = None,
         **kwargs,
     ):
         """Initialize Rime HTTP TTS service.
@@ -706,6 +777,12 @@ class RimeHttpTTSService(TTSService):
 
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.
+            custom_pronunciations: Optional rewriter applied to every outgoing
+                TTS request. Accepts a :class:`CustomPronunciations` instance
+                from :func:`load_custom_pronunciations` (managed + refreshable)
+                or any ``Callable[[str], str]`` for local-only rewriting. On
+                Arcana the rewriter is skipped and a one-time warning is
+                logged, since Arcana does not parse ``{phoneme}`` brackets.
             **kwargs: Additional arguments passed to parent TTSService.
         """
         # 1. Initialize default_settings with hardcoded defaults
@@ -766,6 +843,21 @@ class RimeHttpTTSService(TTSService):
         # Init-only audio format fields (not runtime-updatable)
         self._audio_format = "pcm"
 
+        self._custom_pronunciations = custom_pronunciations
+        self._arcana_warning_logged: list[bool] = [False]
+
+    def set_custom_pronunciations(
+        self, rewriter: Union[CustomPronunciations, TextRewriter, None]
+    ) -> None:
+        """Swap the custom-pronunciations rewriter at runtime.
+
+        The Arcana warn-once flag persists across swaps: once the service has
+        warned about Arcana+rewriter for this instance, it does not warn again.
+        Lifecycle of a :class:`CustomPronunciations` passed here is owned by
+        the caller — the service does not close it.
+        """
+        self._custom_pronunciations = rewriter
+
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
 
@@ -796,6 +888,13 @@ class RimeHttpTTSService(TTSService):
         Yields:
             Frame: Audio frames containing the synthesized speech.
         """
+        text = _apply_rewriter(
+            self._custom_pronunciations,
+            text,
+            self._settings.model,
+            self._arcana_warning_logged,
+            str(self),
+        )
         logger.debug(f"{self}: Generating TTS [{text}]")
 
         headers = {

--- a/tests/test_rime_custom_pronunciations.py
+++ b/tests/test_rime_custom_pronunciations.py
@@ -1,0 +1,771 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+
+from pipecat.services.rime import custom_pronunciations as cp_mod
+from pipecat.services.rime.custom_pronunciations import (
+    CustomPronunciations,
+    _compile_patterns,
+    _project_response,
+    _rewriter_is_nonempty,
+    load_custom_pronunciations,
+)
+from pipecat.services.rime.tts import (
+    _ARCANA_SUPPRESSION_WARNING,
+    RimeHttpTTSService,
+    RimeTTSService,
+    _apply_rewriter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_prons(entries: dict[str, str]) -> CustomPronunciations:
+    """Build a CustomPronunciations with the given entries, no HTTP."""
+    prons = CustomPronunciations()
+    prons._entries = dict(entries)
+    prons._cs_pattern, prons._ci_pattern = _compile_patterns(entries)
+    return prons
+
+
+class _FetchScript:
+    """Scriptable replacement for `_http_get_pronunciations`.
+
+    Each call returns the next scripted response (body dict or an exception
+    to raise). Tracks call count. Use to drive fetch-success, fetch-error,
+    refresh-change scenarios.
+    """
+
+    def __init__(self, *responses: Any) -> None:
+        self.responses = list(responses)
+        self.calls = 0
+
+    async def __call__(self, **_: Any) -> Any:
+        self.calls += 1
+        idx = min(self.calls - 1, len(self.responses) - 1)
+        value = self.responses[idx]
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+
+def _patch_fetch(monkeypatch: pytest.MonkeyPatch, fetch: _FetchScript) -> None:
+    monkeypatch.setattr(cp_mod, "_http_get_pronunciations", fetch)
+
+
+def _patch_zero_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace asyncio.sleep inside custom_pronunciations with an instant sleep.
+
+    Keeps retry/refresh-loop timing out of the way of tests.
+    """
+    orig_sleep = asyncio.sleep
+
+    async def _instant(_: float) -> None:
+        # Yield control once so other tasks can progress, without real delay.
+        await orig_sleep(0)
+
+    monkeypatch.setattr(cp_mod.asyncio, "sleep", _instant)
+
+
+# ---------------------------------------------------------------------------
+# Projection
+# ---------------------------------------------------------------------------
+
+
+def test_project_response_extracts_default_map() -> None:
+    body = {
+        "default": {"Lisinopril": "l0Is1Inxpr0Il", "dr.": "d1aktx0r"},
+        "vocabs": {},
+    }
+    assert _project_response(body) == {
+        "Lisinopril": "l0Is1Inxpr0Il",
+        "dr.": "d1aktx0r",
+    }
+
+
+def test_project_response_ignores_vocabs() -> None:
+    body = {
+        "default": {"foo": "f0U"},
+        "vocabs": {"pediatrics": {"amoxicillin": "@m0ks0Is1Il0In"}},
+    }
+    assert _project_response(body) == {"foo": "f0U"}
+
+
+def test_project_response_drops_invalid_entries() -> None:
+    body = {
+        "default": {
+            "": "x",
+            "good": "",
+            "ok": "1kA",
+            123: "bad",
+            "also_ok": "ok",
+        }
+    }
+    assert _project_response(body) == {"ok": "1kA", "also_ok": "ok"}
+
+
+def test_project_response_handles_missing_default() -> None:
+    assert _project_response({}) == {}
+    assert _project_response({"vocabs": {}}) == {}
+    assert _project_response({"default": None}) == {}
+    assert _project_response({"default": "not a map"}) == {}
+
+
+def test_project_response_preserves_key_case() -> None:
+    body = {"default": {"AT&T": "@t and t", "at&t": "@t @mprs@nd t"}}
+    projected = _project_response(body)
+    assert "AT&T" in projected
+    assert "at&t" in projected
+
+
+# ---------------------------------------------------------------------------
+# Rewrite — compile + apply
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_empty_mapping_returns_input_unchanged() -> None:
+    prons = _make_prons({})
+    assert prons.rewrite("hello world") == "hello world"
+
+
+def test_rewrite_lowercase_key_matches_case_insensitively() -> None:
+    prons = _make_prons({"lisinopril": "l0Is1Inxpr0Il"})
+    assert prons.rewrite("take your Lisinopril") == "take your {l0Is1Inxpr0Il}"
+    assert prons.rewrite("LISINOPRIL is a drug") == "{l0Is1Inxpr0Il} is a drug"
+    assert prons.rewrite("lisinopril") == "{l0Is1Inxpr0Il}"
+
+
+def test_rewrite_uppercase_key_matches_case_sensitively() -> None:
+    prons = _make_prons({"AT&T": "1e t1i 1e t1i"})
+    assert prons.rewrite("AT&T is a carrier") == "{1e t1i 1e t1i} is a carrier"
+    # Case-sensitive: "at&t" should NOT match the cased key.
+    assert prons.rewrite("at&t is lowercase") == "at&t is lowercase"
+
+
+def test_rewrite_mixed_case_and_lowercase_keys_coexist() -> None:
+    prons = _make_prons({"AT&T": "upper_pron", "at&t": "lower_pron"})
+    # Cased literal wins for "AT&T"; lowercased canonical matches "at&t".
+    assert prons.rewrite("AT&T and at&t") == "{upper_pron} and {lower_pron}"
+
+
+def test_rewrite_longest_match_wins() -> None:
+    prons = _make_prons(
+        {
+            "lisinopril": "L",
+            "lisinopril 10mg": "L_10",
+        }
+    )
+    assert prons.rewrite("take lisinopril 10mg now") == "take {L_10} now"
+    # Without the 10mg qualifier, the shorter one fires.
+    assert prons.rewrite("take lisinopril now") == "take {L} now"
+
+
+def test_rewrite_trailing_punctuation_keys_match() -> None:
+    prons = _make_prons({"Dr.": "d1aktx0r"})
+    assert prons.rewrite("Hi Dr. Smith") == "Hi {d1aktx0r} Smith"
+
+
+def test_rewrite_boundary_prevents_partial_word_matches() -> None:
+    prons = _make_prons({"dr": "d1aktx0r"})
+    # "dream" starts with "dr" but shouldn't match — \w lookahead blocks it.
+    assert prons.rewrite("I dream of dr quick") == "I dream of {d1aktx0r} quick"
+
+
+def test_rewrite_metachars_in_keys_escaped() -> None:
+    prons = _make_prons({"c++": "si p1Lxs p1Lxs"})
+    assert prons.rewrite("write c++ fast") == "write {si p1Lxs p1Lxs} fast"
+
+
+def test_rewrite_is_callable_via_dunder_call() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    assert prons("foo bar") == "{f0U} bar"
+
+
+def test_rewriter_is_nonempty_introspects_custom_pronunciations() -> None:
+    assert _rewriter_is_nonempty(_make_prons({})) is False
+    assert _rewriter_is_nonempty(_make_prons({"a": "1"})) is True
+
+
+def test_rewriter_is_nonempty_assumes_callable_nonempty() -> None:
+    assert _rewriter_is_nonempty(None) is False
+    assert _rewriter_is_nonempty(lambda s: s) is True
+
+
+# ---------------------------------------------------------------------------
+# load_custom_pronunciations — happy path + errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_fetches_and_populates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetch = _FetchScript({"default": {"hello": "h1El0U"}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="test", refresh_interval=None)
+    try:
+        assert fetch.calls == 1
+        assert prons.entries == {"hello": "h1El0U"}
+        assert prons.rewrite("hello world") == "{h1El0U} world"
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_load_without_refresh_interval_spawns_no_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    try:
+        assert prons._refresh_task is None
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_load_with_refresh_interval_spawns_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=300)
+    try:
+        assert prons._refresh_task is not None
+        assert not prons._refresh_task.done()
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_load_clamps_below_minimum_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=5)
+    try:
+        # Clamped to _MIN_REFRESH_INTERVAL (30s); we observe clamping via the
+        # task being spawned (would not spawn at all if interval were treated
+        # as invalid rather than clamped).
+        assert prons._refresh_task is not None
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_load_raises_immediately_on_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    req_info = aiohttp.RequestInfo(
+        url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+        method="GET",
+        headers=aiohttp.typedefs.CIMultiDict(),
+        real_url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+    )
+    auth_err = aiohttp.ClientResponseError(
+        request_info=req_info,
+        history=(),
+        status=401,
+        message="Unauthorized",
+    )
+    fetch = _FetchScript(auth_err)
+    _patch_fetch(monkeypatch, fetch)
+
+    with pytest.raises(aiohttp.ClientResponseError) as excinfo:
+        await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    assert excinfo.value.status == 401
+    # No retries on 4xx.
+    assert fetch.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_load_retries_transient_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_zero_sleep(monkeypatch)
+    req_info = aiohttp.RequestInfo(
+        url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+        method="GET",
+        headers=aiohttp.typedefs.CIMultiDict(),
+        real_url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+    )
+    transient = aiohttp.ClientResponseError(
+        request_info=req_info, history=(), status=503, message="Unavailable"
+    )
+    fetch = _FetchScript(
+        transient,
+        {"default": {"foo": "f0U"}, "vocabs": {}},
+    )
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    try:
+        assert fetch.calls == 2
+        assert prons.entries == {"foo": "f0U"}
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_load_raises_after_exhausting_transient_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_zero_sleep(monkeypatch)
+    req_info = aiohttp.RequestInfo(
+        url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+        method="GET",
+        headers=aiohttp.typedefs.CIMultiDict(),
+        real_url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+    )
+    transient = aiohttp.ClientResponseError(
+        request_info=req_info, history=(), status=503, message="Unavailable"
+    )
+    fetch = _FetchScript(transient, transient, transient, transient)
+    _patch_fetch(monkeypatch, fetch)
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    # Initial + 2 retries.
+    assert fetch.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_load_without_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RIME_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="Rime API key"):
+        await load_custom_pronunciations(refresh_interval=None)
+
+
+# ---------------------------------------------------------------------------
+# Refresh — manual trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetch = _FetchScript(
+        {"default": {"one": "1"}, "vocabs": {}},
+        {"default": {"one": "1", "two": "2"}, "vocabs": {}},
+    )
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    try:
+        assert prons.entries == {"one": "1"}
+        await prons.refresh()
+        assert prons.entries == {"one": "1", "two": "2"}
+        assert fetch.calls == 2
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_refresh_coalesces_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A fetch that yields control so the coalescing window is observable.
+    call_count = {"n": 0}
+
+    async def slow_fetch(**_: Any) -> Any:
+        call_count["n"] += 1
+        # Yield a few times to keep the fetch "in flight" while callers pile up.
+        for _i in range(3):
+            await asyncio.sleep(0)
+        return {"default": {"x": "X"}, "vocabs": {}}
+
+    monkeypatch.setattr(cp_mod, "_http_get_pronunciations", slow_fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    # After load, one call has already happened.
+    try:
+        assert call_count["n"] == 1
+        # Fire five concurrent refreshes; they should coalesce.
+        await asyncio.gather(*(prons.refresh() for _ in range(5)))
+        # Exactly one additional fetch for the five concurrent calls.
+        assert call_count["n"] == 2
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_close_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    await prons.aclose()
+
+    # No call is issued; refresh returns cleanly.
+    await prons.refresh()
+    assert fetch.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Refresh loop — automatic ticks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_loop_picks_up_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Relax the 30s floor so we can exercise the loop in test-time.
+    monkeypatch.setattr(cp_mod, "_MIN_REFRESH_INTERVAL", 0.01)
+
+    fetch = _FetchScript(
+        {"default": {"one": "1"}, "vocabs": {}},
+        {"default": {"two": "2"}, "vocabs": {}},
+        {"default": {"two": "2", "three": "3"}, "vocabs": {}},
+    )
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=0.01)
+    try:
+        # Initial state from load().
+        assert prons.entries == {"one": "1"}
+        # Allow the refresh loop to tick at least twice.
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if fetch.calls >= 3:
+                break
+        assert fetch.calls >= 3
+        assert "three" in prons.entries
+    finally:
+        await prons.aclose()
+
+
+@pytest.mark.asyncio
+async def test_refresh_loop_swallows_fetch_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cp_mod, "_MIN_REFRESH_INTERVAL", 0.01)
+
+    req_info = aiohttp.RequestInfo(
+        url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+        method="GET",
+        headers=aiohttp.typedefs.CIMultiDict(),
+        real_url=aiohttp.client.URL("https://users.rime.ai/speech-qa/custom-pronunciations"),
+    )
+    transient = aiohttp.ClientResponseError(
+        request_info=req_info, history=(), status=503, message="Unavailable"
+    )
+    fetch = _FetchScript(
+        {"default": {"stable": "s"}, "vocabs": {}},
+        transient,
+        transient,
+        {"default": {"stable": "s", "new": "n"}, "vocabs": {}},
+    )
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=0.01)
+    try:
+        assert prons.entries == {"stable": "s"}
+        # Wait until the recovery fetch lands.
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            if "new" in prons.entries:
+                break
+        assert prons.entries == {"stable": "s", "new": "n"}
+    finally:
+        await prons.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_with_closes_refresh_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cp_mod, "_MIN_REFRESH_INTERVAL", 0.01)
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    async with await load_custom_pronunciations(api_key="k", refresh_interval=0.01) as prons:
+        task = prons._refresh_task
+        assert task is not None
+        assert not task.done()
+    assert task.done()
+    assert prons._closed is True
+
+
+@pytest.mark.asyncio
+async def test_double_aclose_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetch = _FetchScript({"default": {}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    await prons.aclose()
+    await prons.aclose()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _apply_rewriter — direct tests of the module-level helper
+# ---------------------------------------------------------------------------
+
+
+def test_apply_rewriter_none_returns_text_unchanged() -> None:
+    flag = [False]
+    assert _apply_rewriter(None, "hello foo", "mistv2", flag, "svc") == "hello foo"
+    assert flag == [False]
+
+
+def test_apply_rewriter_mist_applies() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    flag = [False]
+    assert _apply_rewriter(prons, "foo bar", "mistv2", flag, "svc") == "{f0U} bar"
+    assert flag == [False]
+
+
+def test_apply_rewriter_callable_applies() -> None:
+    flag = [False]
+    out = _apply_rewriter(lambda s: s.upper(), "foo", "mistv2", flag, "svc")
+    assert out == "FOO"
+    assert flag == [False]
+
+
+def test_apply_rewriter_arcana_nonempty_warns_and_passes_through() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    flag = [False]
+    assert _apply_rewriter(prons, "foo bar", "arcana", flag, "svc") == "foo bar"
+    assert flag == [True]
+
+
+def test_apply_rewriter_arcana_empty_does_not_warn() -> None:
+    prons = _make_prons({})
+    flag = [False]
+    assert _apply_rewriter(prons, "foo bar", "arcana", flag, "svc") == "foo bar"
+    assert flag == [False]
+
+
+def test_apply_rewriter_arcana_callable_warns_and_passes_through() -> None:
+    flag = [False]
+    out = _apply_rewriter(lambda s: s.upper(), "foo", "arcana", flag, "svc")
+    assert out == "foo"
+    assert flag == [True]
+
+
+def test_apply_rewriter_arcana_warns_once_across_calls() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    flag = [False]
+    _apply_rewriter(prons, "foo", "arcana", flag, "svc")
+    assert flag == [True]
+    # Subsequent Arcana calls with a still-nonempty rewriter do not re-warn.
+    # The flag is the side-effect; we can only observe it flipped once.
+    _apply_rewriter(prons, "foo", "arcana", flag, "svc")
+    _apply_rewriter(prons, "foo", "arcana", flag, "svc")
+    assert flag == [True]
+
+
+def test_apply_rewriter_swallows_rewriter_exception() -> None:
+    def broken(_: str) -> str:
+        raise RuntimeError("bad rewriter")
+
+    flag = [False]
+    assert _apply_rewriter(broken, "foo", "mistv2", flag, "svc") == "foo"
+
+
+# ---------------------------------------------------------------------------
+# RimeHttpTTSService integration
+# ---------------------------------------------------------------------------
+
+# RimeHttpTTSService is used for construction-level assertions because its
+# __init__ does not open any network connection — unlike RimeTTSService which
+# connects only in start(), but still performs extra framework wiring we can
+# sidestep with the HTTP variant.
+
+
+def _make_http_service(
+    *, model: str = "mistv2", custom_pronunciations: Any = None
+) -> RimeHttpTTSService:
+    return RimeHttpTTSService(
+        api_key="k",
+        aiohttp_session=MagicMock(spec=aiohttp.ClientSession),
+        settings=RimeHttpTTSService.Settings(model=model, voice="luna"),
+        custom_pronunciations=custom_pronunciations,
+    )
+
+
+def _make_ws_service(
+    *, model: str = "mistv2", custom_pronunciations: Any = None
+) -> RimeTTSService:
+    return RimeTTSService(
+        api_key="k",
+        settings=RimeTTSService.Settings(model=model, voice="luna"),
+        custom_pronunciations=custom_pronunciations,
+    )
+
+
+def test_http_service_accepts_custom_pronunciations_object() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    svc = _make_http_service(custom_pronunciations=prons)
+    assert svc._custom_pronunciations is prons
+    assert svc._arcana_warning_logged == [False]
+
+
+def test_http_service_accepts_callable_rewriter() -> None:
+    def fn(s: str) -> str:
+        return s.replace("a", "{@}")
+
+    svc = _make_http_service(custom_pronunciations=fn)
+    assert svc._custom_pronunciations is fn
+
+
+def test_http_service_default_custom_pronunciations_is_none() -> None:
+    svc = _make_http_service()
+    assert svc._custom_pronunciations is None
+
+
+def test_ws_service_accepts_custom_pronunciations_object() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    svc = _make_ws_service(custom_pronunciations=prons)
+    assert svc._custom_pronunciations is prons
+    assert svc._arcana_warning_logged == [False]
+
+
+def test_ws_service_set_custom_pronunciations_swaps() -> None:
+    p1 = _make_prons({"foo": "f0U"})
+    p2 = _make_prons({"bar": "b1A"})
+    svc = _make_ws_service(custom_pronunciations=p1)
+    assert svc._custom_pronunciations is p1
+    svc.set_custom_pronunciations(p2)
+    assert svc._custom_pronunciations is p2
+    svc.set_custom_pronunciations(None)
+    assert svc._custom_pronunciations is None
+
+
+def test_http_service_arcana_nonempty_prons_warns_and_passes_through() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    svc = _make_http_service(model="arcana", custom_pronunciations=prons)
+    # Exercise the same helper run_tts uses, with the service's state.
+    out = _apply_rewriter(
+        svc._custom_pronunciations,
+        "foo bar",
+        svc._settings.model,
+        svc._arcana_warning_logged,
+        str(svc),
+    )
+    assert out == "foo bar"
+    assert svc._arcana_warning_logged == [True]
+
+
+def test_http_service_model_swap_activates_and_clears_suppression() -> None:
+    # Cross-model behavior via direct _settings manipulation — we don't need
+    # update_settings' reconnect machinery to exercise the rewrite logic.
+    prons = _make_prons({"foo": "f0U"})
+    svc = _make_http_service(model="mistv2", custom_pronunciations=prons)
+
+    # Mist: rewrites.
+    assert (
+        _apply_rewriter(
+            svc._custom_pronunciations,
+            "foo",
+            svc._settings.model,
+            svc._arcana_warning_logged,
+            str(svc),
+        )
+        == "{f0U}"
+    )
+    assert svc._arcana_warning_logged == [False]
+
+    # Swap to Arcana: warns once, passes through.
+    svc._settings.model = "arcana"
+    out = _apply_rewriter(
+        svc._custom_pronunciations,
+        "foo",
+        svc._settings.model,
+        svc._arcana_warning_logged,
+        str(svc),
+    )
+    assert out == "foo"
+    assert svc._arcana_warning_logged == [True]
+
+    # Back to Mist: rewriter applies again, no suppression state to clear.
+    svc._settings.model = "mistv2"
+    assert (
+        _apply_rewriter(
+            svc._custom_pronunciations,
+            "foo",
+            svc._settings.model,
+            svc._arcana_warning_logged,
+            str(svc),
+        )
+        == "{f0U}"
+    )
+
+    # Arcana again: still warns-once flag stays True; no second warning.
+    svc._settings.model = "arcana"
+    out = _apply_rewriter(
+        svc._custom_pronunciations,
+        "foo",
+        svc._settings.model,
+        svc._arcana_warning_logged,
+        str(svc),
+    )
+    assert out == "foo"
+    assert svc._arcana_warning_logged == [True]
+
+
+@pytest.mark.asyncio
+async def test_shared_prons_across_services_not_closed_by_service_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetch = _FetchScript({"default": {"foo": "f0U"}, "vocabs": {}})
+    _patch_fetch(monkeypatch, fetch)
+    prons = await load_custom_pronunciations(api_key="k", refresh_interval=None)
+    try:
+        svc1 = _make_http_service(custom_pronunciations=prons)
+        svc2 = _make_ws_service(custom_pronunciations=prons)
+
+        # The service holds a reference, but its lifecycle is independent.
+        del svc1
+        del svc2
+
+        assert prons._closed is False
+        assert prons.rewrite("foo") == "{f0U}"
+    finally:
+        await prons.aclose()
+
+
+def test_shared_prons_rewrite_picks_up_changes_across_services() -> None:
+    prons = _make_prons({"foo": "f0U"})
+    svc1 = _make_http_service(custom_pronunciations=prons)
+    svc2 = _make_ws_service(custom_pronunciations=prons)
+
+    # Simulate a refresh that replaces entries.
+    new_entries = {"bar": "b1A"}
+    prons._entries = new_entries
+    prons._cs_pattern, prons._ci_pattern = _compile_patterns(new_entries)
+
+    assert svc1._custom_pronunciations.rewrite("bar") == "{b1A}"
+    assert svc2._custom_pronunciations.rewrite("bar") == "{b1A}"
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports_expected_surface() -> None:
+    """Customers import from these two submodules — verify the shape."""
+    from pipecat.services.rime import custom_pronunciations, tts
+
+    assert custom_pronunciations.CustomPronunciations is CustomPronunciations
+    assert custom_pronunciations.load_custom_pronunciations is load_custom_pronunciations
+    assert hasattr(custom_pronunciations, "TextRewriter")
+    assert tts.RimeTTSService is RimeTTSService
+    assert tts.RimeHttpTTSService is RimeHttpTTSService
+
+
+def test_arcana_suppression_warning_is_informative() -> None:
+    """The module-level warning string should mention the key facts."""
+    assert "arcana" in _ARCANA_SUPPRESSION_WARNING.lower()
+    assert "{phoneme}" in _ARCANA_SUPPRESSION_WARNING or "Mist" in _ARCANA_SUPPRESSION_WARNING


### PR DESCRIPTION
Ship the custom-pronunciations text-rewrite layer end-to-end inside the Rime TTS integration, so Pipecat apps using `RimeHttpTTSService` or `RimeTTSService` can override how specific words are synthesized without modifying the prompt text.

## What's in

- **`src/pipecat/services/rime/custom_pronunciations.py`** — `CustomPronunciations` dict-of-overrides rewriter, plus `APICustomPronunciationsSource` which fetches `{base_url}/speech-qa/custom-pronunciations` at startup and projects the response into a rewrite map.
- **`src/pipecat/services/rime/tts.py`** — `TextRewriter` hook on the Rime TTS services. Applies the rewriter per-utterance before synthesis. Warns and no-ops on `model='arcana'` since Rime's `{phoneme}` bracket syntax is Mist-only; switching to a Mist model lets the overrides apply.
- **`tests/test_rime_custom_pronunciations.py`** — coverage across dict, callable, and API sources, plus the Arcana suppression path.

## Notes

- URL uses the customer-facing SpeechQA prefix (`/speech-qa/custom-pronunciations`). Body shape is `{customPronunciations: [...]}`; parser is in the projector in `custom_pronunciations.py`.
- The rewriter is entirely opt-in — constructing a Rime TTS service without `custom_pronunciations=` leaves behavior unchanged.
