### PR TITLE
fix: improve NVIDIA STT stream shutdown and reconnect handling

### DIFF
--- a/changelog/4512.fixed.md
+++ b/changelog/4512.fixed.md
@@ -1,1 +1,1 @@
-- Fixed `NvidiaSTTService` so dropped gRPC streaming sessions can reconnect cleanly, while service shutdown and cancellation now unblock the active audio iterator instead of leaving the streaming worker stuck waiting for more audio.
+- Fixed `NvidiaSTTService` so unexpected gRPC stream drops reconnect cleanly using the active audio iterator, while service shutdown and cancellation still close that iterator and stop the streaming worker without leaving it stuck waiting for more audio.

--- a/changelog/4512.fixed.md
+++ b/changelog/4512.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `NvidiaSTTService` so dropped gRPC streaming sessions can reconnect cleanly, while service shutdown and cancellation now unblock the active audio iterator instead of leaving the streaming worker stuck waiting for more audio.

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -168,7 +168,6 @@ class AudioChunkIterator:
         """
         self._event_loop = event_loop
         self._queue: asyncio.Queue[bytes | object] = asyncio.Queue()
-        self._broken = False
         self._closed = False
 
     @property
@@ -182,7 +181,7 @@ class AudioChunkIterator:
         Args:
             audio: Raw PCM audio bytes to send to the server.
         """
-        if self._closed or self._broken:
+        if self._closed:
             return
         await self._queue.put(audio)
 
@@ -350,7 +349,6 @@ class NvidiaSTTService(STTService):
 
         self._asr_service = None
         self._audio_iterator: AudioChunkIterator | None = None
-        self._pending_audio_chunks: list[bytes] = []
         self._config = None
         self._thread_task = None
 
@@ -475,7 +473,6 @@ class NvidiaSTTService(STTService):
         await super().start(frame)
         self._initialize_client()
         self._config = self._create_recognition_config()
-        self._pending_audio_chunks.clear()
         self._audio_iterator = AudioChunkIterator(self.get_event_loop())
 
         if not self._thread_task:
@@ -501,12 +498,17 @@ class NvidiaSTTService(STTService):
         await super().cancel(frame)
         await self._stop_tasks()
 
-    async def _stop_tasks(self, clear_pending_audio: bool = True):
+    async def _stop_tasks(self, close_iterator: bool = True):
+        """Stop the active stream thread and optionally close the shared iterator.
+
+        ``close_iterator=False`` is used during reconnect so we can tear down the
+        current gRPC stream but keep buffering audio on the same iterator until
+        the replacement stream starts consuming it.
+        """
         iterator = self._audio_iterator
-        self._audio_iterator = None
-        if clear_pending_audio:
-            self._pending_audio_chunks.clear()
-        if iterator is not None:
+        if close_iterator:
+            self._audio_iterator = None
+        if close_iterator and iterator is not None:
             await iterator.close()
 
         if self._thread_task:
@@ -514,25 +516,13 @@ class NvidiaSTTService(STTService):
             self._thread_task = None
 
     async def _do_reconnect(self):
-        old_iterator = self._audio_iterator
-        buffered_audio = []
-        if old_iterator is not None:
-            while True:
-                try:
-                    audio = old_iterator._queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    break
-                if audio is not old_iterator._QUEUE_SENTINEL:
-                    buffered_audio.append(audio)
-        await self._stop_tasks(clear_pending_audio=False)
+        iterator = self._audio_iterator
+        if iterator is None or iterator.closed:
+            return
+
+        await self._stop_tasks(close_iterator=False)
         self._initialize_client()
         self._config = self._create_recognition_config()
-        self._audio_iterator = AudioChunkIterator(self.get_event_loop())
-        for audio in buffered_audio:
-            await self._audio_iterator.put(audio)
-        for audio in self._pending_audio_chunks:
-            await self._audio_iterator.put(audio)
-        self._pending_audio_chunks.clear()
         self._thread_task = self.create_task(self._thread_task_handler())
 
     async def _handle_stream_drop(self, iterator: AudioChunkIterator, reason: str):
@@ -565,7 +555,6 @@ class NvidiaSTTService(STTService):
             logger.error(f"{self} unexpected streaming error: {e}")
 
         if drop_reason:
-            iterator._broken = True
             asyncio.run_coroutine_threadsafe(
                 self._handle_stream_drop(iterator, drop_reason),
                 self.get_event_loop(),
@@ -637,10 +626,8 @@ class NvidiaSTTService(STTService):
         """
         await self.start_processing_metrics()
         iterator = self._audio_iterator
-        if iterator is not None and not iterator.closed and not iterator._broken:
+        if iterator is not None and not iterator.closed:
             await iterator.put(audio)
-        elif iterator is not None and not iterator.closed:
-            self._pending_audio_chunks.append(audio)
         yield None
 
 

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -148,6 +148,80 @@ class NvidiaSegmentedSTTSettings(_NvidiaBaseSTTSettings):
     pass
 
 
+class AudioChunkIterator:
+    """Per-stream iterator that feeds audio chunks to NVIDIA's gRPC stream.
+
+    The NVIDIA client consumes audio synchronously from a worker thread, while
+    Pipecat produces audio asynchronously on the event loop. This iterator
+    bridges those two worlds and owns the logic for unblocking and closing a
+    single stream cleanly.
+    """
+
+    _QUEUE_SENTINEL = object()
+
+    def __init__(self, event_loop: asyncio.AbstractEventLoop):
+        """Initialize the iterator for a single streaming session.
+
+        Args:
+            event_loop: Event loop used to await queue operations from the
+                worker thread.
+        """
+        self._event_loop = event_loop
+        self._queue: asyncio.Queue[bytes | object] = asyncio.Queue()
+        self._broken = False
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        """Whether the iterator has been closed intentionally."""
+        return self._closed
+
+    async def put(self, audio: bytes) -> None:
+        """Enqueue audio for the active stream.
+
+        Args:
+            audio: Raw PCM audio bytes to send to the server.
+        """
+        if self._closed or self._broken:
+            return
+        await self._queue.put(audio)
+
+    async def close(self) -> None:
+        """Close the iterator and unblock any pending read."""
+        if self._closed:
+            return
+        self._closed = True
+        await self._queue.put(self._QUEUE_SENTINEL)
+
+    def __iter__(self):
+        """Return the iterator instance."""
+        return self
+
+    def __next__(self) -> bytes:
+        """Get the next audio chunk for the active stream.
+
+        Returns:
+            Audio bytes from the queue.
+
+        Raises:
+            StopIteration: When the iterator has been closed.
+        """
+        if self._closed:
+            raise StopIteration
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(self._queue.get(), self._event_loop)
+            audio = future.result()
+        except FuturesCancelledError:
+            raise StopIteration
+
+        if audio is self._QUEUE_SENTINEL:
+            self._closed = True
+            raise StopIteration
+
+        return audio
+
+
 class NvidiaSTTService(STTService):
     """Real-time speech-to-text service using NVIDIA Nemotron Speech streaming ASR.
 
@@ -275,7 +349,8 @@ class NvidiaSTTService(STTService):
         self._function_id = model_function_map.get("function_id")
 
         self._asr_service = None
-        self._queue = None
+        self._audio_iterator: AudioChunkIterator | None = None
+        self._pending_audio_chunks: list[bytes] = []
         self._config = None
         self._thread_task = None
 
@@ -400,8 +475,8 @@ class NvidiaSTTService(STTService):
         await super().start(frame)
         self._initialize_client()
         self._config = self._create_recognition_config()
-
-        self._queue = asyncio.Queue()
+        self._pending_audio_chunks.clear()
+        self._audio_iterator = AudioChunkIterator(self.get_event_loop())
 
         if not self._thread_task:
             self._thread_task = self.create_task(self._thread_task_handler())
@@ -426,15 +501,52 @@ class NvidiaSTTService(STTService):
         await super().cancel(frame)
         await self._stop_tasks()
 
-    async def _stop_tasks(self):
+    async def _stop_tasks(self, clear_pending_audio: bool = True):
+        iterator = self._audio_iterator
+        self._audio_iterator = None
+        if clear_pending_audio:
+            self._pending_audio_chunks.clear()
+        if iterator is not None:
+            await iterator.close()
+
         if self._thread_task:
             await self.cancel_task(self._thread_task)
             self._thread_task = None
 
-    def _response_handler(self):
+    async def _do_reconnect(self):
+        old_iterator = self._audio_iterator
+        buffered_audio = []
+        if old_iterator is not None:
+            while True:
+                try:
+                    audio = old_iterator._queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if audio is not old_iterator._QUEUE_SENTINEL:
+                    buffered_audio.append(audio)
+        await self._stop_tasks(clear_pending_audio=False)
+        self._initialize_client()
+        self._config = self._create_recognition_config()
+        self._audio_iterator = AudioChunkIterator(self.get_event_loop())
+        for audio in buffered_audio:
+            await self._audio_iterator.put(audio)
+        for audio in self._pending_audio_chunks:
+            await self._audio_iterator.put(audio)
+        self._pending_audio_chunks.clear()
+        self._thread_task = self.create_task(self._thread_task_handler())
+
+    async def _handle_stream_drop(self, iterator: AudioChunkIterator, reason: str):
+        if iterator.closed or iterator is not self._audio_iterator:
+            return
+
+        logger.warning(f"{self} stream dropped: {reason}")
+        await self._request_reconnect()
+
+    def _response_handler(self, iterator: AudioChunkIterator):
+        drop_reason = None
         try:
             responses = self._asr_service.streaming_response_generator(
-                audio_chunks=self,
+                audio_chunks=iterator,
                 streaming_config=self._config,
             )
             for response in responses:
@@ -443,21 +555,30 @@ class NvidiaSTTService(STTService):
                 asyncio.run_coroutine_threadsafe(
                     self._handle_response(response), self.get_event_loop()
                 )
+            drop_reason = "server closed the gRPC stream"
         except grpc.RpcError as e:
             status = e.code().name if hasattr(e, "code") else "UNKNOWN"
             details = e.details() if hasattr(e, "details") else str(e)
-            logger.error(f"{self} gRPC streaming error ({status}): {details}")
+            drop_reason = f"gRPC {status}: {details}"
+        except Exception as e:
+            drop_reason = str(e)
+            logger.error(f"{self} unexpected streaming error: {e}")
+
+        if drop_reason:
+            iterator._broken = True
             asyncio.run_coroutine_threadsafe(
-                self.push_error(f"{self} STT streaming failed (gRPC {status}): {details}"),
+                self._handle_stream_drop(iterator, drop_reason),
                 self.get_event_loop(),
             )
 
     async def _thread_task_handler(self):
+        iterator = self._audio_iterator
+        if iterator is None:
+            return
+
         try:
-            self._thread_running = True
-            await asyncio.to_thread(self._response_handler)
+            await asyncio.to_thread(self._response_handler, iterator)
         except asyncio.CancelledError:
-            self._thread_running = False
             raise
 
     @traced_stt
@@ -515,35 +636,12 @@ class NvidiaSTTService(STTService):
             None - transcription results are pushed to the pipeline via frames.
         """
         await self.start_processing_metrics()
-        await self._queue.put(audio)
+        iterator = self._audio_iterator
+        if iterator is not None and not iterator.closed and not iterator._broken:
+            await iterator.put(audio)
+        elif iterator is not None and not iterator.closed:
+            self._pending_audio_chunks.append(audio)
         yield None
-
-    def __next__(self) -> bytes:
-        """Get the next audio chunk for NVIDIA Nemotron Speech processing.
-
-        Returns:
-            Audio bytes from the queue.
-
-        Raises:
-            StopIteration: When the thread is no longer running.
-        """
-        if not self._thread_running:
-            raise StopIteration
-
-        try:
-            future = asyncio.run_coroutine_threadsafe(self._queue.get(), self.get_event_loop())
-            audio = future.result()
-            return audio
-        except FuturesCancelledError:
-            raise StopIteration
-
-    def __iter__(self):
-        """Return iterator for audio chunk processing.
-
-        Returns:
-            Self as iterator.
-        """
-        return self
 
 
 class NvidiaSegmentedSTTService(SegmentedSTTService):


### PR DESCRIPTION
- move NVIDIA streaming audio iteration into a per-stream iterator
- unblock shutdown cleanly by closing the iterator with a sentinel
- add reconnect handling for dropped gRPC streaming sessions