### PR TITLE
Update SambaNova default model to Meta-Llama-3.3-70B-Instruct

### DIFF
--- a/changelog/4687.fixed.md
+++ b/changelog/4687.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SambaNovaLLMService` failing every completion with its default model: SambaNova Cloud removed `Llama-4-Maverick-17B-128E-Instruct`, so the default is now `Meta-Llama-3.3-70B-Instruct`.

--- a/src/pipecat/services/sambanova/llm.py
+++ b/src/pipecat/services/sambanova/llm.py
@@ -60,7 +60,7 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
 
         Args:
             api_key: The API key for accessing SambaNova API.
-            model: The model identifier to use. Defaults to "Llama-4-Maverick-17B-128E-Instruct".
+            model: The model identifier to use. Defaults to "Meta-Llama-3.3-70B-Instruct".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=SambaNovaLLMService.Settings(model=...)`` instead.
@@ -71,7 +71,7 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="Llama-4-Maverick-17B-128E-Instruct")
+        default_settings = self.Settings(model="Meta-Llama-3.3-70B-Instruct")
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:


### PR DESCRIPTION
## Summary

SambaNova Cloud removed `Llama-4-Maverick-17B-128E-Instruct` (see [their deprecations page](https://docs.sambanova.ai/cloud/docs/resources/deprecations)), so every completion with `SambaNovaLLMService`'s default model now fails with:

> The requested model (Llama-4-Maverick-17B-128E-Instruct) is not available on SambaNova Cloud.

This change defaults to `Meta-Llama-3.3-70B-Instruct`, which is currently available and validated to handle function calling correctly (clean `tool_calls` for the weather-tool request the release evals exercise).
