### PR TITLE
Update Nebius default model to Qwen3-30B-A3B-Instruct-2507

### DIFF
--- a/changelog/4688.fixed.md
+++ b/changelog/4688.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `NebiusLLMService` function calls never executing with its default model: Nebius streams `openai/gpt-oss-120b` tool calls with a broken final fragment (`index=1` on a single call), so the default is now `Qwen/Qwen3-30B-A3B-Instruct-2507`, which streams correctly.

--- a/src/pipecat/services/nebius/llm.py
+++ b/src/pipecat/services/nebius/llm.py
@@ -55,7 +55,7 @@ class NebiusLLMService(OpenAILLMService):
         """
         # Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="openai/gpt-oss-120b",
+            model="Qwen/Qwen3-30B-A3B-Instruct-2507",
         )
 
         # Apply settings delta (canonical API, always wins)


### PR DESCRIPTION
## Summary

`NebiusLLMService`'s default model (`openai/gpt-oss-120b`) silently breaks function calling: Nebius's tokenfactory endpoint streams the **final arguments fragment of a tool call with `index=1` instead of `0`**:

```
index=0 id='chatcmpl-tool-…' name='get_current_weather' args=''
index=0 args='{\n'
…
index=0 args='format": "fahren'
index=1 args='heit"\n}'     ← off-by-one on the last fragment
```

Per the OpenAI streaming contract, `index` identifies which call a fragment belongs to, so Pipecat's (spec-correct) reassembly treats this as a second call — the real call's arguments are truncated and the call never executes. The bot produces neither a tool call nor text.

This is **specific to Nebius's gpt-oss adapter**: `meta-llama/Llama-3.3-70B-Instruct` and `Qwen/Qwen3-30B-A3B-Instruct-2507` on the same endpoint stream `index=0` throughout. The bug should be reported to Nebius; Pipecat's parsing stays as is.

## Change

Default to `Qwen/Qwen3-30B-A3B-Instruct-2507`, which streams correctly and passes the function-calling release eval end to end (proper `get_current_weather` call, grounded weather answer). Llama-3.3-70B was also evaluated and rejected: it narrates tool calls as text instead of invoking them under a voice-bot system prompt.
