### PR TITLE
fix: close coroutines cancelled before task start

### DIFF
--- a/src/pipecat/utils/asyncio/task_manager.py
+++ b/src/pipecat/utils/asyncio/task_manager.py
@@ -154,8 +154,11 @@ class TaskManager(BaseTaskManager):
         Raises:
             Exception: If the task manager is not properly set up.
         """
+        coroutine_started = False
 
         async def run_coroutine():
+            nonlocal coroutine_started
+            coroutine_started = True
             try:
                 return await coroutine
             except asyncio.CancelledError:
@@ -167,11 +170,16 @@ class TaskManager(BaseTaskManager):
                 last = tb[-1]
                 logger.error(f"{name} unexpected exception ({last.filename}:{last.lineno}): {e}")
 
+        def close_unstarted_coroutine(task: asyncio.Task):
+            if task.cancelled() and not coroutine_started:
+                coroutine.close()
+
         if not self._params:
             raise Exception("TaskManager is not setup: unable to get event loop")
 
         task = self._params.loop.create_task(run_coroutine())
         task.set_name(name)
+        task.add_done_callback(close_unstarted_coroutine)
         task.add_done_callback(self._task_done_handler)
         self._add_task(TaskData(task=task))
         logger.trace(f"{name}: task created")

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,0 +1,29 @@
+import asyncio
+import gc
+import warnings
+
+import pytest
+
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+
+
+@pytest.mark.asyncio
+async def test_create_task_closes_coroutine_cancelled_before_first_run():
+    task_manager = TaskManager()
+    task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+
+    async def never_started():
+        await asyncio.sleep(0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+
+        task = task_manager.create_task(never_started(), "never-started")
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        gc.collect()
+
+    assert not any("never awaited" in str(w.message) for w in caught)


### PR DESCRIPTION
## Summary
- close the wrapped coroutine when a managed task is cancelled before its wrapper starts running
- keep existing cancellation behavior once the wrapper has reached the original coroutine
- add a regression test that cancels the task immediately and checks no `coroutine was never awaited` warning is emitted

Fixes #4644

## To verify
- `python -m pytest tests\test_task_manager.py -q`
- `python -m ruff check src\pipecat\utils\asyncio\task_manager.py tests\test_task_manager.py`
- `python -m ruff format --check src\pipecat\utils\asyncio\task_manager.py tests\test_task_manager.py`
- `python -m py_compile src\pipecat\utils\asyncio\task_manager.py tests\test_task_manager.py`
- `git diff --check`