### PR TITLE
chore(audio): deprecate ResampyResampler

### DIFF
--- a/changelog/4428.deprecated.md
+++ b/changelog/4428.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated `ResampyResampler` in favor of `SOXRAudioResampler` (or the `create_file_resampler()` / `create_stream_resampler()` factories). Instantiating `ResampyResampler` now emits a `DeprecationWarning`. The class will be removed in Pipecat 2.0 along with the default `resampy` and `numba` dependencies.

--- a/src/pipecat/audio/resamplers/resampy_resampler.py
+++ b/src/pipecat/audio/resamplers/resampy_resampler.py
@@ -10,6 +10,8 @@ This module provides an audio resampler that uses the resampy library
 for high-quality audio sample rate conversion.
 """
 
+import warnings
+
 import numpy as np
 import resampy
 
@@ -21,6 +23,11 @@ class ResampyResampler(BaseAudioResampler):
 
     This resampler uses the resampy library's Kaiser windowing filter
     for high-quality audio resampling with good performance characteristics.
+
+    .. deprecated:: 1.2.0
+        ResampyResampler is deprecated and will be removed in Pipecat 2.0.
+        Use SOXRAudioResampler, create_file_resampler(), or create_stream_resampler()
+        instead.
     """
 
     def __init__(self, **kwargs):
@@ -29,7 +36,15 @@ class ResampyResampler(BaseAudioResampler):
         Args:
             **kwargs: Additional keyword arguments (currently unused).
         """
-        pass
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "ResampyResampler is deprecated and will be removed in Pipecat 2.0. "
+                "Use SOXRAudioResampler, create_file_resampler(), or "
+                "create_stream_resampler() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     async def resample(self, audio: bytes, in_rate: int, out_rate: int) -> bytes:
         """Resample audio data using resampy library.

--- a/tests/test_resampy_resampler.py
+++ b/tests/test_resampy_resampler.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the deprecated resampy resampler."""
+
+import pytest
+
+from pipecat.audio.resamplers.resampy_resampler import ResampyResampler
+
+
+def test_resampy_resampler_emits_deprecation_warning():
+    """Test that instantiating ResampyResampler emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="ResampyResampler is deprecated"):
+        ResampyResampler()


### PR DESCRIPTION
## Summary

- Deprecates `ResampyResampler` in favor of the SOXR resamplers (`SOXRAudioResampler`, `create_file_resampler()`, `create_stream_resampler()`)
- Instantiating `ResampyResampler` now emits a `DeprecationWarning`; the class will be removed in Pipecat 2.0 along with the default `resampy` and `numba` dependencies
- Adds a unit test verifying the warning is emitted

## Testing

- `uv run pytest tests/test_resampy_resampler.py`