### PR TITLE
Add websocket to runner -t transport choices

### DIFF
--- a/changelog/4636.added.md
+++ b/changelog/4636.added.md
@@ -1,0 +1,1 @@
+- Added `websocket` to the development runner's `-t`/`--transport` choices, so you can now run `python bot.py -t websocket` to restrict the server to the plain WebSocket transport (served at `/ws-client`). The startup banner prints a websocket-specific message with the prebuilt UI and `ws(s)://host:port/ws-client` endpoint.

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -279,6 +279,14 @@ def _print_startup_message(args: argparse.Namespace):
             if args.proxy:
                 print(f"   → XML webhook: http://{args.host}:{args.port}/")
             print(f"   → WebSocket:   ws://{args.host}:{args.port}/ws")
+    elif args.transport == "websocket":
+        print("🚀 Bot ready! (WebSocket)")
+        if not _transport_routes_enabled("websocket"):
+            print(f"   → WebSocket disabled ({TRANSPORT_INSTALL_HINTS['websocket']})")
+        else:
+            print(f"   → Open: {_runner_url(args)}")
+            scheme = "wss" if args.host != "localhost" else "ws"
+            print(f"   → WebSocket:   {scheme}://{args.host}:{args.port}/ws-client")
     elif args.transport == "vonage":
         print()
         print("🚀 Bot ready!")
@@ -1223,7 +1231,8 @@ def main(parser: argparse.ArgumentParser | None = None):
        - --host: Server host address (default: localhost)
        - --port: Server port (default: 7860)
        - -t/--transport: Restrict to a single transport and set as default for /start
-         (daily, webrtc, twilio, telnyx, plivo, exotel). Omit to support all transports.
+         (daily, webrtc, websocket, twilio, telnyx, plivo, exotel). Omit to support
+         all transports.
        - -x/--proxy: Public proxy hostname for telephony webhooks
        - -d/--direct: Connect directly to Daily room (automatically sets transport to daily)
        - -f/--folder: Path to downloads folder
@@ -1250,7 +1259,7 @@ def main(parser: argparse.ArgumentParser | None = None):
         "-t",
         "--transport",
         type=str,
-        choices=["daily", "vonage", "webrtc", *TELEPHONY_TRANSPORTS],
+        choices=["daily", "vonage", "webrtc", "websocket", *TELEPHONY_TRANSPORTS],
         default=None,
         help=(
             "Restrict the server to a single transport and set it as the default for /start. "


### PR DESCRIPTION
## Summary

The plain WebSocket transport was already fully wired in the development runner — the `/ws-client` route, the `/start` branch returning the `ws://…/ws-client` URL, the `create_transport` `transport_type == "websocket"` handling, and the startup banner all support it. But `websocket` was missing from the `-t`/`--transport` CLI `choices`, so there was no way to restrict the server to websocket only (argparse would reject `-t websocket`).

## Changes

- Add `"websocket"` to the `-t` `choices` list so `-t websocket` is accepted and restricts `/start` to that transport.
- Add a `websocket` branch to `_print_startup_message` that prints the prebuilt UI URL and the `ws(s)://host:port/ws-client` endpoint, with the disabled-deps fallback, mirroring the other transports.
- Update the `main()` docstring transport list to include `websocket`.

The `/start` restriction enforcement already compares the requested transport against `args.transport` generically, so no change was needed there.

## Test plan

- `uv run ruff check` and `uv run ruff format --check` pass.
- `python bot.py -t websocket` is now accepted and prints a websocket-specific startup banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)