### PR TITLE
Fix overlapping assistant response aggregation

### DIFF
--- a/changelog/4611.fixed.md
+++ b/changelog/4611.fixed.md
@@ -1,0 +1,1 @@
+- Fixed assistant context aggregation when a new LLM response starts before the previous response ends.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1841,6 +1841,8 @@ class LLMAssistantAggregator(LLMContextAggregator):
         if self._realtime_service_mode:
             await self._realtime_handle_llm_start()
             return
+        if self._assistant_turn_start_timestamp and self._aggregation:
+            await self._trigger_assistant_turn_stopped(interrupted=True)
         await self._trigger_assistant_turn_started()
 
     async def _realtime_handle_llm_start(self):

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1001,6 +1001,48 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         assert context.messages[0]["content"] == "Hello Pipecat."
         assert context.messages[1]["content"] == "How are you?"
 
+    async def test_overlapping_response_start_flushes_previous_aggregation(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        stop_messages = []
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            stop_messages.append(message)
+
+        frames_to_send = [
+            LLMFullResponseStartFrame(),
+            LLMTextFrame("[tag] Great"),
+            LLMFullResponseStartFrame(),
+            LLMTextFrame("[tag] thanks, just to confirm."),
+            LLMFullResponseEndFrame(),
+        ]
+        expected_down_frames = [
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+        ]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        self.assertEqual(
+            [message["content"] for message in context.messages],
+            ["[tag] Great", "[tag] thanks, just to confirm."],
+        )
+        self.assertEqual(
+            [message.content for message in stop_messages],
+            [
+                "[tag] Great",
+                "[tag] thanks, just to confirm.",
+            ],
+        )
+        self.assertTrue(stop_messages[0].interrupted)
+        self.assertFalse(stop_messages[1].interrupted)
+
     async def test_multiple_responses_interruption(self):
         context = LLMContext()
         aggregator = LLMAssistantAggregator(context)


### PR DESCRIPTION
## Summary
- flush an in-progress assistant aggregation when a new non-realtime LLM response starts before the previous one ends
- mark the flushed stale turn as interrupted, then start the new assistant turn normally
- add a regression test for overlapping response cycles so the two assistant messages remain separate

Fixes #4611

## Testing
- uv run pytest tests/test_context_aggregators_universal.py -k 'LLMAssistantAggregator and (overlapping_response_start_flushes_previous_aggregation or multiple_responses or multiple_responses_interruption or interruption)'
- uv run ruff check src/pipecat/processors/aggregators/llm_response_universal.py tests/test_context_aggregators_universal.py
- uv run ruff format --check src/pipecat/processors/aggregators/llm_response_universal.py tests/test_context_aggregators_universal.py
- uv run pytest tests/test_context_aggregators_universal.py
- uv run towncrier build --draft --version Unreleased