### PR TITLE
feat(smallest): add word_timestamps support to TTS service

### DIFF
--- a/examples/voice/voice-smallest.py
+++ b/examples/voice/voice-smallest.py
@@ -61,7 +61,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = SmallestTTSService(
         api_key=os.environ["SMALLEST_API_KEY"],
         settings=SmallestTTSService.Settings(
-            voice="sophia",
+            model="lightning_v3.1_pro",
+            voice="meher",
         ),
     )
 

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -97,9 +97,18 @@ class SmallestTTSSettings(TTSSettings):
 
     Parameters:
         speed: Speech speed multiplier (0.5–2.0).
+        word_timestamps: Opt in to per-word timing events on WebSocket streaming.
+            When ``True``, the server interleaves ``word_timestamp`` frames with
+            audio chunks; each carries ``{id, word, start, end}`` where
+            ``start``/``end`` are floats in seconds relative to the audio stream
+            start.  Supported on base-queue English + Hindi voices (``meher``,
+            ``devansh``, ``kartik``, ``maithili``, ``liam``, ``avery``); other
+            voice families silently emit no word events.  Defaults to ``None``
+            (disabled).
     """
 
     speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    word_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class SmallestTTSService(InterruptibleTTSService):
@@ -159,6 +168,7 @@ class SmallestTTSService(InterruptibleTTSService):
             voice=_MODEL_DEFAULT_VOICES[model],
             language=Language.EN,
             speed=None,
+            word_timestamps=None,
         )
 
         if settings is not None:
@@ -221,6 +231,9 @@ class SmallestTTSService(InterruptibleTTSService):
 
         if self._settings.speed is not None:
             msg["speed"] = self._settings.speed
+
+        if self._settings.word_timestamps:
+            msg["word_timestamps"] = True
 
         msg["output_format"] = self._output_format
 
@@ -379,6 +392,12 @@ class SmallestTTSService(InterruptibleTTSService):
                     context_id=context_id,
                 )
                 await self.append_to_audio_context(context_id, frame)
+            elif status == "word_timestamp":
+                data = msg.get("data", {})
+                logger.debug(
+                    f"{self} word_timestamp: id={data.get('id')} word={data.get('word')!r} "
+                    f"start={data.get('start')} end={data.get('end')}"
+                )
             elif status == "error":
                 context_id = self.get_active_audio_context_id()
                 await self.push_frame(TTSStoppedFrame(context_id=context_id))


### PR DESCRIPTION
## Summary

- Added `word_timestamps` opt-in setting to `SmallestTTSService` — sends `word_timestamps: true` in the WebSocket request payload when enabled, receiving interleaved per-word timing events (`id`, `word`, `start`, `end`) alongside audio chunks
- Updated `voice-smallest.py` example to use `lightning_v3.1_pro` model with `meher` voice

## word_timestamps feature

Smallest AI's Lightning v3.1 and v3.1 Pro WebSocket streaming now supports per-word timing events (shipped 2026-06-01). Opt in by setting `word_timestamps=True` in the service settings:

```python
tts = SmallestTTSService(
    api_key=os.environ["SMALLEST_API_KEY"],
    settings=SmallestTTSService.Settings(
        model="lightning_v3.1_pro",
        voice="meher",
        word_timestamps=True,
    ),
)
```

When enabled, the server interleaves `status: "word_timestamp"` frames with audio chunks. Each frame carries `data: { id, word, start, end }` where `start`/`end` are floats in seconds relative to the start of the audio stream, and `word` is the verbatim input text substring (un-normalized — `"$100"` stays `"$100"`).

Supported voices: base-queue English + Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`). Other voice families silently emit no word events — audio works normally.

Defaults to `None` (disabled) — purely opt-in, no behavior change for existing integrations.

## Voice/model fix

`lightning_v3.1_pro` is now the default model and uses `meher` as its default voice. The example was still using `sophia` (the default for the older `lightning_v3.1` model), creating a mismatch. Both `model` and `voice` are now set explicitly.