### PR TITLE
Fix PipelineTask cancellation before StartFrame reaches sink

### DIFF
--- a/changelog/4455.fixed.md
+++ b/changelog/4455.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `PipelineTask.cancel()` hanging when cancellation is requested before the initial `StartFrame` reaches the pipeline sink.

--- a/src/pipecat/pipeline/task.py
+++ b/src/pipecat/pipeline/task.py
@@ -650,6 +650,8 @@ class PipelineTask(BasePipelineTask):
         if not self._cancelled:
             logger.debug(f"Cancelling pipeline task {self}")
             self._cancelled = True
+            if not self._pipeline_start_event.is_set():
+                self._pipeline_start_event.set()
             await self.queue_frame(CancelFrame(reason=reason))
 
     async def _create_tasks(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -625,6 +625,33 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
         except asyncio.CancelledError:
             assert cancelled
 
+    async def test_task_cancel_before_start_reaches_sink(self):
+        class StartBlocker(FrameProcessor):
+            def __init__(self, *, start_received: asyncio.Event, **kwargs):
+                super().__init__(**kwargs)
+                self._start_received = start_received
+                self._block = asyncio.Event()
+
+            async def process_frame(self, frame: Frame, direction: FrameDirection):
+                await super().process_frame(frame, direction)
+
+                if isinstance(frame, StartFrame):
+                    self._start_received.set()
+                    await self._block.wait()
+
+                await self.push_frame(frame, direction)
+
+        start_received = asyncio.Event()
+        pipeline = Pipeline([StartBlocker(start_received=start_received)])
+        task = PipelineTask(pipeline, cancel_timeout_secs=0.1)
+
+        run_task = asyncio.create_task(task.run(PipelineTaskParams(loop=asyncio.get_event_loop())))
+        await start_received.wait()
+        await task.cancel()
+        await asyncio.wait_for(run_task, timeout=1.0)
+
+        assert task.has_finished()
+
     async def test_task_error(self):
         class ErrorProcessor(FrameProcessor):
             def __init__(self, **kwargs):


### PR DESCRIPTION
Fixes #4276.

This prevents `PipelineTask.cancel()` from hanging when cancellation is requested before the initial `StartFrame` reaches the pipeline sink.

Previously, `_process_push_queue()` could be blocked in `_wait_for_pipeline_start()`, while the `CancelFrame` was queued behind that wait and never consumed. This change unblocks the startup wait during cancellation so the queued `CancelFrame` can be processed normally.

Added a regression test that blocks `StartFrame` before it reaches the sink, calls `task.cancel()`, and verifies the task finishes instead of hanging.

Testing:
- `uv run pytest tests/test_pipeline.py::TestPipelineTask::test_task_cancel_before_start_reaches_sink`
- `uv run pytest tests/test_pipeline.py`
- `uv run ruff check src/pipecat/pipeline/task.py tests/test_pipeline.py`
