### PR TITLE
Honor SOXR resampler quality setting

### DIFF
--- a/changelog/4551.fixed.md
+++ b/changelog/4551.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `SOXRAudioResampler` and `SOXRStreamAudioResampler` ignoring the
+  configured quality setting. Both resamplers were hardcoded to `VHQ`, which
+  meant `RNNoiseFilter`'s `resampler_quality` argument (defaulting to `QQ`
+  for low-latency real-time use) had no effect. The resamplers now honor
+  the configured quality, with `VHQ` retained as the default.

--- a/src/pipecat/audio/filters/rnnoise_filter.py
+++ b/src/pipecat/audio/filters/rnnoise_filter.py
@@ -14,6 +14,7 @@ import numpy as np
 from loguru import logger
 
 from pipecat.audio.filters.base_audio_filter import BaseAudioFilter
+from pipecat.audio.resamplers.base_audio_resampler import SoxrQuality
 from pipecat.frames.frames import FilterControlFrame, FilterEnableFrame
 
 try:
@@ -35,7 +36,7 @@ class RNNoiseFilter(BaseAudioFilter):
     processes it in chunks.
     """
 
-    def __init__(self, resampler_quality: str = "QQ") -> None:
+    def __init__(self, resampler_quality: SoxrQuality = "QQ") -> None:
         """Initialize the RNNoise noise suppression filter.
 
         Args:
@@ -49,7 +50,7 @@ class RNNoiseFilter(BaseAudioFilter):
         self._rnnoise_ready = False
         self._resampler_in = None
         self._resampler_out = None
-        self._resampler_quality = resampler_quality
+        self._resampler_quality: SoxrQuality = resampler_quality
 
     async def start(self, sample_rate: int):
         """Initialize the filter with the transport's sample rate.

--- a/src/pipecat/audio/resamplers/base_audio_resampler.py
+++ b/src/pipecat/audio/resamplers/base_audio_resampler.py
@@ -11,6 +11,10 @@ providing a common interface for converting audio between different sample rates
 """
 
 from abc import ABC, abstractmethod
+from typing import Literal
+
+SoxrQuality = Literal["QQ", "LQ", "MQ", "HQ", "VHQ"]
+"""SOXR resampling quality presets, from fastest (QQ) to highest quality (VHQ)."""
 
 
 class BaseAudioResampler(ABC):

--- a/src/pipecat/audio/resamplers/soxr_resampler.py
+++ b/src/pipecat/audio/resamplers/soxr_resampler.py
@@ -18,24 +18,27 @@ When to use the SOXRAudioResampler:
 import numpy as np
 import soxr
 
-from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler
+from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler, SoxrQuality
 
 
 class SOXRAudioResampler(BaseAudioResampler):
     """Audio resampler implementation using the SoX resampler library.
 
     This resampler uses the SoX resampler library configured for very high
-    quality (VHQ) resampling, providing excellent audio quality at the cost
-    of additional computational overhead.
+    quality (VHQ) resampling by default, providing excellent audio quality at
+    the cost of additional computational overhead.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, quality: SoxrQuality = "VHQ", **kwargs):
         """Initialize the SoX audio resampler.
 
         Args:
-            **kwargs: Additional keyword arguments (currently unused).
+            quality: SOXR quality preset. Higher quality means higher CPU cost.
+                One of "VHQ" (default, very high quality), "HQ", "MQ", "LQ",
+                or "QQ" (quick, lowest latency).
+            **kwargs: Reserved for forward compatibility; currently ignored.
         """
-        pass
+        self._quality = quality
 
     async def resample(self, audio: bytes, in_rate: int, out_rate: int) -> bytes:
         """Resample audio data using SoX resampler library.
@@ -51,6 +54,6 @@ class SOXRAudioResampler(BaseAudioResampler):
         if in_rate == out_rate:
             return audio
         audio_data = np.frombuffer(audio, dtype=np.int16)
-        resampled_audio = soxr.resample(audio_data, in_rate, out_rate, quality="VHQ")
+        resampled_audio = soxr.resample(audio_data, in_rate, out_rate, quality=self._quality)
         result = resampled_audio.astype(np.int16).tobytes()
         return result

--- a/src/pipecat/audio/resamplers/soxr_stream_resampler.py
+++ b/src/pipecat/audio/resamplers/soxr_stream_resampler.py
@@ -22,7 +22,7 @@ import time
 import numpy as np
 import soxr
 
-from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler
+from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler, SoxrQuality
 
 CLEAR_STREAM_AFTER_SECS = 0.2
 
@@ -31,8 +31,8 @@ class SOXRStreamAudioResampler(BaseAudioResampler):
     """Audio resampler implementation using the SoX ResampleStream library.
 
     This resampler uses the SoX ResampleStream library configured for very high
-    quality (VHQ) resampling, providing excellent audio quality at the cost
-    of additional computational overhead.
+    quality (VHQ) resampling by default, providing excellent audio quality at
+    the cost of additional computational overhead.
     It keeps an internal history which avoids clicks at chunk boundaries.
 
     Notes:
@@ -40,12 +40,16 @@ class SOXRStreamAudioResampler(BaseAudioResampler):
         - Input must be 16-bit signed PCM audio as raw bytes.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, quality: SoxrQuality = "VHQ", **kwargs):
         """Initialize the resampler.
 
         Args:
-            **kwargs: Additional keyword arguments (currently unused).
+            quality: SOXR quality preset. Higher quality means higher CPU cost.
+                One of "VHQ" (default, very high quality), "HQ", "MQ", "LQ",
+                or "QQ" (quick, lowest latency).
+            **kwargs: Reserved for forward compatibility; currently ignored.
         """
+        self._quality = quality
         self._in_rate: float | None = None
         self._out_rate: float | None = None
         self._last_resample_time: float = 0
@@ -56,7 +60,7 @@ class SOXRStreamAudioResampler(BaseAudioResampler):
         self._out_rate = out_rate
         self._last_resample_time = time.time()
         self._soxr_stream = soxr.ResampleStream(
-            in_rate=in_rate, out_rate=out_rate, num_channels=1, quality="VHQ", dtype="int16"
+            in_rate=in_rate, out_rate=out_rate, num_channels=1, quality=self._quality, dtype="int16"
         )
 
     def _maybe_clear_internal_state(self):

--- a/tests/test_soxr_resamplers.py
+++ b/tests/test_soxr_resamplers.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import numpy as np
+import pytest
+
+from pipecat.audio.filters.rnnoise_filter import RNNoiseFilter
+from pipecat.audio.resamplers.soxr_resampler import SOXRAudioResampler
+from pipecat.audio.resamplers.soxr_stream_resampler import SOXRStreamAudioResampler
+
+
+@pytest.mark.asyncio
+async def test_soxr_audio_resampler_uses_configured_quality(monkeypatch):
+    calls = {}
+
+    def resample(audio_data, in_rate, out_rate, quality):
+        calls["quality"] = quality
+        calls["in_rate"] = in_rate
+        calls["out_rate"] = out_rate
+        return audio_data
+
+    monkeypatch.setattr("pipecat.audio.resamplers.soxr_resampler.soxr.resample", resample)
+
+    audio = np.array([1, 2, 3, 4], dtype=np.int16).tobytes()
+    result = await SOXRAudioResampler(quality="HQ").resample(audio, 8000, 16000)
+
+    assert result == audio
+    assert calls == {"quality": "HQ", "in_rate": 8000, "out_rate": 16000}
+
+
+@pytest.mark.asyncio
+async def test_soxr_audio_resampler_defaults_to_vhq(monkeypatch):
+    calls = {}
+
+    def resample(audio_data, in_rate, out_rate, quality):
+        calls["quality"] = quality
+        return audio_data
+
+    monkeypatch.setattr("pipecat.audio.resamplers.soxr_resampler.soxr.resample", resample)
+
+    audio = np.array([1, 2, 3, 4], dtype=np.int16).tobytes()
+    await SOXRAudioResampler().resample(audio, 8000, 16000)
+
+    assert calls["quality"] == "VHQ"
+
+
+@pytest.mark.asyncio
+async def test_soxr_stream_audio_resampler_uses_configured_quality(monkeypatch):
+    calls = {}
+
+    class ResampleStream:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+        def resample_chunk(self, audio_data):
+            return audio_data
+
+        def clear(self):
+            pass
+
+    monkeypatch.setattr(
+        "pipecat.audio.resamplers.soxr_stream_resampler.soxr.ResampleStream", ResampleStream
+    )
+
+    audio = np.array([1, 2, 3, 4], dtype=np.int16).tobytes()
+    result = await SOXRStreamAudioResampler(quality="QQ").resample(audio, 8000, 16000)
+
+    assert result == audio
+    assert calls == {
+        "in_rate": 8000,
+        "out_rate": 16000,
+        "num_channels": 1,
+        "quality": "QQ",
+        "dtype": "int16",
+    }
+
+
+@pytest.mark.asyncio
+async def test_soxr_stream_audio_resampler_defaults_to_vhq(monkeypatch):
+    calls = {}
+
+    class ResampleStream:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+        def resample_chunk(self, audio_data):
+            return audio_data
+
+        def clear(self):
+            pass
+
+    monkeypatch.setattr(
+        "pipecat.audio.resamplers.soxr_stream_resampler.soxr.ResampleStream", ResampleStream
+    )
+
+    audio = np.array([1, 2, 3, 4], dtype=np.int16).tobytes()
+    await SOXRStreamAudioResampler().resample(audio, 8000, 16000)
+
+    assert calls["quality"] == "VHQ"
+
+
+@pytest.mark.asyncio
+async def test_rnnoise_default_resampler_quality_is_forwarded(monkeypatch):
+    qualities = []
+
+    class RNNoise:
+        def __init__(self, sample_rate):
+            self.sample_rate = sample_rate
+
+    class Resampler:
+        def __init__(self, quality):
+            qualities.append(quality)
+
+    monkeypatch.setattr("pipecat.audio.filters.rnnoise_filter.RNNoise", RNNoise)
+    monkeypatch.setattr(
+        "pipecat.audio.resamplers.soxr_stream_resampler.SOXRStreamAudioResampler", Resampler
+    )
+
+    rnnoise_filter = RNNoiseFilter()
+    await rnnoise_filter.start(16000)
+
+    assert qualities == ["QQ", "QQ"]


### PR DESCRIPTION
## Summary

This makes the SOXR resamplers honor the configured quality setting instead of always using VHQ.

The default remains VHQ, so existing callers keep the same behavior unless they explicitly pass another quality preset.

## Details

RNNoiseFilter already passes resampler_quality into SOXRStreamAudioResampler, defaulting to QQ for lower-latency real-time processing. However, the stream resampler ignored the argument and always initialized SOXR with VHQ.

This updates both SOXR resampler implementations to store and pass through the selected quality preset.

## Tests

- uv run pytest tests/test_soxr_resamplers.py
- uv run pytest tests/test_soxr_resamplers.py tests/test_rnnoise_resampling.py tests/test_rnnoise_filter.py tests/test_resampy_resampler.py
- uv run ruff check src/pipecat/audio/resamplers/soxr_resampler.py src/pipecat/audio/resamplers/soxr_stream_resampler.py src/pipecat/audio/resamplers/soxr_utils.py tests/test_soxr_resamplers.py