### PR TITLE
Add on_tts_request handler to Cartesia examples for context_id tracing

### DIFF
--- a/examples/voice/voice-cartesia-turns.py
+++ b/examples/voice/voice-cartesia-turns.py
@@ -113,7 +113,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await worker.cancel()
 
     @tts.event_handler("on_tts_request")
-    async def on_tts_request(tts, context_id, text):
+    async def on_tts_request(tts, context_id: str, text: str):
         """Surface the context_id for debugging and tracing TTS requests.
 
         Pipecat auto-generates a context_id (UUID) per LLM turn and passes it
@@ -125,7 +125,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
           - Pipecat event: https://docs.pipecat.ai/api-reference/server/events/service-events#on_tts_request
           - Cartesia contexts: https://docs.cartesia.ai/use-the-api/tts-websocket/contexts
         """
-        logger.info(f"TTS request: {context_id} - {text}")
+        logger.debug(f"TTS request: {context_id} - {text}")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 

--- a/examples/voice/voice-cartesia-turns.py
+++ b/examples/voice/voice-cartesia-turns.py
@@ -112,6 +112,21 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info(f"Client disconnected")
         await worker.cancel()
 
+    @tts.event_handler("on_tts_request")
+    async def on_tts_request(tts, context_id, text):
+        """Surface the context_id for debugging and tracing TTS requests.
+
+        Pipecat auto-generates a context_id (UUID) per LLM turn and passes it
+        directly as Cartesia's `context_id` in the WebSocket request. Logging
+        it here lets you correlate your application logs with Cartesia's
+        context-level audio output for end-to-end tracing.
+
+        Docs:
+          - Pipecat event: https://docs.pipecat.ai/api-reference/server/events/service-events#on_tts_request
+          - Cartesia contexts: https://docs.cartesia.ai/use-the-api/tts-websocket/contexts
+        """
+        logger.info(f"TTS request: {context_id} - {text}")
+
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)

--- a/examples/voice/voice-cartesia.py
+++ b/examples/voice/voice-cartesia.py
@@ -109,7 +109,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await worker.cancel()
 
     @tts.event_handler("on_tts_request")
-    async def on_tts_request(tts, context_id, text):
+    async def on_tts_request(tts, context_id: str, text: str):
         """Surface the context_id for debugging and tracing TTS requests.
 
         Pipecat auto-generates a context_id (UUID) per LLM turn and passes it
@@ -121,7 +121,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
           - Pipecat event: https://docs.pipecat.ai/api-reference/server/events/service-events#on_tts_request
           - Cartesia contexts: https://docs.cartesia.ai/use-the-api/tts-websocket/contexts
         """
-        logger.info(f"TTS request: {context_id} - {text}")
+        logger.debug(f"TTS request: {context_id} - {text}")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 

--- a/examples/voice/voice-cartesia.py
+++ b/examples/voice/voice-cartesia.py
@@ -108,6 +108,21 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info(f"Client disconnected")
         await worker.cancel()
 
+    @tts.event_handler("on_tts_request")
+    async def on_tts_request(tts, context_id, text):
+        """Surface the context_id for debugging and tracing TTS requests.
+
+        Pipecat auto-generates a context_id (UUID) per LLM turn and passes it
+        directly as Cartesia's `context_id` in the WebSocket request. Logging
+        it here lets you correlate your application logs with Cartesia's
+        context-level audio output for end-to-end tracing.
+
+        Docs:
+          - Pipecat event: https://docs.pipecat.ai/api-reference/server/events/service-events#on_tts_request
+          - Cartesia contexts: https://docs.cartesia.ai/use-the-api/tts-websocket/contexts
+        """
+        logger.info(f"TTS request: {context_id} - {text}")
+
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)


### PR DESCRIPTION
## Summary

- Adds an `on_tts_request` event handler to `examples/voice/voice-cartesia.py` and `examples/voice/voice-cartesia-turns.py`
- The handler logs the `context_id` and `text` for each TTS request, enabling end-to-end tracing between application logs and Cartesia's context-level audio output
- Includes a docstring explaining the purpose, the auto-generated `context_id` mechanism, and links to the relevant Pipecat and Cartesia docs

## Test plan

- [ ] Verify the handler fires on each TTS request when running either example bot
- [ ] Confirm `context_id` appears in logs alongside the spoken text
- [ ] Confirm no regressions to existing bot behaviour (pipeline still starts, STT/LLM/TTS flow intact)