### PR TITLE
feat(cli): scaffold the eval transport in `pipecat init` via --eval

### DIFF
--- a/changelog/4664.added.md
+++ b/changelog/4664.added.md
@@ -1,0 +1,1 @@
+- Added an opt-in `--eval` flag to `pipecat init` (and an `Enable evals?` wizard prompt, off by default) that scaffolds an `"eval"` entry in the bot's `transport_params`, so the generated bot is runnable with `-t eval` for behavioral evals without any manual edit. The entry mirrors the bot's audio/video settings and is inert unless the bot is run with `-t eval`.

--- a/src/pipecat/cli/commands/init.py
+++ b/src/pipecat/cli/commands/init.py
@@ -110,6 +110,12 @@ def init_command(
     observability: bool = typer.Option(
         False, "--observability/--no-observability", help="Enable observability"
     ),
+    enable_eval: bool = typer.Option(
+        False,
+        "--eval/--no-eval",
+        help="Add an 'eval' transport so the bot is runnable with `-t eval` for "
+        "behavioral evals (see `pipecat eval`). Off by default.",
+    ),
     config: Path | None = typer.Option(
         None, "--config", "-c", help="JSON config file (triggers non-interactive mode)"
     ),
@@ -208,6 +214,9 @@ def init_command(
                 observability = observability or file_data.get(
                     "observability", file_data.get("enable_observability", False)
                 )
+                enable_eval = enable_eval or file_data.get(
+                    "enable_eval", file_data.get("eval", False)
+                )
 
             try:
                 project_config = validate_and_build_config(
@@ -231,6 +240,7 @@ def init_command(
                     deploy_to_cloud=deploy_to_cloud,
                     enable_krisp=enable_krisp,
                     observability=observability,
+                    enable_eval=enable_eval,
                 )
             except ConfigValidationError as e:
                 console.print(f"\n[red]{e}[/red]")

--- a/src/pipecat/cli/config_validator.py
+++ b/src/pipecat/cli/config_validator.py
@@ -57,6 +57,7 @@ def validate_and_build_config(
     deploy_to_cloud: bool = True,
     enable_krisp: bool = False,
     observability: bool = False,
+    enable_eval: bool = False,
 ) -> ProjectConfig:
     """Validate all inputs and build a ProjectConfig.
 
@@ -294,6 +295,7 @@ def validate_and_build_config(
         deploy_to_cloud=deploy_to_cloud,
         enable_krisp=enable_krisp,
         enable_observability=observability,
+        enable_eval=enable_eval,
     )
     return config
 
@@ -333,5 +335,6 @@ def config_to_json(config: ProjectConfig) -> str:
         "deploy_to_cloud": config.deploy_to_cloud,
         "enable_krisp": config.enable_krisp,
         "enable_observability": config.enable_observability,
+        "enable_eval": config.enable_eval,
     }
     return json.dumps(data, indent=2)

--- a/src/pipecat/cli/generators/project.py
+++ b/src/pipecat/cli/generators/project.py
@@ -282,6 +282,7 @@ class ProjectGenerator:
             "recording": self.config.recording,
             "transcription": self.config.transcription,
             "observability": self.config.enable_observability,
+            "eval": self.config.enable_eval,
         }
 
         # Get imports
@@ -312,6 +313,7 @@ class ProjectGenerator:
             "transcription": self.config.transcription,
             "enable_krisp": self.config.enable_krisp,
             "enable_observability": self.config.enable_observability,
+            "enable_eval": self.config.enable_eval,
             "service_configs": ServiceRegistry.SERVICE_CONFIGS,
             "daily_pstn_mode": self.config.daily_pstn_mode,
             "twilio_daily_sip_mode": self.config.twilio_daily_sip_mode,

--- a/src/pipecat/cli/prompts/questions.py
+++ b/src/pipecat/cli/prompts/questions.py
@@ -106,6 +106,10 @@ class ProjectConfig:
     # Observability
     enable_observability: bool = False
 
+    # Evals: add an "eval" entry to transport_params so the bot is runnable with
+    # `-t eval` for behavioral evals (see `pipecat eval`). Off by default.
+    enable_eval: bool = False
+
 
 def ask_project_questions(default_name: str | None = None) -> ProjectConfig:
     """Ask user for project configuration through interactive prompts.
@@ -626,5 +630,15 @@ def ask_project_questions(default_name: str | None = None) -> ProjectConfig:
         replace_question_with_answer(
             "Enable Krisp noise cancellation?", "Yes" if config.enable_krisp else "No"
         )
+
+    # Question 9: Eval transport (behavioral evals). Bot-type agnostic; off by
+    # default — it adds an inert "eval" entry to transport_params that is only used
+    # when the bot is run with `-t eval`.
+    config.enable_eval = questionary.confirm(
+        "Enable evals?",
+        default=False,
+        style=custom_style,
+    ).ask()
+    replace_question_with_answer("Enable evals?", "Yes" if config.enable_eval else "No")
 
     return config

--- a/src/pipecat/cli/registry/_imports.py
+++ b/src/pipecat/cli/registry/_imports.py
@@ -213,6 +213,7 @@ FEATURE_IMPORTS = {
         "from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies"
     ],
     "create_transport": ["from pipecat.runner.utils import create_transport"],
+    "eval": ["from pipecat.transports.websocket.server import WebsocketServerParams"],
 }
 
 # Base imports always included in generated bot files

--- a/src/pipecat/cli/registry/service_loader.py
+++ b/src/pipecat/cli/registry/service_loader.py
@@ -259,6 +259,8 @@ class ServiceLoader:
             imports.update(ServiceRegistry.FEATURE_IMPORTS["transcription"])
         if features.get("observability"):
             imports.update(ServiceRegistry.FEATURE_IMPORTS["observability"])
+        if features.get("eval"):
+            imports.update(ServiceRegistry.FEATURE_IMPORTS["eval"])
 
         # Most bots build transports via create_transport, so import it whenever the
         # bot uses that collapsed path. Only dial-out and SIP keep a bespoke flow that

--- a/src/pipecat/cli/registry/service_metadata.py
+++ b/src/pipecat/cli/registry/service_metadata.py
@@ -111,6 +111,9 @@ FEATURE_DEFINITIONS: dict[str, list[str]] = {
     # Imported on the standard (non-PSTN/SIP) transport path: the collapsed bot()
     # calls create_transport. Dial-out and SIP construct their transports by hand.
     "create_transport": ["create_transport"],
+    # The "eval" transport entry (pc init --eval) needs WebsocketServerParams so the
+    # generated bot is runnable with `-t eval` for behavioral evals.
+    "eval": ["WebsocketServerParams"],
 }
 
 

--- a/src/pipecat/cli/templates/server/bot_cascade.py.jinja2
+++ b/src/pipecat/cli/templates/server/bot_cascade.py.jinja2
@@ -140,6 +140,14 @@ async def bot(runner_args: RunnerArguments):
             audio_out_enabled=True,
         ),
         {% endfor %}
+        {% if enable_eval %}
+        # Behavioral evals: run with `-t eval` to drive this bot via `pipecat eval`.
+        "eval": lambda: WebsocketServerParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            {% if video_input %}video_in_enabled=True,{% endif %}
+        ),
+        {% endif %}
     }
 
     transport = await create_transport(runner_args, transport_params)

--- a/src/pipecat/cli/templates/server/bot_realtime.py.jinja2
+++ b/src/pipecat/cli/templates/server/bot_realtime.py.jinja2
@@ -133,6 +133,14 @@ async def bot(runner_args: RunnerArguments):
             audio_out_enabled=True,
         ),
         {% endfor %}
+        {% if enable_eval %}
+        # Behavioral evals: run with `-t eval` to drive this bot via `pipecat eval`.
+        "eval": lambda: WebsocketServerParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            {% if video_input %}video_in_enabled=True,{% endif %}
+        ),
+        {% endif %}
     }
 
     transport = await create_transport(runner_args, transport_params)

--- a/tests/cli/test_project_generation.py
+++ b/tests/cli/test_project_generation.py
@@ -786,6 +786,39 @@ def test_collapsed_transport_construction(temp_output_dir):
     ast.parse(bot)  # raises if the generated bot has a syntax error
 
 
+def test_eval_transport_opt_in(temp_output_dir):
+    """``enable_eval`` adds an inert ``eval`` transport entry; it's absent otherwise."""
+
+    def gen(name, *, enable_eval):
+        path = temp_output_dir / name
+        if path.exists():
+            shutil.rmtree(path)
+        ProjectGenerator(
+            ProjectConfig(
+                project_name=name,
+                bot_type="web",
+                transports=["smallwebrtc"],
+                mode="cascade",
+                stt_service="deepgram_stt",
+                llm_service="openai_llm",
+                tts_service="cartesia_tts",
+                enable_eval=enable_eval,
+            )
+        ).generate(output_dir=temp_output_dir)
+        return (path / "server" / "bot.py").read_text()
+
+    # Off by default: no eval entry, no WebsocketServerParams import.
+    without = gen("eval-off", enable_eval=False)
+    assert '"eval":' not in without
+    assert "WebsocketServerParams" not in without
+
+    # Opted in: the eval entry and its import are generated, and the bot is valid.
+    with_eval = gen("eval-on", enable_eval=True)
+    assert '"eval": lambda: WebsocketServerParams(' in with_eval
+    assert "from pipecat.transports.websocket.server import WebsocketServerParams" in with_eval
+    ast.parse(with_eval)  # raises if the generated bot has a syntax error
+
+
 def _gen_bot(temp_output_dir, name, **kwargs):
     """Generate a telephony cascade bot and return its bot.py text.
 


### PR DESCRIPTION
## Summary

Adds an opt-in `--eval` / `--no-eval` flag (and an "Enable evals?" wizard question, default **No**) to `pipecat init`. When enabled, the generated bot gets an inert `"eval"` entry in `transport_params` so it's runnable with `-t eval` for behavioral evals — removing the previously-manual step.

The entry mirrors the bot's audio/video flags and is only used when the bot is run with `-t eval`. The required `WebsocketServerParams` import is registered as an `"eval"` feature in `FEATURE_DEFINITIONS` (regenerating `_imports.py`), so it flows through the same registry path as the other feature imports rather than being injected ad hoc.

## Base

Targets `aleix/evals`, which already carries the eval framework, runner `-t eval` support, and the ported init CLI. This branch is just the two init-side commits cherry-picked cleanly on top.

## Changes

- `--eval`/`--no-eval` flag + wizard question on `pipecat init`
- `"eval"` feature in the CLI service registry → imports `WebsocketServerParams`
- `enable_eval` block in the cascade/realtime bot templates emitting the `"eval"` transport entry
- Test coverage in `tests/cli/test_project_generation.py`

## Test plan

- `uv run --extra cli pytest tests/cli/test_project_generation.py` → 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)