### PR TITLE
Adding HMAC token authentication for WebSocket connections.

### DIFF
--- a/changelog/4660.security.md
+++ b/changelog/4660.security.md
@@ -1,0 +1,3 @@
+- Added optional HMAC token authentication for WebSocket connections in the development runner. Set `PIPECAT_WEBSOCKET_AUTH=token` (or pass `--ws-auth token`) to require clients to call `POST /start` and obtain a short-lived signed session token before connecting. Tokens are one-time use and expire after 5 minutes.
+  - Clients can supply the token via `Authorization: Bearer <token>` header, `?token=<token>` query parameter, or URL path segment (`/ws/<token>`, `/ws-client/<token>`) — the path form is recommended for telephony providers like Twilio.
+  - Both the telephony WebSocket (`/ws`) and plain WebSocket (`/ws-client`) endpoints are protected. Connections with invalid, expired, or replayed tokens are rejected with WebSocket close code 4003.

--- a/env.example
+++ b/env.example
@@ -233,3 +233,11 @@ XAI_API_KEY=...
 # All the details here:
 # https://docs.pipecat.ai/api-reference/server/services/transport/small-webrtc#pipecat_sctp_max_chunk_size
 #PIPECAT_SCTP_MAX_CHUNK_SIZE=1100
+
+# Pipecat Runner
+# Enable HMAC token authentication for WebSocket connections.
+# When set to "token", clients must call POST /start to obtain a short-lived
+# signed session token before connecting to /ws or /ws-client. Prevents
+# unauthorized session starts. Mirrors the websocket_auth = "token" setting in
+# Pipecat Cloud deployment config (pcc-deploy.toml). Valid values: none | token.
+#PIPECAT_WEBSOCKET_AUTH=none

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -90,9 +90,14 @@ To run locally:
 
 import argparse
 import asyncio
+import base64
+import hashlib
+import hmac
 import importlib.util
+import json
 import mimetypes
 import os
+import secrets
 import sys
 import time
 import uuid
@@ -153,6 +158,10 @@ PIPECAT_ROOM_EXP_HOURS = 4.0
 RUNNER_DOWNLOADS_FOLDER: str | None = None
 RUNNER_HOST: str = "localhost"
 RUNNER_PORT: int = 7860
+
+# Per-process HMAC secret for WebSocket token authentication. Auto-generated so
+# tokens from one runner instance cannot be replayed against another.
+_WS_AUTH_SECRET: bytes = secrets.token_bytes(32)
 
 app: FastAPI = FastAPI()
 """The FastAPI application instance.
@@ -237,6 +246,69 @@ def _format_transport_status(labels: list[str]) -> str:
     return ", ".join(labels) if labels else "none"
 
 
+def _generate_ws_token(ttl: int = 300) -> str:
+    """Return a signed, self-expiring WebSocket session token.
+
+    The token is ``<base64url-payload>.<hmac-sha256-hex>`` where the payload
+    encodes ``{"exp": unix_timestamp}``. Valid for ``ttl`` seconds (default 5 min).
+    """
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": int(time.time()) + ttl}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    sig = hmac.new(_WS_AUTH_SECRET, payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{sig}"
+
+
+def _validate_ws_token(used: set[str], token: str) -> bool:
+    """Validate a WebSocket session token and mark it as used (one-time use).
+
+    Args:
+        used: Set of already-consumed tokens (mutated on success).
+        token: Token string obtained from :func:`_generate_ws_token`.
+
+    Returns:
+        ``True`` if the token has a valid signature, has not expired, and has
+        not been used before. Adds the token to ``used`` on success so replay
+        attempts are rejected.
+    """
+    try:
+        payload, sig = token.rsplit(".", 1)
+    except ValueError:
+        return False
+    expected = hmac.new(_WS_AUTH_SECRET, payload.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        return False
+    padded = payload + "=" * (-len(payload) % 4)
+    try:
+        data = json.loads(base64.urlsafe_b64decode(padded))
+    except Exception:
+        return False
+    if time.time() > data.get("exp", 0):
+        return False
+    if token in used:
+        return False
+    used.add(token)
+    return True
+
+
+def _extract_ws_token(websocket) -> str | None:
+    """Extract a WebSocket session token from the connection handshake.
+
+    Checks, in order:
+
+    1. ``Authorization: Bearer <token>`` request header.
+    2. ``?token=<token>`` query parameter.
+
+    Returns the token string, or ``None`` if not present.
+    """
+    auth = websocket.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        return auth[7:].strip()
+    return websocket.query_params.get("token")
+
+
 def _print_startup_message(args: argparse.Namespace):
     """Print connection information for the development runner."""
     print()
@@ -279,6 +351,8 @@ def _print_startup_message(args: argparse.Namespace):
             if args.proxy:
                 print(f"   → XML webhook: http://{args.host}:{args.port}/")
             print(f"   → WebSocket:   ws://{args.host}:{args.port}/ws")
+            if args.ws_auth == "token":
+                print("   → WebSocket auth: token (HMAC, call /start to obtain a token)")
     elif args.transport == "websocket":
         print("🚀 Bot ready! (WebSocket)")
         if not _transport_routes_enabled("websocket"):
@@ -287,6 +361,8 @@ def _print_startup_message(args: argparse.Namespace):
             print(f"   → Open: {_runner_url(args)}")
             scheme = "wss" if args.host != "localhost" else "ws"
             print(f"   → WebSocket:   {scheme}://{args.host}:{args.port}/ws-client")
+            if args.ws_auth == "token":
+                print("   → WebSocket auth: token (HMAC, call /start to obtain a token)")
     elif args.transport == "vonage":
         print()
         print("🚀 Bot ready!")
@@ -362,17 +438,41 @@ async def _run_websocket_bot(websocket: WebSocket, args: argparse.Namespace):
     await bot_module.bot(runner_args)
 
 
-def _setup_websocket_routes(app: FastAPI, args: argparse.Namespace):
-    """Set up the plain WebSocket route at ``/ws-client``."""
+def _setup_websocket_routes(app: FastAPI, args: argparse.Namespace, ws_used_tokens: set[str]):
+    """Set up the plain WebSocket route at ``/ws-client``.
+
+    When ``args.ws_auth == "token"``, connections must present a valid HMAC
+    session token obtained via ``POST /start``. The token may be supplied as:
+
+    - ``Authorization: Bearer <token>`` header
+    - ``?token=<token>`` query parameter
+    - URL path segment: ``/ws-client/<token>``
+
+    Invalid or missing tokens are rejected with WebSocket close code 4003.
+    """
     if not _transport_routes_enabled("websocket"):
         return
+
+    async def _handle_plain_ws(websocket: WebSocket, path_token: str | None = None):
+        if args.ws_auth == "token":
+            token = path_token or _extract_ws_token(websocket)
+            if not token or not _validate_ws_token(ws_used_tokens, token):
+                logger.warning("WebSocket connection rejected: invalid or missing token")
+                await websocket.close(code=4003)
+                return
+        await websocket.accept()
+        logger.debug("Plain WebSocket connection accepted")
+        await _run_websocket_bot(websocket, args)
 
     @app.websocket("/ws-client")
     async def websocket_client_endpoint(websocket: WebSocket):
         """Handle plain WebSocket connections (non-telephony)."""
-        await websocket.accept()
-        logger.debug("Plain WebSocket connection accepted")
-        await _run_websocket_bot(websocket, args)
+        await _handle_plain_ws(websocket)
+
+    @app.websocket("/ws-client/{token}")
+    async def websocket_client_endpoint_with_token(websocket: WebSocket, token: str):
+        """Handle plain WebSocket connections with token in the URL path."""
+        await _handle_plain_ws(websocket, path_token=token)
 
 
 def _configure_server_app(args: argparse.Namespace):
@@ -403,11 +503,15 @@ def _configure_server_app(args: argparse.Namespace):
     # flow and the /sessions/{session_id}/... proxy routes.
     active_sessions: dict[str, dict[str, Any]] = {}
 
+    # Consumed WebSocket tokens (one-time use). Shared across both WebSocket
+    # endpoint families (/ws and /ws-client).
+    ws_used_tokens: set[str] = set()
+
     _setup_frontend_routes(app)
     _setup_webrtc_routes(app, args, active_sessions)
     _setup_daily_routes(app, args)
-    _setup_telephony_routes(app, args)
-    _setup_websocket_routes(app, args)
+    _setup_telephony_routes(app, args, ws_used_tokens)
+    _setup_websocket_routes(app, args, ws_used_tokens)
     _setup_unified_start_route(app, args, active_sessions)
 
     if args.whatsapp:
@@ -581,18 +685,20 @@ def _setup_unified_start_route(
             # Telephony: the bot starts when the provider connects to /ws.
             # Return the WebSocket URL so the caller knows where to point their provider.
             scheme = "wss" if args.host != "localhost" else "ws"
-            return StartBotResult(
-                wsUrl=f"{scheme}://{args.host}:{args.port}/ws",
-            )
+            result = StartBotResult(wsUrl=f"{scheme}://{args.host}:{args.port}/ws")
+            if args.ws_auth == "token":
+                result["token"] = _generate_ws_token()
+            return result
 
         elif transport == "websocket":
             # Plain WebSocket: the bot starts when the client connects to /ws-client.
             scheme = "wss" if args.host != "localhost" else "ws"
             session_id = str(uuid.uuid4())
+            token = _generate_ws_token() if args.ws_auth == "token" else None
             return StartBotResult(
                 wsUrl=f"{scheme}://{args.host}:{args.port}/ws-client",
                 sessionId=session_id,
-                token="mock_token",
+                token=token,
             )
 
         else:
@@ -1071,13 +1177,22 @@ def _setup_daily_routes(app: FastAPI, args: argparse.Namespace):
             }
 
 
-def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace):
+def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace, ws_used_tokens: set[str]):
     """Set up telephony-specific routes.
 
     The WebSocket endpoint (``/ws``) is always registered so providers can
     connect directly. The XML webhook (``POST /``) is only registered when a
     specific telephony transport is chosen via ``-t`` because the XML template
     is provider-specific and requires a proxy hostname (``--proxy``).
+
+    When ``args.ws_auth == "token"``, connections must present a valid HMAC
+    session token obtained via ``POST /start``. The token may be supplied as:
+
+    - ``Authorization: Bearer <token>`` header
+    - ``?token=<token>`` query parameter
+    - URL path segment: ``/ws/<token>`` (recommended for telephony providers)
+
+    Invalid or missing tokens are rejected with WebSocket close code 4003.
     """
     if not _transport_routes_enabled("telephony"):
         return
@@ -1121,12 +1236,26 @@ def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace):
                 xml_content = XML_TEMPLATES.get(args.transport, "<Response></Response>")
                 return HTMLResponse(content=xml_content, media_type="application/xml")
 
-    @app.websocket("/ws")
-    async def websocket_endpoint(websocket: WebSocket):
-        """Handle WebSocket connections for telephony."""
+    async def _handle_telephony_ws(websocket: WebSocket, path_token: str | None = None):
+        if args.ws_auth == "token":
+            token = path_token or _extract_ws_token(websocket)
+            if not token or not _validate_ws_token(ws_used_tokens, token):
+                logger.warning("WebSocket connection rejected: invalid or missing token")
+                await websocket.close(code=4003)
+                return
         await websocket.accept()
         logger.debug("WebSocket connection accepted")
         await _run_telephony_bot(websocket, args)
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(websocket: WebSocket):
+        """Handle WebSocket connections for telephony."""
+        await _handle_telephony_ws(websocket)
+
+    @app.websocket("/ws/{token}")
+    async def websocket_endpoint_with_token(websocket: WebSocket, token: str):
+        """Handle WebSocket connections for telephony with token in the URL path."""
+        await _handle_telephony_ws(websocket, path_token=token)
 
 
 async def _run_daily_direct(args: argparse.Namespace):
@@ -1298,6 +1427,18 @@ def main(parser: argparse.ArgumentParser | None = None):
         action="store_true",
         default=False,
         help="Ensure required WhatsApp environment variables are present",
+    )
+    parser.add_argument(
+        "--ws-auth",
+        dest="ws_auth",
+        choices=["none", "token"],
+        default=os.getenv("PIPECAT_WEBSOCKET_AUTH", "none"),
+        help=(
+            "WebSocket authentication mode. 'token' requires clients to call /start "
+            "and obtain a signed HMAC session token before connecting to /ws or "
+            "/ws-client. Defaults to the PIPECAT_WEBSOCKET_AUTH environment variable "
+            "or 'none'."
+        ),
     )
 
     args = parser.parse_args()

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -250,10 +250,13 @@ def _generate_ws_token(ttl: int = 300) -> str:
     """Return a signed, self-expiring WebSocket session token.
 
     The token is ``<base64url-payload>.<hmac-sha256-hex>`` where the payload
-    encodes ``{"exp": unix_timestamp}``. Valid for ``ttl`` seconds (default 5 min).
+    encodes ``{"exp": unix_timestamp, "jti": random_nonce}``. Valid for ``ttl``
+    seconds (default 5 min). The nonce ensures uniqueness within the same second.
     """
     payload = (
-        base64.urlsafe_b64encode(json.dumps({"exp": int(time.time()) + ttl}).encode())
+        base64.urlsafe_b64encode(
+            json.dumps({"exp": int(time.time()) + ttl, "jti": secrets.token_hex(8)}).encode()
+        )
         .decode()
         .rstrip("=")
     )
@@ -261,7 +264,7 @@ def _generate_ws_token(ttl: int = 300) -> str:
     return f"{payload}.{sig}"
 
 
-def _validate_ws_token(used: set[str], token: str) -> bool:
+def _verify_and_consume_ws_token(used: set[str], token: str) -> bool:
     """Validate a WebSocket session token and mark it as used (one-time use).
 
     Args:
@@ -456,7 +459,7 @@ def _setup_websocket_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
     async def _handle_plain_ws(websocket: WebSocket, path_token: str | None = None):
         if args.ws_auth == "token":
             token = path_token or _extract_ws_token(websocket)
-            if not token or not _validate_ws_token(ws_used_tokens, token):
+            if not token or not _verify_and_consume_ws_token(ws_used_tokens, token):
                 logger.warning("WebSocket connection rejected: invalid or missing token")
                 await websocket.close(code=4003)
                 return
@@ -1239,7 +1242,7 @@ def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
     async def _handle_telephony_ws(websocket: WebSocket, path_token: str | None = None):
         if args.ws_auth == "token":
             token = path_token or _extract_ws_token(websocket)
-            if not token or not _validate_ws_token(ws_used_tokens, token):
+            if not token or not _verify_and_consume_ws_token(ws_used_tokens, token):
                 logger.warning("WebSocket connection rejected: invalid or missing token")
                 await websocket.close(code=4003)
                 return

--- a/tests/test_runner_run.py
+++ b/tests/test_runner_run.py
@@ -10,13 +10,16 @@ import sys
 import types
 import unittest
 from contextlib import redirect_stdout
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+from starlette.testclient import WebSocketDisconnect
 
 from pipecat.runner.run import (
+    _extract_ws_token,
+    _generate_ws_token,
     _print_startup_message,
     _setup_daily_routes,
     _setup_telephony_routes,
@@ -25,6 +28,7 @@ from pipecat.runner.run import (
     _setup_websocket_routes,
     _transport_route_dependencies,
     _transport_routes_enabled,
+    _verify_and_consume_ws_token,
 )
 
 
@@ -134,7 +138,7 @@ class TestRunnerRun(unittest.TestCase):
         args = argparse.Namespace()
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=False):
-            _setup_websocket_routes(app, args)
+            _setup_websocket_routes(app, args, set())
 
         paths = {route.path for route in app.routes}
         self.assertNotIn("/ws-client", paths)
@@ -145,7 +149,7 @@ class TestRunnerRun(unittest.TestCase):
         args = argparse.Namespace()
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
-            _setup_websocket_routes(app, args)
+            _setup_websocket_routes(app, args, set())
 
         paths = {route.path for route in app.routes}
         self.assertIn("/ws-client", paths)
@@ -156,7 +160,7 @@ class TestRunnerRun(unittest.TestCase):
         args = argparse.Namespace(transport=None)
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=False):
-            _setup_telephony_routes(app, args)
+            _setup_telephony_routes(app, args, set())
 
         paths = {route.path for route in app.routes}
         self.assertNotIn("/ws", paths)
@@ -167,7 +171,7 @@ class TestRunnerRun(unittest.TestCase):
         args = argparse.Namespace(transport=None)
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
-            _setup_telephony_routes(app, args)
+            _setup_telephony_routes(app, args, set())
 
         paths = {route.path for route in app.routes}
         self.assertIn("/ws", paths)
@@ -178,7 +182,7 @@ class TestRunnerRun(unittest.TestCase):
         args = argparse.Namespace(transport="twilio", proxy="example.ngrok.io")
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
-            _setup_telephony_routes(app, args)
+            _setup_telephony_routes(app, args, set())
 
         post_root_routes = [
             route for route in app.routes if route.path == "/" and "POST" in route.methods
@@ -309,7 +313,11 @@ class TestRunnerRun(unittest.TestCase):
 
     def test_startup_message_telephony_keeps_provider_endpoint_details(self):
         args = argparse.Namespace(
-            transport="twilio", host="localhost", port=7860, proxy="example.ngrok.io"
+            transport="twilio",
+            host="localhost",
+            port=7860,
+            proxy="example.ngrok.io",
+            ws_auth="none",
         )
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
@@ -318,6 +326,261 @@ class TestRunnerRun(unittest.TestCase):
         self.assertIn("   → Open: http://localhost:7860\n", output)
         self.assertIn("   → XML webhook: http://localhost:7860/\n", output)
         self.assertIn("   → WebSocket:   ws://localhost:7860/ws\n", output)
+
+
+class TestWsAuthTokens(unittest.TestCase):
+    """Unit tests for the HMAC WebSocket session token helpers."""
+
+    # --- _generate_ws_token ---
+
+    def test_generate_token_has_two_parts(self):
+        token = _generate_ws_token()
+        parts = token.split(".")
+        self.assertEqual(len(parts), 2, "Token must be <payload>.<signature>")
+
+    def test_generate_token_is_unique(self):
+        self.assertNotEqual(_generate_ws_token(), _generate_ws_token())
+
+    # --- _verify_and_consume_ws_token ---
+
+    def test_validate_accepts_fresh_token(self):
+        token = _generate_ws_token()
+        self.assertTrue(_verify_and_consume_ws_token(set(), token))
+
+    def test_validate_consumes_token_on_success(self):
+        used: set[str] = set()
+        token = _generate_ws_token()
+        _verify_and_consume_ws_token(used, token)
+        self.assertIn(token, used)
+
+    def test_validate_rejects_replayed_token(self):
+        used: set[str] = set()
+        token = _generate_ws_token()
+        self.assertTrue(_verify_and_consume_ws_token(used, token))
+        self.assertFalse(_verify_and_consume_ws_token(used, token))
+
+    def test_validate_rejects_expired_token(self):
+        with patch("pipecat.runner.run.time") as mock_time:
+            mock_time.time.return_value = 1_000_000_000
+            token = _generate_ws_token(ttl=300)
+            mock_time.time.return_value = 1_000_000_000 + 301
+            self.assertFalse(_verify_and_consume_ws_token(set(), token))
+
+    def test_validate_rejects_tampered_signature(self):
+        token = _generate_ws_token()
+        payload, _ = token.rsplit(".", 1)
+        self.assertFalse(_verify_and_consume_ws_token(set(), f"{payload}.badsignature"))
+
+    def test_validate_rejects_tampered_payload(self):
+        import base64
+        import json
+
+        _, sig = _generate_ws_token().rsplit(".", 1)
+        bad_payload = (
+            base64.urlsafe_b64encode(json.dumps({"exp": 9_999_999_999}).encode())
+            .decode()
+            .rstrip("=")
+        )
+        self.assertFalse(_verify_and_consume_ws_token(set(), f"{bad_payload}.{sig}"))
+
+    def test_validate_rejects_malformed_token_no_dot(self):
+        self.assertFalse(_verify_and_consume_ws_token(set(), "nodothere"))
+
+    def test_validate_rejects_malformed_token_bad_base64(self):
+        self.assertFalse(_verify_and_consume_ws_token(set(), "!!!.invalidsig"))
+
+    # --- _extract_ws_token ---
+
+    def test_extract_reads_authorization_bearer_header(self):
+        ws = MagicMock()
+        ws.headers.get.return_value = "Bearer mytoken"
+        ws.query_params.get.return_value = None
+        self.assertEqual(_extract_ws_token(ws), "mytoken")
+
+    def test_extract_bearer_is_case_insensitive(self):
+        ws = MagicMock()
+        ws.headers.get.return_value = "BEARER mytoken"
+        ws.query_params.get.return_value = None
+        self.assertEqual(_extract_ws_token(ws), "mytoken")
+
+    def test_extract_falls_back_to_query_param(self):
+        ws = MagicMock()
+        ws.headers.get.return_value = ""
+        ws.query_params.get.return_value = "qptoken"
+        self.assertEqual(_extract_ws_token(ws), "qptoken")
+
+    def test_extract_prefers_header_over_query_param(self):
+        ws = MagicMock()
+        ws.headers.get.return_value = "Bearer headertoken"
+        ws.query_params.get.return_value = "qptoken"
+        self.assertEqual(_extract_ws_token(ws), "headertoken")
+
+    def test_extract_returns_none_when_absent(self):
+        ws = MagicMock()
+        ws.headers.get.return_value = ""
+        ws.query_params.get.return_value = None
+        self.assertIsNone(_extract_ws_token(ws))
+
+
+class TestWsAuthRouteRegistration(unittest.TestCase):
+    """Route registration tests for path-token WebSocket variants."""
+
+    def test_websocket_routes_register_path_token_route(self):
+        app = FastAPI()
+        args = argparse.Namespace(ws_auth="token")
+
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_websocket_routes(app, args, set())
+
+        paths = {route.path for route in app.routes}
+        self.assertIn("/ws-client", paths)
+        self.assertIn("/ws-client/{token}", paths)
+
+    def test_telephony_routes_register_path_token_route(self):
+        app = FastAPI()
+        args = argparse.Namespace(transport=None, ws_auth="token")
+
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_telephony_routes(app, args, set())
+
+        paths = {route.path for route in app.routes}
+        self.assertIn("/ws", paths)
+        self.assertIn("/ws/{token}", paths)
+
+
+class TestWsAuthStartEndpoint(unittest.TestCase):
+    """Tests for /start returning HMAC tokens when ws_auth='token'."""
+
+    def _make_app(self, ws_auth: str) -> FastAPI:
+        app = FastAPI()
+        args = argparse.Namespace(
+            transport=None,
+            ws_auth=ws_auth,
+            host="localhost",
+            port=7860,
+        )
+        _setup_unified_start_route(app, args, {})
+        return app
+
+    def test_start_websocket_returns_none_when_auth_disabled(self):
+        app = self._make_app(ws_auth="none")
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            response = TestClient(app).post("/start", json={"transport": "websocket"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json().get("token"))
+
+    def test_start_websocket_returns_real_token_when_auth_enabled(self):
+        app = self._make_app(ws_auth="token")
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            response = TestClient(app).post("/start", json={"transport": "websocket"})
+        self.assertEqual(response.status_code, 200)
+        token = response.json()["token"]
+        self.assertNotEqual(token, None)
+        # Token must be a valid, fresh HMAC token
+        self.assertTrue(_verify_and_consume_ws_token(set(), token))
+
+    def test_start_telephony_omits_token_when_auth_disabled(self):
+        app = self._make_app(ws_auth="none")
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            response = TestClient(app).post("/start", json={"transport": "twilio"})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("token", response.json())
+
+    def test_start_telephony_returns_token_when_auth_enabled(self):
+        app = self._make_app(ws_auth="token")
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            response = TestClient(app).post("/start", json={"transport": "twilio"})
+        self.assertEqual(response.status_code, 200)
+        token = response.json().get("token")
+        self.assertIsNotNone(token)
+        self.assertTrue(_verify_and_consume_ws_token(set(), token))
+
+
+class TestWsAuthConnectionBehavior(unittest.TestCase):
+    """WebSocket connection tests verifying auth enforcement at the ASGI layer."""
+
+    def _make_ws_client_app(self, ws_auth: str) -> tuple[FastAPI, set]:
+        app = FastAPI()
+        args = argparse.Namespace(ws_auth=ws_auth)
+        used: set[str] = set()
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_websocket_routes(app, args, used)
+        return app, used
+
+    def _make_telephony_app(self, ws_auth: str) -> tuple[FastAPI, set]:
+        app = FastAPI()
+        args = argparse.Namespace(ws_auth=ws_auth, transport=None)
+        used: set[str] = set()
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_telephony_routes(app, args, used)
+        return app, used
+
+    # /ws-client (plain WebSocket)
+
+    def test_plain_ws_rejects_without_token_when_auth_enabled(self):
+        app, _ = self._make_ws_client_app(ws_auth="token")
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect("/ws-client"):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_plain_ws_rejects_invalid_token_in_query_param(self):
+        app, _ = self._make_ws_client_app(ws_auth="token")
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect("/ws-client?token=badtoken"):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_plain_ws_accepts_valid_token_in_query_param(self):
+        app, _ = self._make_ws_client_app(ws_auth="token")
+        token = _generate_ws_token()
+        with patch("pipecat.runner.run._run_websocket_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(f"/ws-client?token={token}"):
+                pass  # connection accepted; bot mock returns immediately
+
+    def test_plain_ws_accepts_valid_token_in_path(self):
+        app, _ = self._make_ws_client_app(ws_auth="token")
+        token = _generate_ws_token()
+        with patch("pipecat.runner.run._run_websocket_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(f"/ws-client/{token}"):
+                pass
+
+    def test_plain_ws_rejects_replayed_token(self):
+        app, used = self._make_ws_client_app(ws_auth="token")
+        token = _generate_ws_token()
+        used.add(token)  # mark already consumed
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect(f"/ws-client?token={token}"):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_plain_ws_allows_any_connection_when_auth_disabled(self):
+        app, _ = self._make_ws_client_app(ws_auth="none")
+        with patch("pipecat.runner.run._run_websocket_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect("/ws-client"):
+                pass
+
+    # /ws (telephony WebSocket)
+
+    def test_telephony_ws_rejects_without_token_when_auth_enabled(self):
+        app, _ = self._make_telephony_app(ws_auth="token")
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect("/ws"):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_telephony_ws_accepts_valid_token_in_path(self):
+        app, _ = self._make_telephony_app(ws_auth="token")
+        token = _generate_ws_token()
+        with patch("pipecat.runner.run._run_telephony_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(f"/ws/{token}"):
+                pass
+
+    def test_telephony_ws_allows_any_connection_when_auth_disabled(self):
+        app, _ = self._make_telephony_app(ws_auth="none")
+        with patch("pipecat.runner.run._run_telephony_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect("/ws"):
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

  - Added optional HMAC token authentication for WebSocket connections in the development runner, mirroring the `websocket_auth ="token"` setting in Pipecat Cloud
  - When enabled, clients must call `POST /start` to obtain a short-lived signed session token before connecting — no bot resources are allocated until the connection is authenticated
  - Tokens are HMAC-SHA256 signed, one-time use, and expire after 5 minutes
  - Both the telephony WebSocket (`/ws`) and plain WebSocket (`/ws-client`) endpoints are protected; new path-segment routes (`/ws/{token}`, `/ws-client/{token}`) support telephony providers like Twilio that can't send custom headers
  
  ## Configuration

  Enable via environment variable (in `.env`):
  PIPECAT_WEBSOCKET_AUTH=token

  Or via CLI flag:
  python bot.py -t websocket --ws-auth token
  python bot.py -t twilio --ws-auth token

  When enabled, `POST /start` returns a `token` alongside `wsUrl`. Clients attach it as:
  - `Authorization: Bearer <token>` header
  - `?token=<token>` query parameter
  - `/<token>` URL path segment (recommended for telephony providers)

  Invalid, expired, or replayed tokens are rejected with WebSocket close code `4003`