### PR TITLE
feat: add OpenRouter TTS service

### DIFF
--- a/examples/function-calling/function-calling-openrouter.py
+++ b/examples/function-calling/function-calling-openrouter.py
@@ -23,10 +23,10 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
-from pipecat.services.azure.tts import AzureTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openrouter.llm import OpenRouterLLMService
+from pipecat.services.openrouter.tts import OpenRouterTTSService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -62,14 +62,11 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
 
-    tts = AzureTTSService(
-        api_key=os.environ["AZURE_SPEECH_API_KEY"],
-        region=os.environ["AZURE_SPEECH_REGION"],
-        settings=AzureTTSService.Settings(
-            voice="en-US-JennyNeural",
-            language="en-US",
-            rate="1.1",
-            style="cheerful",
+    tts = OpenRouterTTSService(
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        settings=OpenRouterTTSService.Settings(
+            model="openai/gpt-4o-mini-tts-2025-12-15",
+            voice="alloy",
         ),
     )
 

--- a/src/pipecat/services/openrouter/tts.py
+++ b/src/pipecat/services/openrouter/tts.py
@@ -23,8 +23,8 @@ from pipecat.frames.frames import (
     Frame,
     TTSAudioRawFrame,
 )
-from pipecat.services.openai._constants import OPENAI_SAMPLE_RATE
 from pipecat.services.openai.tts import OpenAITTSService, OpenAITTSSettings
+from pipecat.services.tts_service import TTSService
 from pipecat.services.settings import assert_given
 from pipecat.utils.tracing.service_decorators import traced_tts
 
@@ -75,57 +75,20 @@ class OpenRouterTTSService(OpenAITTSService):
         *,
         api_key: str | None = None,
         base_url: str = OPENROUTER_TTS_BASE_URL,
-        voice: str | None = None,
-        model: str | None = None,
-        sample_rate: int | None = None,
-        instructions: str | None = None,
-        speed: float | None = None,
-        params: OpenAITTSService.InputParams | None = None,
         settings: Settings | None = None,
         **kwargs,
     ):
         """Initialize OpenRouter TTS service.
 
         Args:
-            api_key: OpenRouter API key. If None, reads from environment variable.
+            api_key: OpenRouter API key. If None, reads from the ``OPENROUTER_API_KEY``
+                environment variable.
             base_url: OpenRouter API base URL. Defaults to ``https://openrouter.ai/api/v1``.
-            voice: Voice ID to use. Varies by model/provider. Defaults to ``"alloy"``.
-
-                .. deprecated:: 0.0.105
-                    Use ``settings=OpenRouterTTSService.Settings(voice=...)`` instead.
-
-            model: TTS model to use. Defaults to ``"openai/gpt-4o-mini-tts-2025-12-15"``.
-
-                .. deprecated:: 0.0.105
-                    Use ``settings=OpenRouterTTSService.Settings(model=...)`` instead.
-
-            sample_rate: Output audio sample rate in Hz. Defaults to 24000Hz.
-            instructions: Optional instructions to guide voice synthesis behavior.
-                Only honored by supporting models (e.g. OpenAI).
-
-                .. deprecated:: 0.0.105
-                    Use ``settings=OpenRouterTTSService.Settings(instructions=...)`` instead.
-
-            speed: Voice speed multiplier. Only honored by supporting models.
-
-                .. deprecated:: 0.0.105
-                    Use ``settings=OpenRouterTTSService.Settings(speed=...)`` instead.
-
-            params: Optional synthesis controls.
-
-                .. deprecated:: 0.0.105
-                    Use ``settings=OpenRouterTTSService.Settings(...)`` instead.
-
-            settings: Runtime-updatable settings. Takes precedence over deprecated parameters.
-            **kwargs: Additional keyword arguments passed to TTSService.
+            settings: Model, voice, and synthesis options. When omitted, defaults to
+                model ``openai/gpt-4o-mini-tts-2025-12-15`` and voice ``alloy``.
+            **kwargs: Additional keyword arguments passed to TTSService (e.g.
+                ``sample_rate``, ``push_start_frame``).
         """
-        if sample_rate and sample_rate != OPENAI_SAMPLE_RATE:
-            logger.warning(
-                f"OpenRouter TTS returns PCM at {OPENAI_SAMPLE_RATE}Hz. "
-                f"Current rate of {sample_rate}Hz may cause issues."
-            )
-
-        # 1. Initialize default_settings with OpenRouter defaults
         default_settings = self.Settings(
             model=OPENROUTER_DEFAULT_TTS_MODEL,
             voice=OPENROUTER_DEFAULT_TTS_VOICE,
@@ -134,41 +97,11 @@ class OpenRouterTTSService(OpenAITTSService):
             speed=None,
         )
 
-        # 2. Apply direct init arg overrides (deprecated)
-        if voice is not None:
-            self._warn_init_param_moved_to_settings("voice", "voice")
-            default_settings.voice = voice
-        if model is not None:
-            self._warn_init_param_moved_to_settings("model", "model")
-            default_settings.model = model
-        if instructions is not None:
-            self._warn_init_param_moved_to_settings("instructions", "instructions")
-            default_settings.instructions = instructions
-        if speed is not None:
-            self._warn_init_param_moved_to_settings("speed", "speed")
-            default_settings.speed = speed
-
-        # 3. Apply params overrides — only if settings not provided
-        if params is not None:
-            self._warn_init_param_moved_to_settings("params")
-            if not settings:
-                if params.instructions is not None:
-                    default_settings.instructions = params.instructions
-                if params.speed is not None:
-                    default_settings.speed = params.speed
-
-        # 4. Apply settings delta (canonical API, always wins)
         if settings is not None:
             default_settings.apply_update(settings)
 
-        # Skip OpenAITTSService.__init__ and go directly to TTSService to avoid
-        # re-running the OpenAI-specific default_settings setup and sample rate
-        # warnings. We wire up the client ourselves below.
-        from pipecat.services.tts_service import TTSService
-
         TTSService.__init__(
             self,
-            sample_rate=sample_rate,
             push_start_frame=True,
             push_stop_frames=True,
             settings=default_settings,

--- a/src/pipecat/services/openrouter/tts.py
+++ b/src/pipecat/services/openrouter/tts.py
@@ -1,0 +1,239 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""OpenRouter text-to-speech service implementation.
+
+This module provides integration with OpenRouter's text-to-speech API for
+generating high-quality synthetic speech from text input. The API is
+OpenAI-compatible and supports multiple providers (OpenAI, Google, Mistral)
+and their respective voice sets.
+"""
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+from loguru import logger
+from openai import AsyncOpenAI, BadRequestError
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    Frame,
+    TTSAudioRawFrame,
+)
+from pipecat.services.openai._constants import OPENAI_SAMPLE_RATE
+from pipecat.services.openai.tts import OpenAITTSService, OpenAITTSSettings
+from pipecat.services.settings import assert_given
+from pipecat.utils.tracing.service_decorators import traced_tts
+
+OPENROUTER_TTS_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_DEFAULT_TTS_MODEL = "openai/gpt-4o-mini-tts-2025-12-15"
+OPENROUTER_DEFAULT_TTS_VOICE = "alloy"
+
+
+@dataclass
+class OpenRouterTTSSettings(OpenAITTSSettings):
+    """Settings for OpenRouterTTSService.
+
+    Inherits all OpenAI TTS settings. Voice values are provider-namespaced:
+    OpenAI voices use short names (``alloy``, ``nova``), Voxtral encodes
+    language/persona/emotion (e.g. ``en_paul_happy``), and Kokoro prefixes
+    with language/gender (e.g. ``af_bella``).
+    """
+
+    pass
+
+
+class OpenRouterTTSService(OpenAITTSService):
+    """OpenRouter Text-to-Speech service that generates audio from text.
+
+    This service routes TTS requests through OpenRouter's OpenAI-compatible
+    endpoint (``/api/v1/audio/speech``), supporting multiple underlying
+    providers (OpenAI, Google, Mistral) and their respective voice sets.
+
+    PCM audio is returned at 24kHz. Voice identifiers vary by model — check
+    each model's page on openrouter.ai for the supported voices.
+
+    Example usage::
+
+        tts = OpenRouterTTSService(
+            api_key=os.environ["OPENROUTER_API_KEY"],
+            settings=OpenRouterTTSService.Settings(
+                model="openai/gpt-4o-mini-tts-2025-12-15",
+                voice="alloy",
+            ),
+        )
+    """
+
+    Settings = OpenRouterTTSSettings
+    _settings: Settings
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = OPENROUTER_TTS_BASE_URL,
+        voice: str | None = None,
+        model: str | None = None,
+        sample_rate: int | None = None,
+        instructions: str | None = None,
+        speed: float | None = None,
+        params: OpenAITTSService.InputParams | None = None,
+        settings: Settings | None = None,
+        **kwargs,
+    ):
+        """Initialize OpenRouter TTS service.
+
+        Args:
+            api_key: OpenRouter API key. If None, reads from environment variable.
+            base_url: OpenRouter API base URL. Defaults to ``https://openrouter.ai/api/v1``.
+            voice: Voice ID to use. Varies by model/provider. Defaults to ``"alloy"``.
+
+                .. deprecated:: 0.0.105
+                    Use ``settings=OpenRouterTTSService.Settings(voice=...)`` instead.
+
+            model: TTS model to use. Defaults to ``"openai/gpt-4o-mini-tts-2025-12-15"``.
+
+                .. deprecated:: 0.0.105
+                    Use ``settings=OpenRouterTTSService.Settings(model=...)`` instead.
+
+            sample_rate: Output audio sample rate in Hz. Defaults to 24000Hz.
+            instructions: Optional instructions to guide voice synthesis behavior.
+                Only honored by supporting models (e.g. OpenAI).
+
+                .. deprecated:: 0.0.105
+                    Use ``settings=OpenRouterTTSService.Settings(instructions=...)`` instead.
+
+            speed: Voice speed multiplier. Only honored by supporting models.
+
+                .. deprecated:: 0.0.105
+                    Use ``settings=OpenRouterTTSService.Settings(speed=...)`` instead.
+
+            params: Optional synthesis controls.
+
+                .. deprecated:: 0.0.105
+                    Use ``settings=OpenRouterTTSService.Settings(...)`` instead.
+
+            settings: Runtime-updatable settings. Takes precedence over deprecated parameters.
+            **kwargs: Additional keyword arguments passed to TTSService.
+        """
+        if sample_rate and sample_rate != OPENAI_SAMPLE_RATE:
+            logger.warning(
+                f"OpenRouter TTS returns PCM at {OPENAI_SAMPLE_RATE}Hz. "
+                f"Current rate of {sample_rate}Hz may cause issues."
+            )
+
+        # 1. Initialize default_settings with OpenRouter defaults
+        default_settings = self.Settings(
+            model=OPENROUTER_DEFAULT_TTS_MODEL,
+            voice=OPENROUTER_DEFAULT_TTS_VOICE,
+            language=None,
+            instructions=None,
+            speed=None,
+        )
+
+        # 2. Apply direct init arg overrides (deprecated)
+        if voice is not None:
+            self._warn_init_param_moved_to_settings("voice", "voice")
+            default_settings.voice = voice
+        if model is not None:
+            self._warn_init_param_moved_to_settings("model", "model")
+            default_settings.model = model
+        if instructions is not None:
+            self._warn_init_param_moved_to_settings("instructions", "instructions")
+            default_settings.instructions = instructions
+        if speed is not None:
+            self._warn_init_param_moved_to_settings("speed", "speed")
+            default_settings.speed = speed
+
+        # 3. Apply params overrides — only if settings not provided
+        if params is not None:
+            self._warn_init_param_moved_to_settings("params")
+            if not settings:
+                if params.instructions is not None:
+                    default_settings.instructions = params.instructions
+                if params.speed is not None:
+                    default_settings.speed = params.speed
+
+        # 4. Apply settings delta (canonical API, always wins)
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        # Skip OpenAITTSService.__init__ and go directly to TTSService to avoid
+        # re-running the OpenAI-specific default_settings setup and sample rate
+        # warnings. We wire up the client ourselves below.
+        from pipecat.services.tts_service import TTSService
+
+        TTSService.__init__(
+            self,
+            sample_rate=sample_rate,
+            push_start_frame=True,
+            push_stop_frames=True,
+            settings=default_settings,
+            **kwargs,
+        )
+
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+    @traced_tts
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        """Generate speech from text using OpenRouter's TTS API.
+
+        Unlike the OpenAI implementation, voice validation is skipped because
+        OpenRouter supports multiple provider voice sets with different naming
+        conventions (e.g. ``alloy``, ``en_paul_happy``, ``af_bella``).
+
+        Args:
+            text: The text to synthesize into speech.
+            context_id: The context ID for tracking audio frames.
+
+        Yields:
+            Frame: Audio frames containing the synthesized speech data.
+        """
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        voice = assert_given(self._settings.voice)
+        if voice is None:
+            yield ErrorFrame(error="OpenRouter TTS voice must be specified")
+            return
+
+        try:
+            create_params = {
+                "input": text,
+                "model": self._settings.model,
+                "voice": voice,
+                "response_format": "pcm",
+            }
+
+            if self._settings.instructions:
+                create_params["instructions"] = self._settings.instructions
+
+            if self._settings.speed:
+                create_params["speed"] = self._settings.speed
+
+            async with self._client.audio.speech.with_streaming_response.create(
+                **create_params
+            ) as r:
+                if r.status_code != 200:
+                    error = await r.text()
+                    logger.error(
+                        f"{self} error getting audio (status: {r.status_code}, error: {error})"
+                    )
+                    yield ErrorFrame(
+                        error=f"Error getting audio (status: {r.status_code}, error: {error})"
+                    )
+                    return
+
+                await self.start_tts_usage_metrics(text)
+
+                CHUNK_SIZE = self.chunk_size
+
+                async for chunk in r.iter_bytes(CHUNK_SIZE):
+                    if len(chunk) > 0:
+                        await self.stop_ttfb_metrics()
+                        frame = TTSAudioRawFrame(chunk, self.sample_rate, 1, context_id=context_id)
+                        yield frame
+        except BadRequestError as e:
+            yield ErrorFrame(error=f"Unknown error occurred: {e}")

--- a/tests/test_openrouter_tts.py
+++ b/tests/test_openrouter_tts.py
@@ -1,0 +1,249 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for OpenRouterTTSService."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.services.openrouter.tts import (
+    OPENROUTER_DEFAULT_TTS_MODEL,
+    OPENROUTER_DEFAULT_TTS_VOICE,
+    OPENROUTER_TTS_BASE_URL,
+    OpenRouterTTSService,
+    OpenRouterTTSSettings,
+)
+from pipecat.services.settings import NOT_GIVEN, is_given
+
+
+# ---------------------------------------------------------------------------
+# Settings contract (delta-mode and store-mode)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_delta_defaults_are_not_given():
+    """Empty OpenRouterTTSSettings must have all fields set to NOT_GIVEN."""
+    from dataclasses import fields
+
+    s = OpenRouterTTSSettings()
+    for f in fields(s):
+        if f.name == "extra":
+            continue
+        val = getattr(s, f.name)
+        assert not is_given(val), (
+            f"OpenRouterTTSSettings.{f.name} defaults to {val!r}, expected NOT_GIVEN"
+        )
+
+
+def test_service_settings_complete_after_init():
+    """After construction, _settings must have no NOT_GIVEN values."""
+    from dataclasses import fields
+
+    svc = OpenRouterTTSService(api_key="test-key")
+    for f in fields(svc._settings):
+        if f.name == "extra":
+            continue
+        val = getattr(svc._settings, f.name)
+        assert is_given(val), (
+            f"OpenRouterTTSService._settings.{f.name} is NOT_GIVEN after construction"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_base_url():
+    svc = OpenRouterTTSService(api_key="test-key")
+    assert svc._client.base_url.host == "openrouter.ai"
+
+
+def test_default_model():
+    svc = OpenRouterTTSService(api_key="test-key")
+    assert svc._settings.model == OPENROUTER_DEFAULT_TTS_MODEL
+
+
+def test_default_voice():
+    svc = OpenRouterTTSService(api_key="test-key")
+    assert svc._settings.voice == OPENROUTER_DEFAULT_TTS_VOICE
+
+
+def test_settings_override_model_and_voice():
+    svc = OpenRouterTTSService(
+        api_key="test-key",
+        settings=OpenRouterTTSService.Settings(
+            model="google/gemini-flash-tts",
+            voice="en_paul_happy",
+        ),
+    )
+    assert svc._settings.model == "google/gemini-flash-tts"
+    assert svc._settings.voice == "en_paul_happy"
+
+
+def test_non_openai_voices_accepted():
+    """OpenRouter supports provider-namespaced voices — no allowlist rejection."""
+    for voice in ["en_paul_happy", "af_bella", "alloy", "nova", "shimmer"]:
+        svc = OpenRouterTTSService(
+            api_key="test-key",
+            settings=OpenRouterTTSService.Settings(voice=voice),
+        )
+        assert svc._settings.voice == voice
+
+
+# ---------------------------------------------------------------------------
+# run_tts — mocked OpenAI client
+# ---------------------------------------------------------------------------
+
+
+def _make_streaming_response(audio_chunks: list[bytes], status_code: int = 200):
+    """Return an async context manager that yields bytes chunks, mimicking
+    AsyncOpenAI's audio.speech.with_streaming_response.create(...)."""
+
+    async def iter_bytes(chunk_size=None):
+        for chunk in audio_chunks:
+            yield chunk
+
+    response = MagicMock()
+    response.status_code = status_code
+    response.iter_bytes = iter_bytes
+    response.text = AsyncMock(return_value="error body")
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_run_tts_emits_audio_frames():
+    """run_tts should yield TTSAudioRawFrame chunks for a successful response."""
+    audio_data = b"\x00\x01\x02\x03" * 512
+    chunks = [audio_data[:512], audio_data[512:]]
+
+    svc = OpenRouterTTSService(api_key="test-key")
+    svc._sample_rate = 24000  # normally set by StartFrame in a live pipeline
+    svc._client.audio.speech.with_streaming_response.create = MagicMock(
+        return_value=_make_streaming_response(chunks)
+    )
+
+    frames = []
+    async for frame in svc.run_tts("Hello, world!", context_id="ctx-1"):
+        frames.append(frame)
+
+    audio_frames = [f for f in frames if isinstance(f, TTSAudioRawFrame)]
+    assert len(audio_frames) == 2
+    assert all(f.sample_rate == 24000 for f in audio_frames)
+    assert all(f.num_channels == 1 for f in audio_frames)
+    assert all(f.context_id == "ctx-1" for f in audio_frames)
+
+
+@pytest.mark.asyncio
+async def test_run_tts_request_params():
+    """run_tts should pass model, voice, input, and response_format=pcm."""
+    captured = {}
+
+    async def iter_bytes(chunk_size=None):
+        yield b"\x00" * 128
+
+    response = MagicMock()
+    response.status_code = 200
+    response.iter_bytes = iter_bytes
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return cm
+
+    svc = OpenRouterTTSService(api_key="test-key")
+    svc._client.audio.speech.with_streaming_response.create = create
+
+    async for _ in svc.run_tts("Test text", context_id="ctx-2"):
+        pass
+
+    assert captured["input"] == "Test text"
+    assert captured["model"] == OPENROUTER_DEFAULT_TTS_MODEL
+    assert captured["voice"] == OPENROUTER_DEFAULT_TTS_VOICE
+    assert captured["response_format"] == "pcm"
+
+
+@pytest.mark.asyncio
+async def test_run_tts_passes_instructions_and_speed():
+    """run_tts should include optional instructions and speed when set."""
+    captured = {}
+
+    async def iter_bytes(chunk_size=None):
+        yield b"\x00" * 64
+
+    response = MagicMock()
+    response.status_code = 200
+    response.iter_bytes = iter_bytes
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return cm
+
+    svc = OpenRouterTTSService(
+        api_key="test-key",
+        settings=OpenRouterTTSService.Settings(instructions="Speak slowly.", speed=0.8),
+    )
+    svc._client.audio.speech.with_streaming_response.create = create
+
+    async for _ in svc.run_tts("Test", context_id="ctx-3"):
+        pass
+
+    assert captured["instructions"] == "Speak slowly."
+    assert captured["speed"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_run_tts_error_status_yields_error_frame():
+    """A non-200 response should yield an ErrorFrame."""
+    svc = OpenRouterTTSService(api_key="test-key")
+    svc._client.audio.speech.with_streaming_response.create = MagicMock(
+        return_value=_make_streaming_response([], status_code=400)
+    )
+
+    frames = []
+    async for frame in svc.run_tts("Hello", context_id="ctx-4"):
+        frames.append(frame)
+
+    assert any(isinstance(f, ErrorFrame) for f in frames)
+    assert not any(isinstance(f, TTSAudioRawFrame) for f in frames)
+
+
+@pytest.mark.asyncio
+async def test_run_tts_missing_voice_yields_error_frame():
+    """run_tts should yield an ErrorFrame when voice is None."""
+    svc = OpenRouterTTSService(api_key="test-key")
+    svc._settings.voice = None
+
+    frames = []
+    async for frame in svc.run_tts("Hello", context_id="ctx-5"):
+        frames.append(frame)
+
+    assert any(isinstance(f, ErrorFrame) for f in frames)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openrouter_tts.py
+++ b/tests/test_openrouter_tts.py
@@ -6,18 +6,14 @@
 
 """Tests for OpenRouterTTSService."""
 
-import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from pipecat.frames.frames import (
     ErrorFrame,
     TTSAudioRawFrame,
-    TTSSpeakFrame,
-    TTSStartedFrame,
-    TTSStoppedFrame,
 )
 from pipecat.services.openrouter.tts import (
     OPENROUTER_DEFAULT_TTS_MODEL,
@@ -26,7 +22,7 @@ from pipecat.services.openrouter.tts import (
     OpenRouterTTSService,
     OpenRouterTTSSettings,
 )
-from pipecat.services.settings import NOT_GIVEN, is_given
+from pipecat.services.settings import is_given
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `OpenRouterTTSService` to route TTS requests through OpenRouter's OpenAI-compatible `/api/v1/audio/speech` endpoint, supporting multiple providers (OpenAI, Google, Mistral) and their voice sets from a single API key.

- **`src/pipecat/services/openrouter/tts.py`**: new `OpenRouterTTSService` extending `OpenAITTSService` with `base_url=https://openrouter.ai/api/v1`, default model `openai/gpt-4o-mini-tts-2025-12-15`, and relaxed voice validation (OpenRouter voices are provider-namespaced: `alloy`, `en_paul_happy`, `af_bella`, etc.)
- **`tests/test_openrouter_tts.py`**: 12 unit tests covering the full service contract
- **`examples/function-calling/function-calling-openrouter.py`**: updated to use `OpenRouterTTSService` so the example only needs `OPENROUTER_API_KEY`

## Usage

```python
from pipecat.services.openrouter.tts import OpenRouterTTSService

tts = OpenRouterTTSService(
    api_key=os.environ["OPENROUTER_API_KEY"],
    settings=OpenRouterTTSService.Settings(
        model="openai/gpt-4o-mini-tts-2025-12-15",
        voice="alloy",
    ),
)
```

## How we tested it

**Unit tests** (`tests/test_openrouter_tts.py`) — all 12 pass:

```
tests/test_openrouter_tts.py::test_settings_delta_defaults_are_not_given PASSED
tests/test_openrouter_tts.py::test_service_settings_complete_after_init  PASSED
tests/test_openrouter_tts.py::test_default_base_url                      PASSED
tests/test_openrouter_tts.py::test_default_model                         PASSED
tests/test_openrouter_tts.py::test_default_voice                         PASSED
tests/test_openrouter_tts.py::test_settings_override_model_and_voice     PASSED
tests/test_openrouter_tts.py::test_non_openai_voices_accepted            PASSED
tests/test_openrouter_tts.py::test_run_tts_emits_audio_frames            PASSED
tests/test_openrouter_tts.py::test_run_tts_request_params                PASSED
tests/test_openrouter_tts.py::test_run_tts_passes_instructions_and_speed PASSED
tests/test_openrouter_tts.py::test_run_tts_error_status_yields_error_frame PASSED
tests/test_openrouter_tts.py::test_run_tts_missing_voice_yields_error_frame PASSED
12 passed in 0.96s
```

Tests cover:
- **Settings contract**: delta-mode fields all `NOT_GIVEN`; store-mode fields all complete after `__init__` (same checks as `test_service_init.py`)
- **Defaults**: correct `base_url` host, default model, default voice
- **Settings overrides**: `Settings(model=..., voice=...)` takes precedence
- **Voice flexibility**: provider-namespaced voices (`en_paul_happy`, `af_bella`) accepted without error — unlike the OpenAI service which rejects unknown voice IDs
- **`run_tts` happy path**: mock streaming response yields correct `TTSAudioRawFrame` chunks with expected `sample_rate`, `num_channels`, and `context_id`
- **Request params**: `input`, `model`, `voice`, `response_format=pcm` all forwarded correctly
- **Optional params**: `instructions` and `speed` included when set
- **Error handling**: non-200 status → `ErrorFrame`; `voice=None` → `ErrorFrame`

**Auto-discovery** (`test_service_init.py`): `OpenRouterTTSSettings` is automatically picked up and passes the delta-defaults check with no extra configuration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)