### PR TITLE
Update Gradium STT/TTS endpoints to region-neutral URLs

### DIFF
--- a/changelog/4500.changed.md
+++ b/changelog/4500.changed.md
@@ -1,0 +1,1 @@
+- Changed the default WebSocket endpoints for `GradiumSTTService` and `GradiumTTSService` to the region-neutral `wss://api.gradium.ai/api/speech/asr` and `wss://api.gradium.ai/api/speech/tts`. Gradium now automatically routes traffic to the nearest endpoint. Override the url to pin to a specific region.

--- a/examples/transcription/transcription-gradium.py
+++ b/examples/transcription/transcription-gradium.py
@@ -51,7 +51,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     stt = GradiumSTTService(
         api_key=os.environ["GRADIUM_API_KEY"],
-        api_endpoint_base_url="wss://us.api.gradium.ai/api/speech/asr",
         settings=GradiumSTTService.Settings(
             language=Language.EN,
             delay_in_frames=8,

--- a/examples/update-settings/stt/stt-gradium.py
+++ b/examples/update-settings/stt/stt-gradium.py
@@ -50,10 +50,7 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info(f"Starting bot")
 
-    stt = GradiumSTTService(
-        api_key=os.environ["GRADIUM_API_KEY"],
-        api_endpoint_base_url="wss://us.api.gradium.ai/api/speech/asr",
-    )
+    stt = GradiumSTTService(api_key=os.environ["GRADIUM_API_KEY"])
 
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],

--- a/examples/update-settings/tts/tts-gradium.py
+++ b/examples/update-settings/tts/tts-gradium.py
@@ -55,7 +55,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = GradiumTTSService(
         api_key=os.environ["GRADIUM_API_KEY"],
         settings=GradiumTTSService.Settings(voice="YTpq7expH9539ERJ"),
-        url="wss://us.api.gradium.ai/api/speech/tts",
     )
 
     llm = OpenAILLMService(

--- a/examples/voice/voice-gradium.py
+++ b/examples/voice/voice-gradium.py
@@ -54,7 +54,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     stt = GradiumSTTService(
         api_key=os.environ["GRADIUM_API_KEY"],
-        api_endpoint_base_url="wss://us.api.gradium.ai/api/speech/asr",
         settings=GradiumSTTService.Settings(
             language=Language.EN,
         ),
@@ -62,7 +61,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     tts = GradiumTTSService(
         api_key=os.environ["GRADIUM_API_KEY"],
-        url="wss://us.api.gradium.ai/api/speech/tts",
         settings=GradiumTTSService.Settings(
             voice="YTpq7expH9539ERJ",
         ),

--- a/src/pipecat/services/gradium/stt.py
+++ b/src/pipecat/services/gradium/stt.py
@@ -150,7 +150,7 @@ class GradiumSTTService(WebsocketSTTService):
         self,
         *,
         api_key: str,
-        api_endpoint_base_url: str = "wss://eu.api.gradium.ai/api/speech/asr",
+        api_endpoint_base_url: str = "wss://api.gradium.ai/api/speech/asr",
         encoding: str = "pcm",
         sample_rate: int | None = None,
         params: InputParams | None = None,
@@ -163,7 +163,7 @@ class GradiumSTTService(WebsocketSTTService):
 
         Args:
             api_key: Gradium API key for authentication.
-            api_endpoint_base_url: WebSocket endpoint URL. Defaults to Gradium's streaming endpoint.
+            api_endpoint_base_url: WebSocket endpoint URL.
             encoding: Base audio encoding type. One of "pcm", "wav", or "opus".
                 For PCM, the sample rate is appended automatically from the
                 pipeline's audio_in_sample_rate (e.g., "pcm" becomes "pcm_16000").

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -68,7 +68,7 @@ class GradiumTTSService(WebsocketTTSService):
         *,
         api_key: str,
         voice_id: str | None = None,
-        url: str = "wss://eu.api.gradium.ai/api/speech/tts",
+        url: str = "wss://api.gradium.ai/api/speech/tts",
         model: str | None = None,
         json_config: str | None = None,
         params: InputParams | None = None,


### PR DESCRIPTION
## Summary
- Switch the default WebSocket endpoints for `GradiumSTTService` and `GradiumTTSService` from the EU-specific URLs (`wss://eu.api.gradium.ai/...`) to the region-neutral `wss://api.gradium.ai/...`.
- Drop the now-redundant explicit endpoint overrides from the Gradium examples so they exercise the new defaults.

## Test plan
- [x] Run the updated Gradium STT example end-to-end against a live API key.
- [x] Run the updated Gradium TTS example end-to-end against a live API key.
- [x] Confirm the voice and transcription examples still connect and stream successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)