### PR TITLE
Fix GStreamer pipeline source pyright import

### DIFF
--- a/src/pipecat/processors/gstreamer/pipeline_source.py
+++ b/src/pipecat/processors/gstreamer/pipeline_source.py
@@ -27,7 +27,7 @@ try:
 
     gi.require_version("Gst", "1.0")
     gi.require_version("GstApp", "1.0")
-    from gi.repository import Gst, GstApp
+    from gi.repository import Gst, GstApp  # pyright: ignore[reportAttributeAccessIssue]
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(


### PR DESCRIPTION
## Summary

- Fixed Pyright checks failing on the GStreamer pipeline source because `Gst` and `GstApp` are exposed through dynamic `gi.repository` imports
- No changelog since this fix is transparent

## Testing

- `uv run pyright`