### PR TITLE
fix: send realtime input after tool_result so Gemini 3.x runs inference

### DIFF
--- a/changelog/4366.fixed.md
+++ b/changelog/4366.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Gemini Live tool calls stalling silently on Gemini 3.x models. After `_tool_result` sent the function response, the service omitted the `send_realtime_input` kick that Gemini 3.x needs to resume inference — the same kick already applied in `_create_initial_response` and `_create_single_response`. Previously, every tool-call turn stalled until the user spoke again.

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1416,6 +1416,9 @@ class GeminiLiveLLMService(LLMService):
 
         try:
             await self._session.send_tool_response(function_responses=response)
+            # Gemini 3.x wants turn_complete=True, but also won't run inference without a realtime input
+            if self._is_gemini_3:
+                await self._session.send_realtime_input(text=" ")
         except Exception as e:
             await self._handle_send_error(e)
 


### PR DESCRIPTION
## What

After `send_tool_response`, send `send_realtime_input(text=" ")` for Gemini 3.x models. Mirrors the workaround already applied in `_create_initial_response` and `_create_single_response` in the same file.

## Why

Gemini 3.x won't run inference on content it receives unless a realtime input follows. The tool-result path in `GeminiLiveLLMService` was the only remaining send-path missing this workaround. The in-file comment on the existing two sites already states *"Gemini 3.x wants turn_complete=True, but also won't run inference without a realtime input."*

**Symptom:** every tool-call turn stalls silently after the tool returns, until the user speaks again (their speech itself is a realtime input that wakes inference back up). TTFB on affected turns ranges from single-digit seconds to multiple minutes depending on when the user gives up waiting. Reproducible on `gemini-3.1-flash-live-preview` + Daily transport + any function-calling tool. Not reproducible on Gemini 2.5 (which doesn't require the kick).

## The fix

3-line addition to `_tool_result` — the same guarded `send_realtime_input(text=" ")` call that already exists in the two other send paths in the same file, with the identical comment.

## Testing

Verified against a production voice agent using `gemini-3.1-flash-live-preview` + Daily direct mode + a 7-tool function-calling setup (begin_survey, advance_step, record_field, take_photo, flag_issue, go_back, end_survey):

- **Before this fix** (applied locally as a subclass monkeypatch): 20–130s stalls on every tool-result turn.
- **After this fix**: sub-second TTFB on every tool-result turn across 20+ test turns in multiple 6-step survey walkthroughs.

No unit test added — the Gemini Live service's `_session` is an `AsyncSession` from google-genai's bidi WebSocket SDK and the existing test suite doesn't have a mocking pattern for it. Happy to add one if a maintainer has a preferred shape.

## Related

I'll separately open a PR for a related `LLMAssistantAggregator` bug that I found while diagnosing this, and add a summary data point on #4118.