### PR TITLE
fix(base_output): bound _send_silence write timeout

### DIFF
--- a/changelog/4578.fixed.md
+++ b/changelog/4578.fixed.md
@@ -1,0 +1,1 @@
+- Fixed pipeline shutdown hanging on LiveKit when the remote peer disconnected mid-stream. The trailing `audio_out_end_silence_secs` write is now bounded by a timeout.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -819,7 +819,13 @@ class BaseOutputTransport(FrameProcessor):
             silence_frame = OutputAudioRawFrame(
                 audio=silence, sample_rate=self.sample_rate, num_channels=1
             )
-            await self._transport.write_audio_frame(silence_frame)
+            try:
+                await asyncio.wait_for(
+                    self._transport.write_audio_frame(silence_frame),
+                    timeout=secs + 1,
+                )
+            except TimeoutError:
+                logger.warning(f"{self} timed out writing end-frame silence")
 
         async def _audio_task_handler(self):
             """Main audio processing task handler."""


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes: #4547 

**Issue :**   When the remote peer disconnects mid-stream on LiveKit & the pipeline shuts down gracefully, `MediaSender._send_silence` calls `write_audio_frame` to flush the trailing silence. LiveKit's `AudioSource.capture_frame` has buffer backpressure, with no consumer draining, it awaits forever. `MediaSender.stop()` blocks on the audio task, pipeline shutdown hangs.

**Change :**  Wrap the silence write in `asyncio.wait_for(timeout=secs + 1)`. On timeout we log a warning & move on, shutdown proceeds normally.