### PR TITLE
fix: check all tag pairs in parse_start_end_tags

### DIFF
--- a/changelog/4595.fixed.md
+++ b/changelog/4595.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `parse_start_end_tags` giving up on the whole tag list when the first
+  pair was absent from the text. With multiple `StartEndTags` pairs configured
+  (e.g. in `SkipTagsAggregator`), a pair appearing later in the list is now
+  detected even if an earlier pair is not present.

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -211,7 +211,9 @@ def parse_start_end_tags(
         start_tag_count = text[current_tag_index:].count(start_tag)
         end_tag_count = text[current_tag_index:].count(end_tag)
         if start_tag_count == 0 and end_tag_count == 0:
-            return (None, current_tag_index)
+            # Neither tag of this pair is present; keep checking the other
+            # pairs instead of giving up on the whole list.
+            continue
         elif start_tag_count > end_tag_count:
             return ((start_tag, end_tag), len(text))
         elif start_tag_count == end_tag_count:

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -273,6 +273,26 @@ class TestStartEndTags(unittest.IsolatedAsyncioTestCase):
             41,
         )
 
+    async def test_multiple_pairs(self):
+        # With several tag pairs, a pair that is absent from the text must not
+        # stop a later, present pair from being detected.
+        tags = [("<a>", "</a>"), ("<b>", "</b>")]
+
+        # Only the second pair appears, as an open (unclosed) start tag.
+        assert parse_start_end_tags("Hello <b>World", tags, None, 0) == (
+            ("<b>", "</b>"),
+            len("Hello <b>World"),
+        )
+
+        # Only the second pair appears, complete.
+        assert parse_start_end_tags("Hello <b>World</b>!", tags, None, 0) == (
+            None,
+            len("Hello <b>World</b>!"),
+        )
+
+        # No pair appears at all.
+        assert parse_start_end_tags("Hello World", tags, None, 0) == (None, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`parse_start_end_tags` accepts a `Sequence[StartEndTags]` (multiple start/end tag pairs), but it returns as soon as the *first* pair is absent from the text:

```python
for start_tag, end_tag in tags:
    start_tag_count = text[current_tag_index:].count(start_tag)
    end_tag_count = text[current_tag_index:].count(end_tag)
    if start_tag_count == 0 and end_tag_count == 0:
        return (None, current_tag_index)   # <- gives up on the whole list
```

So when more than one pair is configured (e.g. `SkipTagsAggregator` with several tag pairs), a pair that appears later in the list is never detected if an earlier pair happens to be absent. The fix is to `continue` to the next pair instead of returning, and only return `(None, current_tag_index)` once every pair has been checked.

Added `test_multiple_pairs` covering a two-pair list where only the second pair is present (open tag, complete tag, and no tags). The existing single-pair tests are unchanged.