### PR TITLE
fix(aws): surface fatal errors on missing/invalid credentials

### DIFF
--- a/changelog/4389.fixed.md
+++ b/changelog/4389.fixed.md
@@ -1,0 +1,9 @@
+- Fixed AWS services failing silently on missing or invalid credentials.
+  `AWSNovaSonicLLMService`, `AWSBedrockLLMService`, `AWSPollyTTSService`,
+  and `AWSTranscribeSTTService` now push a fatal `ErrorFrame` with a
+  "check AWS credentials and region" hint on auth-class failures, so the
+  pipeline cancels promptly instead of continuing to run with no output.
+- Fixed `AWSNovaSonicLLMService._disconnect` raising `InvalidStateError`
+  from `awscrt/aio/http.py` when cleanup ran on a stream from a failed
+  `invoke_model_with_bidirectional_stream` call. The error was masking
+  the real connect-time auth failure in the logs.

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -43,13 +43,30 @@ from pipecat.utils.tracing.service_decorators import traced_llm
 try:
     import aioboto3
     from botocore.config import Config
-    from botocore.exceptions import ReadTimeoutError
+    from botocore.exceptions import ClientError, ReadTimeoutError
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
         "In order to use AWS services, you need to `pip install pipecat-ai[aws]`. Also, remember to set `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and `AWS_REGION` environment variable."
     )
     raise Exception(f"Missing module: {e}")
+
+
+# AWS error codes that indicate the service won't work until creds/region are
+# fixed. We treat these as fatal so the pipeline stops instead of silently
+# degrading.
+_AWS_AUTH_ERROR_CODES = frozenset(
+    {
+        "UnrecognizedClientException",
+        "InvalidSignatureException",
+        "AccessDeniedException",
+        "ExpiredTokenException",
+        "InvalidAccessKeyId",
+        "SignatureDoesNotMatch",
+        "MissingAuthenticationTokenException",
+        "AuthFailure",
+    }
+)
 
 
 @dataclass
@@ -555,6 +572,20 @@ class AWSBedrockLLMService(LLMService):
             raise
         except (TimeoutError, ReadTimeoutError):
             await self._call_event_handler("on_completion_timeout")
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in _AWS_AUTH_ERROR_CODES:
+                await self.push_error(
+                    error_msg=(
+                        "AWS Bedrock authentication failed. "
+                        "Check AWS credentials and region. "
+                        f"Underlying error: {e}"
+                    ),
+                    exception=e,
+                    fatal=True,
+                )
+            else:
+                await self.push_error(error_msg=f"AWS Bedrock client error: {e}", exception=e)
         except Exception as e:
             await self.push_error(error_msg=f"Unknown error occurred: {e}", exception=e)
         finally:

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -602,7 +602,19 @@ class AWSNovaSonicLLMService(LLMService):
             self._ready_to_send_context = True
             await self._finish_connecting_if_context_available()
         except Exception as e:
-            await self.push_error(error_msg=f"Initialization error: {e}", exception=e)
+            # Connect-time failures (most commonly bad/missing AWS credentials or
+            # an unsupported region) leave the bidirectional stream in a partial
+            # state and produce no audio output. Treat them as fatal so the
+            # pipeline cancels with a clear ERROR rather than continuing silently.
+            await self.push_error(
+                error_msg=(
+                    "AWS Nova Sonic failed to start. "
+                    "Check AWS credentials and region. "
+                    f"Underlying error: {e}"
+                ),
+                exception=e,
+                fatal=True,
+            )
             await self._disconnect()
 
     async def _process_completed_function_calls(self, send_new_results: bool):
@@ -703,17 +715,28 @@ class AWSNovaSonicLLMService(LLMService):
             # NOTE: see explanation of HACK, below
             self._disconnecting = True
 
-            # Clean up client
+            # Clean up client. If connect failed (e.g. bad credentials), the
+            # session may not have started, so end events can fail. Don't let
+            # that mask the real error or block cleanup.
             if self._client:
-                await self._send_session_end_events()
+                try:
+                    await self._send_session_end_events()
+                except Exception as e:
+                    logger.debug(f"Ignoring error while sending session-end events: {e}")
                 self._client = None
 
             # Clean up context
             self._context = None
 
-            # Clean up stream
+            # Clean up stream. A stream from a failed
+            # invoke_model_with_bidirectional_stream call has an already-
+            # cancelled awscrt future; closing it raises InvalidStateError that
+            # otherwise drowns out the real connect error in the logs.
             if self._stream:
-                await self._stream.close()
+                try:
+                    await self._stream.close()
+                except Exception as e:
+                    logger.debug(f"Ignoring error while closing partial stream: {e}")
                 self._stream = None
 
             # NOTE: see explanation of HACK, below

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -323,8 +323,18 @@ class AWSTranscribeSTTService(WebsocketSTTService):
             await self._call_event_handler("on_connected")
             logger.info(f"{self} Successfully connected to AWS Transcribe")
         except Exception as e:
+            # Connect-time failures (most commonly bad/missing AWS credentials,
+            # an unsupported region, or a 403 from the presigned URL) won't
+            # recover on retry. Treat them as fatal so the pipeline cancels
+            # with a clear ERROR rather than silently producing no transcripts.
             await self.push_error(
-                error_msg=f"Unable to connect to AWS Transcribe: {e}", exception=e
+                error_msg=(
+                    "Unable to connect to AWS Transcribe. "
+                    "Check AWS credentials and region. "
+                    f"Underlying error: {e}"
+                ),
+                exception=e,
+                fatal=True,
             )
             raise
 

--- a/src/pipecat/services/aws/tts.py
+++ b/src/pipecat/services/aws/tts.py
@@ -37,6 +37,23 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
+# AWS error codes that indicate the service won't work until creds/region are
+# fixed. We treat these as fatal so the pipeline stops instead of silently
+# degrading.
+_AWS_AUTH_ERROR_CODES = frozenset(
+    {
+        "UnrecognizedClientException",
+        "InvalidSignatureException",
+        "AccessDeniedException",
+        "ExpiredTokenException",
+        "InvalidAccessKeyId",
+        "SignatureDoesNotMatch",
+        "MissingAuthenticationTokenException",
+        "AuthFailure",
+    }
+)
+
+
 def language_to_aws_language(language: Language) -> str | None:
     """Convert a Language enum to AWS Polly language code.
 
@@ -366,6 +383,21 @@ class AWSPollyTTSService(TTSService):
                         frame = TTSAudioRawFrame(chunk, self.sample_rate, 1, context_id=context_id)
                         yield frame
 
-        except (BotoCoreError, ClientError) as error:
-            error_message = f"AWS Polly TTS error: {str(error)}"
-            yield ErrorFrame(error=error_message)
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if error_code in _AWS_AUTH_ERROR_CODES:
+                # Bad/missing credentials won't fix themselves between calls.
+                # Stop the pipeline so the failure surfaces clearly.
+                await self.push_error(
+                    error_msg=(
+                        "AWS Polly authentication failed. "
+                        "Check AWS credentials and region. "
+                        f"Underlying error: {error}"
+                    ),
+                    exception=error,
+                    fatal=True,
+                )
+            else:
+                yield ErrorFrame(error=f"AWS Polly TTS error: {error}")
+        except BotoCoreError as error:
+            yield ErrorFrame(error=f"AWS Polly TTS error: {error}")


### PR DESCRIPTION
## Summary

Surface AWS auth failures clearly instead of letting them rot inside the pipeline.

Spotted while testing #4052 (Vonage Video Connector). With invalid AWS credentials, `AWSNovaSonicLLMService` produced no audio and no clear error: the only tell was an `InvalidStateError` from `awscrt/aio/http.py` printed during pipeline shutdown.

Two root causes:
1. Connect-time auth errors were pushed as non-fatal `ErrorFrame`s, which the pipeline only logs at `warning` level and then continues running.
2. `_disconnect` called `self._stream.close()` on a partially-initialized stream from a failed `invoke_model_with_bidirectional_stream`, which is what produced the `InvalidStateError` noise that masked the real auth error.

This PR makes credential failures fatal and loud across `AWSNovaSonicLLMService`, `AWSBedrockLLMService`, `AWSPollyTTSService`, and `AWSTranscribeSTTService`, and hardens Nova Sonic's disconnect path so cleanup of an uninit stream doesn't add noise on top.

## Why not just check the env vars at construction?

That was my first instinct too. Two reasons it doesn't fit AWS:

1. **The original bug was invalid creds, not missing.** The user had `AWS_ACCESS_KEY_ID` set, just wrong. An "is the env var set?" check would have passed cleanly and the silent failure would still happen.
2. **AWS doesn't only read env vars.** The boto3 credential chain also pulls from IAM instance roles (EC2), task roles (ECS), service accounts (EKS), `~/.aws/config` SSO profiles, and container credentials. A required-env-var check would break valid deployments where creds come from instance metadata instead, e.g. Pipecat Cloud running on EKS.

For reference, only `HumeTTSService` validates an api_key at init in this codebase. Anthropic, OpenAI, Cartesia, ElevenLabs, Deepgram all take the key as a required kwarg and let auth failures surface on first request, same as what this PR now does for AWS. Nova Sonic already takes `secret_access_key` and `access_key_id` as required kwargs, so the "missing" case is already a `TypeError` at construction. The case that was silent was "invalid". This PR makes both cases fatal and loud through one mechanism, regardless of where the creds came from.

## Changes

- **Nova Sonic** (`src/pipecat/services/aws/nova_sonic/llm.py`): `_start_connecting` pushes a fatal `ErrorFrame` with a "check AWS credentials and region" prefix. `_disconnect` wraps `_send_session_end_events` and `self._stream.close()` in their own try/excepts so a partially-initialized stream no longer raises `InvalidStateError` on top of the real connect error.
- **Bedrock LLM** (`src/pipecat/services/aws/llm.py`) and **Polly TTS** (`src/pipecat/services/aws/tts.py`): branch on `botocore.exceptions.ClientError`. Auth-class codes (`UnrecognizedClientException`, `InvalidSignatureException`, `AccessDeniedException`, `ExpiredTokenException`, `InvalidAccessKeyId`, `SignatureDoesNotMatch`, `MissingAuthenticationTokenException`, `AuthFailure`) push a fatal error. Other client errors stay non-fatal (transient).
- **Transcribe STT** (`src/pipecat/services/aws/stt.py`): `_connect_websocket` catch-all now uses `fatal=True`. Presigned URL and websocket connect failures do not recover on retry.

No new dependencies. No `sts:GetCallerIdentity` preflight. No change to default `ErrorFrame(fatal=False)` semantics elsewhere in the pipeline.

## Test plan

- [ ] Run a Nova Sonic foundational example with `AWS_ACCESS_KEY_ID=AKIAINVALID AWS_SECRET_ACCESS_KEY=garbage`. Confirm a single clear `ERROR` log line identifying AWS credentials, the pipeline cancels promptly, and the `InvalidStateError` traceback is gone on shutdown.
- [ ] Repeat with `AWSBedrockLLMService`, `AWSPollyTTSService`, `AWSTranscribeSTTService` against bad credentials. Each fails loudly with a fatal error frame.
- [ ] Confirm valid-credential runs of each service still work normally (no behavior change on the happy path).
- [x] `uv run ruff check src/pipecat/services/aws/`
- [x] `uv run ruff format --check src/pipecat/services/aws/`
- [x] `uv run pytest tests/`: 1234 passed, 5 skipped. Two pre-existing failures on `main` (`test_unified_function_calling_anthropic`, `test_service_settings_complete[NvidiaSegmentedSTTService]`) are unrelated to AWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
