### PR TITLE
Vendor Whisper log-mel feature extractor in Smart Turn v3

### DIFF
--- a/changelog/+smart-turn-v3-vendor-whisper-features.changed.md
+++ b/changelog/+smart-turn-v3-vendor-whisper-features.changed.md
@@ -1,0 +1,4 @@
+- Replaced the `transformers.WhisperFeatureExtractor` dependency in `LocalSmartTurnAnalyzerV3` with a vendored numpy-only implementation, reducing peak RSS at import from ~566 MB to ~60 MB and cold-start time from ~5.0 s to ~0.3 s. Behavior is numerically equivalent (matches the reference numpy code path within 1e-5 absolute tolerance; ONNX model output is bit-identical on representative inputs).
+  - Smart Turn v3 no longer imports `transformers` at module load.
+  - Prepares the ground for making `transformers` an optional dependency in a future release.
+  - The vendored STFT is vectorized via `numpy.lib.stride_tricks.sliding_window_view` + batched `np.fft.rfft`, cutting `_power_spectrogram` runtime by ~55% (~4.0 ms → ~1.8 ms per call on a typical 8-second segment at 16 kHz) while preserving the same parity tolerances against the reference implementation.

--- a/src/pipecat/audio/turn/smart_turn/_whisper_features.py
+++ b/src/pipecat/audio/turn/smart_turn/_whisper_features.py
@@ -1,0 +1,175 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Numpy-only Whisper-style log-mel feature extraction for Smart Turn v3.
+
+Vendored from `transformers.WhisperFeatureExtractor` so Smart Turn v3 can
+compute features without importing the `transformers` package. The math
+mirrors `transformers.models.whisper.feature_extraction_whisper` and
+`transformers.audio_utils` (Apache-2.0 licensed); see those modules in the
+upstream HuggingFace repository for the reference implementation.
+"""
+
+import numpy as np
+from numpy.lib.stride_tricks import sliding_window_view
+
+_N_FFT = 400
+_HOP_LENGTH = 160
+_N_MELS = 80
+_SAMPLING_RATE = 16000
+_MEL_FLOOR = 1e-10
+_NORM_VARIANCE_EPS = 1e-7
+
+
+def _hertz_to_mel_slaney(freq: np.ndarray) -> np.ndarray:
+    """Convert frequencies in hertz to mels using the Slaney scale."""
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+    logstep = 27.0 / np.log(6.4)
+    freq = np.atleast_1d(np.asarray(freq, dtype=np.float64))
+    mels = 3.0 * freq / 200.0
+    log_region = freq >= min_log_hertz
+    mels[log_region] = min_log_mel + np.log(freq[log_region] / min_log_hertz) * logstep
+    return mels
+
+
+def _mel_to_hertz_slaney(mels: np.ndarray) -> np.ndarray:
+    """Convert frequencies in mels to hertz using the Slaney scale."""
+    min_log_hertz = 1000.0
+    min_log_mel = 15.0
+    logstep = np.log(6.4) / 27.0
+    mels = np.atleast_1d(np.asarray(mels, dtype=np.float64))
+    freq = 200.0 * mels / 3.0
+    log_region = mels >= min_log_mel
+    freq[log_region] = min_log_hertz * np.exp(logstep * (mels[log_region] - min_log_mel))
+    return freq
+
+
+def _build_mel_filterbank(
+    num_frequency_bins: int,
+    num_mel_filters: int,
+    min_frequency: float,
+    max_frequency: float,
+    sampling_rate: int,
+) -> np.ndarray:
+    """Build a Slaney-normalized triangular mel filterbank.
+
+    Returns a matrix of shape ``(num_frequency_bins, num_mel_filters)`` that
+    projects a power spectrogram onto the mel scale.
+    """
+    mel_min = float(_hertz_to_mel_slaney(np.array([min_frequency], dtype=np.float64))[0])
+    mel_max = float(_hertz_to_mel_slaney(np.array([max_frequency], dtype=np.float64))[0])
+    mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
+    filter_freqs = _mel_to_hertz_slaney(mel_freqs)
+    fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
+
+    filter_diff = np.diff(filter_freqs)
+    slopes = np.expand_dims(filter_freqs, 0) - np.expand_dims(fft_freqs, 1)
+    down_slopes = -slopes[:, :-2] / filter_diff[:-1]
+    up_slopes = slopes[:, 2:] / filter_diff[1:]
+    mel_filters = np.maximum(np.zeros(1), np.minimum(down_slopes, up_slopes))
+
+    # Slaney area normalization.
+    enorm = 2.0 / (filter_freqs[2 : num_mel_filters + 2] - filter_freqs[:num_mel_filters])
+    mel_filters *= np.expand_dims(enorm, 0)
+    return mel_filters
+
+
+def _periodic_hann_window(window_length: int) -> np.ndarray:
+    """Return a length-``window_length`` periodic Hann window (matches torch.hann_window)."""
+    return np.hanning(window_length + 1)[:-1]
+
+
+# Precomputed constants for the Whisper feature extractor defaults used by Smart Turn v3.
+_HANN_WINDOW = _periodic_hann_window(_N_FFT)
+_MEL_FILTERS = _build_mel_filterbank(
+    num_frequency_bins=_N_FFT // 2 + 1,
+    num_mel_filters=_N_MELS,
+    min_frequency=0.0,
+    max_frequency=_SAMPLING_RATE / 2.0,
+    sampling_rate=_SAMPLING_RATE,
+)
+
+
+def _power_spectrogram(
+    waveform: np.ndarray,
+    window: np.ndarray,
+    frame_length: int,
+    hop_length: int,
+) -> np.ndarray:
+    """Compute a centered power spectrogram (reflect-padded, real-FFT, |.|^2).
+
+    Returns shape ``(num_frequency_bins, num_frames)`` in float64 to match the
+    reference implementation, which promotes to float64 internally.
+    """
+    pad = frame_length // 2
+    padded = np.pad(waveform.astype(np.float64), (pad, pad), mode="reflect")
+    win = window.astype(np.float64)
+
+    # Zero-copy view of all length-`frame_length` windows in `padded`, then
+    # decimate by `hop_length` to land on the analysis frames the loop walked.
+    # Shape: (num_frames, frame_length). Bit-identical to the per-frame slices
+    # the previous Python loop produced.
+    windows = sliding_window_view(padded, frame_length)[::hop_length]
+    # One batched rFFT replaces ~800 Python-level calls into numpy. Output
+    # dtype is complex128, same as the loop's `np.empty(..., complex128)`.
+    spec = np.fft.rfft(windows * win, axis=-1)
+
+    return (np.abs(spec) ** 2).T  # (num_frequency_bins, num_frames)
+
+
+def compute_whisper_log_mel_features(
+    audio: np.ndarray,
+    *,
+    do_normalize: bool = True,
+) -> np.ndarray:
+    """Compute Whisper-style log-mel features for Smart Turn v3.
+
+    Replicates the output of
+    ``transformers.WhisperFeatureExtractor(chunk_length=8)(audio, sampling_rate=16000,
+    padding="max_length", max_length=128000, truncation=True, do_normalize=...,
+    return_tensors="np").input_features.squeeze(0)``.
+
+    Assumes the caller has already padded or truncated the input to exactly
+    ``128000`` samples (8 seconds at 16 kHz); shorter inputs are zero-padded
+    at the end, longer inputs are truncated to the leading window.
+
+    Args:
+        audio: One-dimensional float audio at 16 kHz. Any numeric dtype is
+            accepted; the function casts to float64 internally and returns
+            float32.
+        do_normalize: If True, apply zero-mean unit-variance normalization to
+            the waveform before computing the spectrogram. Matches the
+            transformers ``do_normalize=True`` behavior.
+
+    Returns:
+        Float32 ndarray of shape ``(80, 800)`` containing log-mel features in
+        roughly the ``[-1, 1]`` range.
+    """
+    if audio.ndim != 1:
+        raise ValueError(f"Expected 1-D audio, got shape {audio.shape}")
+
+    x = np.asarray(audio, dtype=np.float32)
+    n_samples = _SAMPLING_RATE * 8  # 128000
+    if x.size < n_samples:
+        x = np.pad(x, (0, n_samples - x.size), mode="constant")
+    elif x.size > n_samples:
+        x = x[:n_samples]
+
+    # Zero-mean unit-variance waveform normalization happens BEFORE the
+    # spectrogram, mirroring transformers' WhisperFeatureExtractor.__call__.
+    # Done in float32 to match the reference's precision (it normalizes the
+    # padded float32 buffer before the spectrogram promotes to float64).
+    if do_normalize:
+        x = (x - x.mean()) / np.sqrt(x.var() + _NORM_VARIANCE_EPS)
+
+    magnitudes = _power_spectrogram(x, _HANN_WINDOW, _N_FFT, _HOP_LENGTH)
+    mel_spec = np.maximum(_MEL_FLOOR, _MEL_FILTERS.T @ magnitudes)
+    log_spec = np.log10(mel_spec)
+    log_spec = log_spec[:, :-1]  # drop the trailing frame, matching the reference.
+    log_spec = np.maximum(log_spec, log_spec.max() - 8.0)
+    log_spec = (log_spec + 4.0) / 4.0
+    return log_spec.astype(np.float32)

--- a/src/pipecat/audio/turn/smart_turn/local_smart_turn_v3.py
+++ b/src/pipecat/audio/turn/smart_turn/local_smart_turn_v3.py
@@ -16,8 +16,8 @@ import numpy as np
 import onnxruntime as ort
 import soxr
 from loguru import logger
-from transformers import WhisperFeatureExtractor
 
+from pipecat.audio.turn.smart_turn._whisper_features import compute_whisper_log_mel_features
 from pipecat.audio.turn.smart_turn.base_smart_turn import BaseSmartTurn
 from pipecat.utils.env import env_truthy
 
@@ -73,7 +73,6 @@ class LocalSmartTurnAnalyzerV3(BaseSmartTurn):
         so.intra_op_num_threads = cpu_count
         so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
 
-        self._feature_extractor = WhisperFeatureExtractor(chunk_length=8)
         self._session = ort.InferenceSession(smart_turn_model_path, sess_options=so)
 
         logger.debug("Loaded Local Smart Turn v3.x")
@@ -161,20 +160,9 @@ class LocalSmartTurnAnalyzerV3(BaseSmartTurn):
         # Truncate to 8 seconds (keeping the end) or pad to 8 seconds
         audio_array = truncate_audio_to_last_n_seconds(audio_array, n_seconds=8)
 
-        # Process audio using Whisper's feature extractor
-        inputs = self._feature_extractor(
-            audio_array,
-            sampling_rate=_MODEL_SAMPLE_RATE,
-            return_tensors="np",
-            padding="max_length",
-            max_length=8 * _MODEL_SAMPLE_RATE,
-            truncation=True,
-            do_normalize=True,
-        )
-
-        # Extract features and ensure correct shape for ONNX
-        input_features = inputs.input_features.squeeze(0).astype(np.float32)
-        input_features = np.expand_dims(input_features, axis=0)  # Add batch dimension
+        # Compute Whisper-style log-mel features (vendored numpy implementation).
+        log_mel = compute_whisper_log_mel_features(audio_array, do_normalize=True)
+        input_features = np.expand_dims(log_mel, axis=0)  # Add batch dimension
 
         # Run ONNX inference
         outputs = self._session.run(None, {"input_features": input_features})

--- a/tests/test_local_smart_turn_v3_features.py
+++ b/tests/test_local_smart_turn_v3_features.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Numerical-equivalence tests for the vendored Whisper log-mel extractor."""
+
+import numpy as np
+import pytest
+
+from pipecat.audio.turn.smart_turn._whisper_features import compute_whisper_log_mel_features
+
+transformers = pytest.importorskip("transformers")
+
+
+_N_SAMPLES = 128_000  # 8 seconds at 16 kHz
+
+
+@pytest.fixture(scope="module")
+def reference_extractor():
+    return transformers.WhisperFeatureExtractor(chunk_length=8)
+
+
+def _silence():
+    return np.zeros(_N_SAMPLES, dtype=np.float32)
+
+
+def _noise():
+    rng = np.random.default_rng(0xC0FFEE)
+    return (rng.standard_normal(_N_SAMPLES) * 0.1).astype(np.float32)
+
+
+def _sweep():
+    t = np.linspace(0, 8, _N_SAMPLES, endpoint=False, dtype=np.float32)
+    return (0.5 * np.sin(2 * np.pi * (200 + (4000 - 200) * t / 8) * t)).astype(np.float32)
+
+
+def _partial():
+    rng = np.random.default_rng(0xC0FFEE)
+    return np.concatenate(
+        [
+            np.zeros(120_000, dtype=np.float32),
+            (rng.standard_normal(8_000) * 0.1).astype(np.float32),
+        ]
+    )
+
+
+FIXTURES = [
+    pytest.param(_silence, id="silence"),
+    pytest.param(_noise, id="noise"),
+    pytest.param(_sweep, id="sweep"),
+    pytest.param(_partial, id="partial"),
+]
+
+
+@pytest.mark.parametrize("audio_factory", FIXTURES)
+@pytest.mark.parametrize("do_normalize", [True, False])
+def test_matches_transformers_numpy_path(reference_extractor, audio_factory, do_normalize):
+    """The vendored implementation matches transformers' numpy code path tightly."""
+    audio = audio_factory()
+    got = compute_whisper_log_mel_features(audio, do_normalize=do_normalize)
+
+    # Replicate the numpy code path: pad-or-truncate (float32), optional normalize, then
+    # call _np_extract_fbank_features directly. This is apples-to-apples; both
+    # implementations are pure numpy.
+    x = audio.astype(np.float32)
+    if x.size < _N_SAMPLES:
+        x = np.pad(x, (0, _N_SAMPLES - x.size), mode="constant")
+    elif x.size > _N_SAMPLES:
+        x = x[:_N_SAMPLES]
+    if do_normalize:
+        x = ((x - x.mean()) / np.sqrt(x.var() + 1e-7)).astype(np.float32)
+
+    expected = reference_extractor._np_extract_fbank_features(x[np.newaxis, :], device="cpu")[0]
+
+    assert got.shape == expected.shape == (80, 800)
+    assert got.dtype == np.float32
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("audio_factory", FIXTURES)
+@pytest.mark.parametrize("do_normalize", [True, False])
+def test_matches_transformers_public_call(reference_extractor, audio_factory, do_normalize):
+    """The vendored implementation matches the public WhisperFeatureExtractor call.
+
+    The public ``__call__`` dispatches to the torch path when torch is installed,
+    which diverges from the numpy path by up to ~1e-4 on high-amplitude inputs
+    purely due to ``torch.stft`` vs ``numpy.fft.rfft`` rounding (the divergence
+    is internal to transformers, not introduced by this port). A looser tolerance
+    is required here than in the numpy-vs-numpy test above.
+    """
+    audio = audio_factory()
+    got = compute_whisper_log_mel_features(audio, do_normalize=do_normalize)
+    out = reference_extractor(
+        audio,
+        sampling_rate=16_000,
+        return_tensors="np",
+        padding="max_length",
+        max_length=_N_SAMPLES,
+        truncation=True,
+        do_normalize=do_normalize,
+    )
+    expected = out.input_features.squeeze(0).astype(np.float32)
+
+    assert got.shape == expected.shape == (80, 800)
+    np.testing.assert_allclose(got, expected, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Smart Turn v3 used `transformers.WhisperFeatureExtractor` only for the log-mel features it feeds to the ONNX model. The underlying numpy path is small and self-contained, so this change vendors a minimal numpy implementation into pipecat and removes the transformers import from the v3 module.

We noticed Smart Turn v3 was using significantly more memory than expected at import time, almost entirely from pulling in the full `transformers` package for a single feature extractor. Measured on this branch (Python 3.12, Linux):

  | Metric                            | Before    | After    |
  | --------------------------------- | --------- | -------- |
  | `import local_smart_turn_v3` time |  5,044 ms |   300 ms |
  | Peak RSS                          |    566 MB |    60 MB |

That is ~17x faster cold-start and ~506 MB less resident memory per process, which is most impactful under pod-per-call deployments where every container pays the import cost.

Per-call CPU and event-loop behavior are unaffected. `_predict_endpoint` remains synchronous and runs off the main loop via the analyzer thread pool, exactly as before; only the implementation of the feature extractor changed.

Behavior is verified numerically equivalent: the vendored output matches the reference numpy code path within 1e-5 absolute tolerance across silence/noise/sine-sweep/partially-padded audio (both `do_normalize=True` and `=False`), and the ONNX model produces bit-identical probabilities on representative inputs.

Smart Turn v3 no longer imports `transformers` at module load. The `transformers` package remains a project dependency because the deprecated v2/CoreML analyzers and the Moondream service still use it; making it optional is out of scope here.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.