### PR TITLE
feat(soniox): update default TTS model to tts-rt-v1

### DIFF
--- a/changelog/4386.changed.md
+++ b/changelog/4386.changed.md
@@ -1,0 +1,1 @@
+- Updated the default `SonioxTTSService` model from `tts-rt-v1-preview` to the generally available `tts-rt-v1`.

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -184,7 +184,7 @@ class SonioxTTSService(WebsocketTTSService):
         """
         # Initialize default_settings
         default_settings = self.Settings(
-            model="tts-rt-v1-preview",
+            model="tts-rt-v1",
             voice="Adrian",
             language=Language.EN,
         )


### PR DESCRIPTION
## Summary

- Promotes the Soniox TTS default model from `tts-rt-v1-preview` to the generally available `tts-rt-v1`.

## Test plan

- [x] Run a Pipecat agent using `SonioxTTSService` without overriding `model` and confirm audio is synthesized end to end.