### PR TITLE
refactor(user_mute): remove unused reset() method from strategies

### DIFF
--- a/src/pipecat/turns/user_mute/always_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/always_user_mute_strategy.py
@@ -18,10 +18,6 @@ class AlwaysUserMuteStrategy(BaseUserMuteStrategy):
         super().__init__()
         self._bot_speaking = False
 
-    async def reset(self):
-        """Reset the strategy to its initial state."""
-        self._bot_speaking = False
-
     async def process_frame(self, frame: Frame) -> bool:
         """Process an incoming frame.
 

--- a/src/pipecat/turns/user_mute/base_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/base_user_mute_strategy.py
@@ -51,10 +51,6 @@ class BaseUserMuteStrategy(BaseObject):
         """Cleanup the strategy."""
         pass
 
-    async def reset(self):
-        """Reset the strategy to its initial state."""
-        pass
-
     async def process_frame(self, frame: Frame) -> bool:
         """Process an incoming frame.
 

--- a/src/pipecat/turns/user_mute/first_speech_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/first_speech_user_mute_strategy.py
@@ -29,11 +29,6 @@ class FirstSpeechUserMuteStrategy(BaseUserMuteStrategy):
         self._bot_speaking = False
         self._first_speech_handled = False
 
-    async def reset(self):
-        """Reset the strategy to its initial state."""
-        self._bot_speaking = False
-        self._first_speech_handled = False
-
     async def process_frame(self, frame: Frame) -> bool:
         """Process an incoming frame.
 

--- a/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
@@ -30,10 +30,6 @@ class FunctionCallUserMuteStrategy(BaseUserMuteStrategy):
         super().__init__()
         self._function_call_in_progress: set[str] = set()
 
-    async def reset(self):
-        """Reset the strategy to its initial state."""
-        self._function_call_in_progress = set()
-
     async def process_frame(self, frame: Frame) -> bool:
         """Process an incoming frame.
 

--- a/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
@@ -30,10 +30,6 @@ class MuteUntilFirstBotCompleteUserMuteStrategy(BaseUserMuteStrategy):
         super().__init__()
         self._first_speech_handled = False
 
-    async def reset(self):
-        """Reset the strategy to its initial state."""
-        self._first_speech_handled = False
-
     async def process_frame(self, frame: Frame) -> bool:
         """Process an incoming frame.
 


### PR DESCRIPTION
## Summary

- Removed the unused `reset()` method from `BaseUserMuteStrategy` and all its subclasses (`AlwaysUserMuteStrategy`, `FirstSpeechUserMuteStrategy`, `FunctionCallUserMuteStrategy`, `MuteUntilFirstBotCompleteUserMuteStrategy`).
- The method was never called anywhere in the codebase, so this is pure internal cleanup with no behavior change.