### PR TITLE
Update default Gradium voice ID

### DIFF
--- a/examples/update-settings/tts/tts-gradium.py
+++ b/examples/update-settings/tts/tts-gradium.py
@@ -54,7 +54,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     tts = GradiumTTSService(
         api_key=os.environ["GRADIUM_API_KEY"],
-        settings=GradiumTTSService.Settings(voice="YTpq7expH9539ERJ"),
+        settings=GradiumTTSService.Settings(voice="_6Aslh2DxfmnRLmP"),
     )
 
     llm = OpenAILLMService(

--- a/examples/voice/voice-gradium.py
+++ b/examples/voice/voice-gradium.py
@@ -62,7 +62,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = GradiumTTSService(
         api_key=os.environ["GRADIUM_API_KEY"],
         settings=GradiumTTSService.Settings(
-            voice="YTpq7expH9539ERJ",
+            voice="_6Aslh2DxfmnRLmP",
         ),
     )
 

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -103,7 +103,7 @@ class GradiumTTSService(WebsocketTTSService):
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
             model="default",
-            voice="YTpq7expH9539ERJ",
+            voice="_6Aslh2DxfmnRLmP",
             language=None,
         )
 


### PR DESCRIPTION
## Summary
- Update the default Gradium voice ID from `YTpq7expH9539ERJ` to `_6Aslh2DxfmnRLmP` across the service default and the two Gradium example bots.

## Files
- `src/pipecat/services/gradium/tts.py` — hardcoded default in `GradiumTTSService.__init__`
- `examples/update-settings/tts/tts-gradium.py` — example settings voice
- `examples/voice/voice-gradium.py` — example settings voice

## Test plan
- [ ] Run `examples/voice/voice-gradium.py` and confirm it synthesizes with the new voice
- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)