### PR TITLE
Set Spanish language on Cartesia TTS in switch-languages example

### DIFF
--- a/examples/features/features-switch-languages.py
+++ b/examples/features/features-switch-languages.py
@@ -29,6 +29,7 @@ from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transcriptions.language import Language
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -51,6 +52,7 @@ class SwitchLanguage(ParallelPipeline):
         spanish_tts = CartesiaTTSService(
             api_key=os.environ["CARTESIA_API_KEY"],
             settings=CartesiaTTSService.Settings(
+                language=Language.ES,
                 voice="d4db5fb9-f44b-4bd1-85fa-192e0f0d75f9",  # Spanish-speaking Lady
             ),
         )


### PR DESCRIPTION
## Summary

The `features-switch-languages.py` example created a Spanish `CartesiaTTSService` without specifying a language, so it fell back to the default language. This sets `language=Language.ES` on the Spanish TTS service so Spanish responses are synthesized with the correct language.

## Test Plan

Run the example and switch to Spanish; verify Spanish text is synthesized with the Spanish voice/language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)