### PR TITLE
Default TTSSpeakFrame.append_to_context to True; deprecate None

### DIFF
--- a/changelog/4642.changed.md
+++ b/changelog/4642.changed.md
@@ -1,0 +1,10 @@
+- ⚠️ Changed the default of `TTSSpeakFrame.append_to_context` from `None` to
+  `True`. The old `None` behavior was situation-dependent and hard to reason
+  about: the spoken text always reached the assistant aggregator's buffer, but
+  whether it was committed to the LLM context depended on what surrounded the
+  frame — committed when the frame was inside an assistant response or
+  immediately followed by one, but silently discarded when it was standalone and
+  followed by a user turn (the interruption cleared the buffer before anything
+  flushed it). `True` is a predictable default: programmatically-spoken text is
+  recorded in the context unless you opt out with `append_to_context=False`.
+  `BusTTSSpeakMessage.append_to_context` now defaults to `True` to match.

--- a/changelog/4642.deprecated.md
+++ b/changelog/4642.deprecated.md
@@ -1,0 +1,5 @@
+- Deprecated passing `append_to_context=None` to `TTSSpeakFrame` (and
+  `BusTTSSpeakMessage`). `None` is no longer a supported value: it is coerced to
+  `True` with a warning and will be unsupported in a future release. Pass `True`
+  or `False` explicitly. See the corresponding "Changed" entry for the full
+  rationale behind the new `True` default.

--- a/src/pipecat/bus/messages.py
+++ b/src/pipecat/bus/messages.py
@@ -113,10 +113,11 @@ class BusTTSSpeakMessage(BusDataMessage):
         text: The text to be spoken.
         append_to_context: Whether the spoken text should also be appended
             to the conversation context (forwarded to `TTSSpeakFrame`).
+            Defaults to True, matching `TTSSpeakFrame.append_to_context`.
     """
 
     text: str
-    append_to_context: bool | None = None
+    append_to_context: bool = True
 
 
 # ---------------------------------------------------------------------------

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -747,15 +747,8 @@ class TTSSpeakFrame(DataFrame):
     Parameters:
         text: The text to be spoken.
         append_to_context: Whether the spoken text should be appended to the LLM
-            context. Defaults to True.
-
-            .. deprecated:: 1.4.0
-                The default changed from ``None`` to ``True``, and ``None`` is
-                no longer a supported value (it is coerced to ``True`` with a
-                warning). The previous ``None`` behavior was situation-dependent
-                which made it hard to reason about. ``True`` records spoken text
-                in the context by default; pass ``False`` to keep it out.
-                ``None`` support will be removed in a future release.
+            context. Defaults to True. (Note that, as of version 1.4.0, ``None`` —
+            the previous default — is no longer a supported value.)
     """
 
     text: str

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -14,6 +14,7 @@ and LLM processing.
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import (
@@ -745,11 +746,36 @@ class TTSSpeakFrame(DataFrame):
 
     Parameters:
         text: The text to be spoken.
-        append_to_context: Whether to append the text to the context.
+        append_to_context: Whether the spoken text should be appended to the LLM
+            context. Defaults to True.
+
+            .. deprecated:: 1.4.0
+                The default changed from ``None`` to ``True``, and ``None`` is
+                no longer a supported value (it is coerced to ``True`` with a
+                warning). The previous ``None`` behavior was situation-dependent
+                which made it hard to reason about. ``True`` records spoken text
+                in the context by default; pass ``False`` to keep it out.
+                ``None`` support will be removed in a future release.
     """
 
     text: str
-    append_to_context: bool | None = None
+    append_to_context: bool = True
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Backward compatibility: callers used to be able to pass None.
+        # Coerce it to the new default of True and warn, so existing code keeps
+        # working while surfacing the change.
+        if self.append_to_context is None:
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "TTSSpeakFrame.append_to_context=None is deprecated and has been "
+                    "converted to True, the new default.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            self.append_to_context = True
 
 
 @dataclass

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -16,6 +16,7 @@ from aiohttp import web
 from pipecat.frames.frames import (
     AggregatedTextFrame,
     ErrorFrame,
+    LLMAssistantPushAggregationFrame,
     TTSAudioRawFrame,
     TTSSpeakFrame,
     TTSStartedFrame,
@@ -98,11 +99,16 @@ async def test_run_piper_tts_success(aiohttp_client):
             "Expected: TTSStartedFrame < TTSTextFrame < TTSStoppedFrame"
         )
 
-        # Frames between Started and Stopped must all be audio or text
+        # Frames between Started and Stopped must all be audio or text. A
+        # LLMAssistantPushAggregationFrame is also expected here: TTSSpeakFrame
+        # defaults to append_to_context=True, so the service emits one at the end
+        # of the utterance to commit the spoken text to the LLM context.
         for i in range(started_idx + 1, stopped_idx):
-            assert frame_types[i] in (TTSAudioRawFrame, TTSTextFrame), (
-                f"Unexpected frame type between Started and Stopped: {frame_types[i]}"
-            )
+            assert frame_types[i] in (
+                TTSAudioRawFrame,
+                TTSTextFrame,
+                LLMAssistantPushAggregationFrame,
+            ), f"Unexpected frame type between Started and Stopped: {frame_types[i]}"
 
         # All audio frames have correct sample rate
         audio_frames = [f for f in down_frames if isinstance(f, TTSAudioRawFrame)]


### PR DESCRIPTION
## Summary

`TTSSpeakFrame.append_to_context` now defaults to `True` instead of `None`, and `None` is no longer a supported value (it's coerced to `True` with a warning).

### Why

The unset (`None`) behavior was situation-dependent and hard to reason about. The spoken text always reached the assistant aggregator's buffer, but whether it was committed to the LLM context depended on what surrounded the frame:

- **Inside an assistant response (or immediately followed by one)** → committed (flushed at the response's `LLMFullResponseEndFrame` or on interruption).
- **Standalone, then followed by a user turn** → silently **discarded**: there's no open assistant turn, so the interruption's turn-stop is a no-op and `reset()` clears the buffer before anything flushes it.

So "speak this and (maybe) record it" depended on conversation timing a developer can't easily predict. `True` is a predictable default: programmatically-spoken text is recorded in the context unless you opt out with `append_to_context=False`.

### Changes

- `TTSSpeakFrame.append_to_context`: `bool | None = None` → `bool = True`.
- Backward compatibility: passing `None` is coerced to `True` and emits a `DeprecationWarning`. `None` support will be removed in a future release.
- `BusTTSSpeakMessage.append_to_context` defaults to `True` to match (it forwards into `TTSSpeakFrame`).
- `tests/test_piper_tts.py`: a default `TTSSpeakFrame` now emits an `LLMAssistantPushAggregationFrame` (to commit the spoken text), so the success-path frame-ordering assertion allows it.

### Compatibility note

This is a behavior change. Code that relied on the old `None` default for a standalone `TTSSpeakFrame` (where the spoken text merged into a following assistant turn, or was dropped before a user turn) will now see that text committed as its own assistant message. Opt out per-frame with `append_to_context=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
