### PR TITLE
fix(xai): update default Grok model to grok-4.20-non-reasoning

### DIFF
--- a/changelog/4429.changed.md
+++ b/changelog/4429.changed.md
@@ -1,0 +1,1 @@
+- Changed the default model for `GrokLLMService` from `grok-3` to `grok-4.20-non-reasoning`. xAI is retiring `grok-3` on May 15, 2026.

--- a/src/pipecat/services/xai/llm.py
+++ b/src/pipecat/services/xai/llm.py
@@ -56,7 +56,7 @@ class GrokLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Grok's API.
             base_url: The base URL for Grok API. Defaults to "https://api.x.ai/v1".
-            model: The model identifier to use. Defaults to "grok-3".
+            model: The model identifier to use. Defaults to "grok-4.20-non-reasoning".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=GrokLLMService.Settings(model=...)`` instead.
@@ -67,7 +67,7 @@ class GrokLLMService(OpenAILLMService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="grok-3",
+            model="grok-4.20-non-reasoning",
         )
 
         # 2. Apply direct init arg overrides (deprecated)


### PR DESCRIPTION
## Summary

- xAI is retiring `grok-3` from their API on May 15, 2026
- Switch the `GrokLLMService` default model to `grok-4.20-non-reasoning`, which xAI recommends for non-reasoning workloads and is appropriate for real-time voice AI

## Test plan

- [ ] Run an existing xAI/Grok example and confirm the default model is accepted by the API and produces conversational output

🤖 Generated with [Claude Code](https://claude.com/claude-code)