### PR TITLE
feat(inworld): default to inworld-tts-2

### DIFF
--- a/changelog/4422.changed.md
+++ b/changelog/4422.changed.md
@@ -1,0 +1,1 @@
+- Changed the default Inworld TTS model from `inworld-tts-1.5-max` to `inworld-tts-2` (Realtime TTS-2) across `InworldHttpTTSService`, `InworldTTSService`, and the `InworldRealtimeLLMService` cascade. Existing users can pin the prior model explicitly via the `model`/`tts_model` argument; both `inworld-tts-1.5-max` and `inworld-tts-1.5-mini` remain valid model IDs.

--- a/src/pipecat/services/inworld/realtime/events.py
+++ b/src/pipecat/services/inworld/realtime/events.py
@@ -124,7 +124,7 @@ class AudioOutput(BaseModel):
 
     Parameters:
         format: The format configuration for output audio.
-        model: The TTS model to use (e.g. "inworld-tts-1.5-max").
+        model: The TTS model to use (e.g. "inworld-tts-2").
         voice: The voice ID to use (e.g. "Sarah", "Clive").
     """
 

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -206,7 +206,7 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
             api_key=os.getenv("INWORLD_API_KEY"),
             llm_model="openai/gpt-4.1-nano",
             voice="Sarah",
-            tts_model="inworld-tts-1.5-max",
+            tts_model="inworld-tts-2",
         )
 
     For full control over session properties (note: ``session_properties``
@@ -231,7 +231,7 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
                         output=AudioOutput(
                             format=PCMAudioFormat(rate=24000),
                             voice="Sarah",
-                            model="inworld-tts-1.5-max",
+                            model="inworld-tts-2",
                         ),
                     ),
                 ),
@@ -269,7 +269,7 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
                 Shorthand for ``session_properties.model``.
             voice: Voice ID for TTS output (e.g. "Sarah", "Clive").
                 Shorthand for ``session_properties.audio.output.voice``.
-            tts_model: TTS model to use (e.g. "inworld-tts-1.5-max").
+            tts_model: TTS model to use (e.g. "inworld-tts-2").
                 Shorthand for ``session_properties.audio.output.model``.
             stt_model: STT model for input transcription
                 (e.g. "assemblyai/universal-streaming-multilingual").
@@ -286,7 +286,7 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
         """
         default_model = llm_model or "openai/gpt-4.1-mini"
         default_voice = voice or "Clive"
-        default_tts_model = tts_model or "inworld-tts-1.5-max"
+        default_tts_model = tts_model or "inworld-tts-2"
         default_stt_model = stt_model or "assemblyai/u3-rt-pro"
 
         default_settings = self.Settings(

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -162,7 +162,7 @@ class InworldHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="inworld-tts-1.5-max",
+            model="inworld-tts-2",
             voice="Ashley",
             language=None,
             speaking_rate=None,
@@ -604,7 +604,7 @@ class InworldTTSService(WebsocketTTSService):
 
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="inworld-tts-1.5-max",
+            model="inworld-tts-2",
             voice="Ashley",
             language=None,
             speaking_rate=None,


### PR DESCRIPTION
## Default Inworld TTS model → `inworld-tts-2`

Flips the default Inworld TTS model from `inworld-tts-1.5-max` to
`inworld-tts-2`, the latest generation Inworld voice model (Realtime
TTS-2). Applies to all three Inworld surfaces in pipecat:

- `InworldHttpTTSService` (HTTP) — `src/pipecat/services/inworld/tts.py`
- `InworldTTSService` (WebSocket) — `src/pipecat/services/inworld/tts.py`
- `InworldRealtimeLLMService` (cascade Realtime) — `src/pipecat/services/inworld/realtime/llm.py`

Docstring examples in `realtime/llm.py` and `realtime/events.py` are
updated to reference `inworld-tts-2`.

## Backwards compatibility

`inworld-tts-1.5-max` (Realtime TTS-1.5-Max) and `inworld-tts-1.5-mini`
(Realtime TTS-1.5-Mini) remain valid model IDs. Existing users who want
to stay on the prior model can pin it explicitly:

```python
# WebSocket
service = InworldTTSService(
    api_key=...,
    settings=InworldTTSService.Settings(model="inworld-tts-1.5-max"),
)

# HTTP
service = InworldHttpTTSService(
    api_key=...,
    aiohttp_session=session,
    settings=InworldHttpTTSService.Settings(model="inworld-tts-1.5-max"),
)

# Realtime cascade
llm = InworldRealtimeLLMService(
    api_key=...,
    tts_model="inworld-tts-1.5-max",
)
```

No public API changes; no schema changes. Only the hardcoded default
string changes.

## Verification

- `python -c "from pipecat.services.inworld.tts import InworldTTSService, InworldHttpTTSService"` — imports clean.
- Instantiating each service without a model produces `model="inworld-tts-2"` on the resulting settings.
- `grep -rn "inworld-tts-1.5-max" src/` — no remaining references.
- `ruff check src/pipecat/services/inworld/` — no new findings (one pre-existing UP038 warning unrelated to this change).
