### PR TITLE
feat(services/qwen): Add QwenTTSService via DashScope HTTP SSE streaming

### DIFF
--- a/changelog/2126.added.md
+++ b/changelog/2126.added.md
@@ -1,0 +1,1 @@
+- Added `QwenTTSService` for Alibaba Cloud's Qwen TTS via the DashScope HTTP SSE API. Supports streaming PCM audio output, configurable voice (e.g. `"Chelsie"`, `"Ethan"`, `"Serena"`), model selection (`qwen3-tts-flash` default), and both the international and China endpoints. Closes [#2126](https://github.com/pipecat-ai/pipecat/issues/2126).

--- a/src/pipecat/services/qwen/tts.py
+++ b/src/pipecat/services/qwen/tts.py
@@ -1,0 +1,261 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Qwen TTS service implementation using DashScope HTTP SSE streaming."""
+
+import base64
+import json
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import aiohttp
+from loguru import logger
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    Frame,
+    TTSAudioRawFrame,
+)
+from pipecat.services.settings import TTSSettings
+from pipecat.services.tts_service import TTSService
+from pipecat.transcriptions.language import Language, resolve_language
+from pipecat.utils.tracing.service_decorators import traced_tts
+
+# DashScope TTS endpoints
+QWEN_TTS_URL_INTL = "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text2audio/generation"
+QWEN_TTS_URL_CN = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text2audio/generation"
+
+
+def language_to_qwen_language(language: Language) -> str | None:
+    """Convert a Language enum to a Qwen TTS language code.
+
+    Args:
+        language: The Language enum value to convert.
+
+    Returns:
+        The corresponding Qwen TTS language code, or None if not supported.
+    """
+    LANGUAGE_MAP = {
+        Language.ZH: "zh",
+        Language.EN: "en",
+        Language.JA: "ja",
+        Language.KO: "ko",
+    }
+    return resolve_language(language, LANGUAGE_MAP, use_base_code=True)
+
+
+@dataclass
+class QwenTTSSettings(TTSSettings):
+    """Settings for QwenTTSService.
+
+    Parameters:
+        model: DashScope TTS model identifier.
+        voice: Voice identifier (e.g. ``"Chelsie"``, ``"Ethan"``, ``"Serena"``).
+        language: Language for synthesis. Qwen TTS uses the voice to infer
+            language, so this setting controls only the ``language_to_service_language``
+            conversion when a voice-level language override is needed.
+    """
+
+    pass
+
+
+class QwenTTSService(TTSService):
+    """Alibaba Cloud Qwen (DashScope) text-to-speech service.
+
+    Provides streaming TTS synthesis using the DashScope HTTP SSE API.
+    Outputs raw 16-bit PCM audio frames at the configured sample rate,
+    suitable for direct use in a Pipecat voice pipeline.
+
+    Requires a DashScope API key. International users should use the default
+    endpoint; users in mainland China should pass ``base_url=QWEN_TTS_URL_CN``.
+
+    Supported voices include ``"Chelsie"`` and ``"Serena"`` (English female),
+    ``"Ethan"`` (English male), ``"Cherry"`` and ``"Aria"`` (Chinese female),
+    ``"Rocky"`` (Chinese male), and others. See the DashScope documentation for
+    the full voice list.
+
+    Example::
+
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            tts = QwenTTSService(
+                api_key="your-dashscope-api-key",
+                aiohttp_session=session,
+                settings=QwenTTSService.Settings(
+                    model="qwen3-tts-flash",
+                    voice="Chelsie",
+                ),
+            )
+    """
+
+    Settings = QwenTTSSettings
+    _settings: Settings
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        aiohttp_session: aiohttp.ClientSession,
+        voice: str | None = None,
+        model: str | None = None,
+        base_url: str = QWEN_TTS_URL_INTL,
+        sample_rate: int | None = None,
+        settings: Settings | None = None,
+        **kwargs,
+    ):
+        """Initialize the Qwen TTS service.
+
+        Args:
+            api_key: DashScope API key for authentication.
+            aiohttp_session: Shared aiohttp session for HTTP requests.
+            voice: Voice identifier (e.g. ``"Chelsie"``).
+
+                .. deprecated:: 0.0.106
+                    Use ``settings=QwenTTSService.Settings(voice=...)`` instead.
+
+            model: TTS model identifier (e.g. ``"qwen3-tts-flash"``).
+
+                .. deprecated:: 0.0.106
+                    Use ``settings=QwenTTSService.Settings(model=...)`` instead.
+
+            base_url: DashScope TTS endpoint URL. Defaults to the international
+                endpoint. Pass ``QWEN_TTS_URL_CN`` for mainland China.
+            sample_rate: Audio sample rate in Hz. If ``None``, uses 22050 Hz,
+                which is the native output rate of most Qwen TTS voices.
+            settings: Runtime-updatable settings object. Takes precedence over
+                deprecated positional arguments when both are provided.
+            **kwargs: Additional keyword arguments forwarded to TTSService.
+        """
+        # Set language=None: Qwen TTS infers language from voice selection,
+        # so there is no service-level language parameter to pass.
+        default_settings = self.Settings(model="qwen3-tts-flash", voice="Chelsie", language=None)
+
+        if model is not None:
+            self._warn_init_param_moved_to_settings("model", "model")
+            default_settings.model = model
+
+        if voice is not None:
+            self._warn_init_param_moved_to_settings("voice", "voice")
+            default_settings.voice = voice
+
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        super().__init__(
+            push_text_frames=False,
+            push_stop_frames=True,
+            push_start_frame=True,
+            sample_rate=sample_rate or 22050,
+            settings=default_settings,
+            **kwargs,
+        )
+
+        self._api_key = api_key
+        self._session = aiohttp_session
+        self._base_url = base_url
+
+    def language_to_service_language(self, language: Language) -> str | None:
+        """Convert a Language enum to a Qwen TTS language code.
+
+        Args:
+            language: The language to convert.
+
+        Returns:
+            A Qwen TTS language code, or ``None`` if the language is not supported.
+        """
+        return language_to_qwen_language(language)
+
+    @traced_tts
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        """Generate speech from text using the Qwen TTS HTTP SSE streaming API.
+
+        Sends a request to the DashScope TTS endpoint with the
+        ``X-DashScope-SSE: enable`` header, then yields :class:`TTSAudioRawFrame`
+        objects as base64-encoded PCM chunks arrive in the SSE stream.
+
+        Args:
+            text: Text to synthesize.
+            context_id: Identifier for the current TTS context.
+
+        Yields:
+            Frame: :class:`TTSAudioRawFrame` for each audio chunk, or an
+            :class:`ErrorFrame` if the request fails.
+        """
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-SSE": "enable",
+        }
+
+        payload = {
+            "model": self._settings.model,
+            "input": {"text": text},
+            "parameters": {
+                "voice": self._settings.voice,
+                "format": "pcm",
+                "sample_rate": self.sample_rate,
+            },
+        }
+
+        try:
+            async with self._session.post(
+                self._base_url, json=payload, headers=headers
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(
+                        f"{self}: DashScope TTS error (HTTP {response.status}): {error_text}"
+                    )
+                    yield ErrorFrame(error=f"Qwen TTS API error: {error_text}")
+                    return
+
+                await self.start_tts_usage_metrics(text)
+
+                async for raw_line in response.content:
+                    line = raw_line.decode("utf-8").strip()
+
+                    # SSE data lines start with "data:"
+                    if not line.startswith("data:"):
+                        continue
+
+                    data_str = line[len("data:") :].strip()
+                    if not data_str:
+                        continue
+
+                    try:
+                        data = json.loads(data_str)
+                    except json.JSONDecodeError as exc:
+                        logger.warning(f"{self}: Failed to parse SSE JSON: {exc}")
+                        continue
+
+                    output = data.get("output", {})
+                    audio_info = output.get("audio")
+
+                    if isinstance(audio_info, dict):
+                        audio_b64 = audio_info.get("data")
+                        if audio_b64:
+                            await self.stop_ttfb_metrics()
+                            audio = base64.b64decode(audio_b64)
+                            yield TTSAudioRawFrame(
+                                audio=audio,
+                                sample_rate=self.sample_rate,
+                                num_channels=1,
+                                context_id=context_id,
+                            )
+
+                    # DashScope signals completion via finish_reason == "stop"
+                    finish_reason = output.get("finish_reason")
+                    if finish_reason == "stop":
+                        break
+
+        except Exception as exc:
+            logger.error(f"{self}: Unexpected error during TTS generation: {exc}")
+            yield ErrorFrame(error=f"Qwen TTS unexpected error: {exc}")
+        finally:
+            await self.stop_ttfb_metrics()

--- a/tests/test_qwen_tts.py
+++ b/tests/test_qwen_tts.py
@@ -1,0 +1,200 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for QwenTTSService."""
+
+import asyncio
+import base64
+import json
+import unittest
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from pipecat.frames.frames import (
+    AggregatedTextFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+    TTSTextFrame,
+)
+from pipecat.services.qwen.tts import QwenTTSService
+from pipecat.tests.utils import run_test
+
+
+def _make_sse_chunk(data: dict) -> bytes:
+    """Encode a dict as a DashScope SSE ``data:`` line."""
+    return f"data:{json.dumps(data)}\n\n".encode()
+
+
+@pytest.mark.asyncio
+async def test_qwen_tts_success(aiohttp_client):
+    """QwenTTSService should send the correct request and emit PCM audio frames."""
+
+    AUDIO_BYTES = b"\x10\x20\x30\x40" * 512
+    captured_requests: list[dict] = []
+
+    async def handler(request: web.Request) -> web.Response:
+        captured_requests.append(
+            {
+                "headers": dict(request.headers),
+                "body": await request.json(),
+            }
+        )
+
+        audio_b64 = base64.b64encode(AUDIO_BYTES).decode("ascii")
+
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await response.prepare(request)
+
+        # First chunk: audio data
+        await response.write(
+            _make_sse_chunk(
+                {
+                    "output": {
+                        "audio": {"data": audio_b64, "frame_id": 1},
+                        "finish_reason": "null",
+                    },
+                    "usage": {"input_characters": 15, "output_characters": 15},
+                    "request_id": "test-request-id",
+                }
+            )
+        )
+        await asyncio.sleep(0.01)
+
+        # Final chunk: finish signal
+        await response.write(
+            _make_sse_chunk(
+                {
+                    "output": {"finish_reason": "stop"},
+                    "usage": {"input_characters": 15, "output_characters": 15},
+                    "request_id": "test-request-id",
+                }
+            )
+        )
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/api/v1/services/aigc/text2audio/generation", handler)
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/api/v1/services/aigc/text2audio/generation"))
+
+    async with aiohttp.ClientSession() as session:
+        tts = QwenTTSService(
+            api_key="test-dashscope-key",
+            aiohttp_session=session,
+            base_url=base_url,
+            sample_rate=22050,
+        )
+
+        down_frames, _ = await run_test(
+            tts,
+            frames_to_send=[TTSSpeakFrame(text="Hello from Qwen TTS.")],
+        )
+
+    frame_types = [type(f) for f in down_frames]
+    assert TTSStartedFrame in frame_types, "Expected TTSStartedFrame in output"
+    assert TTSStoppedFrame in frame_types, "Expected TTSStoppedFrame in output"
+
+    audio_frames = [f for f in down_frames if isinstance(f, TTSAudioRawFrame)]
+    assert audio_frames, "Expected at least one TTSAudioRawFrame"
+    assert all(f.sample_rate == 22050 for f in audio_frames)
+    assert all(f.num_channels == 1 for f in audio_frames)
+    assert b"".join(f.audio for f in audio_frames) == AUDIO_BYTES
+
+    # Verify request format
+    assert len(captured_requests) == 1
+    req = captured_requests[0]
+
+    assert req["headers"]["Authorization"] == "Bearer test-dashscope-key"
+    assert req["headers"]["X-DashScope-SSE"] == "enable"
+
+    body = req["body"]
+    assert body["model"] == "qwen3-tts-flash"
+    assert body["input"]["text"] == "Hello from Qwen TTS."
+    assert body["parameters"]["voice"] == "Chelsie"
+    assert body["parameters"]["format"] == "pcm"
+    assert body["parameters"]["sample_rate"] == 22050
+
+
+@pytest.mark.asyncio
+async def test_qwen_tts_custom_settings(aiohttp_client):
+    """QwenTTSService should use custom model/voice from Settings."""
+
+    captured_requests: list[dict] = []
+
+    async def handler(request: web.Request) -> web.Response:
+        captured_requests.append(await request.json())
+        response = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await response.prepare(request)
+        await response.write(_make_sse_chunk({"output": {"finish_reason": "stop"}, "usage": {}}))
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/tts", handler)
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/tts"))
+
+    async with aiohttp.ClientSession() as session:
+        tts = QwenTTSService(
+            api_key="key",
+            aiohttp_session=session,
+            base_url=base_url,
+            settings=QwenTTSService.Settings(model="qwen-tts-latest", voice="Ethan"),
+        )
+
+        await run_test(
+            tts,
+            frames_to_send=[TTSSpeakFrame(text="Custom voice test.")],
+        )
+
+    assert len(captured_requests) == 1
+    body = captured_requests[0]
+    assert body["model"] == "qwen-tts-latest"
+    assert body["parameters"]["voice"] == "Ethan"
+
+
+@pytest.mark.asyncio
+async def test_qwen_tts_api_error(aiohttp_client):
+    """QwenTTSService should emit an ErrorFrame on non-200 responses."""
+    from pipecat.frames.frames import ErrorFrame
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=401, text='{"error": "Invalid API key"}')
+
+    app = web.Application()
+    app.router.add_post("/tts", handler)
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/tts"))
+
+    async with aiohttp.ClientSession() as session:
+        tts = QwenTTSService(
+            api_key="bad-key",
+            aiohttp_session=session,
+            base_url=base_url,
+        )
+
+        down_frames, up_frames = await run_test(
+            tts,
+            frames_to_send=[TTSSpeakFrame(text="This should fail.")],
+        )
+
+    # ErrorFrame is pushed upstream by the service
+    all_frames = down_frames + up_frames
+    error_frames = [f for f in all_frames if isinstance(f, ErrorFrame)]
+    assert error_frames, "Expected an ErrorFrame on API error"
+    assert any("Qwen TTS API error" in f.error for f in error_frames)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `QwenTTSService` to `src/pipecat/services/qwen/tts.py`, closing #2126
- Implements Alibaba Cloud Qwen TTS using the DashScope HTTP SSE API (`qwen3-tts-flash` by default, also works with `qwen-tts-latest`)
- Outputs 16-bit PCM audio frames at a configurable sample rate (default 22050 Hz, matching Qwen's native output)
- Supports international (`dashscope-intl.aliyuncs.com`) and China (`dashscope.aliyuncs.com`) endpoints via `base_url`
- Follows the same `Settings`-based configuration pattern as `QwenLLMService` and other HTTP TTS services

## Why this is not a duplicate

Searched open PRs for "qwen tts" and "2126 in:body" — no existing PR found. The external [pipecat-dashscope](https://github.com/AbaoFromCUG/pipecat-dashscope) plugin uses the DashScope SDK with callbacks; this PR uses `aiohttp` directly (no new dependency) and matches the HTTP SSE pattern established by `ElevenLabsHttpTTSService` and `XAIHttpTTSService`.

## Implementation notes

- Uses `X-DashScope-SSE: enable` request header to enable SSE streaming
- Parses `data:` lines, base64-decodes the PCM audio chunk, and yields `TTSAudioRawFrame`
- Exits cleanly when `output.finish_reason == "stop"` in the SSE stream
- Sets `push_start_frame=True` and `push_stop_frames=True` so the base class manages `TTSStartedFrame`/`TTSStoppedFrame` lifecycle
- `language=None` in `QwenTTSSettings` because Qwen TTS infers language from the selected voice

## Test plan

- [x] `test_qwen_tts_success` — mock SSE server, verifies request format (headers, model, voice, format, sample_rate) and audio frame content
- [x] `test_qwen_tts_custom_settings` — verifies `Settings(model=..., voice=...)` overrides defaults
- [x] `test_qwen_tts_api_error` — 401 response produces `ErrorFrame` upstream

```
uv run --extra websockets-base pytest tests/test_qwen_tts.py -v
# 3 passed
```

- [x] `ruff check` and `ruff format` pass on both new files