### PR TITLE
Update image processing to use image mode instead of format

### DIFF
--- a/changelog/4483.fixed.md
+++ b/changelog/4483.fixed.md
@@ -1,0 +1,1 @@
+- Fixed output image resizing for generated images when video output dimensions differ from the source image size by consistently using Pillow pixel modes instead of encoded formats.

--- a/src/pipecat/services/azure/image.py
+++ b/src/pipecat/services/azure/image.py
@@ -156,6 +156,6 @@ class AzureImageGenServiceREST(ImageGenService):
                 image_stream = io.BytesIO(await response.content.read())
                 image = Image.open(image_stream)
                 frame = URLImageRawFrame(
-                    url=image_url, image=image.tobytes(), size=image.size, format=image.format
+                    url=image_url, image=image.tobytes(), size=image.size, format=image.mode
                 )
                 yield frame

--- a/src/pipecat/services/fal/image.py
+++ b/src/pipecat/services/fal/image.py
@@ -181,7 +181,7 @@ class FalImageGenService(ImageGenService):
         def load_image_bytes(encoded_image: bytes):
             buffer = io.BytesIO(encoded_image)
             image = Image.open(buffer)
-            return (image.tobytes(), image.size, image.format)
+            return (image.tobytes(), image.size, image.mode)
 
         logger.debug(f"Generating image from prompt: {prompt}")
 

--- a/src/pipecat/services/google/image.py
+++ b/src/pipecat/services/google/image.py
@@ -181,7 +181,7 @@ class GoogleImageGenService(ImageGenService):
                     url=None,  # Google doesn't provide URLs, only image data
                     image=image.tobytes(),
                     size=image.size,
-                    format=image.format,
+                    format=image.mode,
                 )
                 yield frame
 

--- a/src/pipecat/services/openai/image.py
+++ b/src/pipecat/services/openai/image.py
@@ -162,7 +162,7 @@ class OpenAIImageGenService(ImageGenService):
             frame = URLImageRawFrame(
                 image=image.tobytes(),
                 size=image.size,
-                format=image.format,
+                format=image.mode,
                 url=image_url,
             )
             yield frame

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -945,7 +945,7 @@ class BaseOutputTransport(FrameProcessor):
                     resized_image = image.resize(desired_size)
                     # logger.warning(f"{frame} does not have the expected size {desired_size}, resizing")
                     frame = OutputImageRawFrame(
-                        resized_image.tobytes(), resized_image.size, resized_image.format
+                        resized_image.tobytes(), resized_image.size, resized_image.mode
                     )
 
                 return frame


### PR DESCRIPTION
# Fix #2155 
## Summary
Fix image resize failures in output transport by using Pillow pixel modes (`image.mode`) instead of encoded formats (`image.format`) when constructing and propagating `OutputImageRawFrame` metadata.

### Root cause
`BaseOutputTransport` resize logic uses `Image.frombytes(frame.format, frame.size, frame.image)`, where `frame.format` must be an image mode (`RGB`, `RGBA`, etc.). Several image generation services were setting `frame.format` from `image.format` (`PNG`, `JPEG`), causing `ValueError: unrecognized image mode` whenever resizing occurred.

### Changes
- Updated image frame construction to use `image.mode` in:
  - `src/pipecat/services/openai/image.py`
  - `src/pipecat/services/google/image.py`
  - `src/pipecat/services/azure/image.py`
  - `src/pipecat/services/fal/image.py`
- Updated resized frame metadata in:
  - `src/pipecat/transports/base_output.py`
  - `resized_image.format` -> `resized_image.mode`