### PR TITLE
fix(smallwebrtc): clear dead track ref on MediaStreamError

### DIFF
--- a/changelog/4491.fixed.md
+++ b/changelog/4491.fixed.md
@@ -1,5 +1,7 @@
-- Fixed `SmallWebRTCClient.read_audio_frame` and `read_video_frame` looping
-  forever after `MediaStreamError`. On a permanently-failed track, the
-  generators now exit cleanly so the receive task can finish — previously they
-  caught the error, slept 10 ms, and retried `recv()` indefinitely, leaving
-  the receive task wedged.
+- Fixed `SmallWebRTCClient.read_audio_frame` and `read_video_frame` busy-looping
+  on `MediaStreamError`. When a track raises `MediaStreamError`, the generator
+  now clears the track reference (`_audio_input_track` / `_video_input_track` /
+  `_screen_video_track`) so the loop parks on the existing `is None` gate
+  instead of re-entering `recv()` at ~100 Hz on a permanently-failed track.
+  Renegotiation still resumes seamlessly: when `_handle_client_connected`
+  reassigns a fresh track, the loop picks up frames from the new track.

--- a/changelog/4491.fixed.md
+++ b/changelog/4491.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `SmallWebRTCClient.read_audio_frame` and `read_video_frame` looping
+  forever after `MediaStreamError`. On a permanently-failed track, the
+  generators now exit cleanly so the receive task can finish — previously they
+  caught the error, slept 10 ms, and retried `recv()` indefinitely, leaving
+  the receive task wedged.

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -15,7 +15,8 @@ import asyncio
 import fractions
 import time
 from collections import deque
-from typing import Any, Awaitable, Callable, List, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import numpy as np
 from loguru import logger
@@ -235,9 +236,9 @@ class SmallWebRTCClient:
 
         self._audio_output_track = None
         self._video_output_track = None
-        self._audio_input_track: Optional[AudioStreamTrack] = None
-        self._video_input_track: Optional[VideoStreamTrack] = None
-        self._screen_video_track: Optional[VideoStreamTrack] = None
+        self._audio_input_track: AudioStreamTrack | None = None
+        self._video_input_track: VideoStreamTrack | None = None
+        self._screen_video_track: VideoStreamTrack | None = None
 
         self._params = None
         self._audio_in_channels = None
@@ -314,7 +315,7 @@ class SmallWebRTCClient:
 
             try:
                 frame = await asyncio.wait_for(video_track.recv(), timeout=2.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 if (
                     self._webrtc_connection.is_connected()
                     and video_track
@@ -324,11 +325,16 @@ class SmallWebRTCClient:
                     # self._webrtc_connection.ask_to_renegotiate()
                 frame = None
             except MediaStreamError:
-                # Track is permanently dead — every subsequent `recv()` will
-                # raise the same error. Exit the generator so the caller's
-                # `async for` returns and the receive task can finish.
-                logger.warning("Media stream error while reading the video; ending iterator.")
-                break
+                # Track is dead — every subsequent `recv()` would raise the same
+                # error and busy-loop the generator at ~100Hz. Clear the track
+                # reference so the loop parks on the `is None` gate above; a
+                # renegotiation that repopulates the track will resume frames.
+                logger.warning("Media stream error while reading the video; clearing track.")
+                if video_source == CAM_VIDEO_SOURCE:
+                    self._video_input_track = None
+                else:
+                    self._screen_video_track = None
+                frame = None
 
             if frame is None or not isinstance(frame, VideoFrame):
                 # If no valid frame, sleep for a bit
@@ -372,7 +378,7 @@ class SmallWebRTCClient:
 
             try:
                 frame = await asyncio.wait_for(self._audio_input_track.recv(), timeout=2.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 if (
                     self._webrtc_connection.is_connected()
                     and self._audio_input_track
@@ -381,11 +387,13 @@ class SmallWebRTCClient:
                     logger.warning("Timeout: No audio frame received within the specified time.")
                 frame = None
             except MediaStreamError:
-                # Track is permanently dead — every subsequent `recv()` will
-                # raise the same error. Exit the generator so the caller's
-                # `async for` returns and the receive task can finish.
-                logger.warning("Media stream error while reading the audio; ending iterator.")
-                break
+                # Track is dead — every subsequent `recv()` would raise the same
+                # error and busy-loop the generator at ~100Hz. Clear the track
+                # reference so the loop parks on the `is None` gate above; a
+                # renegotiation that repopulates the track will resume frames.
+                logger.warning("Media stream error while reading the audio; clearing track.")
+                self._audio_input_track = None
+                frame = None
 
             if frame is None or not isinstance(frame, AudioFrame):
                 # If we don't read any audio let's sleep for a little bit (i.e. busy wait).
@@ -589,7 +597,7 @@ class SmallWebRTCInputTransport(BaseInputTransport):
         self._receive_audio_task = None
         self._receive_video_task = None
         self._receive_screen_video_task = None
-        self._image_requests: List[UserImageRequestFrame] = []
+        self._image_requests: list[UserImageRequestFrame] = []
 
         # Whether we have seen a StartFrame already.
         self._initialized = False
@@ -903,8 +911,8 @@ class SmallWebRTCTransport(BaseTransport):
         self,
         webrtc_connection: SmallWebRTCConnection,
         params: TransportParams,
-        input_name: Optional[str] = None,
-        output_name: Optional[str] = None,
+        input_name: str | None = None,
+        output_name: str | None = None,
     ):
         """Initialize the WebRTC transport.
 
@@ -925,8 +933,8 @@ class SmallWebRTCTransport(BaseTransport):
 
         self._client = SmallWebRTCClient(webrtc_connection, self._callbacks)
 
-        self._input: Optional[SmallWebRTCInputTransport] = None
-        self._output: Optional[SmallWebRTCOutputTransport] = None
+        self._input: SmallWebRTCInputTransport | None = None
+        self._output: SmallWebRTCOutputTransport | None = None
 
         # Register supported handlers. The user will only be able to register
         # these handlers.

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -324,8 +324,11 @@ class SmallWebRTCClient:
                     # self._webrtc_connection.ask_to_renegotiate()
                 frame = None
             except MediaStreamError:
-                logger.warning("Received an unexpected media stream error while reading the video.")
-                frame = None
+                # Track is permanently dead — every subsequent `recv()` will
+                # raise the same error. Exit the generator so the caller's
+                # `async for` returns and the receive task can finish.
+                logger.warning("Media stream error while reading the video; ending iterator.")
+                break
 
             if frame is None or not isinstance(frame, VideoFrame):
                 # If no valid frame, sleep for a bit
@@ -378,8 +381,11 @@ class SmallWebRTCClient:
                     logger.warning("Timeout: No audio frame received within the specified time.")
                 frame = None
             except MediaStreamError:
-                logger.warning("Received an unexpected media stream error while reading the audio.")
-                frame = None
+                # Track is permanently dead — every subsequent `recv()` will
+                # raise the same error. Exit the generator so the caller's
+                # `async for` returns and the receive task can finish.
+                logger.warning("Media stream error while reading the audio; ending iterator.")
+                break
 
             if frame is None or not isinstance(frame, AudioFrame):
                 # If we don't read any audio let's sleep for a little bit (i.e. busy wait).

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the SmallWebRTC transport client iterators."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from aiortc.mediastreams import MediaStreamError
+
+from pipecat.transports.smallwebrtc.transport import (
+    CAM_VIDEO_SOURCE,
+    SmallWebRTCClient,
+)
+
+
+class TestReadAudioFrameMediaStreamError(unittest.IsolatedAsyncioTestCase):
+    async def test_exits_on_media_stream_error(self):
+        """`read_audio_frame` must exit when the track is permanently dead.
+
+        Regression test: previously the generator caught `MediaStreamError`,
+        slept 10 ms, and re-entered the loop — but the next `recv()` raised
+        the same error, so the iterator never terminated and the caller's
+        receive task stayed wedged forever.
+        """
+        fake_self = MagicMock()
+        fake_self._audio_input_track = MagicMock()
+        fake_self._audio_input_track.recv = AsyncMock(
+            side_effect=MediaStreamError("track ended")
+        )
+
+        iterator = SmallWebRTCClient.read_audio_frame(fake_self)
+
+        async def consume():
+            async for _ in iterator:
+                pass
+
+        # Should return promptly; before the fix this would hit the timeout.
+        await asyncio.wait_for(consume(), timeout=1.0)
+
+
+class TestReadVideoFrameMediaStreamError(unittest.IsolatedAsyncioTestCase):
+    async def test_exits_on_media_stream_error(self):
+        """`read_video_frame` must exit when the track is permanently dead.
+
+        Same regression as the audio case.
+        """
+        fake_self = MagicMock()
+        fake_self._video_input_track = MagicMock()
+        fake_self._video_input_track.recv = AsyncMock(
+            side_effect=MediaStreamError("track ended")
+        )
+
+        iterator = SmallWebRTCClient.read_video_frame(fake_self, CAM_VIDEO_SOURCE)
+
+        async def consume():
+            async for _ in iterator:
+                pass
+
+        await asyncio.wait_for(consume(), timeout=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -4,64 +4,206 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Tests for the SmallWebRTC transport client iterators."""
+"""Tests for the SmallWebRTC transport client iterators.
+
+Covers the `MediaStreamError` handling in
+`SmallWebRTCClient.read_audio_frame` and `read_video_frame`:
+
+1. **Park on dead track** — when the underlying aiortc track is permanently
+   raising `MediaStreamError`, the iterator must stop calling `recv()` on it
+   (clear the track reference) so we don't busy-loop a CPU core. Without the
+   fix, the loop hits `recv()` ~100 times per second indefinitely.
+
+2. **Renegotiation resumes** — after the dead track is replaced by a fresh
+   one (the same mechanism `_handle_client_connected` uses), the iterator
+   must pick up frames from the new track. A plain `break` on
+   `MediaStreamError` would terminate the iterator and regress this path.
+"""
 
 import asyncio
+import fractions
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
 from aiortc.mediastreams import MediaStreamError
+from av import AudioFrame, VideoFrame
 
 from pipecat.transports.smallwebrtc.transport import (
     CAM_VIDEO_SOURCE,
+    SCREEN_VIDEO_SOURCE,
     SmallWebRTCClient,
 )
 
 
+def _make_audio_self(track):
+    fake = MagicMock()
+    fake._audio_input_track = track
+    fake._webrtc_connection = MagicMock()
+    fake._webrtc_connection.is_connected.return_value = True
+    fake._in_sample_rate = 16_000
+    fake._audio_in_channels = 1
+    # Passthrough resampler.
+    fake._audio_in_resampler.resample.side_effect = lambda f: [f]
+    return fake
+
+
+def _make_video_self(video_track=None, screen_track=None):
+    fake = MagicMock()
+    fake._video_input_track = video_track
+    fake._screen_video_track = screen_track
+    fake._webrtc_connection = MagicMock()
+    fake._webrtc_connection.is_connected.return_value = True
+    fake._webrtc_connection.pc_id = "test-pc"
+    fake._convert_frame.side_effect = lambda arr, fmt: arr
+    return fake
+
+
+def _good_audio_frame():
+    samples = 320  # 20 ms @ 16 kHz
+    arr = np.zeros((1, samples), dtype=np.int16)
+    f = AudioFrame.from_ndarray(arr, format="s16", layout="mono")
+    f.sample_rate = 16_000
+    f.pts = 0
+    f.time_base = fractions.Fraction(1, 16_000)
+    return f
+
+
+def _good_video_frame():
+    arr = np.zeros((4, 4, 3), dtype=np.uint8)
+    f = VideoFrame.from_ndarray(arr, format="rgb24")
+    f.pts = 0
+    return f
+
+
 class TestReadAudioFrameMediaStreamError(unittest.IsolatedAsyncioTestCase):
-    async def test_exits_on_media_stream_error(self):
-        """`read_audio_frame` must exit when the track is permanently dead.
+    async def test_parks_on_dead_track(self):
+        """Dead track: iterator must null the track ref and stop calling recv().
 
-        Regression test: previously the generator caught `MediaStreamError`,
-        slept 10 ms, and re-entered the loop — but the next `recv()` raised
-        the same error, so the iterator never terminated and the caller's
-        receive task stayed wedged forever.
+        Without the fix this loop calls `track.recv()` ~100Hz forever, pinning
+        a CPU core. With the fix, `_audio_input_track` is set to None on the
+        first `MediaStreamError` and the loop parks on the `is None` gate.
         """
-        fake_self = MagicMock()
-        fake_self._audio_input_track = MagicMock()
-        fake_self._audio_input_track.recv = AsyncMock(
-            side_effect=MediaStreamError("track ended")
-        )
-
-        iterator = SmallWebRTCClient.read_audio_frame(fake_self)
+        track = MagicMock()
+        track.recv = AsyncMock(side_effect=MediaStreamError("track ended"))
+        fake = _make_audio_self(track)
 
         async def consume():
-            async for _ in iterator:
+            async for _ in SmallWebRTCClient.read_audio_frame(fake):
                 pass
 
-        # Should return promptly; before the fix this would hit the timeout.
-        await asyncio.wait_for(consume(), timeout=1.0)
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+
+        # Exactly one recv() call: after MediaStreamError, the track ref is
+        # cleared and the loop sleeps on `is None` instead of re-calling recv.
+        self.assertEqual(track.recv.await_count, 1)
+        self.assertIsNone(fake._audio_input_track)
+
+    async def test_renegotiation_resumes(self):
+        """After the dead track is replaced, the iterator must yield frames.
+
+        This is the renegotiation path: a plain `break` on `MediaStreamError`
+        would terminate the generator. The track-nulling fix lets the
+        existing `is None: sleep; continue` gate wait for a fresh track from
+        `_handle_client_connected`.
+        """
+        dead = MagicMock()
+        dead.recv = AsyncMock(side_effect=MediaStreamError("track ended"))
+        fresh = MagicMock()
+        fresh.recv = AsyncMock(return_value=_good_audio_frame())
+        fake = _make_audio_self(dead)
+
+        yielded = 0
+
+        async def consume():
+            nonlocal yielded
+            async for _ in SmallWebRTCClient.read_audio_frame(fake):
+                yielded += 1
+                if yielded >= 3:
+                    break
+
+        task = asyncio.create_task(consume())
+        # Let the dead track raise + the loop park on `is None`.
+        await asyncio.sleep(0.05)
+        # Simulate _handle_client_connected reassigning a fresh track.
+        fake._audio_input_track = fresh
+        await asyncio.wait_for(task, timeout=1.0)
+
+        self.assertEqual(dead.recv.await_count, 1)
+        self.assertGreaterEqual(yielded, 3)
 
 
 class TestReadVideoFrameMediaStreamError(unittest.IsolatedAsyncioTestCase):
-    async def test_exits_on_media_stream_error(self):
-        """`read_video_frame` must exit when the track is permanently dead.
-
-        Same regression as the audio case.
-        """
-        fake_self = MagicMock()
-        fake_self._video_input_track = MagicMock()
-        fake_self._video_input_track.recv = AsyncMock(
-            side_effect=MediaStreamError("track ended")
-        )
-
-        iterator = SmallWebRTCClient.read_video_frame(fake_self, CAM_VIDEO_SOURCE)
+    async def test_camera_parks_on_dead_track(self):
+        track = MagicMock()
+        track.recv = AsyncMock(side_effect=MediaStreamError("track ended"))
+        fake = _make_video_self(video_track=track)
 
         async def consume():
-            async for _ in iterator:
+            async for _ in SmallWebRTCClient.read_video_frame(fake, CAM_VIDEO_SOURCE):
                 pass
 
-        await asyncio.wait_for(consume(), timeout=1.0)
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+
+        self.assertEqual(track.recv.await_count, 1)
+        self.assertIsNone(fake._video_input_track)
+
+    async def test_screen_parks_on_dead_track(self):
+        """Screen-share uses a separate track reference."""
+        track = MagicMock()
+        track.recv = AsyncMock(side_effect=MediaStreamError("track ended"))
+        fake = _make_video_self(screen_track=track)
+
+        async def consume():
+            async for _ in SmallWebRTCClient.read_video_frame(fake, SCREEN_VIDEO_SOURCE):
+                pass
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+
+        self.assertEqual(track.recv.await_count, 1)
+        self.assertIsNone(fake._screen_video_track)
+
+    async def test_camera_renegotiation_resumes(self):
+        dead = MagicMock()
+        dead.recv = AsyncMock(side_effect=MediaStreamError("track ended"))
+        fresh = MagicMock()
+        fresh.recv = AsyncMock(return_value=_good_video_frame())
+        fake = _make_video_self(video_track=dead)
+
+        yielded = 0
+
+        async def consume():
+            nonlocal yielded
+            async for _ in SmallWebRTCClient.read_video_frame(fake, CAM_VIDEO_SOURCE):
+                yielded += 1
+                if yielded >= 2:
+                    break
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.05)
+        fake._video_input_track = fresh
+        await asyncio.wait_for(task, timeout=1.0)
+
+        self.assertEqual(dead.recv.await_count, 1)
+        self.assertGreaterEqual(yielded, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -26,10 +26,18 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
-from aiortc.mediastreams import MediaStreamError
-from av import AudioFrame, VideoFrame
+import pytest
 
-from pipecat.transports.smallwebrtc.transport import (
+# The `webrtc` extra is optional; skip the whole module when it (and its
+# transitive `av` dependency) is unavailable, matching the default CI unit
+# test environment which does not install extras.
+pytest.importorskip("aiortc")
+pytest.importorskip("av")
+
+from aiortc.mediastreams import MediaStreamError  # noqa: E402
+from av import AudioFrame, VideoFrame  # noqa: E402
+
+from pipecat.transports.smallwebrtc.transport import (  # noqa: E402
     CAM_VIDEO_SOURCE,
     SCREEN_VIDEO_SOURCE,
     SmallWebRTCClient,


### PR DESCRIPTION
Fixes #4490. Updated in response to @filipi87's feedback that a plain `break` would regress renegotiation.

## Summary

The async generators `SmallWebRTCClient.read_audio_frame` / `read_video_frame` in `src/pipecat/transports/smallwebrtc/transport.py` previously caught `MediaStreamError`, slept 10 ms, and re-entered `recv()` on the same track. Once the underlying aiortc track is permanently dead, every subsequent `recv()` raises the same error — so the loop busy-spins at ~100 Hz forever and the caller's `_receive_audio` task stays wedged on `async for audio_frame in audio_iterator:`. In production this pinned one CPU core for ~28 min via a downstream anyio `CancelScope` busy-loop.

## Fix

On `MediaStreamError`, clear the affected track reference (`_audio_input_track` / `_video_input_track` / `_screen_video_track`) and let the loop park on its existing `is None` sleep gate — the same gate `_handle_peer_disconnected` already uses. When `_handle_client_connected` reassigns a fresh track during renegotiation, the loop resumes from the new track. No new state machine.

This replaces an earlier revision of this PR that used `break`, which would have terminated the iterator on transient mid-renegotiation errors (#4490 review feedback).

## Changes

- `src/pipecat/transports/smallwebrtc/transport.py`: in both `MediaStreamError` handlers, null the relevant track ref instead of leaving it dangling. Video path picks `_video_input_track` vs `_screen_video_track` from `video_source`.
- `tests/test_smallwebrtc_transport.py`: 5 regression tests — park-on-dead-track and renegotiation-resumes for audio + camera-video, plus screen-share park.
- `changelog/4491.fixed.md`: updated to describe nulling approach.

## Test plan

- [x] `pytest tests/test_smallwebrtc_transport.py -v` → 5 passed.
- [x] Reverted the transport fix locally and re-ran → all 5 fail. In particular, `test_renegotiation_resumes` catches the regression the `break`-based fix would have caused.

## Verification table

Driving the real `SmallWebRTCClient.read_audio_frame` against fake aiortc tracks for 500 ms each:

| Scenario | `track.recv()` calls | Frames yielded |
|---|---|---|
| Current upstream (buggy), dead track | **49** (busy-spin at ~100 Hz) | 0 |
| This PR, dead track | **1** (parks on `is None`) | 0 |
| This PR, dead track swapped to fresh @100 ms | dead: 1, fresh: 7550 | 7549 |
