### PR TITLE
Update default Cartesia TTS model to sonic-3.5

### DIFF
--- a/changelog/4462.changed.md
+++ b/changelog/4462.changed.md
@@ -1,0 +1,1 @@
+- Updated the default model for `CartesiaTTSService` and `CartesiaHttpTTSService` from `sonic-3` to `sonic-3.5`.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -304,7 +304,7 @@ class CartesiaTTSService(WebsocketTTSService):
 
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="sonic-3",
+            model="sonic-3.5",
             voice=None,
             language=Language.EN,
             generation_config=None,
@@ -801,7 +801,7 @@ class CartesiaHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="sonic-3",
+            model="sonic-3.5",
             voice=None,
             language=Language.EN,
             generation_config=None,


### PR DESCRIPTION
## Summary

- Updated the default model for `CartesiaTTSService` and `CartesiaHttpTTSService` from `sonic-3` to `sonic-3.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)