### PR TITLE
Handle OpenRouter developer messages conservatively

### DIFF
--- a/changelog/4513.changed.2.md
+++ b/changelog/4513.changed.2.md
@@ -1,0 +1,1 @@
+- OpenRouter LLM requests now convert `developer` messages to `user` messages by default for broader model compatibility. Override this by subclassing `OpenRouterLLMService` or setting `llm.supports_developer_role = True` for models that support the `developer` role.

--- a/changelog/4513.changed.md
+++ b/changelog/4513.changed.md
@@ -1,0 +1,1 @@
+- OpenRouter LLM service now defaults to `openai/gpt-4.1`.

--- a/examples/function-calling/function-calling-azure.py
+++ b/examples/function-calling/function-calling-azure.py
@@ -133,6 +133,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-cerebras.py
+++ b/examples/function-calling/function-calling-cerebras.py
@@ -142,6 +142,9 @@ Start by asking me for my location. Then, use 'get_weather_current' to give me a
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-deepseek.py
+++ b/examples/function-calling/function-calling-deepseek.py
@@ -143,6 +143,9 @@ Start by asking me for my location. Then, use 'get_weather_current' to give me a
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-direct.py
+++ b/examples/function-calling/function-calling-direct.py
@@ -134,6 +134,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-groq.py
+++ b/examples/function-calling/function-calling-groq.py
@@ -131,6 +131,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-mistral.py
+++ b/examples/function-calling/function-calling-mistral.py
@@ -144,6 +144,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-novita.py
+++ b/examples/function-calling/function-calling-novita.py
@@ -149,6 +149,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-nvidia.py
+++ b/examples/function-calling/function-calling-nvidia.py
@@ -135,6 +135,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-ollama.py
+++ b/examples/function-calling/function-calling-ollama.py
@@ -149,6 +149,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-openai-responses-async-stream.py
+++ b/examples/function-calling/function-calling-openai-responses-async-stream.py
@@ -187,6 +187,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-openai.py
+++ b/examples/function-calling/function-calling-openai.py
@@ -148,6 +148,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-openrouter.py
+++ b/examples/function-calling/function-calling-openrouter.py
@@ -76,7 +76,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = OpenRouterLLMService(
         api_key=os.environ["OPENROUTER_API_KEY"],
         settings=OpenRouterLLMService.Settings(
-            model="openai/gpt-4o-2024-11-20",
             system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )
@@ -136,6 +135,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-qwen.py
+++ b/examples/function-calling/function-calling-qwen.py
@@ -134,6 +134,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/examples/function-calling/function-calling-sambanova.py
+++ b/examples/function-calling/function-calling-sambanova.py
@@ -133,6 +133,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/src/pipecat/services/openrouter/llm.py
+++ b/src/pipecat/services/openrouter/llm.py
@@ -37,6 +37,7 @@ class OpenRouterLLMService(OpenAILLMService):
 
     Settings = OpenRouterLLMSettings
     _settings: Settings
+    supports_developer_role = False
 
     def __init__(
         self,

--- a/src/pipecat/services/openrouter/llm.py
+++ b/src/pipecat/services/openrouter/llm.py
@@ -53,7 +53,7 @@ class OpenRouterLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing OpenRouter's API. If None, will attempt
                 to read from environment variables.
-            model: The model identifier to use. Defaults to "openai/gpt-4o-2024-11-20".
+            model: The model identifier to use. Defaults to "openai/gpt-4.1".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=OpenRouterLLMService.Settings(model=...)`` instead.
@@ -64,7 +64,7 @@ class OpenRouterLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="openai/gpt-4o-2024-11-20")
+        default_settings = self.Settings(model="openai/gpt-4.1")
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:

--- a/tests/test_run_inference.py
+++ b/tests/test_run_inference.py
@@ -23,6 +23,7 @@ from pipecat.services.openai.responses.llm import (
     OpenAIResponsesHttpLLMService,
     OpenAIResponsesLLMService,
 )
+from pipecat.services.openrouter.llm import OpenRouterLLMService
 
 
 @pytest.mark.asyncio
@@ -103,6 +104,35 @@ async def test_openai_run_inference_client_exception():
 
         with pytest.raises(Exception, match="API Error"):
             await service.run_inference(mock_context)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_run_inference_converts_developer_messages_to_user():
+    """Test OpenRouter requests convert developer messages for broad model compatibility."""
+    with patch.object(OpenRouterLLMService, "create_client"):
+        service = OpenRouterLLMService(settings=OpenRouterLLMService.Settings(model="gpt-4"))
+        service._client = AsyncMock()
+
+        mock_context = MagicMock(spec=LLMContext)
+        mock_adapter = MagicMock()
+        mock_adapter.get_llm_invocation_params.return_value = OpenAILLMInvocationParams(
+            messages=[{"role": "user", "content": "Tool result"}],
+            tools=OPENAI_NOT_GIVEN,
+            tool_choice=OPENAI_NOT_GIVEN,
+        )
+        service.get_llm_adapter = MagicMock(return_value=mock_adapter)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done"
+        service._client.chat.completions.create.return_value = mock_response
+
+        result = await service.run_inference(mock_context)
+
+        assert result == "Done"
+        mock_adapter.get_llm_invocation_params.assert_called_once_with(
+            mock_context, system_instruction=None, convert_developer_to_user=True
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

I found this one in supporting a customer who was using `google/gemini-2.5-flash`. Function calling wasn't working correctly with the `developer` role set. This feels like a missing feature or bug in OpenRouter. I think the safer path is to just disable the developer message and have developers override as needed.

## Summary

- Convert OpenRouter `developer` messages to `user` messages by default so async tool result messages work across more OpenRouter-backed models.
- Update the OpenRouter default model to `openai/gpt-4.1`.
- Align function-calling examples by adding the initial context message on client connect and letting the OpenRouter example use the service default model.
- Add a changelog entry for the OpenRouter behavior changes.

## Testing

- `uv run pytest tests/test_run_inference.py::test_openrouter_run_inference_converts_developer_messages_to_user`
- `uv run ruff check src/pipecat/services/openrouter/llm.py tests/test_run_inference.py`
- `uv run ruff check examples/function-calling/function-calling-azure.py examples/function-calling/function-calling-cerebras.py examples/function-calling/function-calling-deepseek.py examples/function-calling/function-calling-direct.py examples/function-calling/function-calling-groq.py examples/function-calling/function-calling-mistral.py examples/function-calling/function-calling-novita.py examples/function-calling/function-calling-nvidia.py examples/function-calling/function-calling-ollama.py examples/function-calling/function-calling-openai-responses-async-stream.py examples/function-calling/function-calling-openai.py examples/function-calling/function-calling-openrouter.py examples/function-calling/function-calling-qwen.py examples/function-calling/function-calling-sambanova.py`
