### PR TITLE
fix(mcp): forward image content blocks to LLM as multimodal tool_result

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1229,7 +1229,21 @@ class LLMAssistantAggregator(LLMContextAggregator):
         is_async = not in_progress_frame.cancel_on_interruption
         del self._function_calls_in_progress[frame.tool_call_id]
 
-        result = json.dumps(frame.result, ensure_ascii=False) if frame.result else "COMPLETED"
+        # Multimodal tool results (e.g. an MCP tool returning ImageContent) are
+        # represented as a list of content blocks — e.g.
+        #   [{"type": "text", "text": "..."},
+        #    {"type": "image", "source": {"type": "base64", ...}}]
+        # Anthropic's tool_result.content accepts either a string or a list of
+        # blocks. If we json.dumps a list here, the LLM sees the literal JSON
+        # text instead of an image input and the visual signal is lost.
+        # Pass lists through unchanged; stringify everything else (the existing
+        # text-only behavior).
+        if isinstance(frame.result, list):
+            result = frame.result
+        elif frame.result:
+            result = json.dumps(frame.result, ensure_ascii=False)
+        else:
+            result = "COMPLETED"
 
         if is_async:
             # For async function calls inject a developer message so the LLM is

--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -243,34 +243,82 @@ class MCPClient(BaseObject):
             error_msg = f"Error calling mcp tool {function_name}: {str(e)}"
             logger.error(error_msg)
 
-        response = ""
-        if results:
-            if hasattr(results, "content") and results.content:
-                for i, content in enumerate(results.content):
-                    if hasattr(content, "text") and content.text:
-                        logger.debug(f"Tool response chunk {i}: {content.text}")
-                        response += content.text
-                    else:
-                        # logger.debug(f"Non-text result content: '{content}'")
-                        pass
-            else:
-                logger.error(f"Error getting content from {function_name} results.")
+        # MCP tool results can carry text, image, audio, embedded resource,
+        # or resource link blocks. Walk the list, collect text into a string
+        # and image blocks into Anthropic-shaped image dicts. If any image
+        # block is present we return a list-of-blocks (which downstream LLM
+        # adapters — Anthropic at least — pass straight through as the
+        # `tool_result.content`, giving the model a multimodal tool result).
+        # If only text blocks are present we keep the existing string
+        # behavior for backward compatibility.
+        text_parts: list[str] = []
+        image_blocks: list[dict] = []
+        if results and hasattr(results, "content") and results.content:
+            for i, content in enumerate(results.content):
+                ctype = getattr(content, "type", None)
+                if ctype == "text" and getattr(content, "text", None):
+                    logger.debug(f"Tool response chunk {i} (text): {content.text}")
+                    text_parts.append(content.text)
+                elif ctype == "image" and getattr(content, "data", None):
+                    logger.debug(
+                        f"Tool response chunk {i} (image): {len(content.data)} chars b64 "
+                        f"mimeType={getattr(content, 'mimeType', None)}"
+                    )
+                    image_blocks.append(
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": getattr(content, "mimeType", "image/jpeg"),
+                                "data": content.data,
+                            },
+                        }
+                    )
+                else:
+                    logger.debug(
+                        f"Tool response chunk {i}: unhandled content type={ctype!r}; skipping"
+                    )
+        elif results and (not hasattr(results, "content") or not results.content):
+            logger.error(f"Error getting content from {function_name} results.")
 
-        # Apply output filter if configured for this tool
-        if function_name in self._tools_output_filters:
-            try:
-                response = self._tools_output_filters[function_name](response)
-                logger.debug(f"Final response (after filter): {response}")
-
-            except Exception:
-                logger.error(f"Error applying output filter for {function_name}")
-                response = ""
-
-        if response and len(response) and isinstance(response, str):
-            logger.info(f"Tool '{function_name}' completed successfully")
-            logger.debug(f"Final response: {response}")
+        response: Any
+        if image_blocks:
+            # Multimodal result: emit a list-of-blocks. Output filters that
+            # expect a string get skipped (they're text-only by convention).
+            response = []
+            if text_parts:
+                response.append({"type": "text", "text": "\n".join(text_parts)})
+            response.extend(image_blocks)
+            if function_name in self._tools_output_filters:
+                logger.warning(
+                    f"Tool '{function_name}' returned image content; "
+                    f"skipping configured output filter (filters are text-only)."
+                )
         else:
+            response = "".join(text_parts)
+            # Apply output filter if configured for this tool (text path only).
+            if function_name in self._tools_output_filters:
+                try:
+                    response = self._tools_output_filters[function_name](response)
+                    logger.debug(f"Final response (after filter): {response}")
+                except Exception:
+                    logger.error(f"Error applying output filter for {function_name}")
+                    response = ""
+
+        # Validate: a string-or-empty-list response is treated as failure;
+        # a non-empty list (multimodal) is success.
+        is_empty = (
+            (isinstance(response, str) and not response)
+            or (isinstance(response, list) and not response)
+        )
+        if is_empty:
             response = "Sorry, could not call the mcp tool"
+        else:
+            logger.info(f"Tool '{function_name}' completed successfully")
+            if isinstance(response, str):
+                logger.debug(f"Final response (text): {response}")
+            else:
+                logger.debug(f"Final response (multimodal): {len(response)} block(s)")
 
         await result_callback(response)
 


### PR DESCRIPTION
## Problem

`McpClient._call_tool` (in `pipecat/services/mcp_service.py`) only accumulates `content.text` from `session.call_tool()` results. `ImageContent` / `AudioContent` / `EmbeddedResource` blocks hit the `else: pass` branch and are silently dropped.

If a tool returns only non-text blocks (e.g. a camera-capture tool returning a single `ImageContent`), `response` stays the empty string and the helpful-error fallback fires: `"Sorry, could not call the mcp tool"`. The model receives that string and apologizes for something that did work — there's no signal upstream that a real image came back.

Concretely: we have an Android helper MCP whose `glasses_capture` tool returns a base64-encoded JPEG of the user's smart-glasses camera. Calling it via MCP Inspector or a raw MCP SDK client works perfectly — the JPEG round-trips and renders inline. Calling it via pipecat-routed Claude produces `"Sorry, could not call the mcp tool"` every single time, with no diagnostic in the logs.

## Fix

Walk the content blocks. Collect `TextContent` into a string and `ImageContent` into Anthropic-shaped base64 image dicts (`{"type": "image", "source": {"type": "base64", "media_type": ..., "data": ...}}`).

- **Text-only results** keep the existing string behavior verbatim, so the change is backward-compatible with every existing MCP tool.
- **Any image present** → emit a list-of-blocks as the `result_callback` payload. The downstream LLM adapter (`AnthropicLLMAdapter` confirmed) passes the value straight into `tool_result.content`. The [Anthropic tool-use API](https://docs.anthropic.com/claude/docs/tool-use) accepts either a string or a list of content blocks here, so the multimodal payload propagates cleanly to the model context with no per-LLM-service plumbing required.
- Output filters are skipped for the multimodal path (they're text-only by convention; we warn if one is configured).

## Test

Validated end-to-end against an Android-helper MCP returning a `ImageContent` (base64 JPEG) for a `glasses_capture` tool. Pre-patch: `"Sorry, could not call the mcp tool"`. Post-patch: Claude describes the image content (a wooden keyboard, hands typing, an Acer ultrawide showing terminal text, etc.).

No regression for text-returning tools (`imessage_list_chats`, `android_a11y_get_tree`, etc.) — string path is identical.

## Notes

- I'd be happy to also handle `AudioContent` and `EmbeddedResource` in a follow-up — they're easy adds — but I scoped this PR to just image, since (a) Anthropic's tool_result currently doesn't accept audio inline and (b) embedded-resource semantics need their own discussion.
- The list-of-blocks shape works for Anthropic without further changes. I haven't validated against OpenAI / Gemini adapters; if they reject non-string content, those adapters can pre-process at their layer rather than re-stringifying here.