### PR TITLE
Enable RTVI on LLMWorker unless it is bridged

### DIFF
--- a/changelog/4690.changed.md
+++ b/changelog/4690.changed.md
@@ -1,0 +1,1 @@
+- `LLMWorker` now enables the worker's automatic RTVI support when it is not bridged (`bridged=None`), so a standalone `LLMWorker` driving its own transport gets the `RTVIProcessor`/`RTVIObserver` pair like any `PipelineWorker`. Bridged child workers keep RTVI disabled, since the transport worker owns the client-facing RTVI machinery.

--- a/src/pipecat/workers/llm/llm_worker.py
+++ b/src/pipecat/workers/llm/llm_worker.py
@@ -120,7 +120,7 @@ class LLMWorker(PipelineWorker):
             name=name,
             bridged=bridged,
             exclude_frames=(PipelineFlushFrame,),
-            enable_rtvi=False,
+            enable_rtvi=bridged is None,
             idle_timeout_secs=None,
             params=PipelineParams(
                 enable_metrics=True,


### PR DESCRIPTION
## Summary

`LLMWorker` passed `enable_rtvi=False` to `PipelineWorker` unconditionally, so a standalone `LLMWorker` never got the worker's automatic RTVI support. This change makes it conditional: `enable_rtvi=bridged is None`.

- **Standalone `LLMWorker`** (`bridged=None`): can be the bot's only worker, used directly for its `@tool` collection with a transport in its pipeline. It is client-facing, so the automatic `RTVIProcessor`/`RTVIObserver` pair is now added as for any `PipelineWorker`.
- **Bridged child worker** (`bridged=()` or bridge names): RTVI stays disabled. The transport worker owns the client connection and its RTVI machinery translates the bridged frames; the child generating its own RTVI messages would duplicate them.

## Test plan

- [x] `uv run pytest tests/test_llm_worker.py tests/test_base_worker.py` — 67 passed
- [x] `uv run ruff check` clean
