### PR TITLE
fix: report websocket retry send failures

### DIFF
--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -135,7 +135,12 @@ class WebsocketService(ABC):
             if success and self._websocket is not None:
                 logger.info(f"{self} reconnected successfully, will retry send the message")
                 # trying to send the message one more time
-                await self._websocket.send(message)
+                try:
+                    await self._websocket.send(message)
+                except Exception as retry_error:
+                    msg = f"{self} send failed after reconnect: {retry_error}"
+                    logger.error(msg)
+                    await report_error(ErrorFrame(msg))
             else:
                 logger.error(f"{self} send failed; unable to reconnect")
 

--- a/tests/test_websocket_service.py
+++ b/tests/test_websocket_service.py
@@ -259,6 +259,27 @@ async def test_stable_connection_resets_quick_failure_counter(service, report_er
 
 
 @pytest.mark.asyncio
+async def test_send_with_retry_reports_retry_send_failure(service, report_error):
+    """A failed send after reconnect is reported instead of escaping."""
+    websocket = type("FakeWebsocket", (), {})()
+    websocket.send = AsyncMock(
+        side_effect=[ConnectionError("initial send failed"), RuntimeError("retry failed")]
+    )
+    service._websocket = websocket
+    service._try_reconnect = AsyncMock(return_value=True)
+
+    await service.send_with_retry("message", report_error)
+
+    assert websocket.send.call_count == 2
+    service._try_reconnect.assert_called_once()
+    report_error.assert_called_once()
+    error_frame = report_error.call_args[0][0]
+    assert isinstance(error_frame, ErrorFrame)
+    assert error_frame.fatal is False
+    assert "retry failed" in error_frame.error
+
+
+@pytest.mark.asyncio
 async def test_disconnect_prevents_reconnection(service, report_error):
     """After _disconnect(), errors exit the loop without reconnecting or emitting errors."""
     await service._disconnect()


### PR DESCRIPTION
﻿## Summary
- catch failures from the retry send after a successful reconnect
- report that second failure through the existing ErrorFrame path instead of letting it escape the caller
- add a WebsocketService regression test for the double-send-failure path

## To verify
- uv run pytest tests\test_websocket_service.py -q --basetemp .tmp\pytest
- uv run ruff check src\pipecat\services\websocket_service.py tests\test_websocket_service.py
- uv run ruff format --check src\pipecat\services\websocket_service.py tests\test_websocket_service.py
- uv run python -m py_compile src\pipecat\services\websocket_service.py tests\test_websocket_service.py
- git diff --check

Fixes #4607
