### PR TITLE
fix interruption handling for TTSSpeakFrame utterances

### DIFF
--- a/changelog/4663.fixed.md
+++ b/changelog/4663.fixed.md
@@ -1,0 +1,7 @@
+- Fixed interruption handling for standalone `TTSSpeakFrame(append_to_context=True)` utterances (those not part of an LLM response). Previously, when the user interrupted such an utterance:
+  - `on_assistant_turn_stopped` didn't fire
+  - partially-spoken text wasn't recorded to the context (for TTS services that support word timestamps)
+
+  The problem was that these utterances have no `LLMFullResponseStartFrame` to open the assistant turn, so there was no open turn for the interruption to stop. The assistant aggregator now uses a new `TTSStartedFrame.append_to_context` to open the turn when the utterance begins.
+
+  As a result of this fix, `on_assistant_turn_started` timing is improved for standalone `TTSSpeakFrame` utterances: the event now fires at the start rather than at the end.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1878,9 +1878,13 @@ class TTSStartedFrame(ControlFrame):
 
     Parameters:
         context_id: Unique identifier for this TTS context.
+        append_to_context: Whether the spoken text for this response will be
+            appended to the LLM context. Mirrors the value carried by the
+            response's TTSTextFrames.
     """
 
     context_id: str | None = None
+    append_to_context: bool = True
 
 
 @dataclass

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -61,6 +61,7 @@ from pipecat.frames.frames import (
     TextFrame,
     TranscriptionFrame,
     TranslationFrame,
+    TTSStartedFrame,
     UserImageRawFrame,
     UserMuteStartedFrame,
     UserMuteStoppedFrame,
@@ -1453,6 +1454,9 @@ class LLMAssistantAggregator(LLMContextAggregator):
             await self.push_frame(frame, direction)
         elif isinstance(frame, LLMAssistantPushAggregationFrame):
             await self._handle_push_aggregation()
+        elif isinstance(frame, TTSStartedFrame):
+            await self._handle_tts_started(frame)
+            await self.push_frame(frame, direction)
         elif isinstance(frame, LLMFullResponseStartFrame):
             await self._handle_llm_start(frame)
         elif isinstance(frame, LLMFullResponseEndFrame):
@@ -1866,15 +1870,17 @@ class LLMAssistantAggregator(LLMContextAggregator):
             await self._paired_user_aggregator._realtime_handoff_flush_immediate()
         await self._trigger_assistant_turn_stopped()
 
-    async def _handle_push_aggregation(self):
-        # LLMAssistantPushAggregationFrame is emitted by TTSService at the end
-        # of a TTSSpeakFrame-driven utterance (no surrounding LLM response
-        # cycle), so no LLMFullResponseStartFrame ever set the turn-start
-        # timestamp. Open a turn now so on_assistant_turn_stopped fires for the
-        # greeting text the same way it did before LLMAssistantPushAggregationFrame
-        # was introduced.
-        if not self._assistant_turn_start_timestamp:
+    async def _handle_tts_started(self, frame: TTSStartedFrame):
+        # If this TTS output will be written to context and we don't already have an
+        # open assistant turn, open one. This handles the case of TTSSpeakFrame-driven
+        # utterances that have no surrounding LLM response frames to signal assistant
+        # turn boundaries, while rightly deferring to any earlier LLM-driven turn start.
+        if frame.append_to_context and not self._assistant_turn_start_timestamp:
             await self._trigger_assistant_turn_started()
+
+    async def _handle_push_aggregation(self):
+        # LLMAssistantPushAggregationFrame is emitted at the end of
+        # a TTSSpeakFrame-driven utterance to commit the spoken text.
         await self._trigger_assistant_turn_stopped()
 
     async def _handle_text(self, frame: TextFrame):

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -555,12 +555,7 @@ class NvidiaTTSService(TTSService):
             if not self.audio_context_available(context_id):
                 await self.create_audio_context(context_id)
                 await self.start_ttfb_metrics()
-                started_frame = TTSStartedFrame(context_id=context_id)
-                # Mirror append_to_context from the context (set by the base class).
-                tts_context = self._tts_contexts.get(context_id)
-                if tts_context is not None:
-                    started_frame.append_to_context = tts_context.append_to_context
-                yield started_frame
+                yield TTSStartedFrame(context_id=context_id)
                 self._start_synthesis_stream(context_id)
                 logger.trace(f"{self}: Started synthesis stream for context {context_id}")
 

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -556,10 +556,7 @@ class NvidiaTTSService(TTSService):
                 await self.create_audio_context(context_id)
                 await self.start_ttfb_metrics()
                 started_frame = TTSStartedFrame(context_id=context_id)
-                # Mirror append_to_context from the context (set by the base class)
-                # so the assistant aggregator opens a turn only when the spoken
-                # text will be written to context — matching the base-class
-                # TTSStartedFrame path used by push_start_frame=True services.
+                # Mirror append_to_context from the context (set by the base class).
                 tts_context = self._tts_contexts.get(context_id)
                 if tts_context is not None:
                     started_frame.append_to_context = tts_context.append_to_context

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -555,7 +555,15 @@ class NvidiaTTSService(TTSService):
             if not self.audio_context_available(context_id):
                 await self.create_audio_context(context_id)
                 await self.start_ttfb_metrics()
-                yield TTSStartedFrame(context_id=context_id)
+                started_frame = TTSStartedFrame(context_id=context_id)
+                # Mirror append_to_context from the context (set by the base class)
+                # so the assistant aggregator opens a turn only when the spoken
+                # text will be written to context — matching the base-class
+                # TTSStartedFrame path used by push_start_frame=True services.
+                tts_context = self._tts_contexts.get(context_id)
+                if tts_context is not None:
+                    started_frame.append_to_context = tts_context.append_to_context
+                yield started_frame
                 self._start_synthesis_stream(context_id)
                 logger.trace(f"{self}: Started synthesis stream for context {context_id}")
 

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -988,7 +988,7 @@ class TTSService(AIService):
         self,
         src_frame: AggregatedTextFrame,
         includes_inter_frame_spaces: bool | None = False,
-        append_tts_text_to_context: bool | None = True,
+        append_tts_text_to_context: bool = True,
         push_assistant_aggregation: bool | None = False,
     ):
         type = src_frame.aggregated_by
@@ -1078,9 +1078,7 @@ class TTSService(AIService):
                 transformed_text = await transform(transformed_text, type)
 
         self._tts_contexts[context_id] = TTSContext(
-            append_to_context=append_tts_text_to_context
-            if append_tts_text_to_context is not None
-            else True,
+            append_to_context=append_tts_text_to_context,
             push_assistant_aggregation=push_assistant_aggregation,
         )
 
@@ -1096,9 +1094,7 @@ class TTSService(AIService):
             started_frame = TTSStartedFrame(context_id=context_id)
             # Carry append_to_context so the assistant aggregator can open a turn
             # for TTSSpeakFrame utterances (which have no LLMFullResponseStartFrame).
-            # Only override append_to_context if explicitly set.
-            if append_tts_text_to_context is not None:
-                started_frame.append_to_context = append_tts_text_to_context
+            started_frame.append_to_context = append_tts_text_to_context
             await self.append_to_audio_context(context_id, started_frame)
 
         # Register this spoken frame so the sequencer can track its completion
@@ -1132,9 +1128,7 @@ class TTSService(AIService):
             frame = TTSTextFrame(text, aggregated_by=type)
             frame.includes_inter_frame_spaces = includes_inter_frame_spaces
             frame.context_id = context_id
-            # Only override append_to_context if explicitly set
-            if append_tts_text_to_context is not None:
-                frame.append_to_context = append_tts_text_to_context
+            frame.append_to_context = append_tts_text_to_context
             # Appending to the context, so it preserves the ordering.
             await self.append_to_audio_context(context_id, frame)
             # TTSTextFrame is queued; mark the spoken slot complete so any skipped

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1093,7 +1093,13 @@ class TTSService(AIService):
         if self._push_start_frame and not self.audio_context_available(context_id):
             await self.create_audio_context(context_id)
             await self.start_ttfb_metrics()
-            await self.append_to_audio_context(context_id, TTSStartedFrame(context_id=context_id))
+            started_frame = TTSStartedFrame(context_id=context_id)
+            # Carry append_to_context so the assistant aggregator can open a turn
+            # for TTSSpeakFrame utterances (which have no LLMFullResponseStartFrame).
+            # Only override append_to_context if explicitly set.
+            if append_tts_text_to_context is not None:
+                started_frame.append_to_context = append_tts_text_to_context
+            await self.append_to_audio_context(context_id, started_frame)
 
         # Register this spoken frame so the sequencer can track its completion
         # and unblock any skipped frames queued behind it. Word-timestamp services

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1091,11 +1091,9 @@ class TTSService(AIService):
         if self._push_start_frame and not self.audio_context_available(context_id):
             await self.create_audio_context(context_id)
             await self.start_ttfb_metrics()
-            started_frame = TTSStartedFrame(context_id=context_id)
-            # Carry append_to_context so the assistant aggregator can open a turn
-            # for TTSSpeakFrame utterances (which have no LLMFullResponseStartFrame).
-            started_frame.append_to_context = append_tts_text_to_context
-            await self.append_to_audio_context(context_id, started_frame)
+            # append_to_context is stamped centrally in _handle_audio_context, where
+            # every TTSStartedFrame (base-class- and subclass-emitted) funnels through.
+            await self.append_to_audio_context(context_id, TTSStartedFrame(context_id=context_id))
 
         # Register this spoken frame so the sequencer can track its completion
         # and unblock any skipped frames queued behind it. Word-timestamp services
@@ -1514,6 +1512,14 @@ class TTSService(AIService):
                 if frame:
                     if isinstance(frame, TTSStartedFrame):
                         should_push_stop_frame = self._push_stop_frames
+                        # Stamp append_to_context from the TTS context (the source of
+                        # truth) onto every TTSStartedFrame here — the single point
+                        # both base-class- and subclass-emitted started frames pass
+                        # through. The assistant aggregator uses it to open a turn for
+                        # TTSSpeakFrame utterances (which lack an LLMFullResponseStartFrame).
+                        tts_context = self._tts_contexts.get(context_id)
+                        if tts_context is not None:
+                            frame.append_to_context = tts_context.append_to_context
                     elif isinstance(frame, TTSStoppedFrame):
                         # Checking if we have any remaining spoken slots before pushing the TTSStoppedFrame
                         await self._apply_force_complete()

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1091,8 +1091,9 @@ class TTSService(AIService):
         if self._push_start_frame and not self.audio_context_available(context_id):
             await self.create_audio_context(context_id)
             await self.start_ttfb_metrics()
-            # append_to_context is stamped centrally in _handle_audio_context, where
-            # every TTSStartedFrame (base-class- and subclass-emitted) funnels through.
+            # Note: TTSStartedFrame's append_to_context is stamped in
+            # _handle_audio_context, where every TTSStartedFrame
+            # (base-class- and subclass-emitted) funnels through.
             await self.append_to_audio_context(context_id, TTSStartedFrame(context_id=context_id))
 
         # Register this spoken frame so the sequencer can track its completion
@@ -1512,11 +1513,10 @@ class TTSService(AIService):
                 if frame:
                     if isinstance(frame, TTSStartedFrame):
                         should_push_stop_frame = self._push_stop_frames
-                        # Stamp append_to_context from the TTS context (the source of
-                        # truth) onto every TTSStartedFrame here — the single point
-                        # both base-class- and subclass-emitted started frames pass
-                        # through. The assistant aggregator uses it to open a turn for
-                        # TTSSpeakFrame utterances (which lack an LLMFullResponseStartFrame).
+                        # Stamp appropriate append_to_context value onto every
+                        # TTSStartedFrame here — the single point both
+                        # base-class- and subclass-emitted started frames pass
+                        # through.
                         tts_context = self._tts_contexts.get(context_id)
                         if tts_context is not None:
                             frame.append_to_context = tts_context.append_to_context

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -39,6 +39,7 @@ from pipecat.frames.frames import (
     TextFrame,
     TranscriptionFrame,
     TranslationFrame,
+    TTSStartedFrame,
     TTSTextFrame,
     UserMuteStartedFrame,
     UserStartedSpeakingFrame,
@@ -1194,12 +1195,13 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(stop_messages), 1)
         self.assertEqual(stop_messages[0].content, "Hello from Pipecat!")
 
-    async def test_push_aggregation_fires_turn_stopped_for_tts_speak(self):
-        """LLMAssistantPushAggregationFrame must fire on_assistant_turn_stopped.
+    async def test_tts_speak_fires_turn_started_and_stopped(self):
+        """A TTSSpeakFrame(append_to_context=True) utterance must fire both turn events.
 
-        Mirrors the TTSSpeakFrame(append_to_context=True) greeting flow: TTS-driven
-        TTSTextFrames accumulate without an LLMFullResponseStartFrame, then the
-        TTS service emits LLMAssistantPushAggregationFrame to commit them.
+        Mirrors the TTSSpeakFrame greeting flow with a word-timestamp TTS service:
+        a TTSStartedFrame opens the turn (no surrounding LLMFullResponseStartFrame),
+        word-level TTSTextFrames accumulate, then the TTS service emits
+        LLMAssistantPushAggregationFrame to commit them and stop the turn.
         """
         context = LLMContext()
         aggregator = LLMAssistantAggregator(context)
@@ -1217,12 +1219,17 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
             stop_messages.append(message)
 
         frames_to_send = [
+            TTSStartedFrame(append_to_context=True),
             TTSTextFrame("Hello,", aggregated_by=AggregationType.WORD),
             TTSTextFrame("how", aggregated_by=AggregationType.WORD),
             TTSTextFrame("can I help?", aggregated_by=AggregationType.WORD),
             LLMAssistantPushAggregationFrame(),
         ]
-        expected_down_frames = [LLMContextFrame, LLMContextAssistantTimestampFrame]
+        expected_down_frames = [
+            TTSStartedFrame,
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+        ]
         await run_test(
             aggregator,
             frames_to_send=frames_to_send,
@@ -1236,6 +1243,129 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
             context.messages[-1],
             {"role": "assistant", "content": "Hello, how can I help?"},
         )
+
+    async def test_tts_speak_interruption_records_partial_text(self):
+        """Interrupting a TTSSpeakFrame utterance records the partially-spoken text.
+
+        The TTSStartedFrame opens the turn, so a mid-utterance interruption finds an
+        open turn: the words spoken so far are written to context and
+        on_assistant_turn_stopped fires with interrupted=True. (No
+        LLMAssistantPushAggregationFrame arrives — the interruption cancels the
+        utterance before the TTS service commits it.)
+        """
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        start_count = 0
+        stop_messages = []
+
+        @aggregator.event_handler("on_assistant_turn_started")
+        async def on_assistant_turn_started(aggregator):
+            nonlocal start_count
+            start_count += 1
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            stop_messages.append(message)
+
+        frames_to_send = [
+            TTSStartedFrame(append_to_context=True),
+            TTSTextFrame("Let me", aggregated_by=AggregationType.WORD),
+            TTSTextFrame("check on", aggregated_by=AggregationType.WORD),
+            SleepFrame(),
+            InterruptionFrame(),
+        ]
+        expected_down_frames = [
+            TTSStartedFrame,
+            LLMContextFrame,
+            LLMContextAssistantTimestampFrame,
+            InterruptionFrame,
+        ]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+        self.assertEqual(start_count, 1)
+        self.assertEqual(len(stop_messages), 1)
+        self.assertTrue(stop_messages[0].interrupted)
+        self.assertEqual(stop_messages[0].content, "Let me check on")
+        self.assertEqual(
+            context.messages[-1],
+            {"role": "assistant", "content": "Let me check on"},
+        )
+
+    async def test_tts_started_append_to_context_false_does_not_open_turn(self):
+        """A TTSStartedFrame(append_to_context=False) utterance must not open a turn.
+
+        When the spoken text won't be written to context, neither
+        on_assistant_turn_started nor on_assistant_turn_stopped should fire, and a
+        following interruption must find no open turn.
+        """
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        start_count = 0
+        stop_count = 0
+
+        @aggregator.event_handler("on_assistant_turn_started")
+        async def on_assistant_turn_started(aggregator):
+            nonlocal start_count
+            start_count += 1
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            nonlocal stop_count
+            stop_count += 1
+
+        frames_to_send = [
+            TTSStartedFrame(append_to_context=False),
+            TTSTextFrame("off the record", aggregated_by=AggregationType.WORD),
+            SleepFrame(),
+            InterruptionFrame(),
+        ]
+        expected_down_frames = [TTSStartedFrame, InterruptionFrame]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+        self.assertEqual(start_count, 0)
+        self.assertEqual(stop_count, 0)
+        self.assertEqual(len(context.messages), 0)
+
+    async def test_tts_started_does_not_double_open_during_llm_response(self):
+        """A TTSStartedFrame during an LLM response must not re-open the turn.
+
+        LLMFullResponseStartFrame is the earlier signal and already opened the turn,
+        so the response's TTSStartedFrame is a no-op: on_assistant_turn_started fires
+        exactly once.
+        """
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        start_count = 0
+        stop_messages = []
+
+        @aggregator.event_handler("on_assistant_turn_started")
+        async def on_assistant_turn_started(aggregator):
+            nonlocal start_count
+            start_count += 1
+
+        @aggregator.event_handler("on_assistant_turn_stopped")
+        async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+            stop_messages.append(message)
+
+        frames_to_send = [
+            LLMFullResponseStartFrame(),
+            TTSStartedFrame(append_to_context=True),
+            TTSTextFrame("Hello!", aggregated_by=AggregationType.WORD),
+            LLMFullResponseEndFrame(),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send)
+        self.assertEqual(start_count, 1)
+        self.assertEqual(len(stop_messages), 1)
+        self.assertEqual(stop_messages[0].content, "Hello!")
 
     async def test_push_aggregation_does_not_double_fire_in_llm_response(self):
         """LLMAssistantPushAggregationFrame mid-response must not double-fire turn events.

--- a/tests/test_tts_frame_ordering.py
+++ b/tests/test_tts_frame_ordering.py
@@ -122,6 +122,38 @@ class MockHttpTTSService(TTSService):
         )
 
 
+class MockSelfStartHttpTTSService(TTSService):
+    """Simulates a service that emits its own TTSStartedFrame (push_start_frame=False).
+
+    Mirrors the websocket TTS services (and NvidiaTTSService) that create the audio
+    context and yield TTSStartedFrame from run_tts rather than letting the base class
+    do it. Used to verify append_to_context is stamped centrally for this path too.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            push_start_frame=False,
+            push_stop_frames=True,
+            push_text_frames=False,
+            sample_rate=_SAMPLE_RATE,
+            **kwargs,
+        )
+
+    def can_generate_metrics(self) -> bool:
+        return False
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        if not self.audio_context_available(context_id):
+            await self.create_audio_context(context_id)
+            yield TTSStartedFrame(context_id=context_id)
+        yield TTSAudioRawFrame(
+            audio=_FAKE_AUDIO,
+            sample_rate=_SAMPLE_RATE,
+            num_channels=1,
+            context_id=context_id,
+        )
+
+
 class MockHttpPushTextTTSService(TTSService):
     """Simulates an HTTP TTS service with push_text_frames=True.
 
@@ -1596,6 +1628,32 @@ async def test_cjk_two_sentences_no_extra_spaces_in_assembled_context():
         f"  Expected: {expected!r}\n"
         f"  Got:      {assembled!r}"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("append_to_context", [True, False])
+@pytest.mark.parametrize(
+    "service_factory",
+    [MockHttpTTSService, MockSelfStartHttpTTSService],
+    ids=["base_class_start_frame", "self_yielded_start_frame"],
+)
+async def test_tts_started_carries_append_to_context(service_factory, append_to_context):
+    """TTSStartedFrame must carry the utterance's append_to_context.
+
+    The assistant aggregator reads TTSStartedFrame.append_to_context to decide whether
+    to open an assistant turn for TTSSpeakFrame utterances. This must hold whether the
+    base class emits the TTSStartedFrame (push_start_frame=True) or the service yields
+    its own (push_start_frame=False), since both are stamped centrally from the TTS
+    context in _handle_audio_context.
+    """
+    tts = service_factory()
+    frames_received = await run_test(
+        tts,
+        frames_to_send=[TTSSpeakFrame(text="hello world", append_to_context=append_to_context)],
+    )
+    started = [f for f in frames_received[0] if isinstance(f, TTSStartedFrame)]
+    assert len(started) == 1, f"Expected exactly one TTSStartedFrame, got {len(started)}"
+    assert started[0].append_to_context is append_to_context
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Fixed interruption handling for standalone `TTSSpeakFrame(append_to_context=True)` utterances (those not part of an LLM response — e.g. an intro/greeting spoken before the user's first turn). Previously, when the user interrupted such an utterance:

- `on_assistant_turn_stopped` didn't fire
- partially-spoken text wasn't recorded to the context (for TTS services that support word timestamps)

The problem was that these utterances have no `LLMFullResponseStartFrame` to open the assistant turn, so there was no open turn for the interruption to stop. (`LLMAssistantAggregator` tracks the open-turn state via `_assistant_turn_start_timestamp`, which is set on `LLMFullResponseStartFrame`.)

## Fix

The assistant aggregator now uses a new `TTSStartedFrame.append_to_context` to open the turn when the utterance begins:

- `TTSStartedFrame` carries `append_to_context`, stamped centrally in `TTSService._handle_audio_context` — the single point every started frame funnels through, whether the base class emits it (`push_start_frame=True`) or a service yields its own from `run_tts` (`push_start_frame=False`: `NvidiaTTSService` and the websocket services Inworld/Rime/ElevenLabs/ResembleAI). The TTS context is the source of truth for the value.
- On a `TTSStartedFrame(append_to_context=True)` with no turn already open, the aggregator opens the turn. An in-progress LLM turn (`LLMFullResponseStartFrame`) still takes precedence, as it's the earlier signal.
- This replaces the just-in-time `_trigger_assistant_turn_started` workaround in `_handle_push_aggregation` from #4414.

As a result of this fix, `on_assistant_turn_started` timing is improved for standalone `TTSSpeakFrame` utterances: the event now fires at the start of the utterance rather than at the end.

## Tests

- Reframed the existing push-aggregation test to the real frame sequence (`TTSStartedFrame` opens the turn).
- Aggregator cases: turn opens on `TTSStartedFrame`; interruption records partial text with `interrupted=True`; `append_to_context=False` doesn't open a turn; `TTSStartedFrame` during an LLM response doesn't double-fire `on_assistant_turn_started`.
- TTS-service case: a `TTSSpeakFrame`'s `append_to_context` reaches the emitted `TTSStartedFrame` for both the base-class and self-yielded paths (True and False).

Validated manually against word-timestamp (Cartesia) and all-or-nothing (OpenAI) TTS services across the intro-speech and function-call-filler scenarios, uninterrupted and interrupted.

## Follow-up cleanup

A separate commit (`refactor: drop dead None-handling for append_tts_text_to_context`) removes dead code surfaced while doing the above: `_push_tts_frames` is private and `append_tts_text_to_context` is never `None` at any call site, so its `bool | None` annotation and the `is not None` branches that guarded the impossible case are dropped. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)