### PR TITLE
feat(assemblyai): add continuous_partials and interruption_delay streaming params

### DIFF
--- a/changelog/4593.added.md
+++ b/changelog/4593.added.md
@@ -1,0 +1,6 @@
+- Added `continuous_partials` and `interruption_delay` connection parameters to
+  the AssemblyAI streaming STT service (`u3-rt-pro` only). `continuous_partials`
+  defaults to `True` so voice agents receive interim transcripts at a steady
+  cadence during long turns; `interruption_delay` (0–1000 ms) overrides how soon
+  the first partial is emitted. Both are exposed via
+  `AssemblyAISTTService.Settings` and are omitted for non-`u3-rt-pro` models.

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -104,6 +104,14 @@ class AssemblyAISTTSettings(STTSettings):
             audio frames as silence. Only applicable to u3-rt-pro.
         domain: Optional domain for specialized recognition modes. For example,
             set to "medical-v1" to enable Medical Mode for healthcare transcription.
+        continuous_partials: Emit partial transcripts at a steady cadence during
+            long turns, rather than only one early partial near the turn start.
+            Only applicable to u3-rt-pro; not sent for other models. Defaults to
+            True in this plugin so voice agents receive continuous interim updates.
+        interruption_delay: Override, in milliseconds (0–1000), for how soon the
+            first partial is emitted. The server adds 256ms (MIN_TURN_DURATION_MS)
+            on top, so 0 → 256ms effective. Only applicable to u3-rt-pro. Defaults
+            to None (use the server default).
     """
 
     formatted_finals: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -122,6 +130,8 @@ class AssemblyAISTTSettings(STTSettings):
     speaker_labels: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     vad_threshold: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     domain: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    continuous_partials: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    interruption_delay: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class AssemblyAISTTService(WebsocketSTTService):
@@ -219,6 +229,8 @@ class AssemblyAISTTService(WebsocketSTTService):
             speaker_labels=None,
             vad_threshold=None,
             domain=None,
+            continuous_partials=True,
+            interruption_delay=None,
         )
 
         # 2. Apply direct init arg overrides (deprecated)
@@ -281,6 +293,18 @@ class AssemblyAISTTService(WebsocketSTTService):
                 "voice agents. Bad prompts may lead to bad results. If you'd like to create "
                 "your own prompt, check out our prompting guide at: "
                 "https://www.assemblyai.com/docs/streaming/prompting"
+            )
+
+        # continuous_partials and interruption_delay are u3-rt-pro-only.
+        # isinstance(int) narrows away None/NOT_GIVEN so the range check is type-safe.
+        interruption_delay = default_settings.interruption_delay
+        if isinstance(interruption_delay, int) and not (0 <= interruption_delay <= 1000):
+            raise ValueError("interruption_delay must be between 0 and 1000 ms")
+
+        if not is_u3_pro and isinstance(interruption_delay, int):
+            logger.warning(
+                "interruption_delay is only supported by u3-rt-pro and will be ignored "
+                f"for model '{default_settings.model}'."
             )
 
         # 6. Configure pipecat turn mode (mutates default_settings)
@@ -494,6 +518,11 @@ class AssemblyAISTTService(WebsocketSTTService):
             "vad_threshold": s.vad_threshold,
             "domain": s.domain,
         }
+
+        # continuous_partials and interruption_delay only apply to u3-rt-pro.
+        if s.model == "u3-rt-pro":
+            optional_fields["continuous_partials"] = s.continuous_partials
+            optional_fields["interruption_delay"] = s.interruption_delay
 
         for k, v in optional_fields.items():
             if v is not None:

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the AssemblyAI streaming STT service connection parameters."""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from pipecat.services.assemblyai.stt import AssemblyAISTTService
+
+
+def _query(service: AssemblyAISTTService) -> dict[str, list[str]]:
+    """Build the WebSocket URL and return its parsed query parameters."""
+    return parse_qs(urlparse(service._build_ws_url()).query)
+
+
+def test_continuous_partials_defaults_to_true_for_u3_rt_pro():
+    # u3-rt-pro is the default model; continuous_partials should be on by default.
+    service = AssemblyAISTTService(api_key="test-key")
+    assert _query(service)["continuous_partials"] == ["true"]
+
+
+def test_continuous_partials_can_be_disabled():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(continuous_partials=False),
+    )
+    assert _query(service)["continuous_partials"] == ["false"]
+
+
+def test_continuous_partials_omitted_for_universal_streaming():
+    # continuous_partials is a U3Pro-only parameter and must not be sent otherwise.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(model="universal-streaming-english"),
+    )
+    assert "continuous_partials" not in _query(service)
+
+
+def test_interruption_delay_omitted_by_default():
+    # Unset means "use the server default" — the param should not be sent.
+    service = AssemblyAISTTService(api_key="test-key")
+    assert "interruption_delay" not in _query(service)
+
+
+def test_interruption_delay_sent_for_u3_rt_pro():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(interruption_delay=300),
+    )
+    assert _query(service)["interruption_delay"] == ["300"]
+
+
+def test_interruption_delay_omitted_for_universal_streaming():
+    # interruption_delay is a U3Pro-only parameter.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(
+            model="universal-streaming-english", interruption_delay=300
+        ),
+    )
+    assert "interruption_delay" not in _query(service)
+
+
+@pytest.mark.parametrize("value", [0, 1000])
+def test_interruption_delay_boundaries_allowed(value):
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(interruption_delay=value),
+    )
+    assert _query(service)["interruption_delay"] == [str(value)]
+
+
+@pytest.mark.parametrize("value", [-1, 1001])
+def test_interruption_delay_out_of_range_raises(value):
+    with pytest.raises(ValueError):
+        AssemblyAISTTService(
+            api_key="test-key",
+            settings=AssemblyAISTTService.Settings(interruption_delay=value),
+        )


### PR DESCRIPTION
#### Summary

Adds two AssemblyAI v3 streaming connection parameters to `AssemblyAISTTService.Settings`, bringing the plugin to parity with the current Universal-Streaming / Universal-3 Pro streaming API:

- **`continuous_partials`** (`bool`, default `True`): emit partial transcripts at a steady cadence during long turns instead of just one early partial near the turn start. Defaulted to `True` so voice agents receive continuous interim updates.
- **`interruption_delay`** (`int`, `0–1000` ms, optional): per-stream override of how soon the first partial is emitted (the server adds 256 ms `MIN_TURN_DURATION_MS` on top). Unset → server default.

Both are **`u3-rt-pro`-only**: gated on the model in `_build_ws_url` and omitted for `universal-streaming-*`. `interruption_delay` is range-validated at construction, with a warning if set on a non-`u3-rt-pro` model.

Notes:
- Added only to the canonical `AssemblyAISTTService.Settings`; the deprecated `AssemblyAIConnectionParams` is intentionally left unchanged (consistent with how `formatted_finals` / `word_finalization_max_wait_time` were handled).
- These are connection params with no response-schema impact, so `models.py` is untouched.

#### Testing
- New `tests/test_assemblyai_stt.py` (10 tests): default-on for `u3-rt-pro`, override to `False`, omission for `universal-streaming`, and `interruption_delay` send/omit/boundary/range-error. All pass; `ruff` clean.
- Manually verified against the live streaming API via the examples: `transcription-assemblyai.py`, `voice-assemblyai.py`, and `voice-assemblyai-turn-detection.py`.