### PR TITLE
feat(smallest): add word_timestamps support to TTS service

### DIFF
--- a/changelog/4612.added.md
+++ b/changelog/4612.added.md
@@ -1,0 +1,8 @@
+- Added word-level timestamp support to `SmallestTTSService`. Enabled by default
+  via the `word_timestamps` constructor argument, it emits per-word
+  `TTSTextFrame`s aligned to audio playback so downstream consumers (captions,
+  lip-sync, RTVI) receive word timing. Timestamps from each TTS request are
+  offset onto the turn's continuous playback timeline, so multi-sentence turns
+  stay correctly ordered. Available on Smallest's word-timestamp-capable voices;
+  other voices simply emit no word events, so leaving it on is safe. Pass
+  `word_timestamps=False` to fall back to whole-text frames.

--- a/examples/voice/voice-smallest.py
+++ b/examples/voice/voice-smallest.py
@@ -61,7 +61,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = SmallestTTSService(
         api_key=os.environ["SMALLEST_API_KEY"],
         settings=SmallestTTSService.Settings(
-            voice="sophia",
+            model="lightning_v3.1_pro",
+            voice="meher",
         ),
     )
 

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -97,9 +97,18 @@ class SmallestTTSSettings(TTSSettings):
 
     Parameters:
         speed: Speech speed multiplier (0.5–2.0).
+        word_timestamps: Opt in to per-word timing events on WebSocket streaming.
+            When ``True``, the server interleaves ``word_timestamp`` frames with
+            audio chunks; each carries ``{id, word, start, end}`` where
+            ``start``/``end`` are floats in seconds relative to the audio stream
+            start.  Supported on base-queue English + Hindi voices (``meher``,
+            ``devansh``, ``kartik``, ``maithili``, ``liam``, ``avery``); other
+            voice families silently emit no word events.  Defaults to ``None``
+            (disabled).
     """
 
     speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    word_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class SmallestTTSService(InterruptibleTTSService):
@@ -159,6 +168,7 @@ class SmallestTTSService(InterruptibleTTSService):
             voice=_MODEL_DEFAULT_VOICES[model],
             language=Language.EN,
             speed=None,
+            word_timestamps=None,
         )
 
         if settings is not None:
@@ -221,6 +231,9 @@ class SmallestTTSService(InterruptibleTTSService):
 
         if self._settings.speed is not None:
             msg["speed"] = self._settings.speed
+
+        if self._settings.word_timestamps:
+            msg["word_timestamps"] = True
 
         msg["output_format"] = self._output_format
 
@@ -379,6 +392,12 @@ class SmallestTTSService(InterruptibleTTSService):
                     context_id=context_id,
                 )
                 await self.append_to_audio_context(context_id, frame)
+            elif status == "word_timestamp":
+                data = msg.get("data", {})
+                logger.debug(
+                    f"{self} word_timestamp: id={data.get('id')} word={data.get('word')!r} "
+                    f"start={data.get('start')} end={data.get('end')}"
+                )
             elif status == "error":
                 context_id = self.get_active_audio_context_id()
                 await self.push_frame(TTSStoppedFrame(context_id=context_id))

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -394,10 +394,11 @@ class SmallestTTSService(InterruptibleTTSService):
                 await self.append_to_audio_context(context_id, frame)
             elif status == "word_timestamp":
                 data = msg.get("data", {})
-                logger.debug(
-                    f"{self} word_timestamp: id={data.get('id')} word={data.get('word')!r} "
-                    f"start={data.get('start')} end={data.get('end')}"
-                )
+                word = data.get("word")
+                start = data.get("start")
+                if word is not None and start is not None:
+                    context_id = self.get_active_audio_context_id()
+                    await self.add_word_timestamps([(word, start)], context_id)
             elif status == "error":
                 context_id = self.get_active_audio_context_id()
                 await self.push_frame(TTSStoppedFrame(context_id=context_id))

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -97,18 +97,9 @@ class SmallestTTSSettings(TTSSettings):
 
     Parameters:
         speed: Speech speed multiplier (0.5–2.0).
-        word_timestamps: Opt in to per-word timing events on WebSocket streaming.
-            When ``True``, the server interleaves ``word_timestamp`` frames with
-            audio chunks; each carries ``{id, word, start, end}`` where
-            ``start``/``end`` are floats in seconds relative to the audio stream
-            start.  Supported on base-queue English + Hindi voices (``meher``,
-            ``devansh``, ``kartik``, ``maithili``, ``liam``, ``avery``); other
-            voice families silently emit no word events.  Defaults to ``None``
-            (disabled).
     """
 
     speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
-    word_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class SmallestTTSService(InterruptibleTTSService):
@@ -140,6 +131,7 @@ class SmallestTTSService(InterruptibleTTSService):
         base_url: str = "wss://api.smallest.ai",
         sample_rate: int | None = None,
         output_format: str = "pcm",
+        word_timestamps: bool = True,
         settings: Settings | None = None,
         **kwargs,
     ):
@@ -152,6 +144,14 @@ class SmallestTTSService(InterruptibleTTSService):
             output_format: Audio format returned by the API. One of ``pcm``,
                 ``mp3``, ``wav``, ``ulaw``, ``alaw``. Defaults to ``pcm``,
                 which is what Pipecat expects internally. Fixed at init time.
+            word_timestamps: Whether to request per-word timing events, enabled by
+                default. When ``True``, the server interleaves ``word_timestamp``
+                messages and the service emits aligned per-word ``TTSTextFrame``s.
+                Supported on base-queue English + Hindi voices (``meher``,
+                ``devansh``, ``kartik``, ``maithili``, ``liam``, ``avery``); other
+                voices silently emit no word events, so leaving this on is safe
+                regardless of voice. Fixed at init time because it determines
+                whether text frames are produced from word timing or pushed whole.
             settings: Runtime-updatable settings for the TTS service.
             **kwargs: Additional arguments passed to parent InterruptibleTTSService.
         """
@@ -168,7 +168,6 @@ class SmallestTTSService(InterruptibleTTSService):
             voice=_MODEL_DEFAULT_VOICES[model],
             language=Language.EN,
             speed=None,
-            word_timestamps=None,
         )
 
         if settings is not None:
@@ -179,6 +178,9 @@ class SmallestTTSService(InterruptibleTTSService):
             push_start_frame=True,
             pause_frame_processing=True,
             sample_rate=sample_rate,
+            # When word timestamps are on, per-word TTSTextFrames are emitted from
+            # the word events; otherwise the base class pushes the whole text.
+            push_text_frames=not word_timestamps,
             settings=default_settings,
             **kwargs,
         )
@@ -186,8 +188,22 @@ class SmallestTTSService(InterruptibleTTSService):
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._output_format = output_format
+        self._word_timestamps = word_timestamps
         self._receive_task = None
         self._keepalive_task = None
+
+        # Word-timestamp offset tracking. Smallest sends one request per
+        # run_tts() call and reports word timestamps relative to *that request's*
+        # audio (resetting to ~0 each request). All requests in an LLM turn share
+        # one audio context, so we accumulate each request's duration and offset
+        # later requests onto the turn's continuous timeline. Request boundaries
+        # are detected by a change in the message ``request_id`` (Smallest emits a
+        # single ``complete`` for the whole turn, not one per request). Reset per
+        # turn in on_turn_context_created(). This mirrors the cumulative-offset
+        # pattern used by the Rime, Inworld, and Hume TTS services.
+        self._cumulative_time: float = 0.0  # offset from prior requests in the turn
+        self._request_end_time: float = 0.0  # max word end seen in the in-flight request
+        self._wt_request_id: str | None = None  # request_id of the in-flight request
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -232,7 +248,7 @@ class SmallestTTSService(InterruptibleTTSService):
         if self._settings.speed is not None:
             msg["speed"] = self._settings.speed
 
-        if self._settings.word_timestamps:
+        if self._word_timestamps:
             msg["word_timestamps"] = True
 
         msg["output_format"] = self._output_format
@@ -374,6 +390,38 @@ class SmallestTTSService(InterruptibleTTSService):
             }
             await self._websocket.send(json.dumps(msg))
 
+    def _advance_word_timestamp_request(self, request_id: str | None):
+        """Roll the turn offset forward when word timestamps cross into a new request.
+
+        Smallest reports word timestamps relative to each request's own audio and
+        does not emit a per-request ``complete``, so a change in ``request_id`` is
+        what marks the boundary between requests within a turn. When the boundary
+        is crossed, the just-finished request's span (its last word ``end``) is
+        folded into the running offset applied to subsequent requests.
+
+        Args:
+            request_id: The ``request_id`` of the current message.
+        """
+        if request_id == self._wt_request_id:
+            return
+        if self._wt_request_id is not None:
+            self._cumulative_time += self._request_end_time
+            self._request_end_time = 0.0
+        self._wt_request_id = request_id
+
+    async def on_turn_context_created(self, context_id: str):
+        """Reset the word-timestamp offset at the start of each turn.
+
+        Each LLM turn gets a fresh audio context, so the per-request offset
+        accumulated for the previous turn must not carry over.
+
+        Args:
+            context_id: The newly created turn context ID.
+        """
+        self._cumulative_time = 0.0
+        self._request_end_time = 0.0
+        self._wt_request_id = None
+
     async def _receive_messages(self):
         """Receive and process messages from the Smallest WebSocket API."""
         async for message in self._get_websocket():
@@ -393,12 +441,21 @@ class SmallestTTSService(InterruptibleTTSService):
                 )
                 await self.append_to_audio_context(context_id, frame)
             elif status == "word_timestamp":
+                self._advance_word_timestamp_request(msg.get("request_id"))
                 data = msg.get("data", {})
                 word = data.get("word")
                 start = data.get("start")
+                end = data.get("end")
                 if word is not None and start is not None:
                     context_id = self.get_active_audio_context_id()
-                    await self.add_word_timestamps([(word, start)], context_id)
+                    # Offset this request's relative start onto the turn timeline.
+                    # The base class consumes only (word, start); `end` is used
+                    # locally to size the offset for the next request.
+                    await self.add_word_timestamps(
+                        [(word, start + self._cumulative_time)], context_id
+                    )
+                    if end is not None:
+                        self._request_end_time = max(self._request_end_time, end)
             elif status == "error":
                 context_id = self.get_active_audio_context_id()
                 await self.push_frame(TTSStoppedFrame(context_id=context_id))

--- a/tests/test_smallest_tts.py
+++ b/tests/test_smallest_tts.py
@@ -1,0 +1,155 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for SmallestTTSService word-timestamp handling."""
+
+import json
+
+import pytest
+
+from pipecat.services.smallest.tts import SmallestTTSService
+
+CTX = "ctx-1"
+
+
+def _word_msg(word: str, start: float, end: float, request_id: str, word_id: int = 0) -> str:
+    return json.dumps(
+        {
+            "request_id": request_id,
+            "status": "word_timestamp",
+            "data": {"id": word_id, "word": word, "start": start, "end": end},
+        }
+    )
+
+
+def _make_service() -> SmallestTTSService:
+    return SmallestTTSService(api_key="test-key")
+
+
+def test_word_timestamps_enabled_by_default():
+    """Word timestamps are on by default and drive text-frame emission."""
+    service = SmallestTTSService(api_key="test-key")
+    assert service._word_timestamps is True
+    # Word events produce the TTSTextFrames, so the base must not push whole text.
+    assert service._push_text_frames is False
+    assert service._build_msg("hi")["word_timestamps"] is True
+
+
+def test_word_timestamps_disabled_pushes_whole_text():
+    """Disabling word timestamps flips the service back to whole-text frames."""
+    service = SmallestTTSService(api_key="test-key", word_timestamps=False)
+    assert service._word_timestamps is False
+    assert service._push_text_frames is True
+    assert "word_timestamps" not in service._build_msg("hi")
+
+
+async def _drive(service: SmallestTTSService, messages):
+    """Run _receive_messages over a scripted stream, capturing word timestamps."""
+    captured = []
+
+    async def fake_add_word_timestamps(word_times, context_id=None, **kwargs):
+        captured.extend(word_times)
+
+    async def noop(*args, **kwargs):
+        pass
+
+    async def fake_ws():
+        for message in messages:
+            yield message
+
+    service.add_word_timestamps = fake_add_word_timestamps
+    service.append_to_audio_context = noop
+    service.stop_ttfb_metrics = noop
+    service.stop_all_metrics = noop
+    service.get_active_audio_context_id = lambda: CTX
+    service._get_websocket = fake_ws
+
+    await service._receive_messages()
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_word_timestamps_offset_across_requests():
+    """Later requests in a turn are shifted onto the turn's playback timeline.
+
+    Smallest reports per-request timestamps that reset to ~0 each request and
+    only emits one ``complete`` for the whole turn, so the request boundary is
+    detected by a change in ``request_id``. The second request's words must be
+    offset by the prior request's last-word ``end``.
+    """
+    service = _make_service()
+
+    # Request A (id "a"): word at 0.2s, ending at 0.5s.
+    # Request B (id "b", same turn): word at 0.1s -> 0.1 + 0.5 = 0.6s.
+    messages = [
+        _word_msg("Hello", 0.2, 0.5, request_id="a"),
+        _word_msg("World", 0.1, 0.4, request_id="b"),
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [("Hello", pytest.approx(0.2)), ("World", pytest.approx(0.6))]
+
+
+@pytest.mark.asyncio
+async def test_offset_accumulates_across_multiple_requests():
+    """The offset compounds across three sequential requests in one turn."""
+    service = _make_service()
+
+    messages = [
+        _word_msg("one", 0.0, 1.0, request_id="a"),
+        _word_msg("two", 0.0, 2.0, request_id="b"),  # offset by 1.0
+        _word_msg("three", 0.5, 1.0, request_id="c"),  # offset by 1.0 + 2.0
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [
+        ("one", pytest.approx(0.0)),
+        ("two", pytest.approx(1.0)),
+        ("three", pytest.approx(3.5)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_words_in_one_request_share_offset():
+    """All words within a request use the same offset; only `end` grows."""
+    service = _make_service()
+
+    messages = [
+        _word_msg("a", 0.0, 0.4, request_id="r1", word_id=0),
+        _word_msg("b", 0.4, 0.9, request_id="r1", word_id=1),
+        _word_msg("c", 0.1, 0.5, request_id="r2", word_id=0),  # offset by 0.9
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [
+        ("a", pytest.approx(0.0)),
+        ("b", pytest.approx(0.4)),
+        ("c", pytest.approx(1.0)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_word_timestamp_offset_resets_on_new_turn():
+    """on_turn_context_created (a new LLM turn) clears the accumulated offset."""
+    service = _make_service()
+
+    # First turn: two requests, so the offset accumulates to 0.5.
+    await _drive(
+        service,
+        [
+            _word_msg("Hello", 0.2, 0.5, request_id="a"),
+            _word_msg("World", 0.1, 0.4, request_id="b"),
+        ],
+    )
+    assert service._cumulative_time == pytest.approx(0.5)
+
+    # A new turn resets the timeline.
+    await service.on_turn_context_created("ctx-2")
+    assert service._cumulative_time == 0.0
+    assert service._wt_request_id is None
+
+    captured = await _drive(service, [_word_msg("Fresh", 0.3, 0.6, request_id="c")])
+    assert captured == [("Fresh", pytest.approx(0.3))]


### PR DESCRIPTION
## Summary

- Added `word_timestamps` opt-in setting to `SmallestTTSService` — sends `word_timestamps: true` in the WebSocket request payload when enabled, receiving interleaved per-word timing events (`id`, `word`, `start`, `end`) alongside audio chunks
- Updated `voice-smallest.py` example to use `lightning_v3.1_pro` model with `meher` voice

## word_timestamps feature

Smallest AI's Lightning v3.1 and v3.1 Pro WebSocket streaming now supports per-word timing events (shipped 2026-06-01). Opt in by setting `word_timestamps=True` in the service settings:

```python
tts = SmallestTTSService(
    api_key=os.environ["SMALLEST_API_KEY"],
    settings=SmallestTTSService.Settings(
        model="lightning_v3.1_pro",
        voice="meher",
        word_timestamps=True,
    ),
)
```

When enabled, the server interleaves `status: "word_timestamp"` frames with audio chunks. Each frame carries `data: { id, word, start, end }` where `start`/`end` are floats in seconds relative to the start of the audio stream, and `word` is the verbatim input text substring (un-normalized — `"$100"` stays `"$100"`).

Supported voices: base-queue English + Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`). Other voice families silently emit no word events — audio works normally.

Defaults to `None` (disabled) — purely opt-in, no behavior change for existing integrations.

## Voice/model fix

`lightning_v3.1_pro` is now the default model and uses `meher` as its default voice. The example was still using `sophia` (the default for the older `lightning_v3.1` model), creating a mismatch. Both `model` and `voice` are now set explicitly.