### PR TITLE
Point install instructions at `uv add` instead of `pip install`

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -179,7 +179,7 @@ description: "Brief description"
 ## Installation
 
 ```bash
-pip install "pipecat-ai[package-name]"
+uv add "pipecat-ai[package-name]"
 ```
 
 ## Prerequisites
@@ -248,7 +248,7 @@ Add a new row to the correct category table in `DOCS_PATH/server/services/suppor
 
 Use this format:
 ```
-| [DisplayName](/server/services/{category}/{provider}) | `pip install "pipecat-ai[package]"` |
+| [DisplayName](/server/services/{category}/{provider}) | `uv add "pipecat-ai[package]"` |
 ```
 
 To determine the correct values:

--- a/examples/multi-worker/code-assistant/code_worker.py
+++ b/examples/multi-worker/code-assistant/code_worker.py
@@ -18,7 +18,7 @@ try:
     from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use CodeWorker, you need to `pip install claude-agent-sdk`.")
+    logger.error("In order to use CodeWorker, you need to `uv add claude-agent-sdk`.")
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/examples/multi-worker/distributed-handoff/pgmq-handoff/README.md
+++ b/examples/multi-worker/distributed-handoff/pgmq-handoff/README.md
@@ -1,6 +1,6 @@
 # pgmq-handoff
 
-Same shape as the [Redis handoff](../redis-handoff/), but the bus is backed by [PGMQ](https://github.com/tembo-io/pgmq) on a shared Postgres database (e.g. Supabase). Requires `pip install pipecat-ai[pgmq]`.
+Same shape as the [Redis handoff](../redis-handoff/), but the bus is backed by [PGMQ](https://github.com/tembo-io/pgmq) on a shared Postgres database (e.g. Supabase). Requires `uv add "pipecat-ai[pgmq]"`.
 
 See the [top-level multi-worker README](../../README.md) for shared environment variables.
 

--- a/examples/multi-worker/distributed-handoff/redis-handoff/README.md
+++ b/examples/multi-worker/distributed-handoff/redis-handoff/README.md
@@ -1,6 +1,6 @@
 # redis-handoff
 
-Same two-worker handoff as [`local-handoff`](../../local-handoff/), but each worker runs as a separate process connected via Redis pub/sub. Requires `pip install pipecat-ai[redis]`.
+Same two-worker handoff as [`local-handoff`](../../local-handoff/), but each worker runs as a separate process connected via Redis pub/sub. Requires `uv add "pipecat-ai[redis]"`.
 
 See the [top-level multi-worker README](../../README.md) for shared environment variables.
 

--- a/examples/realtime/realtime-grok.py
+++ b/examples/realtime/realtime-grok.py
@@ -18,7 +18,7 @@ voice conversations. The Grok Voice Agent provides:
 
 Requirements:
     - XAI_API_KEY environment variable set
-    - pip install pipecat-ai[grok]
+    - uv add "pipecat-ai[grok]"
 
 Usage:
     python 50-grok-realtime.py --transport webrtc

--- a/examples/realtime/realtime-inworld.py
+++ b/examples/realtime/realtime-inworld.py
@@ -20,7 +20,7 @@ Features:
 
 Requirements:
     - INWORLD_API_KEY environment variable set
-    - pip install pipecat-ai[inworld]
+    - uv add "pipecat-ai[inworld]"
 
 Usage:
     python realtime-inworld.py --transport webrtc

--- a/examples/voice/voice-aws-strands.py
+++ b/examples/voice/voice-aws-strands.py
@@ -32,7 +32,7 @@ try:
     from strands import Agent, tool
     from strands.models import BedrockModel
 except ImportError:
-    logger.warning("Strands not installed. Please install with: pip install strands-agents")
+    logger.warning("Strands not installed. Please install with: uv add strands-agents")
     Agent = None
     BedrockModel = None
 

--- a/scripts/krisp/test_krisp_viva_filter_audiofile.py
+++ b/scripts/krisp/test_krisp_viva_filter_audiofile.py
@@ -9,7 +9,7 @@ Usage:
     python test_krisp_viva_filter_audiofile.py input.wav output.wav --level 80
 
 Requirements:
-    pip install soundfile numpy pipecat-ai[krisp]
+    uv add soundfile numpy "pipecat-ai[krisp]"
     Set KRISP_VIVA_FILTER_MODEL_PATH environment variable to point to your .kef model file
 """
 
@@ -26,7 +26,7 @@ try:
     from audio_file_utils import calculate_audio_stats, read_audio_file, write_audio_file
 except ImportError as e:
     print(f"Error: Missing required dependencies: {e}")
-    print("Install with: pip install soundfile numpy")
+    print("Install with: uv add soundfile numpy")
     sys.exit(1)
 
 # Add src directory to Python path for development environment
@@ -42,7 +42,7 @@ try:
     from pipecat.audio.krisp_instance import KRISP_SAMPLE_RATES
 except ImportError as e:
     print(f"Error: Could not import Krisp VIVA filter: {e}")
-    print("Make sure pipecat-ai is installed: pip install pipecat-ai[krisp]")
+    print('Make sure pipecat-ai is installed: uv add "pipecat-ai[krisp]"')
     sys.exit(1)
 
 

--- a/scripts/krisp/test_krisp_viva_turn_audiofile.py
+++ b/scripts/krisp/test_krisp_viva_turn_audiofile.py
@@ -10,7 +10,7 @@ Usage:
     python test_krisp_viva_turn_audiofile.py input.wav --frame-duration 20
 
 Requirements:
-    pip install soundfile numpy pipecat-ai[krisp]
+    uv add soundfile numpy "pipecat-ai[krisp]"
     Set KRISP_VIVA_TURN_MODEL_PATH environment variable to point to your .kef model file
 """
 
@@ -27,7 +27,7 @@ try:
     from audio_file_utils import read_audio_file
 except ImportError as e:
     print(f"Error: Missing required dependencies: {e}")
-    print("Install with: pip install soundfile numpy")
+    print("Install with: uv add soundfile numpy")
     sys.exit(1)
 
 # Add src directory to Python path for development environment
@@ -43,7 +43,7 @@ try:
     from pipecat.audio.turn.krisp_viva_turn import KrispTurnParams, KrispVivaTurn
 except ImportError as e:
     print(f"Error: Could not import Krisp VIVA turn analyzer: {e}")
-    print("Make sure pipecat-ai is installed: pip install pipecat-ai[krisp]")
+    print('Make sure pipecat-ai is installed: uv add "pipecat-ai[krisp]"')
     sys.exit(1)
 
 

--- a/src/pipecat/adapters/services/gemini_adapter.py
+++ b/src/pipecat/adapters/services/gemini_adapter.py
@@ -27,7 +27,7 @@ try:
     from google.genai.types import Blob, Content, FileData, FunctionCall, FunctionResponse, Part
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Google AI, you need to `pip install pipecat-ai[google]`.")
+    logger.error('In order to use Google AI, you need to `uv add "pipecat-ai[google]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/audio/filters/koala_filter.py
+++ b/src/pipecat/audio/filters/koala_filter.py
@@ -22,7 +22,7 @@ try:
     import pvkoala
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use the Koala filter, you need to `pip install pipecat-ai[koala]`.")
+    logger.error('In order to use the Koala filter, you need to `uv add "pipecat-ai[koala]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/audio/filters/rnnoise_filter.py
+++ b/src/pipecat/audio/filters/rnnoise_filter.py
@@ -22,9 +22,7 @@ try:
 except ModuleNotFoundError as e:
     RNNoise = None
     logger.error(f"Exception: {e}")
-    logger.error(
-        "In order to use the RNNoise filter, you need to `pip install pipecat-ai[rnnoise]`."
-    )
+    logger.error('In order to use the RNNoise filter, you need to `uv add "pipecat-ai[rnnoise]"`.')
 
 
 class RNNoiseFilter(BaseAudioFilter):

--- a/src/pipecat/audio/mixers/soundfile_mixer.py
+++ b/src/pipecat/audio/mixers/soundfile_mixer.py
@@ -26,7 +26,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use the soundfile mixer, you need to `pip install pipecat-ai[soundfile]`."
+        'In order to use the soundfile mixer, you need to `uv add "pipecat-ai[soundfile]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/audio/turn/smart_turn/local_coreml_smart_turn.py
+++ b/src/pipecat/audio/turn/smart_turn/local_coreml_smart_turn.py
@@ -25,7 +25,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use the LocalSmartTurnAnalyzer, you need to `pip install pipecat-ai[local-smart-turn]`."
+        'In order to use the LocalSmartTurnAnalyzer, you need to `uv add "pipecat-ai[local-smart-turn]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
+++ b/src/pipecat/audio/turn/smart_turn/local_smart_turn_v2.py
@@ -31,7 +31,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use LocalSmartTurnAnalyzerV2, you need to `pip install pipecat-ai[local-smart-turn]`."
+        'In order to use LocalSmartTurnAnalyzerV2, you need to `uv add "pipecat-ai[local-smart-turn]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/audio/vad/silero.py
+++ b/src/pipecat/audio/vad/silero.py
@@ -26,7 +26,7 @@ try:
 
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Silero VAD, you need to `pip install pipecat-ai`.")
+    logger.error("In order to use Silero VAD, you need to `uv add pipecat-ai`.")
     raise ImportError(f"Missing module(s): {e}") from e
 
 

--- a/src/pipecat/bus/network/pgmq.py
+++ b/src/pipecat/bus/network/pgmq.py
@@ -24,7 +24,7 @@ try:
     from pgmq.async_queue import PGMQueue
 except ModuleNotFoundError as e:  # pragma: no cover - exercised only when extra is missing
     logger.error(f"Exception: {e}")
-    logger.error("In order to use PgmqBus, you need to `pip install pipecat-ai[pgmq]`.")
+    logger.error('In order to use PgmqBus, you need to `uv add "pipecat-ai[pgmq]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 
@@ -51,7 +51,7 @@ class PgmqBus(WorkerBus):
     or ``backend=PgmqBackend`` (any backend). The two are mutually exclusive.
 
     Requires the ``pgmq`` extra. Install with
-    ``pip install pipecat-ai[pgmq]``.
+    ``uv add "pipecat-ai[pgmq]"``.
 
     Example::
 

--- a/src/pipecat/bus/network/pgmq_backends.py
+++ b/src/pipecat/bus/network/pgmq_backends.py
@@ -42,7 +42,7 @@ try:
     from pgmq.async_queue import PGMQueue
 except ModuleNotFoundError as e:  # pragma: no cover - exercised only when extra is missing
     logger.error(f"Exception: {e}")
-    logger.error("In order to use PgmqBus backends, you need to `pip install pipecat-ai[pgmq]`.")
+    logger.error('In order to use PgmqBus backends, you need to `uv add "pipecat-ai[pgmq]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/bus/network/redis.py
+++ b/src/pipecat/bus/network/redis.py
@@ -20,7 +20,7 @@ try:
     from redis.asyncio.client import PubSub
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use RedisBus, you need to `pip install pipecat-ai[redis]`.")
+    logger.error('In order to use RedisBus, you need to `uv add "pipecat-ai[redis]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/processors/frameworks/langchain.py
+++ b/src/pipecat/processors/frameworks/langchain.py
@@ -21,7 +21,7 @@ try:
     from langchain_core.messages import AIMessageChunk
     from langchain_core.runnables import Runnable
 except ModuleNotFoundError as e:
-    logger.error("In order to use Langchain, you need to `pip install pipecat-ai[langchain]`. ")
+    logger.error('In order to use Langchain, you need to `uv add "pipecat-ai[langchain]"`. ')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/processors/frameworks/strands_agents.py
+++ b/src/pipecat/processors/frameworks/strands_agents.py
@@ -20,7 +20,7 @@ try:
     from strands import Agent
     from strands.multiagent.graph import Graph
 except ModuleNotFoundError as e:
-    logger.error("In order to use Strands Agents, you need to `pip install strands-agents`.")
+    logger.error("In order to use Strands Agents, you need to `uv add strands-agents`.")
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/processors/gstreamer/pipeline_source.py
+++ b/src/pipecat/processors/gstreamer/pipeline_source.py
@@ -31,7 +31,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use GStreamer, you need to `pip install pipecat-ai[gstreamer]`. Also, you need to install GStreamer in your system."
+        'In order to use GStreamer, you need to `uv add "pipecat-ai[gstreamer]"`. Also, you need to install GStreamer in your system.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/processors/metrics/sentry.py
+++ b/src/pipecat/processors/metrics/sentry.py
@@ -16,7 +16,7 @@ try:
     import sentry_sdk
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Sentry, you need to `pip install pipecat-ai[sentry]`.")
+    logger.error('In order to use Sentry, you need to `uv add "pipecat-ai[sentry]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 from pipecat.processors.metrics.frame_processor_metrics import FrameProcessorMetrics

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -13,7 +13,7 @@ supports multiple transport types with a unified interface.
 
 Install with::
 
-    pip install pipecat-ai[runner]
+    uv add "pipecat-ai[runner]"
 
 All bots must implement a `bot(runner_args)` async function as the entry point.
 The server automatically discovers and executes this function when connections
@@ -129,9 +129,9 @@ try:
     from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 except ImportError as e:
     logger.error(f"Runner dependencies not available: {e}")
-    logger.error("To use Pipecat runners, install with: pip install pipecat-ai[runner]")
+    logger.error('To use Pipecat runners, install with: uv add "pipecat-ai[runner]"')
     raise ImportError(
-        "Runner dependencies required. Install with: pip install pipecat-ai[runner]"
+        'Runner dependencies required. Install with: uv add "pipecat-ai[runner]"'
     ) from e
 
 

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -47,7 +47,7 @@ try:
     from anthropic import NotGiven as AnthropicNotGiven
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Anthropic, you need to `pip install pipecat-ai[anthropic]`.")
+    logger.error('In order to use Anthropic, you need to `uv add "pipecat-ai[anthropic]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -18,6 +18,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
@@ -48,14 +50,6 @@ from .models import (
     TerminationMessage,
     TurnMessage,
 )
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use AssemblyAI, you need to `uv add "pipecat-ai[assemblyai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def map_language_from_assemblyai(language_code: str) -> Language:

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -54,7 +54,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error('In order to use AssemblyAI, you need to `pip install "pipecat-ai[assemblyai]"`.')
+    logger.error('In order to use AssemblyAI, you need to `uv add "pipecat-ai[assemblyai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -38,7 +38,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Async, you need to `pip install pipecat-ai[asyncai]`.")
+    logger.error('In order to use Async, you need to `uv add "pipecat-ai[asyncai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -14,8 +14,11 @@ from dataclasses import dataclass
 from typing import Any
 
 import aiohttp
+import websockets
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -31,15 +34,6 @@ from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import TextAggregationMode, TTSService, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    import websockets
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Async, you need to `uv add "pipecat-ai[asyncai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_async_language(language: Language) -> str:

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -47,7 +47,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use AWS services, you need to `pip install pipecat-ai[aws]`. Also, remember to set `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and `AWS_REGION` environment variable."
+        'In order to use AWS services, you need to `uv add "pipecat-ai[aws]"`. Also, remember to set `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and `AWS_REGION` environment variable.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -78,9 +78,7 @@ try:
     from smithy_core.aio.eventstream import DuplexEventStream
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error(
-        "In order to use AWS services, you need to `pip install pipecat-ai[aws-nova-sonic]`."
-    )
+    logger.error('In order to use AWS services, you need to `uv add "pipecat-ai[aws-nova-sonic]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/aws/sagemaker/bidi_client.py
+++ b/src/pipecat/services/aws/sagemaker/bidi_client.py
@@ -30,7 +30,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use SageMaker BiDi client, you need to `pip install pipecat-ai[sagemaker]`."
+        'In order to use SageMaker BiDi client, you need to `uv add "pipecat-ai[sagemaker]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -47,7 +47,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use AWS services, you need to `pip install pipecat-ai[aws]`.")
+    logger.error('In order to use AWS services, you need to `uv add "pipecat-ai[aws]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/aws/stt.py
+++ b/src/pipecat/services/aws/stt.py
@@ -18,6 +18,9 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from loguru import logger
+from websockets import Subprotocol
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -40,15 +43,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets import Subprotocol
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use AWS services, you need to `uv add "pipecat-ai[aws]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/aws/tts.py
+++ b/src/pipecat/services/aws/tts.py
@@ -33,7 +33,7 @@ try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use AWS services, you need to `pip install pipecat-ai[aws]`.")
+    logger.error('In order to use AWS services, you need to `uv add "pipecat-ai[aws]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/azure/realtime/llm.py
+++ b/src/pipecat/services/azure/realtime/llm.py
@@ -9,15 +9,9 @@
 from dataclasses import dataclass
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
 
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Azure Realtime, you need to `uv add "pipecat-ai[openai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/azure/realtime/llm.py
+++ b/src/pipecat/services/azure/realtime/llm.py
@@ -16,7 +16,7 @@ try:
     from websockets.asyncio.client import connect as websocket_connect
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Azure Realtime, you need to `pip install pipecat-ai[openai]`.")
+    logger.error('In order to use Azure Realtime, you need to `uv add "pipecat-ai[openai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/azure/stt.py
+++ b/src/pipecat/services/azure/stt.py
@@ -49,7 +49,7 @@ try:
     from azure.cognitiveservices.speech.dialog import AudioConfig
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Azure, you need to `pip install pipecat-ai[azure]`.")
+    logger.error('In order to use Azure, you need to `uv add "pipecat-ai[azure]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/azure/tts.py
+++ b/src/pipecat/services/azure/tts.py
@@ -41,7 +41,7 @@ try:
     )
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Azure, you need to `pip install pipecat-ai[azure]`.")
+    logger.error('In order to use Azure, you need to `uv add "pipecat-ai[azure]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -35,14 +37,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -41,7 +41,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Cartesia, you need to `pip install pipecat-ai[cartesia]`.")
+    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -17,6 +17,8 @@ from typing import Any
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -32,15 +34,6 @@ from pipecat.services.tts_service import TextAggregationMode, TTSService, Websoc
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.text.skip_tags_aggregator import SkipTagsAggregator
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-# See .env.example for Cartesia configuration needed
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 class GenerationConfig(BaseModel):

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -39,7 +39,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Cartesia, you need to `pip install pipecat-ai[cartesia]`.")
+    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/cartesia/turns/stt.py
+++ b/src/pipecat/services/cartesia/turns/stt.py
@@ -38,7 +38,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Cartesia, you need to `pip install pipecat-ai[cartesia]`.")
+    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/cartesia/turns/stt.py
+++ b/src/pipecat/services/cartesia/turns/stt.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -32,14 +34,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Cartesia, you need to `uv add "pipecat-ai[cartesia]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -12,6 +12,8 @@ from collections.abc import AsyncGenerator
 
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     ErrorFrame,
@@ -24,14 +26,6 @@ from pipecat.services.deepgram.flux.base import (
     FluxMessageType,
 )
 from pipecat.services.websocket_service import WebsocketService
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Deepgram Flux, you need to `uv add "pipecat-ai[deepgram]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 # Re-export for backward compatibility
 __all__ = [

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -30,7 +30,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Deepgram Flux, you need to `pip install pipecat-ai[deepgram]`.")
+    logger.error('In order to use Deepgram Flux, you need to `uv add "pipecat-ai[deepgram]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # Re-export for backward compatibility

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -48,7 +48,7 @@ try:
     )
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Deepgram, you need to `pip install pipecat-ai[deepgram]`.")
+    logger.error('In order to use Deepgram, you need to `uv add "pipecat-ai[deepgram]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -37,7 +37,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use DeepgramWebsocketTTSService, you need to `pip install pipecat-ai[deepgram]`."
+        'In order to use DeepgramWebsocketTTSService, you need to `uv add "pipecat-ai[deepgram]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/deepgram/tts.py
+++ b/src/pipecat/services/deepgram/tts.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import aiohttp
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -30,16 +32,6 @@ from pipecat.frames.frames import (
 from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import TTSService, WebsocketTTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error(
-        'In order to use DeepgramWebsocketTTSService, you need to `uv add "pipecat-ai[deepgram]"`.'
-    )
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -24,6 +24,8 @@ from urllib.parse import urlencode
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -43,16 +45,6 @@ from pipecat.services.stt_service import SegmentedSTTService, WebsocketSTTServic
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error(
-        'In order to use ElevenLabs Realtime STT, you need to `uv add "pipecat-ai[elevenlabs]"`.'
-    )
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_elevenlabs_language(language: Language) -> str:

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -50,7 +50,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use ElevenLabs Realtime STT, you need to `pip install pipecat-ai[elevenlabs]`."
+        'In order to use ElevenLabs Realtime STT, you need to `uv add "pipecat-ai[elevenlabs]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -23,8 +23,11 @@ from typing import (
 )
 
 import aiohttp
+import websockets
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -47,16 +50,6 @@ from pipecat.services.tts_service import (
 )
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-# See .env.example for ElevenLabs configuration needed
-try:
-    import websockets
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use ElevenLabs, you need to `uv add "pipecat-ai[elevenlabs]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 # Models that support language codes
 # The following models are excluded as they don't support language codes:

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -55,7 +55,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use ElevenLabs, you need to `pip install pipecat-ai[elevenlabs]`.")
+    logger.error('In order to use ElevenLabs, you need to `uv add "pipecat-ai[elevenlabs]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # Models that support language codes

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -37,7 +37,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Fish Audio, you need to `pip install pipecat-ai[fish]`.")
+    logger.error('In order to use Fish Audio, you need to `uv add "pipecat-ai[fish]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # FishAudio supports various output formats

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -18,7 +18,10 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import aiohttp
+import websockets
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
@@ -45,15 +48,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    import websockets
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Gladia, you need to `uv add "pipecat-ai[gladia]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_gladia_language(language: Language) -> str:

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -52,7 +52,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Gladia, you need to `pip install pipecat-ai[gladia]`.")
+    logger.error('In order to use Gladia, you need to `uv add "pipecat-ai[gladia]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -105,7 +105,7 @@ try:
     )
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Google AI, you need to `pip install pipecat-ai[google]`.")
+    logger.error('In order to use Google AI, you need to `uv add "pipecat-ai[google]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/google/gemini_live/vertex/llm.py
+++ b/src/pipecat/services/google/gemini_live/vertex/llm.py
@@ -35,7 +35,7 @@ try:
 
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Google Vertex AI, you need to `pip install pipecat-ai[google]`.")
+    logger.error('In order to use Google Vertex AI, you need to `uv add "pipecat-ai[google]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/google/image.py
+++ b/src/pipecat/services/google/image.py
@@ -34,7 +34,7 @@ try:
     from google.genai import types
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Google AI, you need to `pip install pipecat-ai[google]`.")
+    logger.error('In order to use Google AI, you need to `uv add "pipecat-ai[google]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -64,7 +64,7 @@ try:
     genai._api_client.READ_BUFFER_SIZE = 5 * 1024 * 1024
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Google AI, you need to `pip install pipecat-ai[google]`.")
+    logger.error('In order to use Google AI, you need to `uv add "pipecat-ai[google]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/google/stt.py
+++ b/src/pipecat/services/google/stt.py
@@ -55,7 +55,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use Google AI, you need to `pip install pipecat-ai[google]`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable."
+        'In order to use Google AI, you need to `uv add "pipecat-ai[google]"`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/google/tts.py
+++ b/src/pipecat/services/google/tts.py
@@ -55,7 +55,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use Google AI, you need to `pip install pipecat-ai[google]`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable."
+        'In order to use Google AI, you need to `uv add "pipecat-ai[google]"`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/google/vertex/llm.py
+++ b/src/pipecat/services/google/vertex/llm.py
@@ -33,7 +33,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use Google AI, you need to `pip install pipecat-ai[google]`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable."
+        'In order to use Google AI, you need to `uv add "pipecat-ai[google]"`. Also, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/gradium/stt.py
+++ b/src/pipecat/services/gradium/stt.py
@@ -43,7 +43,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error('In order to use Gradium, you need to `pip install "pipecat-ai[gradium]"`.')
+    logger.error('In order to use Gradium, you need to `uv add "pipecat-ai[gradium]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # Seconds to wait after a "flushed" message for trailing text tokens to arrive

--- a/src/pipecat/services/gradium/stt.py
+++ b/src/pipecat/services/gradium/stt.py
@@ -19,6 +19,8 @@ from typing import Any, cast
 
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -37,14 +39,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Gradium, you need to `uv add "pipecat-ai[gradium]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 # Seconds to wait after a "flushed" message for trailing text tokens to arrive
 # before finalizing the transcription.

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -12,6 +12,9 @@ from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel
+from websockets import ConnectionClosedOK
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -25,15 +28,6 @@ from pipecat.frames.frames import (
 from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import WebsocketTTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets import ConnectionClosedOK
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Gradium, you need to `uv add "pipecat-ai[gradium]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 SAMPLE_RATE = 48000
 

--- a/src/pipecat/services/gradium/tts.py
+++ b/src/pipecat/services/gradium/tts.py
@@ -32,7 +32,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Gradium, you need to `pip install pipecat-ai[gradium]`.")
+    logger.error('In order to use Gradium, you need to `uv add "pipecat-ai[gradium]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 SAMPLE_RATE = 48000

--- a/src/pipecat/services/groq/tts.py
+++ b/src/pipecat/services/groq/tts.py
@@ -29,7 +29,7 @@ try:
     from groq import AsyncGroq
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Groq, you need to `pip install pipecat-ai[groq]`.")
+    logger.error('In order to use Groq, you need to `uv add "pipecat-ai[groq]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # Hint set for `output_format`. The values mirror the Literal that

--- a/src/pipecat/services/heygen/client.py
+++ b/src/pipecat/services/heygen/client.py
@@ -45,7 +45,7 @@ try:
     from websockets.exceptions import ConnectionClosedOK
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use HeyGen, you need to `pip install pipecat-ai[heygen]`.")
+    logger.error('In order to use HeyGen, you need to `uv add "pipecat-ai[heygen]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 HEY_GEN_SAMPLE_RATE = 24000

--- a/src/pipecat/services/hume/tts.py
+++ b/src/pipecat/services/hume/tts.py
@@ -37,7 +37,7 @@ try:
     from hume.tts.types import TimestampMessage
 except ModuleNotFoundError as e:  # pragma: no cover - import-time guidance
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Hume, you need to `pip install pipecat-ai[hume]`.")
+    logger.error('In order to use Hume, you need to `uv add "pipecat-ai[hume]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -20,6 +20,7 @@ from dataclasses import fields as dataclass_fields
 from typing import Any, Literal
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.inworld_realtime_adapter import InworldRealtimeLLMAdapter
@@ -62,13 +63,6 @@ from pipecat.services.settings import (
 from pipecat.utils.time import time_now_iso8601
 
 from . import events
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Inworld Realtime, you need to `uv add "pipecat-ai[inworld]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -67,7 +67,7 @@ try:
     from websockets.asyncio.client import connect as websocket_connect
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Inworld Realtime, you need to `pip install pipecat-ai[inworld]`.")
+    logger.error('In order to use Inworld Realtime, you need to `uv add "pipecat-ai[inworld]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -42,7 +42,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Inworld WebSocket TTS, you need to `pip install websockets`.")
+    logger.error("In order to use Inworld WebSocket TTS, you need to `uv add websockets`.")
     raise ImportError(f"Missing module: {e}") from e
 
 from pipecat.frames.frames import (

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -34,16 +34,8 @@ from pipecat import version as pipecat_version
 
 USER_AGENT = f"pipecat/{pipecat_version()}"
 from pydantic import BaseModel
-
-from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error("In order to use Inworld WebSocket TTS, you need to `uv add websockets`.")
-    raise ImportError(f"Missing module: {e}") from e
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     AggregationType,
@@ -59,6 +51,7 @@ from pipecat.frames.frames import (
     TTSTextFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import TextAggregationMode, TTSService, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts

--- a/src/pipecat/services/kokoro/tts.py
+++ b/src/pipecat/services/kokoro/tts.py
@@ -31,7 +31,7 @@ try:
     from kokoro_onnx import Kokoro
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Kokoro, you need to `pip install pipecat-ai[kokoro]`.")
+    logger.error('In order to use Kokoro, you need to `uv add "pipecat-ai[kokoro]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 KOKORO_CACHE_DIR = Path(os.path.expanduser("~/.cache/kokoro-onnx"))

--- a/src/pipecat/services/lmnt/tts.py
+++ b/src/pipecat/services/lmnt/tts.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -26,15 +28,6 @@ from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import InterruptibleTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-# See .env.example for LMNT configuration needed
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use LMNT, you need to `uv add "pipecat-ai[lmnt]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_lmnt_language(language: Language) -> str:

--- a/src/pipecat/services/lmnt/tts.py
+++ b/src/pipecat/services/lmnt/tts.py
@@ -33,7 +33,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use LMNT, you need to `pip install pipecat-ai[lmnt]`.")
+    logger.error('In order to use LMNT, you need to `uv add "pipecat-ai[lmnt]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/mcp_service.py
+++ b/src/pipecat/services/mcp_service.py
@@ -28,7 +28,7 @@ try:
     from mcp.client.streamable_http import streamablehttp_client
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use an MCP client, you need to `pip install pipecat-ai[mcp]`.")
+    logger.error('In order to use an MCP client, you need to `uv add "pipecat-ai[mcp]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 ServerParameters: TypeAlias = StdioServerParameters | SseServerParameters | StreamableHttpParameters

--- a/src/pipecat/services/mem0/memory.py
+++ b/src/pipecat/services/mem0/memory.py
@@ -27,7 +27,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use Mem0, you need to `pip install mem0ai`. Also, set the environment variable MEM0_API_KEY."
+        "In order to use Mem0, you need to `uv add mem0ai`. Also, set the environment variable MEM0_API_KEY."
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/mistral/stt.py
+++ b/src/pipecat/services/mistral/stt.py
@@ -47,7 +47,7 @@ try:
     from mistralai.extra.realtime import RealtimeConnection, UnknownRealtimeEvent
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Mistral STT, you need to `pip install pipecat-ai[mistral]`.")
+    logger.error('In order to use Mistral STT, you need to `uv add "pipecat-ai[mistral]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/mistral/tts.py
+++ b/src/pipecat/services/mistral/tts.py
@@ -30,7 +30,7 @@ try:
     from mistralai.client import Mistral
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Mistral TTS, you need to `pip install pipecat-ai[mistral]`.")
+    logger.error('In order to use Mistral TTS, you need to `uv add "pipecat-ai[mistral]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/moondream/vision.py
+++ b/src/pipecat/services/moondream/vision.py
@@ -33,7 +33,7 @@ try:
     from transformers import AutoModelForCausalLM
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Moondream, you need to `pip install pipecat-ai[moondream]`.")
+    logger.error('In order to use Moondream, you need to `uv add "pipecat-ai[moondream]"`.')
     raise ImportError(f"Missing module(s): {e}") from e
 
 

--- a/src/pipecat/services/neuphonic/tts.py
+++ b/src/pipecat/services/neuphonic/tts.py
@@ -40,7 +40,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Neuphonic, you need to `pip install pipecat-ai[neuphonic]`.")
+    logger.error('In order to use Neuphonic, you need to `uv add "pipecat-ai[neuphonic]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/neuphonic/tts.py
+++ b/src/pipecat/services/neuphonic/tts.py
@@ -20,6 +20,8 @@ from typing import Any
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -34,14 +36,6 @@ from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import InterruptibleTTSService, TextAggregationMode, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Neuphonic, you need to `uv add "pipecat-ai[neuphonic]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_neuphonic_lang_code(language: Language) -> str:

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -44,7 +44,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use NVIDIA Nemotron Speech STT, you need to `pip install pipecat-ai[nvidia]`."
+        'In order to use NVIDIA Nemotron Speech STT, you need to `uv add "pipecat-ai[nvidia]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -53,7 +53,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use NVIDIA Nemotron Speech TTS, you need to `pip install pipecat-ai[nvidia]`."
+        'In order to use NVIDIA Nemotron Speech TTS, you need to `uv add "pipecat-ai[nvidia]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from loguru import logger
 from PIL import Image
+from websockets.asyncio.client import connect as websocket_connect
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.open_ai_realtime_adapter import (
@@ -66,14 +67,6 @@ from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_openai_realtime, traced_stt
 
 from . import events
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use OpenAI, you need to `uv add "pipecat-ai[openai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
-
 
 # Pre-roll cushion added on top of the auto-sized duration (start_secs), to
 # absorb small timing slop between start_secs and the audio actually clipped,

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -71,7 +71,7 @@ try:
     from websockets.asyncio.client import connect as websocket_connect
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use OpenAI, you need to `pip install pipecat-ai[openai]`.")
+    logger.error('In order to use OpenAI, you need to `uv add "pipecat-ai[openai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -29,6 +29,8 @@ from openai.types.responses import (
     ResponseStreamEvent,
     ResponseTextDeltaEvent,
 )
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.exceptions import ConnectionClosed
 
 from pipecat.adapters.services.open_ai_responses_adapter import (
     OpenAIResponsesLLMAdapter,
@@ -52,15 +54,6 @@ from pipecat.services.llm_service import (
 from pipecat.services.settings import NOT_GIVEN as _NOT_GIVEN
 from pipecat.services.settings import LLMSettings, _NotGiven, assert_given
 from pipecat.utils.tracing.service_decorators import traced_llm
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.exceptions import ConnectionClosed
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use OpenAI, you need to `uv add "pipecat-ai[openai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
-
 
 # ---------------------------------------------------------------------------
 # Private retry exception classes

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -58,7 +58,7 @@ try:
     from websockets.exceptions import ConnectionClosed
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use OpenAI, you need to `pip install pipecat-ai[openai]`.")
+    logger.error('In order to use OpenAI, you need to `uv add "pipecat-ai[openai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/openai/stt.py
+++ b/src/pipecat/services/openai/stt.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.audio.utils import create_stream_resampler
 from pipecat.frames.frames import (
@@ -47,13 +49,6 @@ from pipecat.services.whisper.base_stt import (
 from pipecat.transcriptions.language import Language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError:
-    websocket_connect = None
-    State = None
 
 
 @dataclass

--- a/src/pipecat/services/openai/stt.py
+++ b/src/pipecat/services/openai/stt.py
@@ -300,7 +300,7 @@ class OpenAIRealtimeSTTService(WebsocketSTTService):
         if websocket_connect is None:
             raise ImportError(
                 "websockets is required for OpenAIRealtimeSTTService. "
-                "Install it with: pip install pipecat-ai[openai]"
+                'Install it with: uv add "pipecat-ai[openai]"'
             )
 
         # --- 1. Hardcoded defaults ---

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -29,7 +29,7 @@ try:
     from piper.download_voices import download_voice
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Piper, you need to `pip install pipecat-ai[piper]`.")
+    logger.error('In order to use Piper, you need to `uv add "pipecat-ai[piper]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/resembleai/tts.py
+++ b/src/pipecat/services/resembleai/tts.py
@@ -32,7 +32,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Resemble AI, you need to `pip install pipecat-ai[resembleai]`.")
+    logger.error('In order to use Resemble AI, you need to `uv add "pipecat-ai[resembleai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/resembleai/tts.py
+++ b/src/pipecat/services/resembleai/tts.py
@@ -12,6 +12,8 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -26,14 +28,6 @@ from pipecat.frames.frames import (
 from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import WebsocketTTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Resemble AI, you need to `uv add "pipecat-ai[resembleai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -19,6 +19,8 @@ from typing import Any, ClassVar
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -40,14 +42,6 @@ from pipecat.services.tts_service import (
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.text.skip_tags_aggregator import SkipTagsAggregator
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Rime, you need to `uv add "pipecat-ai[rime]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_rime_language(language: Language) -> str:

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -46,7 +46,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Rime, you need to `pip install pipecat-ai[rime]`.")
+    logger.error('In order to use Rime, you need to `uv add "pipecat-ai[rime]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -52,7 +52,7 @@ try:
     from sarvamai.core.events import EventType
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Sarvam, you need to `pip install pipecat-ai[sarvam]`.")
+    logger.error('In order to use Sarvam, you need to `uv add "pipecat-ai[sarvam]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/sarvam/tts.py
+++ b/src/pipecat/services/sarvam/tts.py
@@ -48,6 +48,8 @@ from typing import Any, ClassVar
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel, Field
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -63,14 +65,6 @@ from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, assert_
 from pipecat.services.tts_service import InterruptibleTTSService, TextAggregationMode, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Sarvam, you need to `uv add "pipecat-ai[sarvam]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 class SarvamTTSModel(StrEnum):

--- a/src/pipecat/services/sarvam/tts.py
+++ b/src/pipecat/services/sarvam/tts.py
@@ -69,7 +69,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Sarvam, you need to `pip install pipecat-ai[sarvam]`.")
+    logger.error('In order to use Sarvam, you need to `uv add "pipecat-ai[sarvam]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/simli/video.py
+++ b/src/pipecat/services/simli/video.py
@@ -34,7 +34,7 @@ try:
     from simli import SimliClient, SimliConfig
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Simli, you need to `pip install pipecat-ai[simli]`.")
+    logger.error('In order to use Simli, you need to `uv add "pipecat-ai[simli]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -47,7 +47,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Smallest, you need to `pip install pipecat-ai[smallest]`.")
+    logger.error('In order to use Smallest, you need to `uv add "pipecat-ai[smallest]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -21,6 +21,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
@@ -41,14 +43,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Smallest, you need to `uv add "pipecat-ai[smallest]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_smallest_stt_language(language: Language) -> str:

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -40,7 +40,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Smallest, you need to `pip install pipecat-ai[smallest]`.")
+    logger.error('In order to use Smallest, you need to `uv add "pipecat-ai[smallest]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/smallest/tts.py
+++ b/src/pipecat/services/smallest/tts.py
@@ -19,6 +19,8 @@ from enum import StrEnum
 from typing import Any
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
@@ -34,14 +36,6 @@ from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import InterruptibleTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Smallest, you need to `uv add "pipecat-ai[smallest]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 class SmallestTTSModel(StrEnum):

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -38,7 +38,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Soniox, you need to `pip install pipecat-ai[soniox]`.")
+    logger.error('In order to use Soniox, you need to `uv add "pipecat-ai[soniox]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -32,15 +34,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Soniox, you need to `uv add "pipecat-ai[soniox]"`.')
-    raise ImportError(f"Missing module: {e}") from e
-
 
 KEEPALIVE_MESSAGE = '{"type": "keepalive"}'
 

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -21,7 +21,10 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any
 
+import websockets
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -36,16 +39,6 @@ from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import TextAggregationMode, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    import websockets
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Soniox, you need to `uv add "pipecat-ai[soniox]"`.')
-    raise ImportError(f"Missing module: {e}") from e
-
 
 # Soniox idle timeout is 20-30s; keepalive cadence must stay well inside it.
 KEEPALIVE_INTERVAL_SECONDS = 20

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -43,7 +43,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Soniox, you need to `pip install pipecat-ai[soniox]`.")
+    logger.error('In order to use Soniox, you need to `uv add "pipecat-ai[soniox]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/speechmatics/stt.py
+++ b/src/pipecat/services/speechmatics/stt.py
@@ -58,9 +58,7 @@ try:
     )
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error(
-        "In order to use Speechmatics, you need to `pip install pipecat-ai[speechmatics]`."
-    )
+    logger.error('In order to use Speechmatics, you need to `uv add "pipecat-ai[speechmatics]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/speechmatics/tts.py
+++ b/src/pipecat/services/speechmatics/tts.py
@@ -29,9 +29,7 @@ try:
     from speechmatics.rt import __version__
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error(
-        "In order to use Speechmatics, you need to `pip install pipecat-ai[speechmatics]`."
-    )
+    logger.error('In order to use Speechmatics, you need to `uv add "pipecat-ai[speechmatics]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/ultravox/llm.py
+++ b/src/pipecat/services/ultravox/llm.py
@@ -57,7 +57,7 @@ try:
     from websockets.exceptions import ConnectionClosed
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Ultravox, you need to `pip install pipecat-ai[ultravox]`.")
+    logger.error('In order to use Ultravox, you need to `uv add "pipecat-ai[ultravox]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/ultravox/llm.py
+++ b/src/pipecat/services/ultravox/llm.py
@@ -21,6 +21,8 @@ from typing import Any, Literal
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel, Field
+from websockets.asyncio import client as websocket_client
+from websockets.exceptions import ConnectionClosed
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.audio.utils import create_stream_resampler
@@ -51,15 +53,6 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService, RealtimeServiceInfo
 from pipecat.services.settings import NOT_GIVEN, LLMSettings, _NotGiven, assert_given
 from pipecat.utils.time import time_now_iso8601
-
-try:
-    from websockets.asyncio import client as websocket_client
-    from websockets.exceptions import ConnectionClosed
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Ultravox, you need to `uv add "pipecat-ai[ultravox]"`.')
-    raise ImportError(f"Missing module: {e}") from e
-
 
 # Result shipped as the client_tool_result when we see an async-tool
 # "started" message — i.e. when an async-registered function call

--- a/src/pipecat/services/whisper/stt.py
+++ b/src/pipecat/services/whisper/stt.py
@@ -32,14 +32,14 @@ if TYPE_CHECKING:
         from faster_whisper import WhisperModel
     except ModuleNotFoundError as e:
         logger.error(f"Exception: {e}")
-        logger.error("In order to use Whisper, you need to `pip install pipecat-ai[whisper]`.")
+        logger.error('In order to use Whisper, you need to `uv add "pipecat-ai[whisper]"`.')
         raise ImportError(f"Missing module: {e}") from e
 
     try:
         import mlx_whisper  # noqa: F401
     except ModuleNotFoundError as e:
         logger.error(f"Exception: {e}")
-        logger.error("In order to use Whisper, you need to `pip install pipecat-ai[mlx-whisper]`.")
+        logger.error('In order to use Whisper, you need to `uv add "pipecat-ai[mlx-whisper]"`.')
         raise ImportError(f"Missing module: {e}") from e
 
 
@@ -327,7 +327,7 @@ class WhisperSTTService(SegmentedSTTService):
             logger.debug("Loaded Whisper model")
         except ModuleNotFoundError as e:
             logger.error(f"Exception: {e}")
-            logger.error("In order to use Whisper, you need to `pip install pipecat-ai[whisper]`.")
+            logger.error('In order to use Whisper, you need to `uv add "pipecat-ai[whisper]"`.')
             self._model = None
 
     @traced_stt

--- a/src/pipecat/services/xai/realtime/llm.py
+++ b/src/pipecat/services/xai/realtime/llm.py
@@ -66,7 +66,7 @@ try:
     from websockets.asyncio.client import connect as websocket_connect
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use Grok Realtime, you need to `pip install pipecat-ai[grok]`.")
+    logger.error('In order to use Grok Realtime, you need to `uv add "pipecat-ai[grok]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/xai/realtime/llm.py
+++ b/src/pipecat/services/xai/realtime/llm.py
@@ -20,6 +20,7 @@ from typing import Any
 from urllib.parse import quote
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.grok_realtime_adapter import GrokRealtimeLLMAdapter
@@ -61,13 +62,6 @@ from pipecat.services.settings import (
 from pipecat.utils.time import time_now_iso8601
 
 from . import events
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use Grok Realtime, you need to `uv add "pipecat-ai[grok]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 @dataclass

--- a/src/pipecat/services/xai/stt.py
+++ b/src/pipecat/services/xai/stt.py
@@ -40,7 +40,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error('In order to use xAI STT, you need to `pip install "pipecat-ai[xai]"`.')
+    logger.error('In order to use xAI STT, you need to `uv add "pipecat-ai[xai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/xai/stt.py
+++ b/src/pipecat/services/xai/stt.py
@@ -18,6 +18,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
@@ -34,14 +36,6 @@ from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use xAI STT, you need to `uv add "pipecat-ai[xai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_xai_stt_language(language: Language) -> str:

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -45,7 +45,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use XAITTSService, you need to `pip install pipecat-ai[xai]`.")
+    logger.error('In order to use XAITTSService, you need to `uv add "pipecat-ai[xai]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -25,6 +25,8 @@ from urllib.parse import urlencode
 
 import aiohttp
 from loguru import logger
+from websockets.asyncio.client import connect as websocket_connect
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -39,14 +41,6 @@ from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import InterruptibleTTSService, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
-
-try:
-    from websockets.asyncio.client import connect as websocket_connect
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use XAITTSService, you need to `uv add "pipecat-ai[xai]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 def language_to_xai_language(language: Language) -> str:

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -72,9 +72,7 @@ try:
     from daily import LogLevel as DailyLogLevel
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error(
-        "In order to use the Daily transport, you need to `pip install pipecat-ai[daily]`."
-    )
+    logger.error('In order to use the Daily transport, you need to `uv add "pipecat-ai[daily]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 VAD_RESET_PERIOD_MS = 2000

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -51,7 +51,7 @@ try:
     from tenacity import retry, stop_after_attempt, wait_exponential
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use LiveKit, you need to `pip install pipecat-ai[livekit]`.")
+    logger.error('In order to use LiveKit, you need to `uv add "pipecat-ai[livekit]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # DTMF mapping according to RFC 4733

--- a/src/pipecat/transports/local/audio.py
+++ b/src/pipecat/transports/local/audio.py
@@ -26,7 +26,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use local audio, you need to `pip install pipecat-ai[local]`. On MacOS, you also need to `brew install portaudio`."
+        'In order to use local audio, you need to `uv add "pipecat-ai[local]"`. On MacOS, you also need to `brew install portaudio`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/transports/local/tk.py
+++ b/src/pipecat/transports/local/tk.py
@@ -32,7 +32,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use local audio, you need to `pip install pipecat-ai[local]`. On MacOS, you also need to `brew install portaudio`."
+        'In order to use local audio, you need to `uv add "pipecat-ai[local]"`. On MacOS, you also need to `brew install portaudio`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/transports/smallwebrtc/connection.py
+++ b/src/pipecat/transports/smallwebrtc/connection.py
@@ -35,7 +35,7 @@ try:
     from av.frame import Frame
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use the SmallWebRTC, you need to `pip install pipecat-ai[webrtc]`.")
+    logger.error('In order to use the SmallWebRTC, you need to `uv add "pipecat-ai[webrtc]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 # Clamp aiortc's SCTP DATA-chunk payload size so the on-wire UDP packet fits

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -51,7 +51,7 @@ try:
     from av import AudioFrame, AudioResampler, VideoFrame
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use the SmallWebRTC, you need to `pip install pipecat-ai[webrtc]`.")
+    logger.error('In order to use the SmallWebRTC, you need to `uv add "pipecat-ai[webrtc]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 CAM_VIDEO_SOURCE = "camera"

--- a/src/pipecat/transports/vonage/client.py
+++ b/src/pipecat/transports/vonage/client.py
@@ -71,7 +71,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use Vonage Video Connector, you need to `pip install pipecat-ai[vonage-video-connector]`."
+        'In order to use Vonage Video Connector, you need to `uv add "pipecat-ai[vonage-video-connector]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -46,7 +46,7 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        "In order to use FastAPI websockets, you need to `pip install pipecat-ai[websocket]`."
+        'In order to use FastAPI websockets, you need to `uv add "pipecat-ai[websocket]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
 

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -17,8 +17,11 @@ import time
 import wave
 from collections.abc import Awaitable, Callable
 
+import websockets
 from loguru import logger
 from pydantic import BaseModel
+from websockets.asyncio.server import serve as websocket_serve
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -38,15 +41,6 @@ from pipecat.serializers.base_serializer import FrameSerializer
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-
-try:
-    import websockets
-    from websockets.asyncio.server import serve as websocket_serve
-    from websockets.protocol import State
-except ModuleNotFoundError as e:
-    logger.error(f"Exception: {e}")
-    logger.error('In order to use websockets, you need to `uv add "pipecat-ai[websocket]"`.')
-    raise ImportError(f"Missing module: {e}") from e
 
 
 class WebsocketServerParams(TransportParams):

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -45,7 +45,7 @@ try:
     from websockets.protocol import State
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use websockets, you need to `pip install pipecat-ai[websocket]`.")
+    logger.error('In order to use websockets, you need to `uv add "pipecat-ai[websocket]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/src/pipecat/workers/proxy/websocket/server.py
+++ b/src/pipecat/workers/proxy/websocket/server.py
@@ -21,7 +21,7 @@ try:
     from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error("In order to use WebSocketProxyServer, you need to `pip install starlette`.")
+    logger.error("In order to use WebSocketProxyServer, you need to `uv add starlette`.")
     raise ImportError(f"Missing module: {e}") from e
 
 

--- a/tests/test_pgmq_backends.py
+++ b/tests/test_pgmq_backends.py
@@ -33,7 +33,7 @@ try:
         PgmqBackend,
     )
 except Exception:
-    raise unittest.SkipTest("pgmq extra not installed (`pip install pipecat-ai[pgmq]`)")
+    raise unittest.SkipTest('pgmq extra not installed (`uv add "pipecat-ai[pgmq]"`)')
 
 # ---------------------------------------------------------------------------
 # IsolatedPgmqBackend: assert it speaks the right SQL to asyncpg.

--- a/tests/test_pgmq_bus.py
+++ b/tests/test_pgmq_bus.py
@@ -28,7 +28,7 @@ from pipecat.workers.base_worker import BaseWorker
 try:
     from pipecat.bus.network.pgmq import PgmqBus
 except Exception:
-    raise unittest.SkipTest("pgmq extra not installed (`pip install pipecat-ai[pgmq]`)")
+    raise unittest.SkipTest('pgmq extra not installed (`uv add "pipecat-ai[pgmq]"`)')
 
 _sub_counter = itertools.count()
 

--- a/tests/test_redis_bus.py
+++ b/tests/test_redis_bus.py
@@ -25,7 +25,7 @@ from pipecat.workers.base_worker import BaseWorker
 try:
     from pipecat.bus.network.redis import RedisBus
 except Exception:
-    raise unittest.SkipTest("redis extra not installed (`pip install pipecat-ai[redis]`)")
+    raise unittest.SkipTest('redis extra not installed (`uv add "pipecat-ai[redis]"`)')
 
 _sub_counter = itertools.count()
 


### PR DESCRIPTION
Consistency pass to align reader-facing install guidance around uv, our recommended package manager (as reflected in the main README).

Also: remove various `websockets` import guards, which are no longer needed now that `websockets` is a core dependency (see https://github.com/pipecat-ai/pipecat/pull/4658).