### PR TITLE
Fix video_out_bitrate deprecation docstring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ All data flows as **Frame** objects through a pipeline of **FrameProcessors**:
 ## Code Style
 
 - **Docstrings**: Google-style. Classes describe purpose; `__init__` has `Args:` section; dataclasses use `Parameters:` section.
+- **Deprecations**: Use the `.. deprecated:: <version>` Sphinx directive in docstrings (never inline tags like `[DEPRECATED]`), and pair it with a runtime `warnings.warn(..., DeprecationWarning)` at the call site. See `CONTRIBUTING.md` for full conventions.
 - **Linting**: Ruff (line length 100). Pre-commit hooks enforce formatting.
 - **Type hints**: Required for complex async code.
 - **Dataclass vs Pydantic**: Use `@dataclass` for frames and internal pipeline data (high-frequency, no validation needed). Use Pydantic `BaseModel` for configuration, parameters, metrics, and external API data (benefits from validation and serialization). Specifically:
@@ -138,6 +139,22 @@ class MyService(LLMService):
             **kwargs: Additional arguments passed to parent.
         """
         super().__init__(**kwargs)
+
+
+# Pydantic params class with a deprecated field
+class MyParams(BaseModel):
+    """Configuration parameters for MyService.
+
+    Parameters:
+        new_setting: Replacement for ``old_setting``.
+        old_setting: Legacy setting, no longer used.
+
+            .. deprecated:: 1.2.0
+                Use ``new_setting`` instead. Will be removed in 2.0.0.
+    """
+
+    new_setting: str = "default"
+    old_setting: str | None = None
 ```
 
 ## Service Implementation

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -47,7 +47,13 @@ class TransportParams(BaseModel):
         video_out_is_live: Enable real-time video output streaming.
         video_out_width: Video output width in pixels.
         video_out_height: Video output height in pixels.
-        video_out_bitrate: [DEPRECATED] Video output bitrate in bits per second.
+        video_out_bitrate: Video output bitrate in bits per second.
+
+            .. deprecated:: 1.1.0
+                Use provider-specific settings instead (e.g.,
+                ``DailyParams.camera_out_send_settings``). This parameter will
+                be removed in 2.0.0.
+
         video_out_framerate: Video output frame rate in FPS.
         video_out_color_format: Video output color format string.
         video_out_codec: Preferred video codec for output (e.g., 'VP8', 'H264', 'H265').


### PR DESCRIPTION
## Summary

- Replaced the inline `[DEPRECATED]` tag on `TransportParams.video_out_bitrate` with a `.. deprecated:: 1.1.0` Sphinx directive, matching the deprecation conventions documented in `CONTRIBUTING.md`. The runtime `warnings.warn()` for this parameter was already in place in `base_output.py`; the docstring change just gets the deprecation to render properly in the docs.
- Added a deprecation convention bullet and a Pydantic `Parameters:` example to `CLAUDE.md`'s Code Style section so future edits (by humans or Claude Code) follow the directive convention instead of inline `[DEPRECATED]` tags.

## Test plan

- [ ] Confirm the rendered docs show the deprecation block under `video_out_bitrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)