### PR TITLE
chore: rebind Gemini Live reconnect changelog fragment to PR #4355

### DIFF
--- a/changelog/4328.fixed.md
+++ b/changelog/4328.fixed.md
@@ -1,1 +1,0 @@
-Fixed Gemini Live losing conversation history in the (rare) case of a WebSocket reconnect before any session resumption handle is received. When the session reconnects (e.g. on system instruction change), conversation history is now re-seeded into the new session before it is marked ready for input.

--- a/changelog/4355.fixed.md
+++ b/changelog/4355.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Gemini Live losing conversation history in the (rare) case of a WebSocket reconnect before any session resumption handle is received. When the session reconnects (e.g. on system instruction change), conversation history is now re-seeded into the new session before it is marked ready for input.


### PR DESCRIPTION
## Summary

- Renames `changelog/4328.fixed.md` → `changelog/4355.fixed.md` so the rendered changelog links to the PR that actually landed the fix (#4355, which superseded #4328).
- Adds the leading `- ` bullet prefix that towncrier expects.

## Test plan

- [x] `uv run towncrier build --draft --version Unreleased` renders the entry correctly and links to PR #4355.