### PR TITLE
fix(rtvi): expose TTS spacing hint

### DIFF
--- a/src/pipecat/processors/frameworks/rtvi/models.py
+++ b/src/pipecat/processors/frameworks/rtvi/models.py
@@ -343,6 +343,7 @@ class TextMessageData(BaseModel):
     """
 
     text: str
+    includes_inter_frame_spaces: bool | None = None
 
 
 class BotOutputMessageData(TextMessageData):

--- a/src/pipecat/processors/frameworks/rtvi/observer.py
+++ b/src/pipecat/processors/frameworks/rtvi/observer.py
@@ -533,12 +533,24 @@ class RTVIObserver(BaseObserver):
 
         if self._params.bot_output_enabled:
             message = RTVI.BotOutputMessage(
-                data=RTVI.BotOutputMessageData(text=text, spoken=isTTS, aggregated_by=agg_type)
+                data=RTVI.BotOutputMessageData(
+                    text=text,
+                    spoken=isTTS,
+                    aggregated_by=agg_type,
+                    includes_inter_frame_spaces=(
+                        frame.includes_inter_frame_spaces if isTTS else None
+                    ),
+                )
             )
             await self.send_rtvi_message(message)
 
         if isTTS and self._params.bot_tts_enabled:
-            tts_message = RTVI.BotTTSTextMessage(data=RTVI.TextMessageData(text=text))
+            tts_message = RTVI.BotTTSTextMessage(
+                data=RTVI.TextMessageData(
+                    text=text,
+                    includes_inter_frame_spaces=frame.includes_inter_frame_spaces,
+                )
+            )
             await self.send_rtvi_message(tts_message)
 
     async def _handle_llm_text_frame(self, frame: LLMTextFrame):

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -8,6 +8,8 @@ import unittest
 from unittest.mock import AsyncMock
 
 import pipecat.processors.frameworks.rtvi.models as RTVI
+from pipecat.frames.frames import AggregationType, TTSTextFrame
+from pipecat.processors.frameworks.rtvi.observer import RTVIObserver
 from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
 
 
@@ -110,6 +112,30 @@ class TestRTVIClientReadyVersionHandling(unittest.IsolatedAsyncioTestCase):
     async def test_client_ready_is_set_when_no_data(self):
         await self._call_handle_client_ready(None)
         self.processor.set_client_ready.assert_called_once()
+
+
+class TestRTVIObserverTextMessages(unittest.IsolatedAsyncioTestCase):
+    async def test_tts_word_messages_include_spacing_hint(self):
+        observer = RTVIObserver()
+        observer.send_rtvi_message = AsyncMock()
+
+        frame = TTSTextFrame(",", AggregationType.WORD)
+        frame.includes_inter_frame_spaces = True
+
+        await observer._send_aggregated_llm_text(frame)
+
+        bot_output, bot_tts = [call.args[0] for call in observer.send_rtvi_message.call_args_list]
+        self.assertIsInstance(bot_output, RTVI.BotOutputMessage)
+        self.assertIsInstance(bot_tts, RTVI.BotTTSTextMessage)
+        self.assertTrue(bot_output.data.includes_inter_frame_spaces)
+        self.assertTrue(bot_tts.data.includes_inter_frame_spaces)
+
+    async def test_unset_spacing_hint_is_omitted_from_text_payloads(self):
+        message = RTVI.BotLLMTextMessage(data=RTVI.TextMessageData(text="hello"))
+
+        payload = message.model_dump(exclude_none=True)
+
+        self.assertNotIn("includes_inter_frame_spaces", payload["data"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes pipecat-ai/pipecat#4630.

`TTSTextFrame.includes_inter_frame_spaces` tells downstream consumers whether word-level TTS tokens already contain their own leading/trailing spacing. The assistant aggregator honors that flag, but RTVI `bot-output` and `bot-tts-text` messages dropped it, so clients that render live word captions could only guess and often inserted separators before punctuation.

This adds an optional `includes_inter_frame_spaces` field to RTVI text message data and populates it for TTS-derived messages:

- `bot-output` includes the hint when the frame is a `TTSTextFrame`
- `bot-tts-text` includes the hint from the same frame
- other text messages keep the field unset, so `exclude_none=True` preserves the previous payload shape

## To verify

- `python -m pytest tests\test_rtvi_processor.py::TestRTVIObserverTextMessages -q` -> `2 passed`
- `python -m py_compile src\pipecat\processors\frameworks\rtvi\models.py src\pipecat\processors\frameworks\rtvi\observer.py tests\test_rtvi_processor.py`
- `python -m ruff check src\pipecat\processors\frameworks\rtvi\models.py src\pipecat\processors\frameworks\rtvi\observer.py tests\test_rtvi_processor.py`
- `python -m ruff format --check src\pipecat\processors\frameworks\rtvi\models.py src\pipecat\processors\frameworks\rtvi\observer.py tests\test_rtvi_processor.py`
- `git diff --check`
