### PR TITLE
fix elevenlabs stt crashing on language None in settings

### DIFF
--- a/changelog/4506.fixed.md
+++ b/changelog/4506.fixed.md
@@ -1,0 +1,4 @@
+```
+- Fixed elevenlabs STT Crashing when language passed as None.
+- STT also auto detects the language of audio if language is not passed.
+```

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -358,7 +358,8 @@ class ElevenLabsSTTService(SegmentedSTTService):
 
         # Add required model_id and language_code
         data.add_field("model_id", self._settings.model)
-        data.add_field("language_code", self._settings.language)
+        if self._settings.language:
+            data.add_field("language_code", self._settings.language)
         if self._settings.tag_audio_events is not None:
             data.add_field("tag_audio_events", str(self._settings.tag_audio_events).lower())
         keyterms = self._settings.keyterms


### PR DESCRIPTION
Elevenlabs STT supports passing language as None after which it should auto detect the language of the user, but while passing the language as None, that gets set as the lang code which crashes the STT service.