### PR TITLE
Passing the WhatsApp call metadata to the runner arguments.

### DIFF
--- a/changelog/4622.added.md
+++ b/changelog/4622.added.md
@@ -1,0 +1,1 @@
+- WhatsApp `connection_callback` now receives the full call metadata (`WhatsAppConnectCall`) as a second argument, available in bot code via `runner_args.body`. This gives bots access to the caller's phone number, call ID, direction, and timestamp without any extra API calls.

--- a/changelog/4622.deprecated.md
+++ b/changelog/4622.deprecated.md
@@ -1,0 +1,1 @@
+- The single-argument `connection_callback(connection)` signature for `WhatsAppClient.handle_webhook_request` is deprecated. Update callbacks to accept `(connection, call: WhatsAppConnectCall)` to receive call metadata alongside the WebRTC connection. The old signature still works but emits a `DeprecationWarning`.

--- a/changelog/4622.fixed.md
+++ b/changelog/4622.fixed.md
@@ -1,0 +1,1 @@
+- 422 validation errors now log the full error details and raw request body for all transports (WhatsApp, WebRTC, telephony, etc.), making malformed payloads easier to debug. Previously this logging only applied to WhatsApp routes.

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -118,6 +118,7 @@ try:
     import uvicorn
     from dotenv import load_dotenv
     from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request, WebSocket
+    from fastapi.encoders import jsonable_encoder
     from fastapi.exceptions import RequestValidationError
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -384,8 +385,11 @@ def _configure_server_app(args: argparse.Namespace):
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
         body = await request.body()
         logger.error(f"422 Validation error on {request.url.path}: {exc.errors()}")
-        logger.error(f"Raw body: {body.decode()}")
-        return JSONResponse(status_code=422, content={"detail": exc.errors()})
+        logger.error(
+            "Raw body: %s",
+            body.decode(errors="replace")[:5000],
+        )
+        return JSONResponse(status_code=422, content=jsonable_encoder({"detail": exc.errors()}))
 
     # Shared session store: session_id -> body data. Used by the WebRTC /start
     # flow and the /sessions/{session_id}/... proxy routes.

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -118,8 +118,9 @@ try:
     import uvicorn
     from dotenv import load_dotenv
     from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request, WebSocket
+    from fastapi.exceptions import RequestValidationError
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import HTMLResponse, RedirectResponse
+    from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 except ImportError as e:
     logger.error(f"Runner dependencies not available: {e}")
     logger.error("To use Pipecat runners, install with: pip install pipecat-ai[runner]")
@@ -374,6 +375,17 @@ def _configure_server_app(args: argparse.Namespace):
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # FastAPI returns 422 Unprocessable Entity for Pydantic validation failures by default, but
+    # swallows the raw request body in the error response. This handler overrides that behavior to
+    # log both the validation errors and the raw body, making it much easier to debug malformed
+    # payloads from any transport (WhatsApp, WebRTC, telephony, etc.).
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        body = await request.body()
+        logger.error(f"422 Validation error on {request.url.path}: {exc.errors()}")
+        logger.error(f"Raw body: {body.decode()}")
+        return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
     # Shared session store: session_id -> body data. Used by the WebRTC /start
     # flow and the /sessions/{session_id}/... proxy routes.
@@ -780,7 +792,7 @@ def _setup_whatsapp_routes(app: FastAPI, args: argparse.Namespace):
 
     try:
         from pipecat.transports.smallwebrtc.connection import SmallWebRTCConnection
-        from pipecat.transports.whatsapp.api import WhatsAppWebhookRequest
+        from pipecat.transports.whatsapp.api import WhatsAppConnectCall, WhatsAppWebhookRequest
         from pipecat.transports.whatsapp.client import WhatsAppClient
     except ImportError as e:
         logger.error(f"WhatsApp transport dependencies not installed: {e}")
@@ -845,18 +857,22 @@ def _setup_whatsapp_routes(app: FastAPI, args: argparse.Namespace):
 
         logger.debug(f"Processing WhatsApp webhook: {body.model_dump()}")
 
-        async def connection_callback(connection: SmallWebRTCConnection):
+        async def connection_callback(connection: SmallWebRTCConnection, call: WhatsAppConnectCall):
             """Handle new WebRTC connections from WhatsApp calls.
 
             Called when a WebRTC connection is established for a WhatsApp call.
             Spawns a bot instance to handle the conversation.
 
             Args:
-                connection: The established WebRTC connection
+                connection: The established WebRTC connection.
+                call: The WhatsApp call metadata (caller phone number, call ID,
+                    direction, timestamp, etc.), passed as ``runner_args.body``.
             """
             bot_module = _get_bot_module()
             runner_args = SmallWebRTCRunnerArguments(
-                webrtc_connection=connection, session_id=str(uuid.uuid4())
+                webrtc_connection=connection,
+                session_id=str(uuid.uuid4()),
+                body=call,
             )
             runner_args.cli_args = args
             background_tasks.add_task(bot_module.bot, runner_args)

--- a/src/pipecat/transports/whatsapp/client.py
+++ b/src/pipecat/transports/whatsapp/client.py
@@ -206,7 +206,7 @@ class WhatsAppClient:
                                with caller metadata; or the legacy
                                ``(connection,)`` signature.
 
-                               .. deprecated:: 1.3.0
+                               .. deprecated:: 1.4.0
                                    The single-argument ``(connection,)`` signature is
                                    deprecated. Use ``(connection, call: WhatsAppConnectCall)``
                                    instead.

--- a/src/pipecat/transports/whatsapp/client.py
+++ b/src/pipecat/transports/whatsapp/client.py
@@ -210,6 +210,7 @@ class WhatsAppClient:
                                    The single-argument ``(connection,)`` signature is
                                    deprecated. Use ``(connection, call: WhatsAppConnectCall)``
                                    instead.
+
             raw_body: Optional bytes containing the raw request body.
             sha256_signature: Optional X-Hub-Signature-256 header value from the request.
 

--- a/src/pipecat/transports/whatsapp/client.py
+++ b/src/pipecat/transports/whatsapp/client.py
@@ -184,7 +184,8 @@ class WhatsAppClient:
     async def handle_webhook_request(
         self,
         request: WhatsAppWebhookRequest,
-        connection_callback: Callable[[SmallWebRTCConnection], Awaitable[None]] | None = None,
+        connection_callback: Callable[[SmallWebRTCConnection, WhatsAppConnectCall], Awaitable[None]]
+        | None = None,
         raw_body: bytes | None = None,
         sha256_signature: str | None = None,
     ) -> bool:
@@ -199,7 +200,8 @@ class WhatsAppClient:
             request: The webhook request from WhatsApp containing call events
             connection_callback: Optional callback function to invoke when a new
                                WebRTC connection is established. The callback
-                               receives the SmallWebRTCConnection instance.
+                               receives the SmallWebRTCConnection instance and
+                               the WhatsAppConnectCall with caller metadata.
             raw_body: Optional bytes containing the raw request body.
             sha256_signature: Optional X-Hub-Signature-256 header value from the request.
 
@@ -226,7 +228,7 @@ class WhatsAppClient:
                                     # Invoke callback if provided
                                     if connection_callback and connection:
                                         try:
-                                            await connection_callback(connection)
+                                            await connection_callback(connection, call)
                                             logger.debug(
                                                 f"Connection callback executed successfully for call {call.id}"
                                             )

--- a/src/pipecat/transports/whatsapp/client.py
+++ b/src/pipecat/transports/whatsapp/client.py
@@ -204,7 +204,12 @@ class WhatsAppClient:
                                ``(connection, call)`` — preferred, receives the
                                SmallWebRTCConnection and the WhatsAppConnectCall
                                with caller metadata; or the legacy
-                               ``(connection,)`` — still supported but deprecated.
+                               ``(connection,)`` signature.
+
+                               .. deprecated:: 1.3.0
+                                   The single-argument ``(connection,)`` signature is
+                                   deprecated. Use ``(connection, call: WhatsAppConnectCall)``
+                                   instead.
             raw_body: Optional bytes containing the raw request body.
             sha256_signature: Optional X-Hub-Signature-256 header value from the request.
 

--- a/src/pipecat/transports/whatsapp/client.py
+++ b/src/pipecat/transports/whatsapp/client.py
@@ -14,6 +14,8 @@ WhatsApp call events.
 import asyncio
 import hashlib
 import hmac
+import inspect
+import warnings
 from collections.abc import Awaitable, Callable
 
 import aiohttp
@@ -184,8 +186,7 @@ class WhatsAppClient:
     async def handle_webhook_request(
         self,
         request: WhatsAppWebhookRequest,
-        connection_callback: Callable[[SmallWebRTCConnection, WhatsAppConnectCall], Awaitable[None]]
-        | None = None,
+        connection_callback: Callable[..., Awaitable[None]] | None = None,
         raw_body: bytes | None = None,
         sha256_signature: str | None = None,
     ) -> bool:
@@ -198,10 +199,12 @@ class WhatsAppClient:
 
         Args:
             request: The webhook request from WhatsApp containing call events
-            connection_callback: Optional callback function to invoke when a new
-                               WebRTC connection is established. The callback
-                               receives the SmallWebRTCConnection instance and
-                               the WhatsAppConnectCall with caller metadata.
+            connection_callback: Optional callback invoked when a new WebRTC
+                               connection is established. Accepts two signatures:
+                               ``(connection, call)`` — preferred, receives the
+                               SmallWebRTCConnection and the WhatsAppConnectCall
+                               with caller metadata; or the legacy
+                               ``(connection,)`` — still supported but deprecated.
             raw_body: Optional bytes containing the raw request body.
             sha256_signature: Optional X-Hub-Signature-256 header value from the request.
 
@@ -228,7 +231,23 @@ class WhatsAppClient:
                                     # Invoke callback if provided
                                     if connection_callback and connection:
                                         try:
-                                            await connection_callback(connection, call)
+                                            if (
+                                                len(
+                                                    inspect.signature(
+                                                        connection_callback
+                                                    ).parameters
+                                                )
+                                                >= 2
+                                            ):
+                                                await connection_callback(connection, call)
+                                            else:
+                                                warnings.warn(
+                                                    "connection_callback with a single (connection) argument is deprecated. "
+                                                    "Update it to accept (connection, call: WhatsAppConnectCall).",
+                                                    DeprecationWarning,
+                                                    stacklevel=2,
+                                                )
+                                                await connection_callback(connection)
                                             logger.debug(
                                                 f"Connection callback executed successfully for call {call.id}"
                                             )


### PR DESCRIPTION
## Summary
  
  - Registered the `RequestValidationError` handler globally in `_configure_server_app()` so 422 validation errors from any transport (WhatsApp, WebRTC, telephony, etc.) log both the error details and the raw request body — previously this handler only existed for WhatsApp routes
  - Passed the `WhatsAppConnectCall` metadata (caller phone number, call ID, direction, timestamp) as `runner_args.body` in the WhatsApp `connection_callback`, giving bot code typed access to call context via `isinstance(runner_args.body, WhatsAppConnectCall)`
  - Updated `WhatsAppClient.handle_webhook_request` to support both the new two-argument callback signature `(connection, call)` and the legacy single-argument `(connection,)` — the old form still works but emits a `DeprecationWarning`