### PR TITLE
fix: harden Deepgram TTS disconnect cleanup

### DIFF
--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -184,11 +184,16 @@ class DeepgramTTSService(WebsocketTTSService):
         """Disconnect from Deepgram WebSocket and clean up tasks."""
         await super()._disconnect()
 
-        if self._receive_task:
-            await self.cancel_task(self._receive_task)
-            self._receive_task = None
-
-        await self._disconnect_websocket()
+        receive_task = self._receive_task
+        try:
+            await self._disconnect_websocket()
+        finally:
+            if receive_task:
+                try:
+                    await self.cancel_task(receive_task)
+                finally:
+                    if self._receive_task is receive_task:
+                        self._receive_task = None
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
         """Apply a settings delta.

--- a/tests/test_deepgram_tts.py
+++ b/tests/test_deepgram_tts.py
@@ -1,0 +1,23 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.services.deepgram.tts import DeepgramTTSService
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_websocket_before_canceling_receive_task():
+    service = DeepgramTTSService(api_key="test")
+    receive_task = object()
+    service._receive_task = receive_task
+    service._disconnect_websocket = AsyncMock()
+    service.cancel_task = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await service._disconnect()
+
+    service._disconnect_websocket.assert_awaited_once()
+    service.cancel_task.assert_awaited_once_with(receive_task)
+    assert service._receive_task is None
+    assert service._disconnecting is True


### PR DESCRIPTION
﻿## Summary
- close the Deepgram TTS websocket before awaiting receive-task cancellation
- keep receive-task cancellation and reference cleanup in a finally block
- add regression coverage for cancellation during disconnect cleanup

Addresses #4409.

## To verify
- python -m pytest tests\test_deepgram_tts.py -q
- python -m py_compile src\pipecat\services\deepgram\tts.py tests\test_deepgram_tts.py
- python -m ruff check src\pipecat\services\deepgram\tts.py tests\test_deepgram_tts.py
- python -m ruff format --check src\pipecat\services\deepgram\tts.py tests\test_deepgram_tts.py
- git diff --check
