### PR TITLE
fix(transports): self-exit with_mixer silence-fill loop when transport is dead

### DIFF
--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -152,6 +152,26 @@ class BaseOutputTransport(FrameProcessor):
         for _, sender in self._media_senders.items():
             await sender.cancel(frame)
 
+    def is_transport_alive(self) -> bool:
+        """Return True if the underlying transport can still deliver frames.
+
+        Used by ``with_mixer()`` to bail out of the empty-queue silence-fill
+        loop when the audio task has survived pipeline cancellation and the
+        underlying transport is closed — see issue #4679. Without this hook
+        the loop runs ``mixer.mix(silence)`` forever on a dead transport and
+        burns a full CPU core indefinitely.
+
+        Subclasses with a connection lifecycle (e.g. WebSocket transports)
+        should override this with a cheap synchronous check on their client
+        state. The default ``True`` keeps existing transports unchanged —
+        they opt into the self-heal behaviour by overriding.
+
+        Returns:
+            True if the transport can still receive audio, False to signal
+            that the audio task should exit because the transport is dead.
+        """
+        return True
+
     async def set_transport_ready(self, frame: StartFrame):
         """Called when the transport is ready to stream.
 
@@ -788,6 +808,27 @@ class BaseOutputTransport(FrameProcessor):
                         yield frame
                         self._audio_queue.task_done()
                     except asyncio.QueueEmpty:
+                        # Cheap dead-transport probe BEFORE doing the heavy
+                        # mixer.mix(silence) work. If the audio task has
+                        # survived pipeline cancellation and the underlying
+                        # transport is closed, exit the generator —
+                        # _audio_task_handler's `async for` ends naturally
+                        # and the asyncio task releases its references.
+                        # Without this, the loop synthesizes silence + mixes
+                        # forever on a dead transport, burning a full CPU
+                        # core (see issue #4679).
+                        #
+                        # is_transport_alive() is a synchronous attribute
+                        # read on subclasses that opt in. Transports that
+                        # haven't overridden it keep the existing
+                        # behaviour (default returns True).
+                        if not self._transport.is_transport_alive():
+                            logger.info(
+                                f"{self._transport} audio task exiting: "
+                                f"transport reports not alive — pipeline "
+                                f"cancellation did not reach this task"
+                            )
+                            return
                         # Fallback: notify the bot stopped speaking upstream if necessary based on timeout.
                         diff_time = time.time() - last_frame_time
                         if diff_time > vad_stop_secs:

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -448,6 +448,15 @@ class FastAPIWebsocketOutputTransport(BaseOutputTransport):
         """
         await self._write_frame(frame)
 
+    def is_transport_alive(self) -> bool:
+        """Return True while the WebSocket can still receive audio.
+
+        Used by the base output transport's ``with_mixer`` empty-queue
+        branch to bail out of the silence-fill loop on a dead connection —
+        see BaseOutputTransport.is_transport_alive() and issue #4679.
+        """
+        return bool(self._client and self._client.is_connected and not self._client.is_closing)
+
     async def write_audio_frame(self, frame: OutputAudioRawFrame) -> bool:
         """Write an audio frame to the WebSocket with timing simulation.
 


### PR DESCRIPTION
Fixes #4679.

## Summary

`BaseOutputTransport.with_mixer()` has an empty-queue branch that synthesizes silence and trails with `await asyncio.sleep(0)`. When the audio task survives pipeline cancellation and the underlying transport is closed (e.g. `FastAPIWebsocketOutputTransport.write_audio_frame()` returns `False` instantly with no TCP backpressure), the loop spins at scheduler dispatch rate and runs `mixer.mix(silence)` + filter + numpy clip on a closed socket indefinitely — a full CPU core consumed per leaked task, in our production fleet sustained for hours after the call ended.

This PR adds a cheap synchronous probe (`is_transport_alive()`) that the `with_mixer` empty-queue branch checks **before** the heavy mix work. When the probe returns False the generator returns, `_audio_task_handler`'s `async for` ends naturally, and the asyncio task releases its references.

A full diagnosis, reproducer script, and py-spy stack from production are in #4679.

## Design

- New method `BaseOutputTransport.is_transport_alive() -> bool`, default `True` — keeps every existing transport unchanged.
- `with_mixer`'s `except asyncio.QueueEmpty:` branch calls it **before** `mixer.mix(silence)`. If it returns `False`, the generator returns.
- `FastAPIWebsocketOutputTransport` opts in by overriding the method to return `self._client.is_connected and not self._client.is_closing` — same flags `write_audio_frame()` already checks.

Other transports (Daily, LiveKit, Twilio, etc.) keep current behaviour and can opt in transport-by-transport in follow-ups.

## Why this design (vs. alternatives I considered)

| Approach | Healthy call | Leaked task | Notes |
|---|---|---|---|
| **This PR (probe before mix)** | +1 attribute read (~10 ns) | Exits in µs on first empty-queue iter | Most surgical |
| Counter on consecutive `write_audio_frame()` failures (post-mix) | No change | Exits after N iters; **N × 5 ms of CPU spike during detection** | Detected too late — still pegs a core for N iters |
| Budget-based pacing (`asyncio.sleep(max(0, chunk_secs - elapsed))`) | No change (backpressure already paces ≥ chunk_secs) | Caps at audio rate ~100 Hz → 0.5 cores | Doesn't end the leak, just slows it |
| Fix the underlying cancellation race | No change | Leak doesn't fire in the first place | Best long-term but the race is hard to pin down deterministically (see issue) — this PR is the band-aid while that audit happens |

## Risk analysis

- **Healthy calls during silence periods:** the probe runs in `with_mixer`'s empty-queue branch, which fires during natural pauses (between bot turns, user thinking). On a healthy WS, `is_connected = True` and `is_closing = False` → probe returns `True` → loop continues. The extra cost is one attribute read.
- **Premature exit on transient blip:** the probe uses `is_connected`/`is_closing`, which flip only on explicit WebSocket lifecycle events (open/close), not on packet loss or jitter. So a brief network hiccup mid-call cannot trip it.
- **`_client` is `None` during early startup:** the override is `bool(self._client and ...)` — short-circuits to `False`, but in practice the audio task isn't created until `set_transport_ready()` runs and `_client` is set. The `bool()` is defense in depth.
- **`without_mixer()` (non-mixer path):** not touched. It uses `await asyncio.wait_for(queue.get(), timeout=BOT_VAD_STOP_SECS)` which blocks for seconds — it doesn't spin and doesn't have this bug.
- **Transports that haven't overridden:** default returns `True`, no behaviour change.

## Logging

The self-exit emits one `logger.info` line so deployments can count occurrences:

```
<transport_repr> audio task exiting: transport reports not alive — pipeline cancellation did not reach this task
```

That gives operators a metric for how often the underlying cancellation race fires. If it's frequent, that points to a deeper bug in pipeline cancellation worth investigating; if it's rare, the self-heal is doing its job and the audit can be deprioritized.

## Test plan

CI runs the existing suite. Manual stage validation we'll run before promoting to prod on our side:

1. Pick an agent with `audio_out_mixer` configured (without mixer the call goes through `without_mixer()` which isn't touched).
2. Normal end-to-end call. Listen during natural silence (between bot turns, while you're thinking). No audio glitches expected — the change is one attribute read per iteration.
3. Confirm CPU on the handling pod stays in the normal envelope during the call and drops to baseline after hang-up.
4. Induce a leak (abrupt mid-stream hangup from the network side, e.g. close the WS forcefully). Watch the pod's CPU:
   - Pre-fix: 1.0 cores stuck.
   - Post-fix: brief micro-spike for the in-flight iteration, then **immediate drop to baseline** and the info-log line appears.
5. Negative control: agent without `audio_out_mixer` → goes through `without_mixer()` → unaffected.

## Files

- `src/pipecat/transports/base_output.py` — +41 lines: new `is_transport_alive()` default impl + probe in `with_mixer`'s empty-queue branch + info log on exit.
- `src/pipecat/transports/websocket/fastapi.py` — +11 lines: override returning `_client.is_connected and not _client.is_closing`.

Happy to iterate on naming, log level, opting in other transports, etc. — wanted to keep the first PR small and self-contained.