### PR TITLE
Add P99 latency for Smallest AI, Mistral, XAI STT

### DIFF
--- a/changelog/4522.changed.md
+++ b/changelog/4522.changed.md
@@ -1,0 +1,1 @@
+- Updated the default p99 TTFS latency values for Smallest AI, Mistral, and XAI STT so turn stop timing uses measured values instead of the conservative fallback.

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -44,17 +44,15 @@ GLADIA_TTFS_P99: float = 1.49
 GOOGLE_TTFS_P99: float = 1.57
 GRADIUM_TTFS_P99: float = 1.61
 GROQ_TTFS_P99: float = 1.54
+MISTRAL_TTFS_P99: float = 1.89
 OPENAI_TTFS_P99: float = 2.01
 OPENAI_REALTIME_TTFS_P99: float = 1.66
 SARVAM_TTFS_P99: float = 1.17
 SMALLEST_TTFS_P99: float = 1.59
 SONIOX_TTFS_P99: float = 0.35
 SPEECHMATICS_TTFS_P99: float = 0.74
+XAI_TTFS_P99: float = 2.14
 
 # These services run locally and should be replaced with measured values
 NVIDIA_TTFS_P99: float = DEFAULT_TTFS_P99
 WHISPER_TTFS_P99: float = DEFAULT_TTFS_P99
-
-# No benchmark available yet; using conservative default
-MISTRAL_TTFS_P99: float = DEFAULT_TTFS_P99
-XAI_TTFS_P99: float = DEFAULT_TTFS_P99

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -47,6 +47,7 @@ GROQ_TTFS_P99: float = 1.54
 OPENAI_TTFS_P99: float = 2.01
 OPENAI_REALTIME_TTFS_P99: float = 1.66
 SARVAM_TTFS_P99: float = 1.17
+SMALLEST_TTFS_P99: float = 1.59
 SONIOX_TTFS_P99: float = 0.35
 SPEECHMATICS_TTFS_P99: float = 0.74
 
@@ -56,5 +57,4 @@ WHISPER_TTFS_P99: float = DEFAULT_TTFS_P99
 
 # No benchmark available yet; using conservative default
 MISTRAL_TTFS_P99: float = DEFAULT_TTFS_P99
-SMALLEST_TTFS_P99: float = DEFAULT_TTFS_P99
 XAI_TTFS_P99: float = DEFAULT_TTFS_P99


### PR DESCRIPTION
## Summary

- Replaces the conservative default P99 time-to-first-speech estimate for Smallest AI STT with a benchmarked value (1.59s), giving consumers of `stt_latency` a more accurate latency budget for that provider.
- Also adding Mistral and XAI P99 latency numbers.