### PR TITLE
chore: drop transformers from base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "wait_for2>=0.4.1,<1; python_version<'3.12'",
     # Required by LocalSmartTurnAnalyzerV3
     # Inlined here instead of using a self-referential extra for Poetry compatibility.
-    "transformers>=4.48.0,<6",
     "onnxruntime~=1.24.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4219,7 +4219,6 @@ dependencies = [
     { name = "pyloudnorm" },
     { name = "resampy" },
     { name = "soxr" },
-    { name = "transformers" },
     { name = "wait-for2", marker = "python_full_version < '3.12'" },
 ]
 
@@ -4566,7 +4565,6 @@ requires-dist = [
     { name = "timm", marker = "extra == 'moondream'", specifier = "~=1.0.13" },
     { name = "torch", marker = "extra == 'local-smart-turn'", specifier = ">=2.5.0,<3" },
     { name = "torchaudio", marker = "extra == 'local-smart-turn'", specifier = ">=2.5.0,<3" },
-    { name = "transformers", specifier = ">=4.48.0,<6" },
     { name = "transformers", marker = "extra == 'local-smart-turn'", specifier = ">=4.48.0,<6" },
     { name = "transformers", marker = "extra == 'moondream'", specifier = ">=4.48.0,<6" },
     { name = "uvicorn", marker = "extra == 'runner'", specifier = ">=0.32.0,<1.0.0" },


### PR DESCRIPTION
Thanks to https://github.com/pipecat-ai/pipecat/pull/4536, we can now drop `transformers` from the core `dependencies` list.

This offers a huge performance improvement in cold start time and reduction of image size.

Note: `transformers` is still used in other places, but in all cases, it's included as an optional dependency. (e.g. `local-smart-turn` and `moondream`.

## Summary

Removes `transformers` from the top-level `[project] dependencies` in `pyproject.toml` so a base `pip install pipecat-ai` no longer pulls in the (heavy) `transformers` package.

`transformers` was inlined into the base deps solely because `LocalSmartTurnAnalyzerV3` needed it. After #PREVIOUS (commit `31aa4ac65`, "Vendor Whisper log-mel feature extractor in Smart Turn v3"), V3 vendors its log-mel feature extractor and no longer imports `transformers` at all — making the base-dep entry obsolete. That commit explicitly flagged this as a follow-up ("making it optional is out of scope here").

## Why it's safe

The only remaining users of `transformers` all import it behind `try/except ModuleNotFoundError` guards (never at base-package load time) and already declare it in their respective extras:

| User | Extra | Extra declares `transformers`? |
| --- | --- | --- |
| `local_smart_turn_v2.py` (deprecated) | `local-smart-turn` | ✅ |
| `local_coreml_smart_turn.py` (deprecated) | `local-smart-turn` | ✅ |
| `moondream/vision.py` | `moondream` | ✅ |

`onnxruntime` stays in the base deps — Smart Turn v3 still requires it.

## Changes

- `pyproject.toml`: remove `transformers>=4.48.0,<6` from base `dependencies`; keep `onnxruntime` and its V3 comment. Extras untouched.
- `uv.lock`: regenerated (resolves cleanly; `transformers` still present via the extras).

🤖 Generated with [Claude Code](https://claude.com/claude-code)