### PR TITLE
[codex] Fix Korean Cartesia timestamp spacing

### DIFF
--- a/changelog/4453.fixed.md
+++ b/changelog/4453.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Cartesia Korean word timestamp handling so assistant transcript text preserves spaces between Korean words.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -26,6 +26,7 @@ from pipecat.frames.frames import (
     TTSAudioRawFrame,
     TTSStoppedFrame,
 )
+from pipecat.services.cartesia.utils import process_word_timestamps_for_language
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, assert_given
 from pipecat.services.tts_service import TextAggregationMode, TTSService, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
@@ -395,19 +396,6 @@ class CartesiaTTSService(WebsocketTTSService):
         """Convenience method to create a speed tag."""
         return f'<speed ratio="{speed}" />'
 
-    def _is_cjk_language(self, language: str) -> bool:
-        """Check if the given language is CJK (Chinese, Japanese, Korean).
-
-        Args:
-            language: The language code to check.
-
-        Returns:
-            True if the language is Chinese, Japanese, or Korean.
-        """
-        cjk_languages = {"zh", "ja", "ko"}
-        base_lang = language.split("-")[0].lower()
-        return base_lang in cjk_languages
-
     def _process_word_timestamps_for_language(
         self, words: list[str], starts: list[float]
     ) -> list[tuple[str, float]]:
@@ -415,8 +403,9 @@ class CartesiaTTSService(WebsocketTTSService):
 
         For CJK languages, Cartesia groups related characters in the same timestamp message.
         For example, in Japanese a single message might be `['こ', 'ん', 'に', 'ち', 'は', '。']`.
-        We combine these into single words so the downstream aggregator can add natural
-        spacing between meaningful units rather than individual characters.
+        We combine these into single timestamp entries so the downstream aggregator can add
+        natural spacing between meaningful units rather than individual characters. Chinese
+        and Japanese do not use inter-word spaces, but Korean does.
 
         For non-CJK languages, words are already properly separated and are used as-is.
 
@@ -428,20 +417,7 @@ class CartesiaTTSService(WebsocketTTSService):
             List of (word, start_time) tuples processed for the language.
         """
         current_language = assert_given(self._settings.language)
-
-        # Check if this is a CJK language (if language is None, treat as non-CJK)
-        if current_language and self._is_cjk_language(current_language):
-            # For CJK languages, combine all characters in this message into one word
-            # using the first character's start time
-            if words and starts:
-                combined_word = "".join(words)
-                first_start = starts[0]
-                return [(combined_word, first_start)]
-            else:
-                return []
-        else:
-            # For non-CJK languages, use as-is
-            return list(zip(words, starts))
+        return process_word_timestamps_for_language(words, starts, current_language)
 
     def _build_msg(
         self,

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -399,23 +399,7 @@ class CartesiaTTSService(WebsocketTTSService):
     def _process_word_timestamps_for_language(
         self, words: list[str], starts: list[float]
     ) -> list[tuple[str, float]]:
-        """Process word timestamps based on the current language.
-
-        For CJK languages, Cartesia groups related characters in the same timestamp message.
-        For example, in Japanese a single message might be `['こ', 'ん', 'に', 'ち', 'は', '。']`.
-        We combine these into single timestamp entries so the downstream aggregator can add
-        natural spacing between meaningful units rather than individual characters. Chinese
-        and Japanese do not use inter-word spaces, but Korean does.
-
-        For non-CJK languages, words are already properly separated and are used as-is.
-
-        Args:
-            words: List of words/characters from Cartesia.
-            starts: List of start timestamps for each word/character.
-
-        Returns:
-            List of (word, start_time) tuples processed for the language.
-        """
+        """Normalize word timestamps based on the configured language."""
         current_language = assert_given(self._settings.language)
         return process_word_timestamps_for_language(words, starts, current_language)
 

--- a/src/pipecat/services/cartesia/utils.py
+++ b/src/pipecat/services/cartesia/utils.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Utilities for Cartesia service implementations."""
+
+
+def is_cjk_language(language: str) -> bool:
+    """Check if the given language is CJK (Chinese, Japanese, Korean).
+
+    Args:
+        language: The language code to check.
+
+    Returns:
+        True if the language is Chinese, Japanese, or Korean.
+    """
+    cjk_languages = {"zh", "ja", "ko"}
+    base_lang = language.split("-")[0].lower()
+    return base_lang in cjk_languages
+
+
+def is_korean_language(language: str) -> bool:
+    """Check if the given language is Korean.
+
+    Args:
+        language: The language code to check.
+
+    Returns:
+        True if the language is Korean.
+    """
+    base_lang = language.split("-")[0].lower()
+    return base_lang == "ko"
+
+
+def process_word_timestamps_for_language(
+    words: list[str],
+    starts: list[float],
+    language: str | None,
+) -> list[tuple[str, float]]:
+    """Process Cartesia word timestamps based on the current language.
+
+    For CJK languages, Cartesia groups related characters in the same timestamp message.
+    For example, in Japanese a single message might be `['こ', 'ん', 'に', 'ち', 'は', '。']`.
+    We combine these into single timestamp entries so the downstream aggregator can add
+    natural spacing between meaningful units rather than individual characters. Chinese
+    and Japanese do not use inter-word spaces, but Korean does.
+
+    For non-CJK languages, words are already properly separated and are used as-is.
+
+    Args:
+        words: List of words/characters from Cartesia.
+        starts: List of start timestamps for each word/character.
+        language: Language code to process timestamps for.
+
+    Returns:
+        List of (word, start_time) tuples processed for the language.
+    """
+    if language and is_cjk_language(language):
+        # For CJK languages, combine all characters in this message into one timestamp
+        # entry using the first character's start time. Korean uses spaces between
+        # words, while Chinese and Japanese do not.
+        if words and starts:
+            separator = " " if is_korean_language(language) else ""
+            combined_word = separator.join(words)
+            first_start = starts[0]
+            return [(combined_word, first_start)]
+        else:
+            return []
+    else:
+        return list(zip(words, starts))

--- a/src/pipecat/services/cartesia/utils.py
+++ b/src/pipecat/services/cartesia/utils.py
@@ -7,29 +7,12 @@
 """Utilities for Cartesia service implementations."""
 
 
-def is_cjk_language(language: str) -> bool:
-    """Check if the given language is CJK (Chinese, Japanese, Korean).
-
-    Args:
-        language: The language code to check.
-
-    Returns:
-        True if the language is Chinese, Japanese, or Korean.
-    """
-    cjk_languages = {"zh", "ja", "ko"}
+def _is_cjk_language(language: str) -> bool:
     base_lang = language.split("-")[0].lower()
-    return base_lang in cjk_languages
+    return base_lang in {"zh", "ja", "ko"}
 
 
-def is_korean_language(language: str) -> bool:
-    """Check if the given language is Korean.
-
-    Args:
-        language: The language code to check.
-
-    Returns:
-        True if the language is Korean.
-    """
+def _is_korean_language(language: str) -> bool:
     base_lang = language.split("-")[0].lower()
     return base_lang == "ko"
 
@@ -39,33 +22,21 @@ def process_word_timestamps_for_language(
     starts: list[float],
     language: str | None,
 ) -> list[tuple[str, float]]:
-    """Process Cartesia word timestamps based on the current language.
-
-    For CJK languages, Cartesia groups related characters in the same timestamp message.
-    For example, in Japanese a single message might be `['こ', 'ん', 'に', 'ち', 'は', '。']`.
-    We combine these into single timestamp entries so the downstream aggregator can add
-    natural spacing between meaningful units rather than individual characters. Chinese
-    and Japanese do not use inter-word spaces, but Korean does.
-
-    For non-CJK languages, words are already properly separated and are used as-is.
+    """Normalize Cartesia word timestamps for the current language.
 
     Args:
-        words: List of words/characters from Cartesia.
-        starts: List of start timestamps for each word/character.
-        language: Language code to process timestamps for.
+        words: Words or characters from Cartesia.
+        starts: Start timestamps for each item in ``words``.
+        language: Language code to normalize for.
 
     Returns:
-        List of (word, start_time) tuples processed for the language.
+        Word timestamp pairs normalized for downstream transcript aggregation.
     """
-    if language and is_cjk_language(language):
-        # For CJK languages, combine all characters in this message into one timestamp
-        # entry using the first character's start time. Korean uses spaces between
-        # words, while Chinese and Japanese do not.
+    if language and _is_cjk_language(language):
         if words and starts:
-            separator = " " if is_korean_language(language) else ""
+            separator = " " if _is_korean_language(language) else ""
             combined_word = separator.join(words)
-            first_start = starts[0]
-            return [(combined_word, first_start)]
+            return [(combined_word, starts[0])]
         else:
             return []
     else:

--- a/tests/test_cartesia_tts.py
+++ b/tests/test_cartesia_tts.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from pipecat.services.cartesia.utils import process_word_timestamps_for_language
+
+
+def test_cartesia_cjk_word_timestamps_join_chinese_without_spaces():
+    assert process_word_timestamps_for_language(
+        words=["你", "好", "。"],
+        starts=[0.0, 0.1, 0.2],
+        language="zh",
+    ) == [("你好。", 0.0)]
+
+
+def test_cartesia_cjk_word_timestamps_join_japanese_without_spaces():
+    assert process_word_timestamps_for_language(
+        words=["こ", "ん", "に", "ち", "は", "。"],
+        starts=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+        language="ja",
+    ) == [("こんにちは。", 0.0)]
+
+
+def test_cartesia_korean_word_timestamps_join_with_spaces():
+    assert process_word_timestamps_for_language(
+        words=["안녕하세요", "반갑습니다"],
+        starts=[0.0, 0.2],
+        language="ko",
+    ) == [("안녕하세요 반갑습니다", 0.0)]


### PR DESCRIPTION
## What changed
- Keep Cartesia Chinese and Japanese timestamp groups joined without spaces.
- Join Cartesia Korean timestamp groups with spaces so assistant transcripts preserve Korean word spacing.
- Move the timestamp normalization into a small Cartesia utility so the behavior is unit tested without websocket extras.
- Added the required changelog fragment: changelog/4453.fixed.md.

## Why
Cartesia groups CJK timestamp tokens before Pipecat rebuilds assistant transcript text. Korean uses spaces between words, so handling it like Chinese/Japanese can collapse Korean spacing in displayed assistant transcripts.

## Repository checks
- Confirmed CONTRIBUTING.md requirements: changelog fragment, ruff style, tests, Google-style docstrings for public helpers.
- Confirmed .github/PULL_REQUEST_TEMPLATE.md only asks for a clear change description.
- Trimmed helper/wrapper docs so the PR does not add broad explanatory comments beyond the small public utility docstring.

## Validation
- uv run pytest tests/test_cartesia_tts.py
- uv run --extra websockets-base pytest tests/test_tts_frame_ordering.py tests/test_context_aggregators_universal.py
- uv run ruff format --diff
- uv run ruff check
- uv run pyright src/pipecat/services/cartesia/tts.py src/pipecat/services/cartesia/utils.py tests/test_cartesia_tts.py
- uv run towncrier build --draft --version Unreleased

Note: full uv run pyright currently reports pre-existing errors outside this PR in scripts/daily/test_tavus_transport.py and src/pipecat/utils/tracing/turn_trace_observer.py; changed files pass targeted pyright.