### PR TITLE
fix: make test_task_heartbeats robust to timing jitter

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -353,11 +353,16 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
         assert "Second" in upstream_texts
 
     async def test_task_heartbeats(self):
+        period_secs = 0.2
+        expected_heartbeats = 5
         heartbeats_counter = 0
+        received_expected = asyncio.Event()
 
         async def heartbeat_received(processor: FrameProcessor, heartbeat: HeartbeatFrame):
             nonlocal heartbeats_counter
             heartbeats_counter += 1
+            if heartbeats_counter >= expected_heartbeats:
+                received_expected.set()
 
         identity = IdentityFilter()
         pipeline = Pipeline([identity])
@@ -368,23 +373,41 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
             pipeline,
             params=PipelineParams(
                 enable_heartbeats=True,
-                heartbeats_period_secs=0.2,
+                heartbeats_period_secs=period_secs,
             ),
             observers=[heartbeats_observer],
             cancel_on_idle_timeout=False,
         )
 
-        expected_heartbeats = 1.0 / 0.2
+        async def wait_for_heartbeats():
+            # Wait until we've observed the expected number of heartbeats, then
+            # stop the pipeline. We don't assert on the count observed within a
+            # fixed wall-clock window: heartbeats are timer-driven, so the count
+            # in any given window depends on event-loop scheduling precision and
+            # is off-by-one under load (which made this test flaky in CI). The
+            # generous timeout only guards against heartbeats never firing.
+            try:
+                await asyncio.wait_for(received_expected.wait(), timeout=5.0)
+            except TimeoutError:
+                pass
+            await task.queue_frame(EndFrame())
 
         await task.queue_frame(TextFrame(text="Hello!"))
-        try:
-            await asyncio.wait_for(
-                task.run(PipelineTaskParams(loop=asyncio.get_event_loop())),
-                timeout=1.0,
-            )
-        except TimeoutError:
-            pass
-        assert heartbeats_counter == expected_heartbeats
+
+        start_time = time.time()
+        await asyncio.gather(
+            task.run(PipelineTaskParams(loop=asyncio.get_event_loop())),
+            wait_for_heartbeats(),
+        )
+        elapsed = time.time() - start_time
+
+        # We observed the expected number of heartbeats...
+        assert heartbeats_counter >= expected_heartbeats
+        # ...and they were paced by the configured period: each heartbeat waits a
+        # full period, so N heartbeats span at least (N - 1) periods. asyncio.sleep
+        # is a guaranteed lower bound, so this is robust to scheduling jitter while
+        # still catching heartbeats that fire too fast.
+        assert elapsed >= (expected_heartbeats - 1) * period_secs
 
     async def test_heartbeat_monitor_respects_custom_timeout(self):
         """Verify the heartbeat monitor uses heartbeats_monitor_secs from params."""


### PR DESCRIPTION
This test keeps failing in CI. This PR is to make the timing more deterministic.

## Summary

- Fixes flaky `tests/test_pipeline.py::TestPipelineTask::test_task_heartbeats` (`assert 4 == 5.0` in CI, passes locally).
- Root cause: the test asserted an **exact** count of timer-driven heartbeats over a fixed 1.0s wall-clock window, so the result depended on event-loop scheduling precision.
- Test-only change — no library code is affected.

## Details

The test asserted an exact heartbeat count inside a fixed 1.0s window:

```python
expected_heartbeats = 1.0 / 0.2   # == 5.0
await asyncio.wait_for(task.run(...), timeout=1.0)
assert heartbeats_counter == expected_heartbeats
```

The heartbeat handler pushes one `HeartbeatFrame` immediately, then `asyncio.sleep(0.2)` between each, so heartbeats land at roughly `ε, ε+0.2, …, ε+0.8, ε+1.0` where `ε` is startup latency. Whether exactly 5 fall inside the 1.0s window depends entirely on scheduling precision — fine locally, but under CI load a tick slips past the cutoff and only 4 are observed.

The fix stops coupling the assertion to the wall-clock window. It waits until the expected number of heartbeats has actually been observed (with a generous 5s safety-net timeout that only triggers if heartbeats never fire), then stops the pipeline and asserts:

- `heartbeats_counter >= expected_heartbeats` — they fire and reach the observer.
- `elapsed >= (expected_heartbeats - 1) * period_secs` — they're properly paced. Since `asyncio.sleep` is a guaranteed lower bound, N heartbeats span at least `(N−1)` periods. This is immune to scheduling jitter (which can only delay, never speed up) while still catching heartbeats that fire too fast.

This preserves the original two-sided intent (right number, right rate) without depending on timer precision.

## Testing

- Passes consistently (~1.3s), including under heavy CPU contention where the original off-by-one surfaced.
- Full `TestPipelineTask` class passes (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)