### PR TITLE
Add audio fade-out functionality and interruption handling

### DIFF
--- a/changelog/4364.added.md
+++ b/changelog/4364.added.md
@@ -1,0 +1,3 @@
+- Output transports can optionally release user interruptions with a short tail of already-buffered assistant audio (plus an optional linear fade) instead of an immediate hard cut, via `InterruptionReleaseMode` (`immediate_cut` or `bounded_drain`) and `interruption_max_release_drain_ms` / `interruption_fade_out_ms` on `TransportParams` (default remains immediate cut).
+    - `bounded_drain` is used from `BaseOutputTransport` when audio out is on, no output mixer, and a drain budget is set; the uninterruptible-frame path is unchanged.
+    - LiveKit and FastAPI WebSocket output adjust native/WebSocket buffer clearing so bounded drain and fixed packetization do not drop the tail or keep stale send-buffer bytes before the new audio.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -283,3 +283,26 @@ def is_silence(pcm_bytes: bytes) -> bool:
 
     # If max value is lower than SPEAKING_THRESHOLD, consider it as silence
     return max_value <= SPEAKING_THRESHOLD
+
+
+def apply_fade_out_to_pcm16(
+    pcm: bytes, *, sample_rate: int, num_channels: int, fade_out_ms: int
+) -> bytes:
+    """Linear fade on the last ``fade_out_ms`` of interleaved 16-bit PCM (in place on a copy)."""
+    if not pcm or fade_out_ms <= 0 or sample_rate <= 0 or num_channels <= 0:
+        return pcm
+    frame_b = 2 * num_channels
+    if len(pcm) < frame_b or len(pcm) % frame_b:
+        return pcm
+    nframes = len(pcm) // frame_b
+    fade_nframes = int(sample_rate * fade_out_ms / 1000.0)
+    fade_nframes = min(fade_nframes, nframes)
+    if fade_nframes <= 0:
+        return pcm
+    out = np.frombuffer(pcm, dtype=np.int16).copy()
+    start = nframes - fade_nframes
+    for j in range(fade_nframes):
+        g = (fade_nframes - j) / fade_nframes
+        sl = slice((start + j) * num_channels, (start + j + 1) * num_channels)
+        out[sl] = (out[sl].astype(np.float32) * g).astype(np.int16)
+    return out.tobytes()

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -22,7 +22,11 @@ from PIL import Image
 
 from pipecat.audio.dtmf.utils import load_dtmf_audio
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
-from pipecat.audio.utils import create_stream_resampler, is_silence
+from pipecat.audio.utils import (
+    apply_fade_out_to_pcm16,
+    create_stream_resampler,
+    is_silence,
+)
 from pipecat.frames.frames import (
     AssistantImageRawFrame,
     BotSpeakingFrame,
@@ -48,7 +52,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.transports.base_transport import TransportParams
+from pipecat.transports.base_transport import InterruptionReleaseMode, TransportParams
 from pipecat.utils.frame_queue import FrameQueue
 from pipecat.utils.time import nanoseconds_to_seconds
 
@@ -520,6 +524,47 @@ class BaseOutputTransport(FrameProcessor):
             if self._mixer:
                 await self._mixer.stop()
 
+        def _collect_bounded_drain_pcm(
+            self, old_buffer: bytearray, old_queue: FrameQueue, max_bytes: int
+        ) -> bytes:
+            combined = bytearray()
+            rem = max_bytes
+            take = min(len(old_buffer), rem)
+            combined.extend(old_buffer[:take])
+            rem -= take
+            try:
+                while True:
+                    item = old_queue.get_nowait()
+                    if isinstance(item, OutputAudioRawFrame) and rem > 0:
+                        t = min(len(item.audio), rem)
+                        combined.extend(item.audio[:t])
+                        rem -= t
+                    old_queue.task_done()
+            except asyncio.QueueEmpty:
+                pass
+            return bytes(combined)
+
+        async def _write_interruption_release_tail(self, pcm: bytes) -> None:
+            nch = self._params.audio_out_channels
+            off = 0
+            clen = self._audio_chunk_size
+            while off < len(pcm):
+                take = min(clen, len(pcm) - off)
+                chunk = OutputAudioRawFrame(
+                    bytes(pcm[off : off + take]),
+                    sample_rate=self._sample_rate,
+                    num_channels=nch,
+                )
+                chunk.transport_destination = self._destination
+                try:
+                    push_downstream = await self._transport.write_audio_frame(chunk)
+                except Exception as e:
+                    logger.error(f"{self} Error writing {chunk} to transport: {e}")
+                    push_downstream = False
+                if push_downstream:
+                    await self._transport.push_frame(chunk)
+                off += take
+
         async def handle_interruptions(self, _: InterruptionFrame):
             """Handle interruption events by restarting tasks and clearing buffers.
 
@@ -535,8 +580,40 @@ class BaseOutputTransport(FrameProcessor):
                 # so the pending UninterruptibleFrames are still delivered.
                 self._audio_queue.reset()
             else:
-                await self._cancel_audio_task()
-                self._create_audio_task()
+                use_bounded = (
+                    self._params.audio_out_enabled
+                    and not self._mixer
+                    and self._params.interruption_release_mode
+                    == InterruptionReleaseMode.BOUNDED_DRAIN
+                    and self._params.interruption_max_release_drain_ms > 0
+                    and self._sample_rate > 0
+                    and self._audio_task
+                )
+                if use_bounded:
+                    max_bytes = int(
+                        self._sample_rate
+                        * (self._params.interruption_max_release_drain_ms / 1000.0)
+                        * 2
+                        * self._params.audio_out_channels
+                    )
+                    old_buffer = bytearray(self._audio_buffer)
+                    old_queue = self._audio_queue
+                    await self._cancel_audio_task()
+                    tail = self._collect_bounded_drain_pcm(old_buffer, old_queue, max_bytes)
+                    self._audio_buffer = bytearray()
+                    if tail and self._params.interruption_fade_out_ms > 0:
+                        tail = apply_fade_out_to_pcm16(
+                            tail,
+                            sample_rate=self._sample_rate,
+                            num_channels=self._params.audio_out_channels,
+                            fade_out_ms=self._params.interruption_fade_out_ms,
+                        )
+                    if tail:
+                        await self._write_interruption_release_tail(tail)
+                    self._create_audio_task()
+                else:
+                    await self._cancel_audio_task()
+                    self._create_audio_task()
 
             # Create tasks.
             self._create_video_task()

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -13,6 +13,7 @@ functionality.
 
 from abc import abstractmethod
 from collections.abc import Mapping
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -20,6 +21,13 @@ from pipecat.audio.filters.base_audio_filter import BaseAudioFilter
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.utils.base_object import BaseObject
+
+
+class InterruptionReleaseMode(StrEnum):
+    """How output transports release audio on user interruption."""
+
+    IMMEDIATE_CUT = "immediate_cut"
+    BOUNDED_DRAIN = "bounded_drain"
 
 
 class TransportParams(BaseModel):
@@ -52,6 +60,12 @@ class TransportParams(BaseModel):
         video_out_color_format: Video output color format string.
         video_out_codec: Preferred video codec for output (e.g., 'VP8', 'H264', 'H265').
         video_out_destinations: List of video output destination identifiers.
+        interruption_release_mode: Whether to hard-cut or play a short drained tail
+            of already-buffered output audio.
+        interruption_max_release_drain_ms: Max duration of audio to play after
+            ``BOUNDED_DRAIN`` (at the output sample rate).
+        interruption_fade_out_ms: Linear fade length applied to the end of the
+            drained tail (0 disables fading).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -81,6 +95,9 @@ class TransportParams(BaseModel):
     video_out_color_format: str = "RGB"
     video_out_codec: str | None = None
     video_out_destinations: list[str] = Field(default_factory=list)
+    interruption_release_mode: InterruptionReleaseMode = InterruptionReleaseMode.IMMEDIATE_CUT
+    interruption_max_release_drain_ms: int = 60
+    interruption_fade_out_ms: int = 20
 
 
 class BaseTransport(BaseObject):

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -42,7 +42,11 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
-from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.base_transport import (
+    BaseTransport,
+    InterruptionReleaseMode,
+    TransportParams,
+)
 from pipecat.utils.asyncio.task_manager import BaseTaskManager
 
 try:
@@ -831,16 +835,23 @@ class LiveKitOutputTransport(BaseOutputTransport):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames, clearing the LiveKit AudioSource buffer on interruption.
 
-        When an InterruptionFrame arrives, any audio already submitted to the
-        LiveKit AudioSource (but not yet played out) is cleared immediately so
-        the bot stops speaking without delay.
+        When an InterruptionFrame arrives, the LiveKit AudioSource queue is
+        cleared. For ``BOUNDED_DRAIN``, the queue is cleared before the base
+        output transport so only the drained tail is published; for
+        ``IMMEDIATE_CUT`` it is cleared after.
 
         Args:
             frame: The frame to process.
             direction: The direction of frame flow in the pipeline.
         """
+        mode = self._params.interruption_release_mode
+        has_audio_source = (
+            isinstance(frame, InterruptionFrame) and self._client._audio_source is not None
+        )
+        if has_audio_source and mode == InterruptionReleaseMode.BOUNDED_DRAIN:
+            self._client._audio_source.clear_queue()
         await super().process_frame(frame, direction)
-        if isinstance(frame, InterruptionFrame) and self._client._audio_source is not None:
+        if has_audio_source and mode == InterruptionReleaseMode.IMMEDIATE_CUT:
             self._client._audio_source.clear_queue()
 
     async def setup(self, setup: FrameProcessorSetup):

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -38,7 +38,11 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.serializers.base_serializer import FrameSerializer
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
-from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.base_transport import (
+    BaseTransport,
+    InterruptionReleaseMode,
+    TransportParams,
+)
 
 try:
     from fastapi import WebSocket
@@ -426,11 +430,18 @@ class FastAPIWebsocketOutputTransport(BaseOutputTransport):
             frame: The frame to process.
             direction: The direction of frame flow in the pipeline.
         """
+        if (
+            isinstance(frame, InterruptionFrame)
+            and self._params.fixed_audio_packet_size
+            and self._params.interruption_release_mode == InterruptionReleaseMode.BOUNDED_DRAIN
+        ):
+            self._audio_send_buffer.clear()
         await super().process_frame(frame, direction)
 
         if isinstance(frame, InterruptionFrame):
-            # Drop any partially buffered audio to avoid replaying stale PCM
-            if self._params.fixed_audio_packet_size:
+            if self._params.fixed_audio_packet_size and (
+                self._params.interruption_release_mode == InterruptionReleaseMode.IMMEDIATE_CUT
+            ):
                 self._audio_send_buffer.clear()
 
             await self._write_frame(frame)

--- a/tests/test_interruption_release.py
+++ b/tests/test_interruption_release.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+
+import numpy as np
+
+from pipecat.audio.utils import apply_fade_out_to_pcm16
+from pipecat.frames.frames import OutputAudioRawFrame
+from pipecat.transports.base_output import BaseOutputTransport
+from pipecat.transports.base_transport import InterruptionReleaseMode, TransportParams
+from pipecat.utils.frame_queue import FrameQueue
+
+
+class TestInterruptionReleaseParams(unittest.TestCase):
+    def test_default_transport_params(self):
+        p = TransportParams()
+        self.assertIs(p.interruption_release_mode, InterruptionReleaseMode.IMMEDIATE_CUT)
+        self.assertEqual(p.interruption_max_release_drain_ms, 60)
+        self.assertEqual(p.interruption_fade_out_ms, 20)
+
+    def test_bounded_drain_mode(self):
+        p = TransportParams(
+            interruption_release_mode=InterruptionReleaseMode.BOUNDED_DRAIN,
+            interruption_max_release_drain_ms=40,
+            interruption_fade_out_ms=10,
+        )
+        self.assertIs(p.interruption_release_mode, InterruptionReleaseMode.BOUNDED_DRAIN)
+        self.assertEqual(p.interruption_max_release_drain_ms, 40)
+        self.assertEqual(p.interruption_fade_out_ms, 10)
+
+
+class TestApplyFadeOutPcm16(unittest.TestCase):
+    def test_fade_out_lowers_end_of_tail(self):
+        sample_rate = 8000
+        n = 200
+        pcm = (np.ones(n, dtype=np.int16) * 10000).tobytes()
+        out = apply_fade_out_to_pcm16(
+            pcm,
+            sample_rate=sample_rate,
+            num_channels=1,
+            fade_out_ms=20,
+        )
+        self.assertEqual(len(out), len(pcm))
+        tail = np.frombuffer(out[-4:], dtype=np.int16)
+        head = np.frombuffer(out[:4], dtype=np.int16)
+        self.assertLess(np.abs(tail).max(), np.abs(head).max())
+
+
+class TestCollectBoundedDrainPcm(unittest.TestCase):
+    def test_respects_max_bytes_buffer_then_queue(self):
+        params = TransportParams()
+        t = BaseOutputTransport(params=params, name="test-out")
+        t._sample_rate = 16000
+        t._audio_chunk_size = 320
+        ms = BaseOutputTransport.MediaSender(
+            t, destination=None, sample_rate=16000, audio_chunk_size=320, params=params
+        )
+        old_buf = bytearray(b"abcdefghij")
+        q = FrameQueue()
+        q.put_nowait(
+            OutputAudioRawFrame(
+                audio=b"klmnopqrst",
+                sample_rate=16000,
+                num_channels=1,
+            )
+        )
+        out = ms._collect_bounded_drain_pcm(old_buf, q, max_bytes=15)
+        self.assertEqual(out, b"abcdefghijklmno")
+        self.assertTrue(q.empty())
+
+    def test_empty_buffer_and_queue(self):
+        params = TransportParams()
+        t = BaseOutputTransport(params=params, name="test-out-2")
+        t._sample_rate = 16000
+        t._audio_chunk_size = 320
+        ms = BaseOutputTransport.MediaSender(
+            t, destination=None, sample_rate=16000, audio_chunk_size=320, params=params
+        )
+        out = ms._collect_bounded_drain_pcm(bytearray(), FrameQueue(), max_bytes=10)
+        self.assertEqual(out, b"")


### PR DESCRIPTION
## Graceful interruption - addresses #3985

- Introduced `apply_fade_out_to_pcm16` function for linear fade-out on PCM audio.
- Updated `BaseOutputTransport` to support `bounded drain` mode for audio interruptions, allowing a controlled release of audio with optional fade-out.
- Enhanced `TransportParams` to include settings for interruption release mode, maximum drain duration, and fade-out duration.
- Added a unit test for the new functionality, ensuring correct behaviour of fade-out and bounded drain logic.