### PR TITLE
fix(tts): release pause on interruption

### DIFF
--- a/changelog/4421.fixed.md
+++ b/changelog/4421.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TTSService` going silent after a mid-TTFB interrupt on a turn with a tool call. The pause armed by `pause_frame_processing` is now released directly in `_handle_interruption`, since `BotStoppedSpeakingFrame` (the usual resume trigger) doesn't fire when no audio reached the output.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -884,6 +884,11 @@ class TTSService(AIService):
         self._word_last_pts = 0
         self._create_audio_context_task()
 
+        # Release the pause here too: a mid-TTFB interruption produces no audio,
+        # so the `BotStoppedSpeakingFrame` that would normally resume us never
+        # arrives.
+        await self._maybe_resume_frame_processing()
+
     async def _maybe_pause_frame_processing(self):
         if self._processing_text and self._pause_frame_processing:
             await self.pause_processing_frames()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #4418 

### Issue :
With `pause_frame_processing=True` (Rime, ElevenLabs, etc.), if the user barges in mid-TTFB on a turn that emits filler text + a tool call, TTS goes permanently silent.                                                                                        

Trace: pause arms on `LLMFullResponseEndFrame` → `FunctionCallResultFrame` (`UninterruptibleFrame`) lands in the queue → worker pops it and parks on `__process_event.wait()` → user interrupts → `_start_interruption` takes the uninterruptible-preserve branch and never resets pause state. `BotStoppedSpeakingFrame` (the usual resume) doesn't fire either, because no audio reached the output transport.                                     

### Fix :
Release the pause in `_handle_interruption`. Mirrors the existing `_maybe_pause_frame_processing` call site, uses the same self-gating helper, no-op for services that don't opt in.      