### PR TITLE
Fix unhandled exception in WebsocketService.send_with_retry retry path Closes #4618

### DIFF
--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -134,10 +134,21 @@ class WebsocketService(ABC):
             success = await self._try_reconnect(report_error=report_error)
             if success and self._websocket is not None:
                 logger.info(f"{self} reconnected successfully, will retry send the message")
-                # trying to send the message one more time
-                await self._websocket.send(message)
+                # Trying to send the message one more time. This retry must stay
+                # inside its own try/except: if the send fails again (e.g. the
+                # server closes the freshly reconnected socket), the exception
+                # would otherwise escape send_with_retry unhandled and crash the
+                # calling service on the audio hot path.
+                try:
+                    await self._websocket.send(message)
+                except Exception as retry_error:
+                    logger.error(f"{self} send failed after reconnect: {retry_error}")
+                    await report_error(
+                        ErrorFrame(f"{self} send failed after reconnect: {retry_error}")
+                    )
             else:
                 logger.error(f"{self} send failed; unable to reconnect")
+                # _try_reconnect already reported the failure via report_error.
 
     async def _maybe_try_reconnect(
         self,

--- a/tests/test_websocket_service.py
+++ b/tests/test_websocket_service.py
@@ -256,7 +256,25 @@ async def test_stable_connection_resets_quick_failure_counter(service, report_er
 # ---------------------------------------------------------------------------
 # Lifecycle and guards
 # ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_send_with_retry_reports_retry_send_failure(service, report_error):
+    """A failed send after reconnect is reported instead of escaping."""
+    websocket = type("FakeWebsocket", (), {})()
+    websocket.send = AsyncMock(
+        side_effect=[ConnectionError("initial send failed"), RuntimeError("retry failed")]
+    )
+    service._websocket = websocket
+    service._try_reconnect = AsyncMock(return_value=True)
 
+    await service.send_with_retry("message", report_error)
+
+    assert websocket.send.call_count == 2
+    service._try_reconnect.assert_called_once()
+    report_error.assert_called_once()
+    error_frame = report_error.call_args[0][0]
+    assert isinstance(error_frame, ErrorFrame)
+    assert error_frame.fatal is False
+    assert "retry failed" in error_frame.error
 
 @pytest.mark.asyncio
 async def test_disconnect_prevents_reconnection(service, report_error):


### PR DESCRIPTION
Fix unhandled exception in WebsocketService.send_with_retry retry path

  The retry send after a successful reconnect was outside the try/except,
  so a second send failure (e.g. server closing the freshly reconnected
  socket) propagated unhandled out of send_with_retry, crashing services
  on the audio hot path (Inworld TTS, Cartesia STT, Deepgram Flux STT).

  Wrap the retry send in its own try/except and report the failure via the
  report_error callback, consistent with the other error paths.