### PR TITLE
livekit: aclose owned audio/video streams + cancel producers on track unsubscribe

### DIFF
--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -169,8 +169,14 @@ class LiveKitTransportClient:
         self._audio_track: rtc.LocalAudioTrack | None = None
         self._audio_tracks = {}
         self._audio_queue = asyncio.Queue()
+        # Per-participant ``(AudioStream, Task)`` so unsubscribe can close
+        # the owned native stream and cancel its producer task instead of
+        # leaking both on every track republish.
+        self._audio_streams: dict[str, tuple[rtc.AudioStream, asyncio.Task]] = {}
         self._video_tracks = {}
         self._video_queue = asyncio.Queue()
+        # Symmetric registry for video streams.
+        self._video_streams: dict[str, tuple[rtc.VideoStream, asyncio.Task]] = {}
         self._other_participant_has_joined = False
         self._task_manager: BaseTaskManager | None = None
         self._async_lock = asyncio.Lock()
@@ -498,24 +504,34 @@ class LiveKitTransportClient:
         """Handle track subscribed events."""
         if track.kind == rtc.TrackKind.KIND_AUDIO:
             logger.info(f"Audio track subscribed: {track.sid} from participant {participant.sid}")
+            # If the participant is re-publishing (e.g. mute/unmute cycle),
+            # close + cancel the previous stream/task before replacing the
+            # registry entry, so two producers never feed ``_audio_queue``
+            # for the same participant.
+            await self._close_audio_stream(participant.sid)
             self._audio_tracks[participant.sid] = track
             audio_stream = rtc.AudioStream(track)
-            self._task_manager.create_task(
+            task = self._task_manager.create_task(
                 self._process_audio_stream(audio_stream, participant.sid),
                 f"{self}::_process_audio_stream",
             )
+            self._audio_streams[participant.sid] = (audio_stream, task)
             await self._callbacks.on_audio_track_subscribed(participant.sid)
         elif track.kind == rtc.TrackKind.KIND_VIDEO:
             logger.info(f"Video track subscribed: {track.sid} from participant {participant.sid}")
+            # Symmetric: clean up any prior video stream/task for the same
+            # participant before replacing.
+            await self._close_video_stream(participant.sid)
             self._video_tracks[participant.sid] = track
             # Only process video stream if video input is enabled to prevent
             # unbounded queue growth when there is no consumer for video frames.
             if self._params.video_in_enabled:
                 video_stream = rtc.VideoStream(track)
-                self._task_manager.create_task(
+                task = self._task_manager.create_task(
                     self._process_video_stream(video_stream, participant.sid),
                     f"{self}::_process_video_stream",
                 )
+                self._video_streams[participant.sid] = (video_stream, task)
             await self._callbacks.on_video_track_subscribed(participant.sid)
 
     async def _async_on_track_unsubscribed(
@@ -527,9 +543,45 @@ class LiveKitTransportClient:
         """Handle track unsubscribed events."""
         logger.info(f"Track unsubscribed: {publication.sid} from {participant.identity}")
         if track.kind == rtc.TrackKind.KIND_AUDIO:
+            await self._close_audio_stream(participant.sid)
             await self._callbacks.on_audio_track_unsubscribed(participant.sid)
         elif track.kind == rtc.TrackKind.KIND_VIDEO:
+            await self._close_video_stream(participant.sid)
             await self._callbacks.on_video_track_unsubscribed(participant.sid)
+
+    async def _close_audio_stream(self, participant_id: str) -> None:
+        """Close a participant's owned audio stream and cancel its producer task.
+
+        Idempotent: no-op when there is no registered stream for the
+        participant.
+        """
+        entry = self._audio_streams.pop(participant_id, None)
+        if entry is None:
+            return
+        stream, task = entry
+        try:
+            await asyncio.wait_for(stream.aclose(), timeout=2.0)
+        except Exception as e:
+            logger.warning(f"AudioStream.aclose failed for {participant_id}: {e}")
+        if task is not None and not task.done():
+            task.cancel()
+
+    async def _close_video_stream(self, participant_id: str) -> None:
+        """Close a participant's owned video stream and cancel its producer task.
+
+        Idempotent: no-op when there is no registered stream for the
+        participant.
+        """
+        entry = self._video_streams.pop(participant_id, None)
+        if entry is None:
+            return
+        stream, task = entry
+        try:
+            await asyncio.wait_for(stream.aclose(), timeout=2.0)
+        except Exception as e:
+            logger.warning(f"VideoStream.aclose failed for {participant_id}: {e}")
+        if task is not None and not task.done():
+            task.cancel()
 
     async def _async_on_data_received(self, data: rtc.DataPacket):
         """Handle data received events."""

--- a/tests/test_livekit_transport.py
+++ b/tests/test_livekit_transport.py
@@ -120,5 +120,163 @@ class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
         client._callbacks.on_video_track_subscribed.assert_called_once()
 
 
+@unittest.skipUnless(LIVEKIT_AVAILABLE, "livekit package not installed")
+class TestLiveKitAudioStreamLeakOnUnsubscribe(unittest.IsolatedAsyncioTestCase):
+    """Regression tests for AudioStream leak on track unsubscribe.
+
+    The bug: ``_async_on_track_subscribed`` creates an owned ``rtc.AudioStream``
+    plus a ``_process_audio_stream`` task feeding the shared ``_audio_queue``,
+    but only saves the track. ``_async_on_track_unsubscribed`` never closes the
+    stream or cancels the task. Per livekit-rtc ``audio_stream.py``, an owned
+    ``AudioStream._run`` loops over the FFI queue and exits only on a native
+    ``eos`` event emitted by ``aclose()`` → ``_ffi_handle.dispose()``. So when a
+    participant republishes their mic (e.g. mute/unmute), the previous stream
+    keeps pushing frames forever; N republishes → N concurrent producers
+    interleave audio into the shared queue and downstream STT receives garbage.
+
+    The fix: store ``(stream, task)`` per ``participant.sid`` in
+    ``_audio_streams`` on subscribe, then ``aclose()`` + cancel on unsubscribe
+    and again on a re-subscribe for the same sid (to handle missed unsubscribe).
+    Symmetric for video.
+    """
+
+    def _create_client(self, video_in_enabled: bool = False) -> LiveKitTransportClient:
+        params = LiveKitParams(video_in_enabled=video_in_enabled)
+        callbacks = LiveKitCallbacks(
+            on_connected=AsyncMock(),
+            on_disconnected=AsyncMock(),
+            on_before_disconnect=AsyncMock(),
+            on_participant_connected=AsyncMock(),
+            on_participant_disconnected=AsyncMock(),
+            on_audio_track_subscribed=AsyncMock(),
+            on_audio_track_unsubscribed=AsyncMock(),
+            on_video_track_subscribed=AsyncMock(),
+            on_video_track_unsubscribed=AsyncMock(),
+            on_data_received=AsyncMock(),
+            on_first_participant_joined=AsyncMock(),
+        )
+        client = LiveKitTransportClient(
+            url="wss://test.livekit.cloud",
+            token="test-token",
+            room_name="test-room",
+            params=params,
+            callbacks=callbacks,
+            transport_name="test-transport",
+        )
+        client._task_manager = MagicMock()
+
+        # Return a real (mockable) Task so the cleanup path can call ``.done()``
+        # and ``.cancel()`` on it without blowing up.
+        def _make_task(coro, name):
+            coro.close()  # we never run the producer in the unit test
+            t = MagicMock()
+            t.done.return_value = False
+            t.cancel = MagicMock()
+            return t
+
+        client._task_manager.create_task.side_effect = _make_task
+        return client
+
+    def _audio_track(self, sid: str = "audio-track-1", participant_sid: str = "p-1"):
+        track = MagicMock()
+        track.kind = rtc.TrackKind.KIND_AUDIO
+        track.sid = sid
+        publication = MagicMock()
+        publication.sid = sid
+        participant = MagicMock()
+        participant.sid = participant_sid
+        participant.identity = "user"
+        return track, publication, participant
+
+    def _video_track(self, sid: str = "video-track-1", participant_sid: str = "p-1"):
+        track = MagicMock()
+        track.kind = rtc.TrackKind.KIND_VIDEO
+        track.sid = sid
+        publication = MagicMock()
+        publication.sid = sid
+        participant = MagicMock()
+        participant.sid = participant_sid
+        participant.identity = "user"
+        return track, publication, participant
+
+    async def test_audio_stream_registered_on_subscribe(self):
+        """Subscribing an audio track registers ``(stream, task)`` for the sid."""
+        client = self._create_client()
+        track, pub, participant = self._audio_track()
+
+        mock_stream = MagicMock()
+        mock_stream.aclose = AsyncMock()
+        with patch.object(rtc, "AudioStream", return_value=mock_stream):
+            await client._async_on_track_subscribed(track, pub, participant)
+
+        self.assertIn(participant.sid, client._audio_streams)
+        stream, task = client._audio_streams[participant.sid]
+        self.assertIs(stream, mock_stream)
+        self.assertIsNotNone(task)
+
+    async def test_audio_stream_closed_and_task_cancelled_on_unsubscribe(self):
+        """Unsubscribing closes the stream, cancels the task, clears the registry."""
+        client = self._create_client()
+        track, pub, participant = self._audio_track()
+
+        mock_stream = MagicMock()
+        mock_stream.aclose = AsyncMock()
+        with patch.object(rtc, "AudioStream", return_value=mock_stream):
+            await client._async_on_track_subscribed(track, pub, participant)
+        _, task = client._audio_streams[participant.sid]
+
+        await client._async_on_track_unsubscribed(track, pub, participant)
+
+        mock_stream.aclose.assert_awaited_once()
+        task.cancel.assert_called_once()
+        self.assertNotIn(participant.sid, client._audio_streams)
+        client._callbacks.on_audio_track_unsubscribed.assert_called_once()
+
+    async def test_resubscribe_closes_previous_audio_stream(self):
+        """Re-subscribing the same sid (mic republish) closes the prior stream."""
+        client = self._create_client()
+        track, pub, participant = self._audio_track()
+
+        first = MagicMock()
+        first.aclose = AsyncMock()
+        second = MagicMock()
+        second.aclose = AsyncMock()
+
+        with patch.object(rtc, "AudioStream", return_value=first):
+            await client._async_on_track_subscribed(track, pub, participant)
+        first_task = client._audio_streams[participant.sid][1]
+
+        # Republish without an explicit unsubscribe in between.
+        with patch.object(rtc, "AudioStream", return_value=second):
+            await client._async_on_track_subscribed(track, pub, participant)
+
+        first.aclose.assert_awaited_once()
+        first_task.cancel.assert_called_once()
+        self.assertIs(client._audio_streams[participant.sid][0], second)
+
+    async def test_unsubscribe_without_subscribe_is_noop(self):
+        """Unsubscribe for an unknown sid does not raise."""
+        client = self._create_client()
+        track, pub, participant = self._audio_track()
+        # No subscribe before this call.
+        await client._async_on_track_unsubscribed(track, pub, participant)
+        client._callbacks.on_audio_track_unsubscribed.assert_called_once()
+
+    async def test_video_stream_closed_on_unsubscribe(self):
+        """Symmetric behaviour for video when ``video_in_enabled=True``."""
+        client = self._create_client(video_in_enabled=True)
+        track, pub, participant = self._video_track()
+
+        mock_stream = MagicMock()
+        mock_stream.aclose = AsyncMock()
+        with patch.object(rtc, "VideoStream", return_value=mock_stream):
+            await client._async_on_track_subscribed(track, pub, participant)
+        self.assertIn(participant.sid, client._video_streams)
+
+        await client._async_on_track_unsubscribed(track, pub, participant)
+        mock_stream.aclose.assert_awaited_once()
+        self.assertNotIn(participant.sid, client._video_streams)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `LiveKitTransportClient._async_on_track_subscribed` creates an owned `rtc.AudioStream(track)` + a `_process_audio_stream` task that feeds the shared `_audio_queue`, but only stored the track. The matching `_async_on_track_unsubscribed` only fired the user callback — it never closed the stream or cancelled the task.
- Per livekit-rtc `audio_stream.py`, an owned `AudioStream._run` loops over the FFI queue forever and exits only on a native `eos` event emitted by `aclose()` → `_ffi_handle.dispose()`. So a track unsubscribe (common when a web client republishes the mic on mute/unmute or text↔voice toggle) leaks the prior stream + task. After N republishes for the same participant, N concurrent producers push frames into the shared `_audio_queue`; downstream STT receives interleaved audio and stops producing transcripts. Same shape on video.

## Fix

Store `(stream, task)` per `participant.sid` in new `_audio_streams` / `_video_streams` dicts on subscribe; on unsubscribe pop the entry, `aclose()` the stream (bounded by `wait_for(timeout=2.0)` so a missing `eos` can't wedge the handler), then `task.cancel()` as a backstop. Re-subscribing the same sid (mic republish without explicit unsubscribe) also closes the prior stream first, so two producers never run for the same participant.

## Test plan

- [x] `uv run pytest tests/test_livekit_transport.py -v` — 7 passed (5 new + 2 pre-existing video-leak tests)
- [x] `uv run ruff check / format` clean
- [x] **End-to-end verified on a real web call**: applied this patch into a downstream worker's `.venv`, removed the local workaround, ran a bot with 5 voice↔text toggles. Result: 5 subscribe + 5 unsubscribe events, 0 `aclose failed` warnings, STT kept transcribing correctly after every toggle and the bot responded normally. Without the fix the same scenario produces N alive producers interleaving audio → STT goes silent → bot deaf.