### PR TITLE
Remove vad_analyzer from create_transport docstring example

### DIFF
--- a/src/pipecat/runner/utils.py
+++ b/src/pipecat/runner/utils.py
@@ -509,35 +509,29 @@ async def create_transport(
             "daily": lambda: DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
             ),
             "webrtc": lambda: TransportParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
             ),
             "twilio": lambda: FastAPIWebsocketParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
                 # add_wav_header and serializer will be set automatically
             ),
             "telnyx": lambda: FastAPIWebsocketParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
                 # add_wav_header and serializer will be set automatically
             ),
             "plivo": lambda: FastAPIWebsocketParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
                 # add_wav_header and serializer will be set automatically
             ),
             "exotel": lambda: FastAPIWebsocketParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,
-                vad_analyzer=SileroVADAnalyzer(),
                 # add_wav_header and serializer will be set automatically
             ),
         }


### PR DESCRIPTION
## Summary

Removes the `vad_analyzer=SileroVADAnalyzer()` lines from the `create_transport` docstring example in `src/pipecat/runner/utils.py`. The example now shows transport params without a hardcoded VAD analyzer.

## Changes

- Drop `vad_analyzer=SileroVADAnalyzer()` from each transport factory in the `create_transport` docstring `Example::` block (daily, webrtc, twilio, telnyx, plivo, exotel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)