### PR TITLE
create_transport() refactor

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -38,6 +38,7 @@ jobs:
             --extra anthropic \
             --extra aws \
             --extra azure \
+            --extra daily \
             --extra deepgram \
             --extra google \
             --extra langchain \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,7 @@ jobs:
             --extra anthropic \
             --extra aws \
             --extra azure \
+            --extra daily \
             --extra deepgram \
             --extra google \
             --extra langchain \

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -1207,7 +1207,8 @@ def main(parser: argparse.ArgumentParser | None = None):
        - -x/--proxy: Public proxy hostname for telephony webhooks
        - -d/--direct: Connect directly to Daily room (automatically sets transport to daily)
        - -f/--folder: Path to downloads folder
-       - --dialin: Enable Daily PSTN dial-in webhook handling
+       - --dialin/--no-dialin: Mount the Daily PSTN dial-in webhook for -t daily
+         (on by default; --no-dialin disables it)
        - --esp32: Enable SDP munging for ESP32 compatibility (requires --host with IP address)
        - --whatsapp: Ensure required WhatsApp environment variables are present
        - -v/--verbose: Increase logging verbosity
@@ -1250,9 +1251,12 @@ def main(parser: argparse.ArgumentParser | None = None):
     )
     parser.add_argument(
         "--dialin",
-        action="store_true",
-        default=False,
-        help="Enable Daily PSTN dial-in webhook handling",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Mount the Daily PSTN dial-in webhook for -t daily. On by default (a local "
+            "stand-in for Pipecat Cloud's dial-in handler); use --no-dialin to disable."
+        ),
     )
     parser.add_argument(
         "--esp32",
@@ -1286,10 +1290,8 @@ def main(parser: argparse.ArgumentParser | None = None):
         logger.error("For ESP32, you need to specify `--host IP` so we can do SDP munging.")
         return
 
-    # Validate dial-in requirements
-    if args.dialin and args.transport is not None and args.transport != "daily":
-        logger.error("--dialin flag only works with Daily transport (-t daily)")
-        return
+    # The dial-in webhook is mounted only inside _setup_daily_routes, so --dialin is a
+    # no-op for non-Daily transports; nothing to validate here.
 
     # Log level
     logger.remove()

--- a/src/pipecat/runner/types.py
+++ b/src/pipecat/runner/types.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from fastapi import WebSocket
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DialinSettings(BaseModel):
@@ -56,6 +56,82 @@ class DailyDialinRequest(BaseModel):
     daily_api_url: str
 
 
+class CallData(BaseModel):
+    """Parsed telephony handshake data from the provider's first WebSocket messages.
+
+    Populated by :func:`pipecat.runner.utils.parse_telephony_websocket` and exposed on
+    ``WebSocketRunnerArguments.call_data`` by ``create_transport``. Gives typed
+    attribute access — ``call_data.to_number``, ``call_data.call_id`` — while staying
+    dict-compatible (``call_data["call_id"]``, ``call_data.get("body", {})``) so bots
+    written against the old dict keep working.
+
+    Fields are populated per provider; absent ones stay ``None``. Provider-specific keys
+    not modeled here remain accessible (``extra="allow"``).
+
+    This base holds the fields common to all providers. Provider-specific fields live
+    on subclasses (:class:`TelnyxCallData`, :class:`ExotelCallData`), which
+    ``parse_telephony_websocket`` / ``create_transport`` construct per provider.
+
+    Parameters:
+        stream_id: Provider media-stream identifier.
+        call_id: Provider call identifier, normalized across providers (Twilio
+            ``callSid``, Plivo ``callId``, Exotel ``call_sid``, Telnyx
+            ``call_control_id``).
+        from_number: Caller's number. Wire key ``from``.
+        to_number: Dialed number. Wire key ``to``.
+        body: Custom parameters sent by the provider (e.g. Twilio TwiML stream
+            parameters).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    stream_id: str | None = None
+    call_id: str | None = None
+    from_number: str | None = Field(default=None, alias="from")
+    to_number: str | None = Field(default=None, alias="to")
+    body: dict = Field(default_factory=dict)
+
+    def _wire_dict(self) -> dict:
+        """The original provider dict shape (wire/alias keys, including extras)."""
+        return self.model_dump(by_alias=True)
+
+    def __getitem__(self, key: str):
+        """Dict-style access, e.g. ``call_data["call_id"]``."""
+        return self._wire_dict()[key]
+
+    def __contains__(self, key: str) -> bool:
+        """``"call_id" in call_data`` — True only when the provider set the value."""
+        wire = self._wire_dict()
+        return key in wire and wire[key] is not None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-style ``.get`` returning ``default`` when the key is missing or unset."""
+        value = self._wire_dict().get(key, default)
+        return default if value is None else value
+
+
+class TelnyxCallData(CallData):
+    """Telnyx-specific parsed telephony handshake data.
+
+    Parameters:
+        outbound_encoding: Telnyx outbound media encoding.
+    """
+
+    outbound_encoding: str | None = None
+
+
+class ExotelCallData(CallData):
+    """Exotel-specific parsed telephony handshake data.
+
+    Parameters:
+        account_sid: Exotel account sid.
+        custom_parameters: Exotel custom parameters.
+    """
+
+    account_sid: str | None = None
+    custom_parameters: str | dict | None = None
+
+
 @dataclass
 class RunnerArguments:
     """Base class for runner session arguments.
@@ -66,6 +142,12 @@ class RunnerArguments:
         pipeline_idle_timeout_secs: Seconds the pipeline may stay idle before
             shutting down.
         body: Optional request body data passed from the runner entry point.
+        call_data: Parsed telephony handshake as a :class:`CallData` model — typed
+            attribute access (``call_data.to_number``) that's also dict-compatible
+            (``call_data["call_id"]``). Populated by ``create_transport`` (or a direct
+            ``parse_telephony_websocket`` call) for telephony connections; ``None``
+            otherwise. Lives on the base so any bot can read ``runner_args.call_data``
+            uniformly, mirroring ``body``.
         session_id: Identifier for this bot session.
         cli_args: Parsed CLI arguments from the runner, when launched via the
             development runner.
@@ -76,6 +158,7 @@ class RunnerArguments:
     handle_sigterm: bool = field(init=False, kw_only=True)
     pipeline_idle_timeout_secs: int = field(init=False, kw_only=True)
     body: Any | None = field(default_factory=dict, kw_only=True)
+    call_data: CallData | None = field(default=None, kw_only=True)
     session_id: str | None = field(default=None, kw_only=True)
     cli_args: argparse.Namespace | None = field(default=None, init=False, kw_only=True)
 
@@ -118,11 +201,15 @@ class VonageRunnerArguments(RunnerArguments):
 class WebSocketRunnerArguments(RunnerArguments):
     """WebSocket transport session arguments for the runner.
 
+    The parsed telephony handshake is available on the inherited ``call_data`` field
+    (a :class:`CallData` model), populated by ``create_transport``.
+
     Parameters:
         websocket: WebSocket connection for audio streaming
         transport_type: Transport type identifier. Set to ``"websocket"`` for plain
             WebSocket connections; ``None`` triggers auto-detection from the first
-            telephony provider message.
+            telephony provider message. After auto-detection, ``create_transport``
+            overwrites this in place with the detected provider (e.g. ``"twilio"``).
         body: Additional request data
     """
 

--- a/src/pipecat/runner/utils.py
+++ b/src/pipecat/runner/utils.py
@@ -39,9 +39,12 @@ from fastapi import WebSocket
 from loguru import logger
 
 from pipecat.runner.types import (
+    CallData,
     DailyRunnerArguments,
+    ExotelCallData,
     LiveKitRunnerArguments,
     SmallWebRTCRunnerArguments,
+    TelnyxCallData,
     VonageRunnerArguments,
     WebSocketRunnerArguments,
 )
@@ -102,9 +105,12 @@ async def parse_telephony_websocket(websocket: WebSocket):
         websocket: FastAPI WebSocket connection from telephony provider.
 
     Returns:
-        tuple: (transport_type: str, call_data: dict)
+        tuple: (transport_type: str, call_data: CallData)
 
-        call_data contains provider-specific fields:
+        ``call_data`` is a :class:`~pipecat.runner.types.CallData` model with typed
+        attribute access (``call_data.to_number``) that is also dict-compatible
+        (``call_data["call_id"]``, ``call_data.get("body", {})``). Fields populated
+        per provider:
 
         - Twilio::
 
@@ -118,7 +124,7 @@ async def parse_telephony_websocket(websocket: WebSocket):
 
             {
                 "stream_id": str,
-                "call_control_id": str,
+                "call_id": str,  # normalized from Telnyx's call_control_id
                 "outbound_encoding": str,
                 "from": str,
                 "to": str,
@@ -147,9 +153,23 @@ async def parse_telephony_websocket(websocket: WebSocket):
     Example usage::
 
         transport_type, call_data = await parse_telephony_websocket(websocket)
-        if transport_type == "twilio":
-            user_id = call_data["body"]["user_id"]
+        caller = call_data.from_number  # typed attribute access
+        user_id = call_data.body.get("user_id")  # custom params still a dict
+        # dict-style access also works: call_data["call_id"]
+
+    The parsed result is cached on the websocket, so this is idempotent: the
+    underlying ``websocket.iter_text()`` stream is single-use, but calling this
+    function again (e.g. once inside ``create_transport`` and once in bot code)
+    returns the same ``(transport_type, call_data)`` without re-consuming it.
     """
+    # Return the cached parse if this websocket has already been parsed — the
+    # message stream below can only be consumed once. The cache is always a
+    # (transport_type, call_data) tuple; isinstance keeps this robust against
+    # mock/auto-attr websockets in tests.
+    cached = getattr(websocket, "_pipecat_parsed_telephony", None)
+    if isinstance(cached, tuple):
+        return cached
+
     # Read first two messages
     message_stream = websocket.iter_text()
     first_message = {}
@@ -203,12 +223,18 @@ async def parse_telephony_websocket(websocket: WebSocket):
                 "call_id": start_data.get("callSid"),
                 # All custom parameters
                 "body": body_data,
+                # Promote common custom params so the typed API is uniform across
+                # providers (Twilio carries from/to as TwiML stream parameters).
+                "from": body_data.get("from_number"),
+                "to": body_data.get("to_number"),
             }
 
         elif transport_type == "telnyx":
             call_data = {
                 "stream_id": call_data_raw.get("stream_id"),
-                "call_control_id": call_data_raw.get("start", {}).get("call_control_id"),
+                # Telnyx's call identifier is its call_control_id; normalize it onto
+                # the common `call_id` field.
+                "call_id": call_data_raw.get("start", {}).get("call_control_id"),
                 "outbound_encoding": call_data_raw.get("start", {})
                 .get("media_format", {})
                 .get("encoding"),
@@ -238,7 +264,20 @@ async def parse_telephony_websocket(websocket: WebSocket):
             call_data = {}
 
         logger.debug(f"Parsed - Type: {transport_type}, Data: {call_data}")
-        return transport_type, call_data
+        # Return a typed, dict-compatible CallData model (attribute access for new
+        # code; subscript/.get for existing dict-style code). model_validate maps the
+        # wire keys (e.g. "from"/"to") onto the aliased fields. Providers with extra
+        # fields get a specific subclass so those fields are typed, not just extras.
+        call_data_type = {"telnyx": TelnyxCallData, "exotel": ExotelCallData}.get(
+            transport_type, CallData
+        )
+        result = (transport_type, call_data_type.model_validate(call_data))
+        # Cache on the websocket so subsequent calls don't re-consume the stream.
+        # Only successful parses are cached; the raising paths stay retryable.
+        # setattr (not attribute assignment) since WebSocket has no such declared
+        # field; mirrors the getattr-based read above.
+        setattr(websocket, "_pipecat_parsed_telephony", result)
+        return result
 
     except Exception as e:
         logger.error(f"Error parsing telephony WebSocket: {e}")
@@ -445,7 +484,7 @@ async def _create_telephony_transport(
     websocket: WebSocket,
     params: Any,
     transport_type: str,
-    call_data: dict,
+    call_data: CallData,
 ) -> BaseTransport:
     """Create a telephony transport with pre-parsed WebSocket data.
 
@@ -453,7 +492,7 @@ async def _create_telephony_transport(
         websocket: FastAPI WebSocket connection from telephony provider
         params: FastAPIWebsocketParams (required)
         transport_type: Pre-detected provider type ("twilio", "telnyx", "plivo")
-        call_data: Pre-parsed call data dict with provider-specific fields
+        call_data: Pre-parsed :class:`CallData` with provider-specific fields
 
     Returns:
         Configured FastAPIWebsocketTransport ready for telephony use.
@@ -465,6 +504,9 @@ async def _create_telephony_transport(
 
     logger.info(f"Using pre-detected telephony provider: {transport_type}")
 
+    # Build serializers from the raw wire values via subscript access (the detected
+    # provider guarantees these identifier fields are present). Bots use the typed
+    # attribute API instead — call_data.from_number, call_data.call_id, etc.
     if transport_type == "twilio":
         from pipecat.serializers.twilio import TwilioFrameSerializer
 
@@ -479,7 +521,7 @@ async def _create_telephony_transport(
 
         params.serializer = TelnyxFrameSerializer(
             stream_id=call_data["stream_id"],
-            call_control_id=call_data["call_control_id"],
+            call_control_id=call_data["call_id"],
             outbound_encoding=call_data["outbound_encoding"],
             inbound_encoding="PCMU",  # Standard default
             api_key=os.getenv("TELNYX_API_KEY", ""),
@@ -507,6 +549,47 @@ async def _create_telephony_transport(
         )
 
     return FastAPIWebsocketTransport(websocket=websocket, params=params)
+
+
+def _maybe_apply_daily_dialin(params: Any, body: Any) -> None:
+    """Wire Daily PSTN dial-in settings from ``runner_args.body`` into ``DailyParams``.
+
+    The dev runner places a ``DailyDialinRequest`` in ``runner_args.body`` for
+    inbound PSTN calls. When present, merge its dial-in settings (and the Daily
+    API key/url it carries, which are load-bearing for the pinless handshake) into
+    the ``DailyParams`` the bot's factory produced. No-op when ``body`` doesn't
+    carry dial-in, so non-dial-in Daily bots are unaffected.
+
+    Args:
+        params: The ``DailyParams`` instance from the bot's transport factory.
+        body: ``runner_args.body`` — a ``DailyDialinRequest``, its ``model_dump()``
+            dict, or unrelated content.
+    """
+    if not body:
+        return
+
+    from pipecat.runner.types import DailyDialinRequest
+
+    try:
+        if isinstance(body, DailyDialinRequest):
+            request = body
+        elif isinstance(body, dict) and "dialin_settings" in body:
+            request = DailyDialinRequest.model_validate(body)
+        else:
+            return
+    except Exception as e:
+        logger.debug(f"runner_args.body present but not a Daily dial-in request, skipping: {e}")
+        return
+
+    from pipecat.transports.daily.transport import DailyDialinSettings
+
+    params.dialin_settings = DailyDialinSettings(
+        call_id=request.dialin_settings.call_id,
+        call_domain=request.dialin_settings.call_domain,
+    )
+    # The dial-in request is authoritative for these (matches the inbound flow).
+    params.api_key = request.daily_api_key
+    params.api_url = request.daily_api_url
 
 
 async def create_transport(
@@ -573,6 +656,9 @@ async def create_transport(
     if isinstance(runner_args, DailyRunnerArguments):
         params = _get_transport_params("daily", transport_params)
 
+        # Transparently wire PSTN dial-in (no-op when body has none).
+        _maybe_apply_daily_dialin(params, runner_args.body)
+
         from pipecat.transports.daily.transport import DailyTransport
 
         return DailyTransport(
@@ -601,6 +687,12 @@ async def create_transport(
 
         # Parse once to determine the provider and get data
         transport_type, call_data = await parse_telephony_websocket(runner_args.websocket)
+
+        # Expose the parsed handshake to the bot so it can personalize the call
+        # (caller lookup, routing, etc.) without re-parsing the single-use stream.
+        runner_args.transport_type = transport_type
+        runner_args.call_data = call_data
+
         params = _get_transport_params(transport_type, transport_params)
 
         # Create telephony transport with pre-parsed data

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -6,9 +6,67 @@
 
 import json
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from pipecat.runner.utils import parse_telephony_websocket
+from pipecat.runner.types import (
+    CallData,
+    ExotelCallData,
+    TelnyxCallData,
+    WebSocketRunnerArguments,
+)
+from pipecat.runner.utils import (
+    _maybe_apply_daily_dialin,
+    create_transport,
+    parse_telephony_websocket,
+)
+
+try:
+    import daily  # noqa: F401
+
+    DAILY_AVAILABLE = True
+except ImportError:
+    DAILY_AVAILABLE = False
+
+
+class TestCallData(unittest.TestCase):
+    """CallData gives typed attribute access while staying dict-compatible."""
+
+    def test_attribute_access_with_alias(self):
+        cd = CallData.model_validate(
+            {"stream_id": "MZ1", "call_id": "CA1", "from": "+1555", "to": "+1666"}
+        )
+        # Wire keys "from"/"to" map onto from_number/to_number (no keyword clash).
+        self.assertEqual(cd.from_number, "+1555")
+        self.assertEqual(cd.to_number, "+1666")
+        self.assertEqual(cd.call_id, "CA1")
+
+    def test_dict_compat_access(self):
+        cd = CallData.model_validate({"stream_id": "MZ1", "from": "+1555"})
+        # Subscript / get / in use the original wire keys.
+        self.assertEqual(cd["from"], "+1555")
+        self.assertEqual(cd["stream_id"], "MZ1")
+        self.assertEqual(cd.get("from"), "+1555")
+        self.assertEqual(cd.get("to", "n/a"), "n/a")  # unset -> default
+        self.assertIn("from", cd)
+        self.assertNotIn("to", cd)  # unset fields aren't "in"
+
+    def test_unset_fields_are_none(self):
+        cd = CallData.model_validate({"call_id": "CA1"})
+        self.assertIsNone(cd.to_number)
+        self.assertEqual(cd.body, {})
+
+    def test_extra_provider_keys_preserved(self):
+        cd = CallData.model_validate({"call_id": "CA1", "weird_provider_field": "x"})
+        # extra="allow": unmodeled keys remain reachable via dict access.
+        self.assertEqual(cd["weird_provider_field"], "x")
+
+    def test_call_data_is_a_base_field(self):
+        """call_data lives on the base, so any runner_args exposes it (defaults None),
+        letting bots read runner_args.call_data uniformly without getattr guards."""
+        from pipecat.runner.types import DailyRunnerArguments, RunnerArguments
+
+        self.assertIsNone(RunnerArguments().call_data)
+        self.assertIsNone(DailyRunnerArguments(room_url="https://example.daily.co/room").call_data)
 
 
 class MockAsyncIterator:
@@ -85,6 +143,29 @@ class TestParseTelephonyWebSocket(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_data["stream_id"], "MZ456")
         self.assertEqual(call_data["call_id"], "CA456")
 
+    async def test_twilio_promotes_from_to_custom_params(self):
+        """Twilio from/to TwiML stream params are promoted for a uniform typed API."""
+        twilio_message = json.dumps(
+            {
+                "event": "start",
+                "start": {
+                    "streamSid": "MZ789",
+                    "callSid": "CA789",
+                    "customParameters": {"from_number": "+1555", "to_number": "+1666"},
+                },
+            }
+        )
+        mock_websocket = MagicMock()
+        mock_websocket.iter_text.return_value = MockAsyncIterator([twilio_message])
+
+        transport_type, call_data = await parse_telephony_websocket(mock_websocket)
+
+        self.assertEqual(transport_type, "twilio")
+        self.assertEqual(call_data.from_number, "+1555")
+        self.assertEqual(call_data.to_number, "+1666")
+        # Raw custom params still available under body.
+        self.assertEqual(call_data.body["to_number"], "+1666")
+
     async def test_telnyx_detection(self):
         """Test Telnyx provider detection."""
         telnyx_message = json.dumps(
@@ -105,8 +186,12 @@ class TestParseTelephonyWebSocket(unittest.IsolatedAsyncioTestCase):
         transport_type, call_data = await parse_telephony_websocket(mock_websocket)
 
         self.assertEqual(transport_type, "telnyx")
+        self.assertIsInstance(call_data, TelnyxCallData)
         self.assertEqual(call_data["stream_id"], "stream_123")
-        self.assertEqual(call_data["call_control_id"], "cc_123")
+        # Telnyx's call_control_id is normalized onto the common call_id field.
+        self.assertEqual(call_data["call_id"], "cc_123")
+        # Provider-specific field is typed on the subclass.
+        self.assertEqual(call_data.outbound_encoding, "PCMU")
 
     async def test_plivo_detection(self):
         """Test Plivo provider detection."""
@@ -144,9 +229,83 @@ class TestParseTelephonyWebSocket(unittest.IsolatedAsyncioTestCase):
         transport_type, call_data = await parse_telephony_websocket(mock_websocket)
 
         self.assertEqual(transport_type, "exotel")
+        self.assertIsInstance(call_data, ExotelCallData)
         self.assertEqual(call_data["stream_id"], "stream_exo_123")
         self.assertEqual(call_data["call_id"], "call_exo_123")
         self.assertEqual(call_data["account_sid"], "acc_123")
+
+
+class TestParseTelephonyIdempotent(unittest.IsolatedAsyncioTestCase):
+    async def test_second_call_returns_cached_parse(self):
+        """The single-use stream is consumed once; a second call returns the cache."""
+        twilio_message = json.dumps(
+            {"event": "start", "start": {"streamSid": "MZ1", "callSid": "CA1"}}
+        )
+        ws = MagicMock()
+        # One iterator, exhausted after the first parse. A second *real* parse would
+        # raise ValueError ("closed before receiving"); the cache must prevent that.
+        ws.iter_text.return_value = MockAsyncIterator([twilio_message])
+
+        first = await parse_telephony_websocket(ws)
+        second = await parse_telephony_websocket(ws)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first[0], "twilio")
+        self.assertEqual(first[1]["call_id"], "CA1")
+
+
+class TestCreateTransportExposesCallData(unittest.IsolatedAsyncioTestCase):
+    async def test_telephony_call_data_set_on_runner_args(self):
+        """create_transport exposes the parsed handshake on runner_args for the bot."""
+        twilio_message = json.dumps(
+            {"event": "start", "start": {"streamSid": "MZ9", "callSid": "CA9"}}
+        )
+        ws = MagicMock()
+        ws.iter_text.return_value = MockAsyncIterator([twilio_message])
+        args = WebSocketRunnerArguments(websocket=ws)  # transport_type=None -> telephony
+
+        sentinel = object()
+        with patch(
+            "pipecat.runner.utils._create_telephony_transport",
+            new=AsyncMock(return_value=sentinel),
+        ):
+            result = await create_transport(args, {"twilio": lambda: MagicMock()})
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(args.transport_type, "twilio")
+        self.assertIsNotNone(args.call_data)
+        # Both styles work: typed attribute access and dict-style subscript.
+        self.assertEqual(args.call_data.call_id, "CA9")
+        self.assertEqual(args.call_data["call_id"], "CA9")
+
+
+@unittest.skipUnless(DAILY_AVAILABLE, "requires the daily-python SDK")
+class TestMaybeApplyDailyDialin(unittest.IsolatedAsyncioTestCase):
+    def _params(self):
+        from pipecat.transports.daily.transport import DailyParams
+
+        return DailyParams()
+
+    def test_dialin_body_populates_params(self):
+        params = self._params()
+        body = {
+            "dialin_settings": {"call_id": "c1", "call_domain": "d1"},
+            "daily_api_key": "key123",
+            "daily_api_url": "https://example.test/v1",
+        }
+        _maybe_apply_daily_dialin(params, body)
+
+        self.assertIsNotNone(params.dialin_settings)
+        self.assertEqual(params.dialin_settings.call_id, "c1")
+        self.assertEqual(params.dialin_settings.call_domain, "d1")
+        self.assertEqual(params.api_key, "key123")
+        self.assertEqual(params.api_url, "https://example.test/v1")
+
+    def test_noop_for_non_dialin_body(self):
+        for body in (None, {}, {"something": "else"}):
+            params = self._params()
+            _maybe_apply_daily_dialin(params, body)
+            self.assertIsNone(params.dialin_settings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### My overview

The goal of this change is to simplify specifying the transport down to a single utility: `create_transport()`. This was largely possible already with the exception of two cases:
1. Daily PSTN Dial-in: A special Daily Param arg is required, which was being special cased. That's been folded in.
2. Websocket transports required a different pattern if you wanted to parse the websocket message for call data (e.g. to and from numbers).

Now, you can write your bot() function like this for essentially all transports:
```python
async def bot(runner_args: RunnerArguments, testing: bool | None = False):
    """Main bot entry point compatible with Pipecat Cloud."""

    transport_params = {
        "twilio": lambda: FastAPIWebsocketParams(
            audio_in_enabled=True,
            audio_out_enabled=True,
        ),
    }

    transport = await create_transport(runner_args, transport_params)

    await run_bot(transport, runner_args)
```

1 remaining caveat:
- Daily dial-out and SIP use cases require a server to create a room in a different way, so I'm leaving those two cases out for now...

---

### Claude's overview

Makes `create_transport()` the single, feature-complete way to build any transport, so bots don't hand-roll transport construction or telephony parsing. Public signatures are unchanged (`create_transport -> BaseTransport`, `parse_telephony_websocket -> (type, call_data)`).

### `create_transport` feature-complete for telephony and eval

- **Typed `CallData` model** for the parsed telephony handshake: attribute access (`call_data.to_number`, with `from`/`to` aliased off the Python-keyword wire keys) that stays dict-compatible (`call_data["call_id"]`, `.get(...)`) so bots written against the old dict keep working. `parse_telephony_websocket` returns it; the Twilio branch promotes `from`/`to` custom params for a uniform API.
- **`call_data` on the base `RunnerArguments`**, next to `body`, so every bot reads `runner_args.call_data` uniformly. `transport_type` is overwritten with the detected provider so bots can personalize without re-parsing the single-use stream.
- **Idempotent `parse_telephony_websocket`** — caches the result on the websocket; only successful parses are cached, so failures stay retryable and a verbose bot calling it directly coexists with `create_transport`'s internal call.
- **Transparent Daily PSTN dial-in** via `_maybe_apply_daily_dialin`: applies `dialin_settings`/`api_key`/`api_url` from the request body in the Daily branch; no-op when the body carries no dial-in.

### Mount the Daily dial-in webhook by default for `-t daily`

- `--dialin` becomes a `BooleanOptionalAction` defaulting `True` (so `bot.py -t daily` supports inbound PSTN testing out of the box); `--no-dialin` opts out. The webhook is mounted only inside `_setup_daily_routes`, so it's a no-op for non-Daily transports — the old "`--dialin` only works with `-t daily`" validation is dropped.

Local-runner convenience only; the bot contract, `runner_args` shape, and Cloud behavior are unchanged.

### Tests

Adds coverage in `tests/test_runner_utils.py` for `CallData` attribute/dict access and aliasing, `call_data` on the base, idempotent parse, and dial-in body application.
