### PR TITLE
Let turn-based STT services opt out of TTFS

### DIFF
--- a/changelog/4585.added.md
+++ b/changelog/4585.added.md
@@ -1,0 +1,1 @@
+- Added the `STTService.supports_ttfs` property, which subclasses can override to return `False` when TTFS doesn't apply to their architecture (e.g. turn-based STTs where the server defines turn boundaries). When `False`, `STTMetadataFrame` is broadcast with `ttfs_p99_latency=0.0` and the "ttfs_p99_latency not set" warning is suppressed.

--- a/changelog/4585.fixed.md
+++ b/changelog/4585.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a spurious `ttfs_p99_latency not set, using default 1.0s` warning emitted by turn-based STT services (`CartesiaTurnsSTTService`, `DeepgramFluxSTTService`) at pipeline start. These services have no meaningful "speech end → final transcript" interval to measure, because the server defines turn boundaries directly.

--- a/src/pipecat/services/cartesia/turns/stt.py
+++ b/src/pipecat/services/cartesia/turns/stt.py
@@ -173,6 +173,11 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
         """
         return True
 
+    @property
+    def supports_ttfs(self) -> bool:
+        """TTFS doesn't apply: the server defines turn boundaries directly."""
+        return False
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -239,6 +239,11 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
         self._websocket_url = None
         self._receive_task = None
 
+    @property
+    def supports_ttfs(self) -> bool:
+        """TTFS doesn't apply: Flux defines turn boundaries directly."""
+        return False
+
     # ------------------------------------------------------------------
     # Transport interface implementation
     # ------------------------------------------------------------------

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -25,6 +25,13 @@ Run the TTFS benchmark for your service and configuration, then pass the
 measured value to your STT service constructor:
 
     stt = DeepgramSTTService(api_key="...", ttfs_p99_latency=0.45)
+
+Turn-based STT services (e.g. ``CartesiaTurnsSTTService``,
+``DeepgramFluxSTTService``) have no meaningful TTFS metric — the server
+defines the turn boundary directly, so there is no separate "speech end →
+final transcript" interval to measure. Those services override the
+``STTService.supports_ttfs`` property to return False rather than supplying
+a constant here.
 """
 
 # Conservative fallback for services without measured values

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -108,6 +108,8 @@ class STTService(AIService):
                 This is broadcast via STTMetadataFrame at pipeline start for downstream
                 processors (e.g., turn strategies) to optimize timing. Subclasses provide
                 measured defaults; pass a value here to override for your deployment.
+                Turn-based services where the server defines turn boundaries should
+                override :attr:`supports_ttfs` to return False instead of supplying a value.
             keepalive_timeout: Seconds of no audio before sending silence to keep the
                 connection alive. None disables keepalive. Useful for services that
                 close idle connections (e.g. behind a ServiceSwitcher).
@@ -468,8 +470,24 @@ class STTService(AIService):
 
         await super().push_frame(frame, direction)
 
+    @property
+    def supports_ttfs(self) -> bool:
+        """Whether this STT service has a meaningful TTFS-to-final-transcript metric.
+
+        Returns False for turn-based STTs where the server defines the turn
+        boundary, so there is no separate "speech end → final transcript"
+        interval to measure. Downstream turn-stop strategies that consume
+        :class:`STTMetadataFrame` treat a 0 latency as "no extra wait."
+        """
+        return True
+
     async def _push_stt_metadata(self):
         """Push STT metadata frame for downstream processors (e.g., turn strategies)."""
+        if not self.supports_ttfs:
+            await self.broadcast_frame(
+                STTMetadataFrame, service_name=self.name, ttfs_p99_latency=0.0
+            )
+            return
         ttfs = self._ttfs_p99_latency
         if ttfs is None:
             ttfs = DEFAULT_TTFS_P99


### PR DESCRIPTION
## Summary

- Turn-based STT services (`CartesiaTurnsSTTService`, `DeepgramFluxSTTService`) have no meaningful "speech end → final transcript" interval — the server defines turn boundaries directly. Omitting `ttfs_p99_latency` on these previously produced a spurious `ttfs_p99_latency not set, using default 1.0s` warning at pipeline start.
- Adds the `STTService.supports_ttfs` property (default `True`). When a subclass returns `False`, `_push_stt_metadata` broadcasts `STTMetadataFrame` with `ttfs_p99_latency=0.0` and skips the warning. Downstream turn-stop strategies already treat `0.0` as "no extra wait."
- Overrides `supports_ttfs` to return `False` on the two turn-based services.

## Testing

- Run `examples/voice/voice-cartesia-turns.py` and `examples/voice/voice-deepgram-flux.py`; confirm the `ttfs_p99_latency not set` warning no longer appears at pipeline start.