### PR TITLE
feat: support new async-tool mechanism in AWS Nova Sonic

### DIFF
--- a/changelog/4402.added.md
+++ b/changelog/4402.added.md
@@ -1,0 +1,1 @@
+- Added support to `AWSNovaSonicLLMService` for the new "async tool call" mechanism activated by `cancel_on_interruption=False`, which includes delivering results asynchronously, delivering result streams, and cancelling running async tools. Support for the other major realtime services (`GeminiLiveLLMService`, `OpenAIRealtimeLLMService`) will be added in a follow-up PR.

--- a/changelog/4402.fixed.md
+++ b/changelog/4402.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a regression in `AWSNovaSonicLLMService` where `cancel_on_interruption=False` (which previously worked under the old async-tool-call mechanism, by simply avoiding discarding tool calls on interruptions) stopped working after the introduction of the new "async tool call" mechanism.

--- a/examples/realtime/realtime-aws-nova-sonic-async-stream-tool.py
+++ b/examples/realtime/realtime-aws-nova-sonic-async-stream-tool.py
@@ -1,0 +1,182 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Example: streaming async function call with the AWS Nova Sonic LLM service.
+
+The ``track_current_location`` tool simulates a GPS tracker reporting the
+device's position during a road trip from San Francisco to San Diego. It
+sends two intermediate updates (via ``params.result_callback`` with
+``is_final=False``) as the vehicle passes through cities along the way, then
+delivers the final destination.
+
+The placeholder is sent as a formal Nova Sonic ``toolResult``; each
+intermediate result is forwarded as a cross-modal user-role text input event
+so the model can fold each update into its next turn.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import FunctionCallResultProperties, LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.aws.nova_sonic.llm import AWSNovaSonicLLMService
+from pipecat.services.llm_service import FunctionCallParams
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+
+load_dotenv(override=True)
+
+
+async def track_current_location(params: FunctionCallParams):
+    """Simulate a GPS tracker reporting position during a road trip."""
+    gps = {"lat": 37.7310, "lng": -122.4527}
+    await params.result_callback(
+        {"gps": gps, "city": "San Francisco"},
+        properties=FunctionCallResultProperties(is_final=False),
+    )
+
+    await asyncio.sleep(10)
+    gps = {"lat": 33.96003, "lng": -118.40639}
+    await params.result_callback(
+        {"gps": gps, "city": "Los Angeles"},
+        properties=FunctionCallResultProperties(is_final=False),
+    )
+
+    await asyncio.sleep(10)
+    gps = {"lat": 32.743569, "lng": -117.20466}
+    await params.result_callback({"gps": gps, "city": "San Diego"})
+
+
+location_function = FunctionSchema(
+    name="track_current_location",
+    description=(
+        "Start tracking the user's current GPS location, reporting position "
+        "updates until the user reaches their destination. "
+        "Once this tracker is started, it doesn't need to be started again for subsequent updates; "
+        "just call this function once to kick it off and the updates will come in automatically."
+    ),
+    properties={},
+    required=[],
+)
+
+tools = ToolsSchema(standard_tools=[location_function])
+
+
+transport_params = {
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    system_instruction = (
+        "You are a friendly assistant. The user and you will engage in a spoken "
+        "dialog exchanging the transcripts of a natural real-time conversation. "
+        "Keep your responses short, generally two or three sentences for chatty "
+        "scenarios. You have access to a function that starts tracking the user's "
+        "location and provides regular updates on it. Narrate each position "
+        "update to the user as it arrives (city only, no coordinates). "
+        "When you receive the final location, tell the user the destination has "
+        "been reached."
+    )
+
+    llm = AWSNovaSonicLLMService(
+        secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        region=os.environ["AWS_REGION"],
+        session_token=os.getenv("AWS_SESSION_TOKEN"),
+        settings=AWSNovaSonicLLMService.Settings(
+            voice="tiffany",
+            system_instruction=system_instruction,
+        ),
+    )
+
+    llm.register_function(
+        "track_current_location",
+        track_current_location,
+        cancel_on_interruption=False,
+    )
+
+    context = LLMContext(tools=tools)
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            user_aggregator,
+            llm,
+            transport.output(),
+            assistant_aggregator,
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
+    await runner.run(task)
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/examples/realtime/realtime-aws-nova-sonic-async-tool.py
+++ b/examples/realtime/realtime-aws-nova-sonic-async-tool.py
@@ -4,7 +4,16 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+"""Example: async function call with the AWS Nova Sonic LLM service.
 
+The ``get_current_weather`` tool is registered with
+``cancel_on_interruption=False`` and simulates a slow API call (20s sleep).
+While the call is in flight the conversation continues; the result arrives
+later via the async-tool mechanism and is forwarded to Nova Sonic so the
+model can integrate it naturally into its next turn.
+"""
+
+import asyncio
 import os
 import random
 from datetime import datetime
@@ -21,25 +30,24 @@ from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
-    AssistantTurnStoppedMessage,
     LLMContextAggregatorPair,
     LLMUserAggregatorParams,
-    UserTurnStoppedMessage,
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.aws.nova_sonic.llm import AWSNovaSonicLLMService
-from pipecat.services.aws.nova_sonic.session_continuation import SessionContinuationParams
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
 
-# Load environment variables
 load_dotenv(override=True)
 
 
 async def fetch_weather_from_api(params: FunctionCallParams):
+    # Simulate a long-running API call so we can demonstrate that the
+    # conversation continues while the tool is in flight.
+    await asyncio.sleep(20)
     temperature = (
         random.randint(60, 85)
         if params.arguments["format"] == "fahrenheit"
@@ -73,12 +81,9 @@ weather_function = FunctionSchema(
     required=["location", "format"],
 )
 
-# Create tools schema
 tools = ToolsSchema(standard_tools=[weather_function])
 
 
-# We use lambdas to defer transport parameter creation until the transport
-# type is selected at runtime.
 transport_params = {
     "daily": lambda: DailyParams(
         audio_in_enabled=True,
@@ -98,62 +103,38 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info(f"Starting bot")
 
-    # Specify initial system instruction.
     system_instruction = (
-        "You are a friendly assistant. The user and you will engage in a spoken dialog exchanging "
-        "the transcripts of a natural real-time conversation. Keep your responses short, generally "
-        "two or three sentences for chatty scenarios."
-        # HACK: if using the older Nova Sonic (pre-2) model, note that you need to inject a special
-        # bit of text into this instruction to allow the first assistant response to be
-        # programmatically triggered (which happens in the on_client_connected handler)
-        # f"{AWSNovaSonicLLMService.AWAIT_TRIGGER_ASSISTANT_RESPONSE_INSTRUCTION}"
+        "You are a friendly assistant. The user and you will engage in a spoken "
+        "dialog exchanging the transcripts of a natural real-time conversation. "
+        "Keep your responses short, generally two or three sentences for chatty "
+        "scenarios. When the user asks for the weather, call get_current_weather. "
+        "While you wait for the result, keep chatting with the user. When the "
+        "result arrives, share it with the user naturally."
     )
 
-    # Create the AWS Nova Sonic LLM service
     llm = AWSNovaSonicLLMService(
         secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
         access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-        # as of 2025-12-09, these are the supported regions:
-        # - Nova 2 Sonic (the default model):
-        #   - us-east-1
-        #   - us-west-2
-        #   - ap-northeast-1
-        # - Nova Sonic (the older model):
-        #   - us-east-1
-        #   - ap-northeast-1
         region=os.environ["AWS_REGION"],
         session_token=os.getenv("AWS_SESSION_TOKEN"),
         settings=AWSNovaSonicLLMService.Settings(
             voice="tiffany",
             system_instruction=system_instruction,
         ),
-        # Session continuation is enabled by default, allowing seamless
-        # conversations longer than the AWS ~8-minute session limit.
-        # The service rotates sessions in the background with no
-        # user-perceptible interruption. You can tune the threshold or
-        # disable it with: session_continuation=SessionContinuationParams(enabled=False)
-        session_continuation=SessionContinuationParams(
-            # When to start preparing the next session (default: 360 = 6 min).
-            # Lower this (e.g. 20) to see a handoff happen quickly during testing.
-            transition_threshold_seconds=360,
-        ),
-        # you could choose to pass tools here rather than via context
-        # tools=tools
     )
 
-    # Register function for function calls
-    # you can either register a single function for all function calls, or specific functions
-    # llm.register_function(None, fetch_weather_from_api)
-    llm.register_function("get_current_weather", fetch_weather_from_api)
+    llm.register_function(
+        "get_current_weather",
+        fetch_weather_from_api,
+        cancel_on_interruption=False,
+    )
 
-    # Set up context and context management.
     context = LLMContext(tools=tools)
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
         user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
     )
 
-    # Build the pipeline
     pipeline = Pipeline(
         [
             transport.input(),
@@ -164,7 +145,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
-    # Configure the pipeline task
     task = PipelineTask(
         pipeline,
         params=PipelineParams(
@@ -174,39 +154,19 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    # Handle client connection event
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
-        # Kick off the conversation.
         context.add_message(
             {"role": "developer", "content": "Please introduce yourself to the user."}
         )
         await task.queue_frames([LLMRunFrame()])
-        # HACK: if using the older Nova Sonic (pre-2) model, you need this special way of
-        # triggering the first assistant response. Note that this trigger requires a special
-        # corresponding bit of text in the system instruction.
-        # await llm.trigger_assistant_response()
 
-    # Handle client disconnection events
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
         await task.cancel()
 
-    @user_aggregator.event_handler("on_user_turn_stopped")
-    async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
-        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
-        line = f"{timestamp}user: {message.content}"
-        logger.info(f"Transcript: {line}")
-
-    @assistant_aggregator.event_handler("on_assistant_turn_stopped")
-    async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
-        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
-        line = f"{timestamp}assistant: {message.content}"
-        logger.info(f"Transcript: {line}")
-
-    # Run the pipeline
     runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
     await runner.run(task)
 

--- a/src/pipecat/processors/aggregators/async_tool_messages.py
+++ b/src/pipecat/processors/aggregators/async_tool_messages.py
@@ -1,0 +1,158 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Helpers for detecting and decoding async-tool messages in an LLM context.
+
+When a function is registered with ``cancel_on_interruption=False``, the
+``LLMUserContextAggregator`` / ``LLMAssistantContextAggregator`` pair appends
+async-tool messages to the conversation context as the underlying task
+progresses:
+
+- A ``placeholder`` message (``role="tool"``) is appended immediately when the
+  tool starts running.
+- An ``intermediate`` message (``role="developer"``) is appended each time an
+  intermediate result is reported via
+  ``result_callback(..., FunctionCallResultProperties(is_final=False))``.
+- A ``final`` message (``role="developer"``) is appended when the task
+  finishes.
+
+Realtime LLM services need to recognize these messages to forward async results
+to their providers. This module exposes the detection and decoding primitives.
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+AsyncToolMessageKind = Literal["placeholder", "intermediate", "final"]
+
+
+@dataclass(frozen=True)
+class AsyncToolMessage:
+    """A parsed async-tool message extracted from an LLM context entry.
+
+    Parameters:
+        kind: Which of the three async-tool message stages this is.
+        tool_call_id: The id of the tool invocation this message relates to.
+        status: ``"running"`` for placeholder/intermediate, ``"finished"`` for
+            the final message.
+        description: Human-readable description from the message envelope. May
+            be empty.
+        result: For ``intermediate`` and ``final`` messages, the JSON-encoded
+            result string (or the literal ``"COMPLETED"`` if the function
+            returned no value). ``None`` for ``placeholder`` messages.
+        raw_content: The original JSON-encoded envelope string (i.e. the
+            ``content`` field of the source LLM context message). Use this
+            when forwarding the message to a provider as a formal tool
+            result, so the provider receives the complete envelope (with
+            ``type``, ``status``, ``tool_call_id``, ``description``, and any
+            ``result``) rather than just a sub-field.
+    """
+
+    kind: AsyncToolMessageKind
+    tool_call_id: str
+    status: Literal["running", "finished"]
+    description: str
+    result: str | None
+    raw_content: str
+
+
+def is_async_tool_message(message: dict[str, Any]) -> bool:
+    """Return True if ``message`` is an async-tool message envelope."""
+    return parse_async_tool_message(message) is not None
+
+
+def parse_async_tool_message(message: dict[str, Any]) -> AsyncToolMessage | None:
+    """Decode an async-tool message envelope, or return None if not async-tool.
+
+    Args:
+        message: A message dict from the LLM context.
+
+    Returns:
+        An ``AsyncToolMessage`` if the message is a recognized async-tool
+        envelope, otherwise ``None``.
+    """
+    role = message.get("role")
+    if role not in ("tool", "developer"):
+        return None
+    content = message.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        envelope = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(envelope, dict) or envelope.get("type") != "async_tool":
+        return None
+    tool_call_id = envelope.get("tool_call_id")
+    status = envelope.get("status")
+    if not isinstance(tool_call_id, str) or status not in ("running", "finished"):
+        return None
+    description = envelope.get("description", "")
+    if not isinstance(description, str):
+        description = ""
+    result = envelope.get("result")
+    if result is not None and not isinstance(result, str):
+        result = None
+    if result is None:
+        kind: AsyncToolMessageKind = "placeholder"
+    elif status == "finished":
+        kind = "final"
+    else:
+        kind = "intermediate"
+    return AsyncToolMessage(
+        kind=kind,
+        tool_call_id=tool_call_id,
+        status=status,
+        description=description,
+        result=result,
+        raw_content=content,
+    )
+
+
+_DEFAULT_PROVIDER_TEXT_TEMPLATE = (
+    "[Async tool update for tool_call_id={tool_call_id}, status={status}] {result}"
+)
+
+
+def format_async_tool_text_for_provider(
+    info: AsyncToolMessage,
+    *,
+    template: str | None = None,
+) -> str:
+    """Render an async-tool result as text for mid-conversation provider injection.
+
+    Realtime services that fully honor the async-tool mechanism send the
+    ``placeholder`` message via the formal tool-result channel and then send
+    subsequent ``intermediate`` / ``final`` results as text injected
+    mid-conversation. This function produces the text payload for that
+    injection.
+
+    Args:
+        info: The parsed async-tool message. Must not be a ``placeholder``.
+        template: Optional override format string. Available substitution
+            keys are ``tool_call_id``, ``status``, ``result``, and
+            ``description``.
+
+    Returns:
+        The rendered text.
+
+    Raises:
+        ValueError: If ``info.kind == "placeholder"``. Placeholders should be
+            sent via the formal tool-result channel, not as text.
+    """
+    if info.kind == "placeholder":
+        raise ValueError(
+            "format_async_tool_text_for_provider should not be called on placeholder "
+            "messages; placeholders should be sent via the formal tool-result channel."
+        )
+    fmt = template if template is not None else _DEFAULT_PROVIDER_TEXT_TEMPLATE
+    return fmt.format(
+        tool_call_id=info.tool_call_id,
+        status=info.status,
+        result=info.result or "",
+        description=info.description,
+    )

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -49,6 +49,11 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
+from pipecat.processors.aggregators.async_tool_messages import (
+    AsyncToolMessage,
+    format_async_tool_text_for_provider,
+    parse_async_tool_message,
+)
 from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.aws.nova_sonic.session_continuation import (
@@ -414,6 +419,7 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
         self._wants_connection = False
         self._user_text_buffer = ""
         self._completed_tool_calls = set()
+        self._async_tool_text_dispatched: set[str] = set()
         self._audio_input_started = False
 
         # Session continuation helper. The service itself implements the
@@ -620,6 +626,13 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
             # standard tool-result messages — skip them.
             if isinstance(message, LLMSpecificMessage):
                 continue
+
+            async_info = parse_async_tool_message(message)
+            if async_info is not None:
+                # Async-tool message — dispatch per the configured support tier.
+                await self._dispatch_async_tool_message(async_info, send_new_results)
+                continue
+
             if message.get("role") == "tool" and message.get("content") not in [
                 "IN_PROGRESS",
                 "CANCELLED",
@@ -630,6 +643,77 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
                     if send_new_results:
                         await self._send_tool_result(tool_call_id, message.get("content"))
                     self._completed_tool_calls.add(tool_call_id)
+
+    async def _dispatch_async_tool_message(self, info: AsyncToolMessage, send_new_results: bool):
+        """Dispatch an async-tool message to Nova Sonic.
+
+        The placeholder is sent as a formal ``toolResult``; subsequent
+        intermediate/final results are injected as cross-modal user-role text
+        input events (supporting streaming async results).
+        """
+        logger.trace(
+            f"{self}: async_tool dispatch: kind={info.kind} "
+            f"tool_call_id={info.tool_call_id} status={info.status} "
+            f"send_new_results={send_new_results}"
+        )
+
+        if info.kind == "placeholder":
+            if info.tool_call_id in self._completed_tool_calls:
+                logger.trace(
+                    f"{self}: async_tool placeholder already sent: tool_call_id={info.tool_call_id}"
+                )
+                return
+            if send_new_results:
+                logger.debug(
+                    f"{self}: async_tool send placeholder as tool result: "
+                    f"tool_call_id={info.tool_call_id} payload={info.raw_content!r}"
+                )
+                await self._send_tool_result(info.tool_call_id, info.raw_content)
+            else:
+                logger.trace(
+                    f"{self}: async_tool placeholder mark-handled (no send): "
+                    f"tool_call_id={info.tool_call_id}"
+                )
+            self._completed_tool_calls.add(info.tool_call_id)
+            return
+
+        # info.kind in ("intermediate", "final")
+        signature = self._async_tool_message_signature(info)
+        if signature in self._async_tool_text_dispatched:
+            logger.trace(
+                f"{self}: async_tool {info.kind} already dispatched: "
+                f"tool_call_id={info.tool_call_id}"
+            )
+            return
+        if send_new_results:
+            text = format_async_tool_text_for_provider(info)
+            logger.debug(
+                f"{self}: async_tool send {info.kind} as text input: "
+                f"tool_call_id={info.tool_call_id} text={text!r}"
+            )
+            await self._send_async_tool_text(text)
+        else:
+            logger.trace(
+                f"{self}: async_tool {info.kind} mark-handled (no send): "
+                f"tool_call_id={info.tool_call_id}"
+            )
+        self._async_tool_text_dispatched.add(signature)
+
+    @staticmethod
+    def _async_tool_message_signature(info: AsyncToolMessage) -> str:
+        return f"{info.tool_call_id}|{info.status}|{info.result or ''}"
+
+    async def _send_async_tool_text(self, text: str):
+        """Inject mid-conversation text via Nova Sonic's cross-modal user text input.
+
+        Used to forward intermediate/final async-tool results to the provider.
+        Sends a USER-role text content block (contentStart/textInput/contentEnd)
+        with ``interactive=True``, the documented cross-modal pattern for mid-
+        conversation text injection.
+        """
+        if not self._stream or not self._prompt_name or not text:
+            return
+        await self._send_text_event(text=text, role=Role.USER, interactive=True)
 
     async def _finish_connecting_if_context_available(self):
         # We can only finish connecting once we've gotten our initial context and we're ready to
@@ -758,6 +842,7 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
             self._connected_time = None
             self._user_text_buffer = ""
             self._completed_tool_calls = set()
+            self._async_tool_text_dispatched = set()
             self._audio_input_started = False
             self._pending_speculative_text = None
 

--- a/tests/test_async_tool_messages.py
+++ b/tests/test_async_tool_messages.py
@@ -1,0 +1,291 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import json
+import unittest
+
+from pipecat.processors.aggregators.async_tool_messages import (
+    AsyncToolMessage,
+    format_async_tool_text_for_provider,
+    is_async_tool_message,
+    parse_async_tool_message,
+)
+
+
+def _placeholder_message(tool_call_id: str = "call_123") -> dict:
+    """Build a placeholder async-tool message matching the aggregator's output."""
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "status": "running",
+                "tool_call_id": tool_call_id,
+                "description": (
+                    "An asynchronous task associated with this tool_call_id has started "
+                    "running. Expect results to arrive later as developer messages..."
+                ),
+            }
+        ),
+    }
+
+
+def _intermediate_message(
+    tool_call_id: str = "call_123",
+    result: str = '"intermediate-1"',
+) -> dict:
+    """Build an intermediate async-tool message matching the aggregator's output."""
+    return {
+        "role": "developer",
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "tool_call_id": tool_call_id,
+                "status": "running",
+                "description": "This is an intermediate result for the asynchronous task...",
+                "result": result,
+            }
+        ),
+    }
+
+
+def _final_message(
+    tool_call_id: str = "call_123",
+    result: str = '"final-result"',
+) -> dict:
+    """Build a final async-tool message matching the aggregator's output."""
+    return {
+        "role": "developer",
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "tool_call_id": tool_call_id,
+                "status": "finished",
+                "description": "This is the final result for the asynchronous task...",
+                "result": result,
+            }
+        ),
+    }
+
+
+class TestParseAsyncToolMessage(unittest.TestCase):
+    def test_parses_placeholder(self):
+        info = parse_async_tool_message(_placeholder_message("abc"))
+        assert info is not None
+        assert info.kind == "placeholder"
+        assert info.tool_call_id == "abc"
+        assert info.status == "running"
+        assert info.result is None
+        assert "asynchronous task" in info.description
+
+    def test_parses_intermediate(self):
+        info = parse_async_tool_message(_intermediate_message("abc", '"hello"'))
+        assert info is not None
+        assert info.kind == "intermediate"
+        assert info.tool_call_id == "abc"
+        assert info.status == "running"
+        assert info.result == '"hello"'
+
+    def test_parses_final(self):
+        info = parse_async_tool_message(_final_message("abc", '"done"'))
+        assert info is not None
+        assert info.kind == "final"
+        assert info.tool_call_id == "abc"
+        assert info.status == "finished"
+        assert info.result == '"done"'
+
+    def test_raw_content_preserves_original_envelope(self):
+        # raw_content should round-trip the source message's `content` field so
+        # services can forward the full envelope to providers.
+        msg = _final_message("abc", '"done"')
+        info = parse_async_tool_message(msg)
+        assert info is not None
+        assert info.raw_content == msg["content"]
+        # Sanity: it should parse back to the original envelope dict.
+        envelope = json.loads(info.raw_content)
+        assert envelope["type"] == "async_tool"
+        assert envelope["tool_call_id"] == "abc"
+        assert envelope["status"] == "finished"
+        assert envelope["result"] == '"done"'
+
+    def test_parses_completed_sentinel_result(self):
+        # When the async function returns no value, the aggregator sets result to "COMPLETED".
+        info = parse_async_tool_message(_final_message("abc", "COMPLETED"))
+        assert info is not None
+        assert info.kind == "final"
+        assert info.result == "COMPLETED"
+
+    def test_returns_none_for_regular_user_message(self):
+        assert parse_async_tool_message({"role": "user", "content": "hello"}) is None
+
+    def test_returns_none_for_regular_assistant_message(self):
+        assert parse_async_tool_message({"role": "assistant", "content": "hi"}) is None
+
+    def test_returns_none_for_regular_tool_message(self):
+        # IN_PROGRESS / regular tool result string content.
+        assert (
+            parse_async_tool_message(
+                {"role": "tool", "tool_call_id": "x", "content": "IN_PROGRESS"}
+            )
+            is None
+        )
+        assert (
+            parse_async_tool_message(
+                {"role": "tool", "tool_call_id": "x", "content": "weather: sunny"}
+            )
+            is None
+        )
+
+    def test_returns_none_for_developer_message_without_envelope(self):
+        # role=developer is also used for non-async-tool things (potentially).
+        assert (
+            parse_async_tool_message({"role": "developer", "content": "some other developer note"})
+            is None
+        )
+
+    def test_returns_none_for_invalid_json_content(self):
+        assert parse_async_tool_message({"role": "tool", "content": "{not json"}) is None
+
+    def test_returns_none_for_non_dict_json(self):
+        assert parse_async_tool_message({"role": "tool", "content": "[1, 2, 3]"}) is None
+
+    def test_returns_none_for_wrong_envelope_type(self):
+        assert (
+            parse_async_tool_message(
+                {
+                    "role": "tool",
+                    "content": json.dumps({"type": "something_else", "tool_call_id": "x"}),
+                }
+            )
+            is None
+        )
+
+    def test_returns_none_when_tool_call_id_missing(self):
+        assert (
+            parse_async_tool_message(
+                {
+                    "role": "tool",
+                    "content": json.dumps({"type": "async_tool", "status": "running"}),
+                }
+            )
+            is None
+        )
+
+    def test_returns_none_when_status_invalid(self):
+        assert (
+            parse_async_tool_message(
+                {
+                    "role": "tool",
+                    "content": json.dumps(
+                        {"type": "async_tool", "tool_call_id": "x", "status": "weird"}
+                    ),
+                }
+            )
+            is None
+        )
+
+    def test_returns_none_for_non_string_content(self):
+        # A multimodal message with content as a list would not be an async-tool message.
+        assert (
+            parse_async_tool_message({"role": "tool", "content": [{"type": "text", "text": "hi"}]})
+            is None
+        )
+
+    def test_returns_none_for_missing_role(self):
+        assert parse_async_tool_message({"content": "{}"}) is None
+
+
+class TestIsAsyncToolMessage(unittest.TestCase):
+    def test_true_for_placeholder(self):
+        assert is_async_tool_message(_placeholder_message()) is True
+
+    def test_true_for_intermediate(self):
+        assert is_async_tool_message(_intermediate_message()) is True
+
+    def test_true_for_final(self):
+        assert is_async_tool_message(_final_message()) is True
+
+    def test_false_for_regular_message(self):
+        assert is_async_tool_message({"role": "user", "content": "hi"}) is False
+        assert (
+            is_async_tool_message({"role": "tool", "tool_call_id": "x", "content": "IN_PROGRESS"})
+            is False
+        )
+
+
+class TestFormatAsyncToolTextForProvider(unittest.TestCase):
+    def test_default_template_includes_id_status_and_result(self):
+        info = AsyncToolMessage(
+            kind="final",
+            tool_call_id="call_42",
+            status="finished",
+            description="done",
+            result='"the answer"',
+            raw_content="{}",
+        )
+        text = format_async_tool_text_for_provider(info)
+        assert "call_42" in text
+        assert "finished" in text
+        assert '"the answer"' in text
+
+    def test_custom_template(self):
+        info = AsyncToolMessage(
+            kind="intermediate",
+            tool_call_id="call_99",
+            status="running",
+            description="",
+            result='"step-1"',
+            raw_content="{}",
+        )
+        text = format_async_tool_text_for_provider(
+            info,
+            template="tool {tool_call_id} -> {result} ({status})",
+        )
+        assert text == 'tool call_99 -> "step-1" (running)'
+
+    def test_template_can_use_description_field(self):
+        info = AsyncToolMessage(
+            kind="final",
+            tool_call_id="call_1",
+            status="finished",
+            description="my description",
+            result='"x"',
+            raw_content="{}",
+        )
+        text = format_async_tool_text_for_provider(info, template="{description}: {result}")
+        assert text == 'my description: "x"'
+
+    def test_raises_on_placeholder(self):
+        info = AsyncToolMessage(
+            kind="placeholder",
+            tool_call_id="x",
+            status="running",
+            description="",
+            result=None,
+            raw_content="{}",
+        )
+        with self.assertRaises(ValueError):
+            format_async_tool_text_for_provider(info)
+
+    def test_handles_none_result_in_intermediate_via_default_template(self):
+        # Defensive: if result somehow ends up None on a non-placeholder, the
+        # formatter substitutes empty string rather than raising.
+        info = AsyncToolMessage(
+            kind="intermediate",
+            tool_call_id="x",
+            status="running",
+            description="",
+            result=None,
+            raw_content="{}",
+        )
+        text = format_async_tool_text_for_provider(info)
+        assert "x" in text
+        assert "running" in text
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add support to `AWSNovaSonicLLMService` for the new "async tool call" mechanism activated by `cancel_on_interruption=False`, which includes:

- delivering results asynchronously
- delivering result streams
- cancelling running async tools

Note that the introduction of the new mechanism had actually caused a regression in AWS Nova Sonic, which previously supported `cancel_on_interruption=False` with the old mechanism (simply avoiding discarding tool calls on interruptions).

Support for the other major realtime services (`GeminiLiveLLMService`, `OpenAIRealtimeLLMService`) will follow in a separate PR — Gemini Live in particular needs more work before it can support long-running tool calls reliably. This PR also lays the groundwork for those follow-ups: the new provider-agnostic helper module `pipecat.processors.aggregators.async_tool_messages` (with unit tests) and the placeholder-as-formal-tool-result + intermediate/final-as-text-injection pattern established here are intended to be reused by the Gemini Live and OpenAI Realtime implementations.

## Test plan

- [x] Helper unit tests pass (`uv run pytest tests/test_async_tool_messages.py`)
- [x] Existing test suite still passes
- [x] AWS Nova Sonic — confirmed working at the "full" tier (single-shot async + streaming async)