### PR TITLE
Use explicit .value for Language enum wire serialization

### DIFF
--- a/changelog/4676.changed.md
+++ b/changelog/4676.changed.md
@@ -1,0 +1,1 @@
+- Language enum values are now serialized to wire formats (query params, payloads, trace attributes) using explicit `.value` instead of `str()`, removing a dependency on `StrEnum.__str__` semantics.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -290,7 +290,10 @@ class DeepgramSageMakerSTTService(STTService):
         if is_given(s.model) and s.model is not None:
             params["model"] = str(s.model)
         if is_given(s.language) and s.language is not None:
-            params["language"] = str(s.language)
+            # Be explicit about enum serialization: use .value rather than str()
+            # so the wire value never depends on StrEnum's __str__ semantics.
+            language = s.language
+            params["language"] = language.value if isinstance(language, Language) else str(language)
 
         # Init-only connection config
         params["encoding"] = self._encoding

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -563,7 +563,12 @@ class DeepgramSTTService(STTService):
         if is_given(s.model) and s.model is not None:
             kwargs["model"] = str(s.model)
         if is_given(s.language) and s.language is not None:
-            kwargs["language"] = str(s.language)
+            # Be explicit about enum serialization: use .value rather than str().
+            # On the 0.0.10x line with Python 3.10, the vendored StrEnum fallback
+            # made str() return the member name ("Language.EN"), which ended up
+            # in the Deepgram query string and caused a WS 400 on every connect.
+            language = s.language
+            kwargs["language"] = language.value if isinstance(language, Language) else str(language)
 
         # Init-only connection config
         kwargs["encoding"] = self._encoding

--- a/src/pipecat/services/groq/tts.py
+++ b/src/pipecat/services/groq/tts.py
@@ -144,7 +144,13 @@ class GroqTTSService(TTSService):
         if params is not None:
             self._warn_init_param_moved_to_settings("params")
             if not settings:
-                default_settings.language = str(params.language) if params.language else "en"
+                language = params.language
+                if language:
+                    default_settings.language = (
+                        language.value if isinstance(language, Language) else str(language)
+                    )
+                else:
+                    default_settings.language = "en"
                 default_settings.speed = params.speed
 
         # 4. Apply settings delta (canonical API, always wins)

--- a/src/pipecat/services/openai/stt.py
+++ b/src/pipecat/services/openai/stt.py
@@ -372,7 +372,8 @@ class OpenAIRealtimeSTTService(WebsocketSTTService):
             Two-letter ISO-639-1 language code.
         """
         # Language value is e.g. "en", "en-US", "fr", "zh".
-        return str(language).split("-")[0].lower()
+        lang_str = language.value if isinstance(language, Language) else str(language)
+        return lang_str.split("-")[0].lower()
 
     def can_generate_metrics(self) -> bool:
         """Check if the service can generate processing metrics.

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -202,7 +202,10 @@ class XAIHttpTTSService(TTSService):
             },
         }
         if self._settings.language:
-            payload["language"] = str(self._settings.language)
+            language = self._settings.language
+            payload["language"] = (
+                language.value if isinstance(language, Language) else str(language)
+            )
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",

--- a/src/pipecat/transcriptions/language.py
+++ b/src/pipecat/transcriptions/language.py
@@ -617,7 +617,7 @@ def resolve_language(
         return result
 
     # Not in map - fall back with warning
-    lang_str = str(language)
+    lang_str = language.value if isinstance(language, Language) else str(language)
 
     if use_base_code:
         # Extract base code (e.g., "en" from "en-US")

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -33,6 +33,7 @@ from pipecat.frames.frames import (
 from pipecat.metrics.metrics import TTFBMetricsData
 from pipecat.processors.aggregators.llm_context import NOT_GIVEN
 from pipecat.processors.frame_processor import FrameDirection
+from pipecat.transcriptions.language import Language
 from pipecat.utils.tracing.service_attributes import (
     add_gemini_live_span_attributes,
     add_llm_span_attributes,
@@ -613,7 +614,11 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                         span.set_attribute("transcript", " ".join(state["segments"]).strip())
                     span.set_attribute("is_final", bool(frame.finalized))
                     if frame.language:
-                        span.set_attribute("language", str(frame.language))
+                        language = frame.language
+                        span.set_attribute(
+                            "language",
+                            language.value if isinstance(language, Language) else str(language),
+                        )
                     if frame.user_id:
                         span.set_attribute("user_id", frame.user_id)
                     if frame.finalized:

--- a/tests/test_language_serialization.py
+++ b/tests/test_language_serialization.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Language enum wire serialization.
+
+These tests guard against serialization regressions where ``str(Language.X)``
+is used to build wire values (query params, payloads). ``str()`` on a
+``StrEnum`` member depends on the enum's ``__str__`` semantics: the stdlib
+``StrEnum`` (Python 3.11+) returns the value (``"en"``), while a plain
+``class StrEnum(str, Enum)`` fallback inherits ``Enum.__str__`` and returns
+the member name (``"Language.EN"``). On the pipecat 0.0.10x line running
+Python 3.10, this caused DeepgramSTTService to send ``language=Language.EN``
+in the WebSocket query string, resulting in a 400 on every connect.
+
+Wire serialization should always use ``.value`` so it never depends on
+``__str__`` semantics.
+"""
+
+from enum import Enum
+
+import pytest
+
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.transcriptions.language import Language
+
+
+@pytest.fixture
+def legacy_strenum_str():
+    """Simulate the pre-3.11 vendored StrEnum fallback.
+
+    The fallback (``class StrEnum(str, Enum)`` with only ``__new__``) inherits
+    ``Enum.__str__``, so ``str(Language.EN)`` returns ``"Language.EN"`` instead
+    of ``"en"``. Restores the original ``__str__`` after the test.
+    """
+    original = Language.__str__
+    Language.__str__ = Enum.__str__
+    yield
+    Language.__str__ = original
+
+
+def test_deepgram_connect_kwargs_language_uses_enum_value():
+    """The Deepgram connect kwargs must contain the enum value, not the member name."""
+    service = DeepgramSTTService(api_key="test-key")
+    kwargs = service._build_connect_kwargs()
+    assert kwargs["language"] == "en"
+
+
+def test_deepgram_connect_kwargs_language_is_str_independent(legacy_strenum_str):
+    """Language serialization must not depend on StrEnum.__str__ semantics.
+
+    With ``__str__`` behaving like the pre-3.11 vendored fallback,
+    ``str(Language.EN)`` returns ``"Language.EN"``. The wire value must still
+    be ``"en"`` because serialization goes through ``.value``.
+    """
+    assert str(Language.EN) == "Language.EN"  # sanity-check the simulation
+    service = DeepgramSTTService(api_key="test-key")
+    kwargs = service._build_connect_kwargs()
+    assert kwargs["language"] == "en"
+
+
+def test_deepgram_connect_kwargs_language_accepts_plain_string():
+    """Plain string language values must pass through unchanged."""
+    service = DeepgramSTTService(
+        api_key="test-key",
+        settings=DeepgramSTTService.Settings(language="en-US"),
+    )
+    kwargs = service._build_connect_kwargs()
+    assert kwargs["language"] == "en-US"


### PR DESCRIPTION
## What

Replaces `str(language)` with explicit `.value` extraction (`language.value if isinstance(language, Language) else str(language)`) at every site where a `Language` enum member is serialized into a wire value (query params, request payloads, trace attributes):

- `services/deepgram/stt.py` — WS connect query param
- `services/deepgram/sagemaker/stt.py` — connect query param
- `services/xai/tts.py` — HTTP payload (the WS path in `_build_url` already does this correctly; this aligns the HTTP service with it)
- `services/groq/tts.py` — legacy `params.language` migration path
- `services/openai/stt.py` — `_language_to_code`
- `transcriptions/language.py` — `resolve_language` fallback path
- `utils/tracing/service_decorators.py` — span attribute

Adds `tests/test_language_serialization.py` with a regression test that simulates the legacy `__str__` behavior and asserts the wire value stays `"en"`.

Refs #4675

## Why

`str()` on a `StrEnum` member silently depends on the enum's `__str__` semantics. On the 0.0.10x line with Python 3.10, the vendored `StrEnum` fallback (which only defined `__new__`, not `__str__`) made `str(Language.EN)` return `"Language.EN"`, which went into the Deepgram WS query string and produced a 400 on every connect — full analysis in #4675.

`main` (Python ≥3.11, stdlib `StrEnum`) is not affected today — this is a hardening change, not a bug fix, hence "Refs" rather than "Fixes". `.value` states the intent explicitly and makes the wire format independent of `__str__`, so this regression class becomes structurally impossible regardless of how `StrEnum` is sourced or whether any subclass ever overrides `__str__`/`__format__`. It also makes the codebase consistent with itself: `xai/tts.py`'s `_build_url` already uses the `isinstance(language, Language)` + `.value` pattern.

The new test locks this in: it swaps in `Enum.__str__` (exactly what the legacy fallback resolved to), confirms `str(Language.EN) == "Language.EN"`, and asserts `DeepgramSTTService._build_connect_kwargs()` still emits `language="en"`.

## Behavior change

None on any supported Python version. Output is byte-identical; this only removes an implicit dependency on `__str__`.

## Testing

- `pytest tests/test_language_serialization.py tests/test_deepgram_stt.py` — 16 passed
- `pytest tests/test_xai_tts.py tests/test_tracing_context.py` — same results as `main` (one pre-existing fixture error on `test_run_xai_tts_success`, present on a clean checkout too)
- `ruff format --check` / `ruff check` clean on all touched files

Happy to scope this down to just the Deepgram services if you'd prefer a smaller diff.
