### PR TITLE
bus: serialise inbound bus frames via worker.queue_frame to fix multi-worker set_node race

### DIFF
--- a/src/pipecat/bus/bridge_processor.py
+++ b/src/pipecat/bus/bridge_processor.py
@@ -32,7 +32,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor, FrameProcessorSetup
 
 if TYPE_CHECKING:
-    from pipecat.workers.base_worker import BaseWorker
+    from pipecat.pipeline.worker import PipelineWorker
 
 _LIFECYCLE_FRAMES = (StartFrame, EndFrame, CancelFrame, StopFrame)
 _PASSTHROUGH_FRAMES = (OutputTransportMessageUrgentFrame,)
@@ -161,7 +161,7 @@ class _BusEdgeProcessor(FrameProcessor, BusSubscriber):
     def __init__(
         self,
         *,
-        worker: "BaseWorker",
+        worker: "PipelineWorker",
         direction: FrameDirection,
         bridges: tuple[str, ...] = (),
         exclude_frames: tuple[type[Frame], ...] | None = None,
@@ -172,7 +172,7 @@ class _BusEdgeProcessor(FrameProcessor, BusSubscriber):
         Args:
             worker: The owning worker; the edge reads ``worker.bus`` lazily
                 so the bus only needs to be set (via
-                :meth:`BaseWorker.attach`) by the time the processor is
+                :meth:`PipelineWorker.attach`) by the time the processor is
                 set up. ``worker.name`` is the message source and
                 ``worker.active`` gates inbound frames.
             direction: Direction this edge captures and forwards to the
@@ -230,4 +230,7 @@ class _BusEdgeProcessor(FrameProcessor, BusSubscriber):
             return
         if self._bridges and message.bridge not in self._bridges:
             return
-        await self.push_frame(message.frame, message.direction)
+        # Route via the worker's push queue (rather than ``push_frame`` from
+        # this edge) so bus inbound serialises with frames the worker queues
+        # itself (e.g. those a flow framework enqueues from ``set_node``).
+        await self._task.queue_frame(message.frame, message.direction)

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -264,5 +264,91 @@ class TestBusBridgeProcessor(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(injected), 0)
 
 
+class TestBusEdgeProcessorOrdering(unittest.IsolatedAsyncioTestCase):
+    """Frames received from the bus by ``_BusEdgeProcessor.on_bus_message``
+    are serialised with frames the owning worker queues via
+    ``queue_frame``/``queue_frames``, so a bus inbound frame cannot
+    interleave between a multi-frame sequence the worker enqueues itself
+    (regression test for the multi-worker ``set_node`` apply race where
+    an ``LLMContextFrame`` from a user input would reach the LLM before
+    the new node's ``LLMSetToolsFrame`` had landed)."""
+
+    async def test_bus_inbound_drains_after_worker_queued_frames(self):
+        """A frame received from the bus is observed downstream **after**
+        any frames queued via ``worker.queue_frame`` before it, because
+        both paths share the worker's single ``_push_queue`` (FIFO)."""
+        from pipecat.frames.frames import EndFrame
+        from pipecat.pipeline.worker import PipelineWorker
+        from pipecat.processors.frame_processor import FrameProcessor
+        from pipecat.workers.runner import WorkerRunner
+
+        class RecordingProcessor(FrameProcessor):
+            """Appends every ``TextFrame`` it sees to a shared list."""
+
+            def __init__(self, observed: list, **kwargs):
+                super().__init__(**kwargs)
+                self._observed = observed
+
+            async def process_frame(self, frame, direction):
+                await super().process_frame(frame, direction)
+                if isinstance(frame, TextFrame):
+                    self._observed.append(frame.text)
+                await self.push_frame(frame, direction)
+
+        observed: list[str] = []
+        bus = AsyncQueueBus()
+        recorder = RecordingProcessor(observed)
+        # ``bridged=()`` wraps the pipeline with _BusEdgeProcessor at both
+        # ends so frames received from the bus are injected here.
+        worker = PipelineWorker(
+            Pipeline([recorder]),
+            cancel_on_idle_timeout=False,
+            bridged=(),
+        )
+
+        ready = asyncio.Event()
+
+        @worker.event_handler("on_pipeline_started")
+        async def _on_started(_w, _f):
+            ready.set()
+
+        async def drive():
+            await asyncio.wait_for(ready.wait(), timeout=5)
+            # Queue an APPLY-like frame on the worker FIRST, then push a
+            # bus message. If the bus path bypassed the queue (the old
+            # behaviour), the bus frame could race ahead and be observed
+            # before "apply". With this fix it is queued and drains after.
+            await worker.queue_frame(TextFrame(text="apply"))
+            await bus.send(
+                BusFrameMessage(
+                    source="other_task",
+                    frame=TextFrame(text="from_bus"),
+                    direction=FrameDirection.DOWNSTREAM,
+                )
+            )
+            await asyncio.sleep(0.2)
+            await worker.queue_frame(EndFrame())
+
+        runner = WorkerRunner(bus=bus, handle_sigint=False)
+        await runner.add_workers(worker)
+        await asyncio.gather(runner.run(), drive())
+
+        # The bus inbound frame must NEVER precede the previously queued
+        # apply frame. ``"apply"`` is queued first; ``"from_bus"`` arrives
+        # via on_bus_message after that put. With the fix both frames
+        # land in the same ``_push_queue`` and drain FIFO, so the order
+        # observed downstream is deterministic.
+        apply_idx = observed.index("apply") if "apply" in observed else -1
+        bus_idx = observed.index("from_bus") if "from_bus" in observed else -1
+        self.assertGreaterEqual(apply_idx, 0, f"apply missing from {observed}")
+        self.assertGreaterEqual(bus_idx, 0, f"from_bus missing from {observed}")
+        self.assertLess(
+            apply_idx,
+            bus_idx,
+            f"bus inbound 'from_bus' raced ahead of locally queued 'apply' "
+            f"(observed order: {observed})",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

In a multi-worker setup with a child `LLMWorker` bridged onto the bus, `_BusEdgeProcessor.on_bus_message` used to push received frames directly from the edge into the local pipeline. The worker's own outbound path goes via `worker.queue_frame` → `_push_queue` → `_process_push_queue` (drained FIFO) → `_pipeline.queue_frame`. The two paths converge at the same processors but enter from different async tasks, so frames in one stream can interleave with frames in the other.

Witnessed with `pipecat-flows`: `set_node` enqueues `[LLMMessagesUpdate, LLMSetTools]` (and optionally `LLMRunFrame`) on the child via `worker.queue_frames`. A concurrent user input on the main worker becomes an `LLMContextFrame` and is routed via the bus back to the child. The bus inbound, being pushed directly by the edge, can reach the `LLMService` before the new node's `LLMSetToolsFrame` has landed on the shared aggregators, and the LLM generates against the previous node's context.

## Fix

Route bus inbound through `self._task.queue_frame` instead of `self.push_frame`. Both paths now share the worker's single `_push_queue` (drained FIFO by `_process_push_queue`), so the "apply before run" ordering held within a single `queue_frames` call is preserved against concurrent bus inbound.

The change is local to a single method and does not alter any frame shape, frame type, or external API. Lifecycle/excluded frame filtering upstream is unchanged.

## Test plan

- [x] `uv run pytest tests/test_bridge_processor.py -v` — 8 passed (1 new `test_bus_inbound_drains_after_worker_queued_frames`)
- [x] `uv run ruff check / format` clean
- [x] **End-to-end deterministic repro** of the race: multi-worker pipecat-flows with a fake LLM logging the context it sees. Without the fix the LLM generates against the previous node's task_messages/tools on 10/10 trials when the race window is amplified; with the fix applied it generates against the new node's content on 10/10 trials.
- [x] **Verified live on a downstream worker** (5x sinistri + 3x bookings runs) with an existing intra-worker mute-during-set_node workaround disabled: zero stale-context generations, zero "No tools provided" errors, no interaction with the existing `BusBridgeProcessor` frame dedup.
