### PR TITLE
chore(smallwebrtc): lower app message log to trace level

### DIFF
--- a/changelog/4397.changed.md
+++ b/changelog/4397.changed.md
@@ -1,0 +1,1 @@
+- Lowered the per-message log in `SmallWebRTCInputTransport._handle_app_message` from `debug` to `trace`. App messages can be high-frequency and were noisy at debug level; set the loguru level to `TRACE` to see them again.

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -706,7 +706,7 @@ class SmallWebRTCInputTransport(BaseInputTransport):
         Args:
             message: The application message to process.
         """
-        logger.debug(f"Received app message inside SmallWebRTCInputTransport  {message}")
+        logger.trace(f"Received app message inside SmallWebRTCInputTransport  {message}")
         await self.broadcast_frame(InputTransportMessageFrame, message=message)
 
     # Add this method similar to DailyInputTransport.request_participant_image


### PR DESCRIPTION
## Summary

- Lower the per-message log in `SmallWebRTCInputTransport._handle_app_message` from `debug` to `trace` to reduce noise, since app messages can be high-frequency.

## Testing

- Run a SmallWebRTC session that sends app messages with the loguru log level at `DEBUG` and confirm the per-message log no longer appears.
- Set the loguru log level to `TRACE` and confirm the messages are still emitted.