### PR TITLE
Remove redundant inline [DEPRECATED] tags from LLMUserAggregatorParams docstring

### DIFF
--- a/changelog/4592.changed.md
+++ b/changelog/4592.changed.md
@@ -1,0 +1,3 @@
+- Aligned the deprecation docstrings in `LLMUserAggregatorParams` with the
+  project's documented convention by removing redundant inline `[DEPRECATED]`
+  tags, keeping only the `.. deprecated::` Sphinx directive.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -128,18 +128,16 @@ class LLMUserAggregatorParams:
             has been idle (not speaking) for this duration. Set to 0 to disable
             idle detection.
         vad_analyzer: Voice Activity Detection analyzer instance.
-        filter_incomplete_user_turns: [DEPRECATED] Use
-            ``user_turn_strategies=FilterIncompleteUserTurnStrategies()``
-            instead. When enabled, the LLM outputs a turn-completion
-            marker at the start of each response: ✓ (complete), ○
-            (incomplete short), or ◐ (incomplete long). Incomplete
+        filter_incomplete_user_turns: When enabled, the LLM outputs a
+            turn-completion marker at the start of each response: ✓ (complete),
+            ○ (incomplete short), or ◐ (incomplete long). Incomplete
             responses are suppressed and timeouts trigger re-prompting.
 
             .. deprecated:: 1.2.0
                 Use ``user_turn_strategies=FilterIncompleteUserTurnStrategies()``
                 instead. Will be removed in version 2.0.0.
 
-        user_turn_completion_config: [DEPRECATED] Configuration for turn
+        user_turn_completion_config: Configuration for turn
             completion behavior including custom instructions, timeouts, and
             prompts. Only used when filter_incomplete_user_turns is True
             (deprecated path) — for the new strategy-based API, pass the config


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Per `CONTRIBUTING.md`/`AGENTS.md`, deprecations should use the `.. deprecated::` Sphinx directive — "never inline tags like `[DEPRECATED]`". The two `LLMUserAggregatorParams` fields (`filter_incomplete_user_turns` and `user_turn_completion_config`) carried both an inline `[DEPRECATED]` tag **and** the proper directive.

This removes the redundant inline tags while keeping the `.. deprecated:: 1.2.0` directives and all descriptive text intact. These were the only two remaining violations in the codebase. No behavior change.

A changelog fragment is included.