### PR TITLE
Add option to disable repeated sequence filtering in MarkdownTextFilter

### DIFF
--- a/changelog/4674.added.md
+++ b/changelog/4674.added.md
@@ -1,0 +1,1 @@
+- Added `filter_repeated_sequences` parameter to `MarkdownTextFilter.InputParams` to allow disabling repeated sequence removal.

--- a/src/pipecat/utils/text/markdown_text_filter.py
+++ b/src/pipecat/utils/text/markdown_text_filter.py
@@ -36,11 +36,13 @@ class MarkdownTextFilter(BaseTextFilter):
             enable_text_filter: Whether to apply Markdown filtering. Defaults to True.
             filter_code: Whether to remove code blocks from the text. Defaults to False.
             filter_tables: Whether to remove table content from the text. Defaults to False.
+            filter_repeated_sequences: Whether to remove repeated sequences from the text. Defaults to True.
         """
 
         enable_text_filter: bool | None = True
         filter_code: bool | None = False
         filter_tables: bool | None = False
+        filter_repeated_sequences: bool | None = True
 
     def __init__(self, params: InputParams | None = None, **kwargs):
         """Initialize the Markdown text filter.
@@ -82,7 +84,8 @@ class MarkdownTextFilter(BaseTextFilter):
             filtered_text = re.sub(r"(?<!`)`([^`\n]+)`(?!`)", r"\1", filtered_text)
 
             # Remove repeated sequences of 5 or more characters
-            filtered_text = re.sub(r"(\S)(\1{4,})", "", filtered_text)
+            if self._settings.filter_repeated_sequences:
+                filtered_text = re.sub(r"(\S)(\1{4,})", "", filtered_text)
 
             # Preserve numbered list items with a unique marker, §NUM§
             filtered_text = re.sub(r"^(\d+\.)\s", r"§NUM§\1 ", filtered_text)

--- a/tests/test_markdown_text_filter.py
+++ b/tests/test_markdown_text_filter.py
@@ -77,16 +77,21 @@ class TestMarkdownTextFilter(unittest.IsolatedAsyncioTestCase):
                 expected,
                 f"Failed to handle repeated characters in: '{input_text}'\nExpected: '{expected}'\nGot: '{result}'",
             )
-            
+
     async def test_preserve_repeated_characters(self):
         """Test preservation of repeated characters (5 or more)."""
-        filter = MarkdownTextFilter(params=MarkdownTextFilter.InputParams(filter_repeated_sequences=False))
+        filter = MarkdownTextFilter(
+            params=MarkdownTextFilter.InputParams(filter_repeated_sequences=False)
+        )
         repeated_sequence = "55555"
 
         result = await filter.filter(repeated_sequence)
 
-        self.assertEqual(result, repeated_sequence, f"Preserve repeated sequences failed.\nExpected:\n{repeated_sequence}\nGot:\n{result}")
-
+        self.assertEqual(
+            result,
+            repeated_sequence,
+            f"Preserve repeated sequences failed.\nExpected:\n{repeated_sequence}\nGot:\n{result}",
+        )
 
     async def test_numbered_list_preservation(self):
         """Test that numbered lists are preserved correctly."""

--- a/tests/test_markdown_text_filter.py
+++ b/tests/test_markdown_text_filter.py
@@ -77,6 +77,16 @@ class TestMarkdownTextFilter(unittest.IsolatedAsyncioTestCase):
                 expected,
                 f"Failed to handle repeated characters in: '{input_text}'\nExpected: '{expected}'\nGot: '{result}'",
             )
+            
+    async def test_preserve_repeated_characters(self):
+        """Test preservation of repeated characters (5 or more)."""
+        filter = MarkdownTextFilter(params=MarkdownTextFilter.InputParams(filter_repeated_sequences=False))
+        repeated_sequence = "55555"
+
+        result = await filter.filter(repeated_sequence)
+
+        self.assertEqual(result, repeated_sequence, f"Preserve repeated sequences failed.\nExpected:\n{repeated_sequence}\nGot:\n{result}")
+
 
     async def test_numbered_list_preservation(self):
         """Test that numbered lists are preserved correctly."""


### PR DESCRIPTION
## Summary

Adds a `filter_repeated_sequences` parameter to `MarkdownTextFilter.InputParams` that allows disabling the repeated sequence removal (regex that strips 5+ repeated characters).

## Changes

- Added `filter_repeated_sequences: bool | None = True` to `InputParams`
- Wrapped the repeated sequence regex in a conditional check
- Added unit tests for the new parameter

## Motivation

Some use cases need to preserve repeated characters in the output text (e.g., phone extension numbers like `22222`). This option allows disabling that specific filter while keeping all other markdown filtering active.

Defaults to `True` to preserve existing behavior.

## Documentation

- Docs PR: https://github.com/pipecat-ai/docs/pull/881