### PR TITLE
feat(dtmf): add opt-in finalize_transcripts to DTMFAggregator

### DIFF
--- a/changelog/0000.added.md
+++ b/changelog/0000.added.md
@@ -1,0 +1,7 @@
+- Added a `finalize_transcripts` option to `DTMFAggregator`. When enabled, the
+  flushed `TranscriptionFrame` is marked `finalized=True` so user turn-stop
+  strategies (e.g. `TurnAnalyzerUserTurnStopStrategy`,
+  `SpeechTimeoutUserTurnStopStrategy`) close the turn from the DTMF transcript
+  alone and the LLM runs immediately. Without this, once VAD has fired earlier
+  in the session, DTMF-only input does not trigger inference until the caller
+  also speaks. Defaults to `False` to preserve existing behavior.

--- a/src/pipecat/processors/aggregators/dtmf_aggregator.py
+++ b/src/pipecat/processors/aggregators/dtmf_aggregator.py
@@ -37,6 +37,12 @@ class DTMFAggregator(FrameProcessor):
     - EndFrame or CancelFrame is received
 
     Emits TranscriptionFrame for compatibility with existing LLM context aggregators.
+
+    By default the emitted ``TranscriptionFrame`` is not finalized to preserve
+    the original behavior. Pass ``finalize_transcripts=True`` so user turn-stop
+    strategies close the turn from the DTMF transcript alone — necessary when
+    the caller has already spoken in the session, because turn-stop strategies
+    otherwise wait for VAD events that DTMF does not produce.
     """
 
     def __init__(
@@ -44,6 +50,7 @@ class DTMFAggregator(FrameProcessor):
         timeout: float = 2.0,
         termination_digit: KeypadEntry = KeypadEntry.POUND,
         prefix: str = "DTMF: ",
+        finalize_transcripts: bool = False,
         **kwargs,
     ):
         """Initialize the DTMF aggregator.
@@ -52,6 +59,16 @@ class DTMFAggregator(FrameProcessor):
             timeout: Idle timeout in seconds before flushing
             termination_digit: Digit that triggers immediate flush
             prefix: Prefix added to DTMF sequence in transcription
+            finalize_transcripts: When True, emit the flushed ``TranscriptionFrame``
+                with ``finalized=True``. By the time the aggregator flushes
+                (terminator, idle timeout, or pipeline end) the DTMF sequence is
+                definitionally complete, so the transcript can be marked final.
+                This lets the user turn-stop strategy close the turn from the
+                DTMF transcript alone — without it, callers who have already
+                spoken once in the session must speak again before the LLM is
+                invoked on a DTMF-only input, because turn-stop strategies key
+                on VAD events that DTMF does not produce. Defaults to ``False``
+                to preserve existing behavior.
             **kwargs: Additional arguments passed to FrameProcessor
         """
         super().__init__(**kwargs)
@@ -59,6 +76,7 @@ class DTMFAggregator(FrameProcessor):
         self._idle_timeout = timeout
         self._termination_digit = termination_digit
         self._prefix = prefix
+        self._finalize_transcripts = finalize_transcripts
 
         self._digit_event = asyncio.Event()
         self._aggregation_task: asyncio.Task | None = None
@@ -142,7 +160,10 @@ class DTMFAggregator(FrameProcessor):
         transcription_text = f"{self._prefix}{sequence}"
 
         transcription_frame = TranscriptionFrame(
-            text=transcription_text, user_id="", timestamp=time_now_iso8601()
+            text=transcription_text,
+            user_id="",
+            timestamp=time_now_iso8601(),
+            finalized=self._finalize_transcripts,
         )
         await self.push_frame(transcription_frame)
 

--- a/tests/test_dtmf_aggregator.py
+++ b/tests/test_dtmf_aggregator.py
@@ -204,6 +204,61 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(transcription_frames), 1)
         self.assertEqual(transcription_frames[0].text, "DTMF: 12*")
 
+    async def test_default_emits_non_finalized_transcription(self):
+        """Default ``finalize_transcripts=False`` emits non-finalized frames."""
+        aggregator = DTMFAggregator()
+        frames_to_send = [
+            InputDTMFFrame(button=KeypadEntry.ONE),
+            InputDTMFFrame(button=KeypadEntry.POUND),
+        ]
+        expected_down_frames = [
+            InputDTMFFrame,
+            InterruptionFrame,
+            InputDTMFFrame,
+            TranscriptionFrame,
+        ]
+
+        received_down_frames, _ = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        transcription_frames = [
+            f for f in received_down_frames if isinstance(f, TranscriptionFrame)
+        ]
+        self.assertEqual(len(transcription_frames), 1)
+        self.assertFalse(transcription_frames[0].finalized)
+
+    async def test_finalize_transcripts_opt_in(self):
+        """``finalize_transcripts=True`` marks the flushed transcript as final."""
+        aggregator = DTMFAggregator(finalize_transcripts=True)
+        frames_to_send = [
+            InputDTMFFrame(button=KeypadEntry.ONE),
+            InputDTMFFrame(button=KeypadEntry.TWO),
+            InputDTMFFrame(button=KeypadEntry.POUND),
+        ]
+        expected_down_frames = [
+            InputDTMFFrame,
+            InterruptionFrame,
+            InputDTMFFrame,
+            InputDTMFFrame,
+            TranscriptionFrame,
+        ]
+
+        received_down_frames, _ = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        transcription_frames = [
+            f for f in received_down_frames if isinstance(f, TranscriptionFrame)
+        ]
+        self.assertEqual(len(transcription_frames), 1)
+        self.assertEqual(transcription_frames[0].text, "DTMF: 12#")
+        self.assertTrue(transcription_frames[0].finalized)
+
     async def test_all_keypad_entries(self):
         """Test all possible keypad entries."""
         aggregator = DTMFAggregator()


### PR DESCRIPTION
## Summary
Adds an opt-in `finalize_transcripts` parameter (default `False`) to `DTMFAggregator`. When enabled, the flushed `TranscriptionFrame` is marked `finalized=True` so user turn-stop strategies close the turn from the DTMF transcript alone.

## The bug this fixes

In a typical telephony flow, the agent prompts the caller to enter digits and the caller responds via keypad. What actually happens today:

1. Call starts. Caller speaks: *"Hi, I want to pay my bill."*
2. VAD fires `UserStartedSpeakingFrame` → STT produces a transcript → VAD fires `UserStoppedSpeakingFrame` → turn-stop strategy closes the turn → LLM responds, asks for account number.
3. Caller presses `1`, `2`, `3`, `4`, `#` on the keypad. `DTMFAggregator` aggregates the digits and pushes `TranscriptionFrame(text="DTMF: 1234#")` downstream.
4. **The agent does nothing.** The transcript sits buffered in `LLMUserContextAggregator` waiting for a turn-stop signal that never comes.
5. Caller, confused, says *"hello?"* → VAD fires → turn-stop strategy finally closes the turn → LLM is invoked with the buffered DTMF transcript + the spoken word.

The agent ignored the keypad entry until the caller also spoke.

## Why this happens

Turn-stop strategies (`TurnAnalyzerUserTurnStopStrategy`, `SpeechTimeoutUserTurnStopStrategy`) close a turn from a transcript alone only when one of these is true:

- The transcript is marked `finalized=True` — STT has signalled "nothing more coming."
- A fallback path runs: `_vad_user_speaking is False and _vad_stopped_time is None`, i.e. VAD has *never* fired in this session.

DTMF transcripts are produced with the default `finalized=False`. Once the caller has spoken once, `_vad_stopped_time` is set, so the fallback is permanently disabled. The buffered DTMF transcript has no path to trigger inference, and the strategy continues waiting for the next VAD `UserStoppedSpeakingFrame` — which only arrives when the caller speaks again.

## The fix

Add a `finalize_transcripts: bool = False` constructor parameter. When `True`, the flushed `TranscriptionFrame` is emitted with `finalized=True`, which routes through the strategies' "finalized transcript triggers turn stop" path and runs the LLM immediately on the DTMF input alone.

This is semantically correct: by the time `_flush_aggregation` runs, the DTMF sequence is definitionally complete (terminator pressed, idle timeout expired, or `EndFrame` received). There is nothing more coming from this synthetic transcript source, so marking it final is accurate — not just convenient.

The default stays `False` to preserve existing behavior. Users opt in with:

```python
dtmf = DTMFAggregator(finalize_transcripts=True)
