### PR TITLE
bus: dedup duplicate frame deliveries at BusBridgeProcessor

### DIFF
--- a/src/pipecat/bus/bridge_processor.py
+++ b/src/pipecat/bus/bridge_processor.py
@@ -16,6 +16,7 @@ Provides:
   to the bus).
 """
 
+from collections import deque
 from typing import TYPE_CHECKING
 
 from pipecat.bus.bus import WorkerBus
@@ -75,6 +76,16 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
         self._target_task = target_task
         self._bridge = bridge
         self._exclude_frames = exclude_frames or ()
+        # Bounded LRU dedup against sibling worker re-broadcast.
+        # In a multi-worker setup, sibling workers briefly co-existing as
+        # ``active=True`` during a handoff transient re-broadcast frames
+        # originally emitted by another worker back onto the bus. The host
+        # bridge then receives the same ``frame.id`` from multiple sources
+        # (the original and N siblings). Dropping the duplicate delivery
+        # here keeps the assistant aggregator from recording duplicate
+        # tool round-trips in the LLM context.
+        self._seen_bus_ids: set[int] = set()
+        self._seen_bus_history: deque[int] = deque(maxlen=512)
 
     async def setup(self, setup: FrameProcessorSetup):
         """Subscribe to the bus during processor setup."""
@@ -144,6 +155,20 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
         # If message targeted at someone else, skip
         if message.target and message.target != self._worker_name:
             return
+
+        # Skip duplicate delivery when a sibling worker, briefly active
+        # during a handoff transient, re-broadcasts a frame originally
+        # emitted by another worker. The bus loop is by-design (it
+        # propagates upstream frames to processors upstream of the
+        # BusBridge in the host pipeline, e.g. LLMUserAggregator), so
+        # we dedup at the receiver instead of skipping at the sender.
+        fid = message.frame.id
+        if fid in self._seen_bus_ids:
+            return
+        self._seen_bus_ids.add(fid)
+        self._seen_bus_history.append(fid)
+        if len(self._seen_bus_ids) > len(self._seen_bus_history):
+            self._seen_bus_ids = set(self._seen_bus_history)
 
         await self.push_frame(message.frame, message.direction)
 

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -263,6 +263,157 @@ class TestBusBridgeProcessor(unittest.IsolatedAsyncioTestCase):
         await processor.on_bus_message(msg)
         self.assertEqual(len(injected), 0)
 
+    async def test_duplicate_frame_id_from_sibling_dropped(self):
+        """Sibling re-broadcast of the same frame.id is dropped at the receiver.
+
+        In a multi-worker setup, sibling workers briefly co-existing as
+        ``active=True`` during a handoff transient re-broadcast frames
+        originally emitted by another worker. Without dedup the host
+        bridge delivers the same ``frame.id`` once per re-broadcasting
+        sibling, which pollutes the assistant aggregator's LLM context.
+
+        Regression: same ``frame.id`` received twice (once from the
+        original emitter, once from a sibling) is pushed only once.
+        """
+        bus = AsyncQueueBus()
+        processor = BusBridgeProcessor(
+            bus=bus,
+            worker_name="main_task",
+        )
+
+        injected = []
+        original_push = processor.push_frame
+
+        async def capture_push(frame, direction=FrameDirection.DOWNSTREAM):
+            injected.append(frame)
+            await original_push(frame, direction)
+
+        processor.push_frame = capture_push
+
+        # Same TextFrame instance (same ``frame.id``) re-broadcast by a
+        # sibling worker during the handoff transient.
+        original_frame = TextFrame(text="result")
+
+        first_delivery = BusFrameMessage(
+            source="child_a",
+            frame=original_frame,
+            direction=FrameDirection.DOWNSTREAM,
+        )
+        sibling_rebroadcast = BusFrameMessage(
+            source="child_b",
+            frame=original_frame,
+            direction=FrameDirection.DOWNSTREAM,
+        )
+
+        await processor.on_bus_message(first_delivery)
+        await processor.on_bus_message(sibling_rebroadcast)
+
+        # Only the first delivery reaches the pipeline.
+        self.assertEqual(len(injected), 1)
+        self.assertEqual(injected[0].text, "result")
+
+    async def test_dedup_distinct_frame_ids_all_delivered(self):
+        """Distinct ``frame.id``s are always delivered (dedup is by id).
+
+        Sanity check: the dedup key is the frame id, not the frame type
+        or content. Two frames with different ids must both pass through.
+        """
+        bus = AsyncQueueBus()
+        processor = BusBridgeProcessor(
+            bus=bus,
+            worker_name="main_task",
+        )
+
+        injected = []
+        original_push = processor.push_frame
+
+        async def capture_push(frame, direction=FrameDirection.DOWNSTREAM):
+            injected.append(frame)
+            await original_push(frame, direction)
+
+        processor.push_frame = capture_push
+
+        # Two distinct frames (different ``frame.id``) with identical text.
+        first = TextFrame(text="same_text")
+        second = TextFrame(text="same_text")
+        self.assertNotEqual(first.id, second.id)
+
+        await processor.on_bus_message(
+            BusFrameMessage(
+                source="child",
+                frame=first,
+                direction=FrameDirection.DOWNSTREAM,
+            )
+        )
+        await processor.on_bus_message(
+            BusFrameMessage(
+                source="child",
+                frame=second,
+                direction=FrameDirection.DOWNSTREAM,
+            )
+        )
+
+        self.assertEqual(len(injected), 2)
+
+    async def test_dedup_lru_eviction_rebuilds_set_from_history(self):
+        """LRU eviction path: bounded deque + set stay consistent.
+
+        The dedup state is a ``set[int]`` (O(1) membership) backed by a
+        ``deque(maxlen=512)`` history. When the 513th distinct id is
+        appended, the deque silently evicts its oldest entry. The set
+        does not get the eviction signal, so it must be rebuilt from the
+        history to keep memory bounded and to allow very old ids to be
+        delivered again if they ever recur.
+
+        Regression: after pushing more than 512 distinct frames, the
+        oldest evicted id is no longer in the dedup set (so a hypothetical
+        re-delivery would pass through), and the most recent 512 ids
+        remain deduplicated.
+        """
+        bus = AsyncQueueBus()
+        processor = BusBridgeProcessor(
+            bus=bus,
+            worker_name="main_task",
+        )
+
+        injected = []
+        original_push = processor.push_frame
+
+        async def capture_push(frame, direction=FrameDirection.DOWNSTREAM):
+            injected.append(frame)
+            await original_push(frame, direction)
+
+        processor.push_frame = capture_push
+
+        # Push 513 distinct frames → deque is full (maxlen=512) and the
+        # first frame's id has been evicted from the history. The set
+        # rebuild branch must fire on the 513th delivery.
+        frames = [TextFrame(text=f"f{i}") for i in range(513)]
+        for f in frames:
+            await processor.on_bus_message(
+                BusFrameMessage(
+                    source="child",
+                    frame=f,
+                    direction=FrameDirection.DOWNSTREAM,
+                )
+            )
+
+        # All 513 distinct ids were delivered exactly once.
+        self.assertEqual(len(injected), 513)
+
+        # Dedup state is now bounded to the deque length (set was
+        # rebuilt from history when it overgrew the deque).
+        self.assertEqual(len(processor._seen_bus_history), 512)
+        self.assertEqual(len(processor._seen_bus_ids), 512)
+        self.assertEqual(processor._seen_bus_ids, set(processor._seen_bus_history))
+
+        # The oldest frame's id has been evicted from both structures —
+        # if the same id ever recurred, it would no longer be dropped.
+        self.assertNotIn(frames[0].id, processor._seen_bus_ids)
+        # The most recent 512 ids are still tracked.
+        self.assertIn(frames[-1].id, processor._seen_bus_ids)
+        self.assertIn(frames[1].id, processor._seen_bus_ids)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #4628.

In a multi-worker setup with `BusBridgeProcessor` plus child
`LLMWorker`s, two sibling workers briefly end up `active=True` during
a handoff transient. You can see the race in `activate_worker`:

```python
# pipecat/workers/base_worker.py
async def activate_worker(self, worker_name, args, deactivate_self):
    if self._active and deactivate_self:
        await self.deactivate_worker(self.name)         # publish, no ack
    await self.send_bus_message(
        BusActivateWorkerMessage(target=worker_name)    # publish, no ack
    )

async def deactivate_worker(self, worker_name):
    await self.send_bus_message(
        BusDeactivateWorkerMessage(target=worker_name)
    )
    # returns as soon as the message is published, doesn't wait for
    # the subscriber to flip `self._active = False`.
```

Both `deactivate` and `activate` are fire-and-forget through the bus,
so the target can flip to `active=True` before the caller's
`_handle_worker_deactivate` runs and sets `self._active = False`.
During that window both workers receive bus broadcasts and re-broadcast
frames originally emitted by the other side, so the host bridge ends
up receiving the same `frame.id` from multiple sources. The duplicate
delivery reaches the assistant aggregator and the LLM context picks
up duplicate `assistant.tool_calls` + `tool` result pairs — I hit this
in production as a caller stalling for 90s after a sub-bot return, and
as a hallucinated mid-conversation end_call.

#4624 (closed) tried to drop a whitelist of "emitter-local" frame
types on the receive side of `_BusEdgeProcessor`. That masked the
symptom but the bus loop is actually load-bearing on the upstream
direction (it's how upstream frames reach processors that sit
*upstream* of `BusBridge` in the host pipeline — e.g.
`LLMUserAggregator` so `MuteUntilFirstBotCompleteUserMuteStrategy`
can unmute the user). Skipping it on the sender side leaves SIP voice
with the user permanently muted after the greeting.

This PR dedups at the receiver instead: a bounded LRU of recently
seen `frame.id`s in `BusBridgeProcessor.on_bus_message`, so when a
sibling re-broadcasts a frame already delivered by the original
source, the second copy is silently dropped before it reaches
`push_frame`. Same shape Pipecat already uses elsewhere to dedup
bus-replicated frames by id. The loop itself isn't touched, and the
deactivation race isn't relied on.

I went with a receiver-side dedup rather than tightening the
lifecycle for two reasons. The deactivate happens through the bus
asynchronously, so even awaiting it deterministically only narrows
the window. And the sender side of `_BusEdgeProcessor.process_frame`
doesn't gate on `self._task.active` — a frame already in flight in
the soon-to-be-deactivated worker's pipeline still goes onto the bus.
Bounded LRU at the host catches both without locking the hot path.

Verified against the same scenario that opened the issue: in chat
mode the assistant aggregator sees `FunctionCallResultFrame:call_bot`
exactly once per call (vs twice without the fix, deterministic across
runs); on SIP voice the handoff race that was hitting ~33% drops to
zero across 12 runs; and a real SIP voice call goes through cleanly
— bot greets, user speaks, sub-bot handoff completes, no muted STT
regression, audit clean.

Added a regression test (`test_duplicate_frame_id_from_sibling_dropped`
plus a sanity check that distinct ids still pass through). It
reproduces the bug deterministically without the fix (asserts
`2 != 1` at the receiver).
