### PR TITLE
Remove sleep(0) workarounds obsoleted by the task-manager fix

### DIFF
--- a/changelog/4692.changed.md
+++ b/changelog/4692.changed.md
@@ -1,0 +1,1 @@
+- Removed the `asyncio.sleep(0)` workarounds that let a just-created timer task start before a possible immediate cancellation. `TaskManager.create_task()` now cleans up never-started coroutines centrally, so the yields served no purpose.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -997,11 +997,6 @@ class LLMUserAggregator(LLMContextAggregator):
             self._realtime_deferred_handoff_flush(),
             name=f"{self}::realtime_handoff_flush",
         )
-        # Yield so the task's wrapper coroutine starts running before
-        # any immediate cancellation by the failsafe path — otherwise
-        # asyncio GCs the inner coroutine without ever entering it and
-        # emits a "coroutine was never awaited" warning.
-        await asyncio.sleep(0)
 
     async def _realtime_deferred_handoff_flush(self) -> None:
         """Wait one ``ttfs_p99_latency`` window, then flush whatever has arrived."""

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1924,8 +1924,6 @@ class GeminiLiveLLMService(LLMService[GeminiLLMAdapter]):
             self._transcription_timeout_task = self.create_task(
                 self._transcription_timeout_handler()
             )
-            # Let the event loop schedule the taks before it gets cancelled.
-            await asyncio.sleep(0)
 
     async def _handle_msg_output_transcription(self, message: LiveServerMessage):
         """Handle the output transcription message."""

--- a/src/pipecat/turns/user_idle_controller.py
+++ b/src/pipecat/turns/user_idle_controller.py
@@ -121,8 +121,6 @@ class UserIdleController(BaseObject):
             return
         await self._cancel_idle_timer()
         self._idle_timer_task = self.create_task(self._idle_timer_expired())
-        # Make sure the task is scheduled.
-        await asyncio.sleep(0)
 
     async def _cancel_idle_timer(self):
         """Cancel the idle timer if running."""

--- a/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
@@ -197,9 +197,6 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
                 f"{self}::_stt_timeout_handler",
             )
 
-        # Make sure the tasks are scheduled.
-        await asyncio.sleep(0)
-
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
         self._text += frame.text
@@ -238,9 +235,6 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
             self._user_speech_timeout_handler(self._user_speech_timeout),
             f"{self}::_user_speech_timeout_handler",
         )
-        # Make sure the task is scheduled so it can't be cancelled before
-        # starting (which would leave its coroutine un-awaited).
-        await asyncio.sleep(0)
 
     async def _user_speech_timeout_handler(self, timeout: float):
         """Wait user_speech_timeout then attempt to trigger user turn stopped.

--- a/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
@@ -223,8 +223,6 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._timeout_task = self.task_manager.create_task(
             self._timeout_handler(timeout), f"{self}::_timeout_handler"
         )
-        # Make sure the task is scheduled.
-        await asyncio.sleep(0)
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
@@ -256,8 +254,6 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
             self._timeout_task = self.task_manager.create_task(
                 self._timeout_handler(timeout), f"{self}::_timeout_handler"
             )
-            # Make sure the task is scheduled.
-            await asyncio.sleep(0)
 
     async def _handle_prediction_result(self, result: MetricsData | None):
         """Handle a prediction result event from the turn analyzer."""

--- a/src/pipecat/turns/user_turn_completion_mixin.py
+++ b/src/pipecat/turns/user_turn_completion_mixin.py
@@ -287,8 +287,6 @@ class UserTurnCompletionLLMServiceMixin(FrameProcessor):
             self._incomplete_timeout_handler(incomplete_type, timeout),
             f"_incomplete_timeout_{incomplete_type}",
         )
-        # Make sure the task is scheduled.
-        await asyncio.sleep(0)
 
     async def _cancel_incomplete_timeout(self):
         """Cancel any pending incomplete timeout task."""


### PR DESCRIPTION
## Summary

Since #4649, `TaskManager.create_task()` closes a never-started inner coroutine from a done callback, so cancelling a task before its wrapper runs no longer emits `RuntimeWarning: coroutine '...' was never awaited`. That makes the `await asyncio.sleep(0)` calls whose only purpose was to let a just-created timer task start before a possible immediate cancel unnecessary. #4649 already removed the one in `LLMService._run_function_call`; this removes the remaining eight:

- `processors/aggregators/llm_response_universal.py` (realtime handoff flush task)
- `services/google/gemini_live/llm.py` (transcription timeout task)
- `turns/user_idle_controller.py` (idle timer)
- `turns/user_turn_completion_mixin.py` (incomplete timeout)
- `turns/user_stop/speech_timeout_user_turn_stop_strategy.py` (two sites: STT wait + user speech timeout)
- `turns/user_stop/turn_analyzer_user_turn_stop_strategy.py` (two sites: timeout handler)

Several of the removed comments stated the purpose verbatim ("which would leave its coroutine un-awaited", "emits a 'coroutine was never awaited' warning").

## Deliberately kept

The remaining `asyncio.sleep(0)` calls serve different purposes and are untouched:

- `transports/base_output.py`: prevents a 100% CPU spin in the audio loop under cancellation.
- `bus/bus.py` (x2), `bus/network/redis.py`, `bus/network/pgmq.py`, `workers/runner.py`, `workers/proxy/websocket/{client,server}.py`: start-up yields so reader/dispatch loops begin promptly — #4649 changes nothing about when tasks start, only how never-started ones are cleaned up.

## Test plan

- [x] `tests/test_context_aggregators_universal.py`, `test_llm_response.py`, `test_task_manager.py`, `test_idle_frame_processor.py` — 84 passed
- [x] All six turn-strategy test files (completion mixin, controller, processor, start/stop strategies, wake phrase) — 72 passed
- [x] `tests/test_user_turn_stop_strategy.py` with `-W error::RuntimeWarning` — 24 passed, no never-awaited warnings
- [x] `ruff check` clean
