### PR TITLE
fix(daily): guard send_message when client is closed

### DIFF
--- a/changelog/4411.fixed.md
+++ b/changelog/4411.fixed.md
@@ -1,0 +1,1 @@
+- Guarded `DailyTransportClient.send_message` against the underlying Daily client being released during teardown.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -611,6 +611,9 @@ class DailyTransportClient(EventHandler):
         Returns:
             error: An error description or None.
         """
+        if not self._client:
+            return None
+
         if not self._joined:
             self._join_message_queue.append(frame)
             return None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #4369.                                                                                                                                                                                                                           
         
Restore the `if not self._client: return None` guard at the top of the method. Same placement as [be14ce46](https://github.com/pipecat-ai/pipecat/commit/be14ce465d839e3cb4343fdc94cc0f1de4a6db46), which [5b6d9a10](https://github.com/pipecat-ai/pipecat/commit/5b6d9a1050dd74bb1c007c612de269ffa64950dc) accidentally dropped when replacing `_leaving` with the ref-counter.