### PR TITLE
bus: stop relaying emitter-local output frames across the bus

### DIFF
--- a/src/pipecat/bus/bridge_processor.py
+++ b/src/pipecat/bus/bridge_processor.py
@@ -25,9 +25,15 @@ from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
     Frame,
+    FunctionCallCancelFrame,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    FunctionCallsStartedFrame,
+    MetricsFrame,
     OutputTransportMessageUrgentFrame,
     StartFrame,
     StopFrame,
+    TTSSpeakFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor, FrameProcessorSetup
 
@@ -36,6 +42,21 @@ if TYPE_CHECKING:
 
 _LIFECYCLE_FRAMES = (StartFrame, EndFrame, CancelFrame, StopFrame)
 _PASSTHROUGH_FRAMES = (OutputTransportMessageUrgentFrame,)
+
+# Frames that are semantically local to the emitting worker's pipeline and
+# must never be relayed across the bus. Broadcasting them would cause the
+# same frame instance to be processed once per sibling task: duplicate
+# entries in each task's context aggregator for the function-call frames,
+# double TTS playback for ``TTSSpeakFrame``, inflated counters for
+# ``MetricsFrame``. None of these have legitimate cross-task semantics.
+_LOCAL_ONLY_FRAMES = (
+    TTSSpeakFrame,
+    FunctionCallsStartedFrame,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    FunctionCallCancelFrame,
+    MetricsFrame,
+)
 
 
 class BusBridgeProcessor(FrameProcessor, BusSubscriber):
@@ -103,6 +124,13 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
         # Urgent transport frames pass through directly. They need to
         # reach the transport even when no child worker is active yet.
         if isinstance(frame, _PASSTHROUGH_FRAMES):
+            await self.push_frame(frame, direction)
+            return
+
+        # Emitter-local frames never cross the bus (see comment on
+        # ``_LOCAL_ONLY_FRAMES`` above). They continue downstream in this
+        # worker's pipeline only.
+        if isinstance(frame, _LOCAL_ONLY_FRAMES):
             await self.push_frame(frame, direction)
             return
 
@@ -208,6 +236,8 @@ class _BusEdgeProcessor(FrameProcessor, BusSubscriber):
         if direction != self._direction:
             return
         if isinstance(frame, _LIFECYCLE_FRAMES):
+            return
+        if isinstance(frame, _LOCAL_ONLY_FRAMES):
             return
         if self._exclude_frames and isinstance(frame, self._exclude_frames):
             return

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -8,7 +8,16 @@ import asyncio
 import unittest
 
 from pipecat.bus import AsyncQueueBus, BusBridgeProcessor, BusFrameMessage
-from pipecat.frames.frames import TextFrame
+from pipecat.bus.bridge_processor import _LOCAL_ONLY_FRAMES
+from pipecat.frames.frames import (
+    FunctionCallCancelFrame,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    FunctionCallsStartedFrame,
+    MetricsFrame,
+    TextFrame,
+    TTSSpeakFrame,
+)
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.tests.utils import run_test
@@ -262,6 +271,74 @@ class TestBusBridgeProcessor(unittest.IsolatedAsyncioTestCase):
         )
         await processor.on_bus_message(msg)
         self.assertEqual(len(injected), 0)
+
+    async def test_local_only_frames_not_sent_to_bus(self):
+        """Emitter-local output frames (``TTSSpeakFrame``,
+        ``FunctionCall*Frame``, ``MetricsFrame``) pass through downstream
+        in the emitting worker's pipeline but are never relayed across
+        the bus, so sibling tasks never see duplicate copies."""
+        bus = AsyncQueueBus()
+        sent_to_bus = []
+        original_send = bus.send
+
+        async def capture_send(msg):
+            sent_to_bus.append(msg)
+            await original_send(msg)
+
+        bus.send = capture_send
+
+        processor = BusBridgeProcessor(bus=bus, worker_name="test_task")
+        pipeline = Pipeline([processor])
+
+        # One of each local-only frame type. ``MetricsFrame`` requires a
+        # data argument; an empty list is the canonical no-op shape.
+        # System vs Data frames get reordered downstream by pipecat, so we
+        # don't pin the downstream order here — only that nothing leaks to
+        # the bus, which is the invariant the fix protects.
+        frames_to_send = [
+            TTSSpeakFrame(text="hello"),
+            FunctionCallsStartedFrame(function_calls=[]),
+            FunctionCallInProgressFrame(function_name="x", tool_call_id="id1", arguments={}),
+            FunctionCallResultFrame(
+                function_name="x",
+                tool_call_id="id1",
+                arguments={},
+                result={"ok": True},
+            ),
+            FunctionCallCancelFrame(function_name="x", tool_call_id="id1"),
+            MetricsFrame(data=[]),
+        ]
+
+        await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+            ignore_start=True,
+        )
+
+        # None of them reached the bus.
+        bus_frame_msgs = [m for m in sent_to_bus if isinstance(m, BusFrameMessage)]
+        self.assertEqual(
+            len(bus_frame_msgs),
+            0,
+            f"expected 0 bus messages, got {[type(m.frame).__name__ for m in bus_frame_msgs]}",
+        )
+
+    def test_local_only_frames_tuple_pin(self):
+        """Pin the exact contents of ``_LOCAL_ONLY_FRAMES``. Adding a new
+        emitter-local frame type or removing one is a behaviour change
+        that downstream multi-worker deployments depend on — make it
+        intentional by updating this test in the same commit."""
+        self.assertEqual(
+            set(_LOCAL_ONLY_FRAMES),
+            {
+                TTSSpeakFrame,
+                FunctionCallsStartedFrame,
+                FunctionCallInProgressFrame,
+                FunctionCallResultFrame,
+                FunctionCallCancelFrame,
+                MetricsFrame,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`BusBridgeProcessor` and `_BusEdgeProcessor` currently relay every frame across the bus by default, including frames that are semantically local to the emitting worker. In a multi-worker setup with `BusBridgeProcessor`, sibling tasks end up processing the same frame instance multiple times.

Observed in production (pipecat 1.3.0 + 1.3.1.dev, verified the bug exists on `main` HEAD as well):

- **`FunctionCallsStartedFrame` / `FunctionCallResultFrame`** duplicated in every active task's context aggregator → LLM context contains the same `assistant.tool_calls` + `tool` result twice → flow blocks at the next `set_node`. Reproduced deterministically (100% hit rate, 2/2 runs): caller `charlie` post-resume from sub-bot `carrozzerie`, user dictates a location, `data_nearby` completes successfully with `outcome=found`, but `set_node(present_result)` never fires; bot silent for 90 s until timeout. Log evidence (room id elided):

  ```
  12:04:39.420  LLMAssistantAggregator#13 FunctionCallResultFrame: [call_bot:E7hhTOCiz]  ← 1×
  12:04:39.420  LLMAssistantAggregator#13 FunctionCallResultFrame: [call_bot:E7hhTOCiz]  ← 2× (DUPLICATE, same ms)
  ```

  The duplicate has the **same `frame.id`** as the original — it's the same Python instance routed through the bus a second time, not a fresh emission.

- **`TTSSpeakFrame`** queued by a pre_action plays twice on the audio path (Azure TTS synthesises the same utterance twice in rapid succession on the SIP voice channel; on web chat we mute downstream synthesis with a sink so the text relay forwards the frame twice to the widget → same chat bubble appears twice).

- **`MetricsFrame`** counters inflated ~N× (N = number of active sibling tasks) → CDR token billing wrong. Observed on a 5-turn voice call: 30 metric samples, 3 distinct values (13× 644.5 + 13× 396.8 + 4× 888.1) — confirmed each frame seen 13× via the pipeline's 13 processors.

The pattern affects only frames that have no legitimate cross-task meaning. Pipecat already uses class-based exclusion (`_LIFECYCLE_FRAMES`, `_PASSTHROUGH_FRAMES`). This PR adds `_LOCAL_ONLY_FRAMES` for the six emitter-local frame types.

## Fix

Add a new module-level constant:

```python
_LOCAL_ONLY_FRAMES = (
    TTSSpeakFrame,
    FunctionCallsStartedFrame,
    FunctionCallInProgressFrame,
    FunctionCallResultFrame,
    FunctionCallCancelFrame,
    MetricsFrame,
)
```

…and short-circuit in both `BusBridgeProcessor.process_frame` and `_BusEdgeProcessor.process_frame`: when the frame is an instance of `_LOCAL_ONLY_FRAMES`, continue downstream locally and skip the `bus.send`. Same shape as the existing `_LIFECYCLE_FRAMES` exclusion two lines above.

## Test plan

- [x] **New tests** in `tests/test_bridge_processor.py`:
  - `test_local_only_frames_not_sent_to_bus` — instantiates one of each local-only frame type, asserts none reach the bus.
  - `test_local_only_frames_tuple_pin` — pins the exact set membership so any future add/remove of a local-only frame type is a deliberate code change.
- [x] Full regression: `pytest tests/test_bridge_processor.py tests/test_bus.py tests/test_bus_network.py tests/test_base_worker.py` → **80 passed, 0 regressions**.
- [x] `ruff check` + `ruff format --check` clean on both touched files.

## Compat

This is a behaviour change: a subscriber that relied on seeing one of these six frame types cross the bus will stop seeing them. We are not aware of any legitimate consumer — these frames are produced by the LLM/TTS/metrics services in the emitting task and consumed by the aggregator/sink/TTS service in the **same** task. If a use case for cross-task relay exists, a follow-up could expose an `include_local_frames=False` kwarg with opt-in restore — happy to add it in this PR if maintainers prefer.

## Related

This PR consolidates 3 separate downstream workarounds we've been carrying for the same root cause (bus broadcast not scoped to emitter):
- bounded-id dedup in our `CallMetricsObserver` for the `MetricsFrame` 13× duplication
- `set.remove` → `set.discard` monkey-patch on `FunctionCallUserMuteStrategy` for `FunctionCallsStartedFrame` double-broadcast
- bounded-id dedup sink + relay for `TTSSpeakFrame` double-broadcast

Happy to test any review/rebase against current `main`.