### PR TITLE
Switch OpenAIRealtimeLLMService default model to gpt-realtime-2

### DIFF
--- a/changelog/4472.changed.md
+++ b/changelog/4472.changed.md
@@ -1,0 +1,1 @@
+- Changed the default model for `OpenAIRealtimeLLMService` from `gpt-realtime-1.5` to `gpt-realtime-2`.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -254,7 +254,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="gpt-realtime-1.5",
+            model="gpt-realtime-2",
             system_instruction=None,
             temperature=None,
             max_tokens=None,


### PR DESCRIPTION
## Summary

Switches the default model for `OpenAIRealtimeLLMService` from `gpt-realtime-1.5` to `gpt-realtime-2`.

## Test plan

- [x] Verify a fresh `OpenAIRealtimeLLMService(api_key=...)` (no model override) connects against `gpt-realtime-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)