### PR TITLE
Point the README CLI link at the docs (CLI now ships with pipecat-ai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Want to build beautiful and engaging experiences? Checkout the [Voice UI Kit](ht
 
 ### 🛠️ Create and deploy projects
 
-Create a new project in under a minute with the [Pipecat CLI](https://github.com/pipecat-ai/pipecat-cli). Then use the CLI to monitor and deploy your agent to production.
+Create a new project in under a minute with the [Pipecat CLI](https://docs.pipecat.ai/api-reference/cli/overview), included with `pipecat-ai[cli]`. Then use it to deploy your agent to production.
 
 ### 🔍 Debugging
 


### PR DESCRIPTION
**⚠️ Wait to merge with the 1.4.0 release**

## Summary

The Pipecat CLI moved into `pipecat-ai` as the optional `[cli]` extra (#4631), and the standalone `pipecat-ai/pipecat-cli` repo is now archived. The README's "Create and deploy projects" link still pointed at that archived repo.

This updates the link to the canonical CLI docs and tidies the sentence:

- Link → [CLI overview docs](https://docs.pipecat.ai/api-reference/cli/overview) instead of the archived repo.
- Note the CLI is included with `pipecat-ai[cli]`.
- Drop "monitor" — that was the `tail` command, which is deferred from the bundled CLI; today it scaffolds (`init`) and deploys (`cloud`).

```diff
-Create a new project in under a minute with the [Pipecat CLI](https://github.com/pipecat-ai/pipecat-cli). Then use the CLI to monitor and deploy your agent to production.
+Create a new project in under a minute with the [Pipecat CLI](https://docs.pipecat.ai/api-reference/cli/overview), included with `pipecat-ai[cli]`. Then use it to deploy your agent to production.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)