### PR TITLE
Expose LiveKit transport options and subscription failures

### DIFF
--- a/changelog/4489.added.md
+++ b/changelog/4489.added.md
@@ -1,0 +1,1 @@
+- Added `single_peer_connection` configuration and track subscription failure callbacks to the LiveKit transport.

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -96,10 +96,12 @@ class LiveKitOutputTransportMessageUrgentFrame(OutputTransportMessageUrgentFrame
 class LiveKitParams(TransportParams):
     """Configuration parameters for LiveKit transport.
 
-    Inherits all parameters from TransportParams without additional configuration.
+    Parameters:
+        single_peer_connection: Use a single WebRTC peer connection for both publishing
+            and subscribing. When None, LiveKit uses its default connection behavior.
     """
 
-    pass
+    single_peer_connection: bool | None = None
 
 
 class LiveKitCallbacks(BaseModel):
@@ -112,6 +114,7 @@ class LiveKitCallbacks(BaseModel):
         on_participant_disconnected: Called when a participant leaves the room.
         on_audio_track_subscribed: Called when an audio track is subscribed.
         on_audio_track_unsubscribed: Called when an audio track is unsubscribed.
+        on_track_subscription_failed: Called when a track subscription fails.
         on_data_received: Called when data is received from a participant.
         on_first_participant_joined: Called when the first participant joins.
     """
@@ -125,6 +128,7 @@ class LiveKitCallbacks(BaseModel):
     on_audio_track_unsubscribed: Callable[[str], Awaitable[None]]
     on_video_track_subscribed: Callable[[str], Awaitable[None]]
     on_video_track_unsubscribed: Callable[[str], Awaitable[None]]
+    on_track_subscription_failed: Callable[[str, str, str], Awaitable[None]]
     on_data_received: Callable[[bytes, str], Awaitable[None]]
     on_first_participant_joined: Callable[[str], Awaitable[None]]
 
@@ -215,6 +219,7 @@ class LiveKitTransportClient:
         self.room.on("participant_disconnected")(self._on_participant_disconnected_wrapper)
         self.room.on("track_subscribed")(self._on_track_subscribed_wrapper)
         self.room.on("track_unsubscribed")(self._on_track_unsubscribed_wrapper)
+        self.room.on("track_subscription_failed")(self._on_track_subscription_failed_wrapper)
         self.room.on("data_received")(self._on_data_received_wrapper)
         self.room.on("connected")(self._on_connected_wrapper)
         self.room.on("disconnected")(self._on_disconnected_wrapper)
@@ -243,10 +248,13 @@ class LiveKitTransportClient:
             logger.info(f"Connecting to {self._room_name}")
 
             try:
+                room_options = rtc.RoomOptions(auto_subscribe=True)
+                room_options.single_peer_connection = self._params.single_peer_connection
+
                 await self.room.connect(
                     self._url,
                     self._token,
-                    options=rtc.RoomOptions(auto_subscribe=True),
+                    options=room_options,
                 )
                 self._connected = True
                 # Increment disconnect counter if we successfully connected.
@@ -456,6 +464,18 @@ class LiveKitTransportClient:
             f"{self}::_async_on_track_unsubscribed",
         )
 
+    def _on_track_subscription_failed_wrapper(
+        self,
+        participant: rtc.RemoteParticipant,
+        track_sid: str,
+        error: str,
+    ):
+        """Wrapper for track subscription failed events."""
+        self._task_manager.create_task(
+            self._async_on_track_subscription_failed(participant, track_sid, error),
+            f"{self}::_async_on_track_subscription_failed",
+        )
+
     def _on_data_received_wrapper(self, data: rtc.DataPacket):
         """Wrapper for data received events."""
         self._task_manager.create_task(
@@ -530,6 +550,18 @@ class LiveKitTransportClient:
             await self._callbacks.on_audio_track_unsubscribed(participant.sid)
         elif track.kind == rtc.TrackKind.KIND_VIDEO:
             await self._callbacks.on_video_track_unsubscribed(participant.sid)
+
+    async def _async_on_track_subscription_failed(
+        self,
+        participant: rtc.RemoteParticipant,
+        track_sid: str,
+        error: str,
+    ):
+        """Handle track subscription failed events."""
+        logger.warning(
+            f"Track subscription failed: {track_sid} from participant {participant.sid}: {error}"
+        )
+        await self._callbacks.on_track_subscription_failed(participant.sid, track_sid, error)
 
     async def _async_on_data_received(self, data: rtc.DataPacket):
         """Handle data received events."""
@@ -953,6 +985,8 @@ class LiveKitTransport(BaseTransport):
       Args: (participant_id: str)
     - on_video_track_unsubscribed: Called when a video track is unsubscribed.
       Args: (participant_id: str)
+    - on_track_subscription_failed: Called when a track subscription fails.
+      Args: (participant_id: str, track_sid: str, error: str)
     - on_data_received: Called when data is received from a participant.
       Args: (data: bytes, participant_id: str)
 
@@ -998,6 +1032,7 @@ class LiveKitTransport(BaseTransport):
             on_audio_track_unsubscribed=self._on_audio_track_unsubscribed,
             on_video_track_subscribed=self._on_video_track_subscribed,
             on_video_track_unsubscribed=self._on_video_track_unsubscribed,
+            on_track_subscription_failed=self._on_track_subscription_failed,
             on_data_received=self._on_data_received,
             on_first_participant_joined=self._on_first_participant_joined,
         )
@@ -1017,6 +1052,7 @@ class LiveKitTransport(BaseTransport):
         self._register_event_handler("on_audio_track_unsubscribed")
         self._register_event_handler("on_video_track_subscribed")
         self._register_event_handler("on_video_track_unsubscribed")
+        self._register_event_handler("on_track_subscription_failed")
         self._register_event_handler("on_data_received")
         self._register_event_handler("on_first_participant_joined")
         self._register_event_handler("on_participant_left")
@@ -1160,6 +1196,12 @@ class LiveKitTransport(BaseTransport):
     async def _on_video_track_unsubscribed(self, participant_id: str):
         """Handle video track unsubscribed events."""
         await self._call_event_handler("on_video_track_unsubscribed", participant_id)
+
+    async def _on_track_subscription_failed(self, participant_id: str, track_sid: str, error: str):
+        """Handle track subscription failed events."""
+        await self._call_event_handler(
+            "on_track_subscription_failed", participant_id, track_sid, error
+        )
 
     async def _on_data_received(self, data: bytes, participant_id: str):
         """Handle data received events."""

--- a/tests/test_livekit_transport.py
+++ b/tests/test_livekit_transport.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Tests for LiveKit transport video stream handling.
+"""Tests for LiveKit transport behavior.
 
 Regression tests for issue #3116: Memory leak when video_in_enabled=False
 but video tracks are subscribed. The fix ensures video stream processing
@@ -29,19 +29,25 @@ except ImportError:
 
 
 @unittest.skipUnless(LIVEKIT_AVAILABLE, "livekit package not installed")
-class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
-    """Regression tests for video queue memory leak (#3116).
+class TestLiveKitTransportClient(unittest.IsolatedAsyncioTestCase):
+    """Tests for the LiveKit transport client.
 
-    The bug: When video_in_enabled=False, subscribing to a video track would
-    start a producer that fills _video_queue, but no consumer would drain it,
-    causing unbounded memory growth (~3GB/min).
+    Includes regression tests for the video queue memory leak (#3116). When
+    video_in_enabled=False, subscribing to a video track would start a producer
+    that fills _video_queue, but no consumer would drain it, causing unbounded
+    memory growth.
 
-    The fix: Only start video stream processing when video_in_enabled=True.
+    The fix was to only start video stream processing when video_in_enabled=True.
     """
 
-    def _create_client(self, video_in_enabled: bool) -> LiveKitTransportClient:
+    def _create_client(
+        self, video_in_enabled: bool, single_peer_connection: bool | None = None
+    ) -> "LiveKitTransportClient":
         """Create a client with the specified video input setting."""
-        params = LiveKitParams(video_in_enabled=video_in_enabled)
+        params = LiveKitParams(
+            video_in_enabled=video_in_enabled,
+            single_peer_connection=single_peer_connection,
+        )
         callbacks = LiveKitCallbacks(
             on_connected=AsyncMock(),
             on_disconnected=AsyncMock(),
@@ -52,6 +58,7 @@ class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
             on_audio_track_unsubscribed=AsyncMock(),
             on_video_track_subscribed=AsyncMock(),
             on_video_track_unsubscribed=AsyncMock(),
+            on_track_subscription_failed=AsyncMock(),
             on_data_received=AsyncMock(),
             on_first_participant_joined=AsyncMock(),
         )
@@ -64,6 +71,7 @@ class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
             transport_name="test-transport",
         )
         client._task_manager = MagicMock()
+        client._task_manager.create_task.side_effect = lambda coro, _name: coro.close()
         return client
 
     def _create_mock_video_track(self):
@@ -118,6 +126,48 @@ class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
 
         # Callback should fire
         client._callbacks.on_video_track_subscribed.assert_called_once()
+
+    async def test_single_peer_connection_is_passed_to_room_options(self):
+        """When configured, single_peer_connection should be forwarded to LiveKit."""
+        out_sample_rate = 16000
+        local_participant_id = "local-participant"
+
+        client = self._create_client(video_in_enabled=False, single_peer_connection=True)
+        client._out_sample_rate = out_sample_rate
+
+        room = MagicMock()
+        room.connect = AsyncMock()
+        room.local_participant.sid = local_participant_id
+        room.local_participant.publish_track = AsyncMock()
+        room.remote_participants = {}
+        client._room = room
+
+        with (
+            patch.object(rtc, "AudioSource"),
+            patch.object(rtc.LocalAudioTrack, "create_audio_track", return_value=MagicMock()),
+            patch.object(rtc, "TrackPublishOptions", return_value=MagicMock()),
+        ):
+            await client.connect()
+
+        room_options = room.connect.call_args.kwargs["options"]
+        self.assertTrue(room_options.auto_subscribe)
+        self.assertTrue(room_options.single_peer_connection)
+
+    async def test_track_subscription_failed_callback_fires(self):
+        """Track subscription failures should be exposed through transport callbacks."""
+        participant_id = "participant-456"
+        track_sid = "track-123"
+        error = "track not bound"
+
+        client = self._create_client(video_in_enabled=False)
+        participant = MagicMock()
+        participant.sid = participant_id
+
+        await client._async_on_track_subscription_failed(participant, track_sid, error)
+
+        client._callbacks.on_track_subscription_failed.assert_awaited_once_with(
+            participant_id, track_sid, error
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
During testing with LiveKit and Pipecat, we saw SIP audio tracks publish successfully but Pipecat fail to subscribe with track not bound, so this adds LiveKitParams(single_peer_connection=True) as a possible mitigation and on_track_subscription_failed(participant_id, track_sid, error) as an API hook for detecting the failure and triggering recovery.

## Summary
- add LiveKitParams.single_peer_connection and forward it to rtc.RoomOptions
- register LiveKit track_subscription_failed events and expose an on_track_subscription_failed transport callback
- add LiveKit transport tests for both behaviors

## Tests
- uv run ruff format --check src/pipecat/transports/livekit/transport.py tests/test_livekit_transport.py
- uv run ruff check src/pipecat/transports/livekit/transport.py tests/test_livekit_transport.py
- uv run --extra livekit pytest tests/test_livekit_transport.py