### PR TITLE
fix(cli): make --eval tri-state so explicit flags beat --config values

### DIFF
--- a/changelog/4693.fixed.md
+++ b/changelog/4693.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `pipecat init` ignoring an explicit `--no-eval` when the `--config` file sets `"enable_eval": true`. The flag is now tri-state: an explicit `--eval`/`--no-eval` always wins, and the file value only applies when the flag is omitted.

--- a/src/pipecat/cli/commands/init.py
+++ b/src/pipecat/cli/commands/init.py
@@ -110,8 +110,8 @@ def init_command(
     observability: bool = typer.Option(
         False, "--observability/--no-observability", help="Enable observability"
     ),
-    enable_eval: bool = typer.Option(
-        False,
+    enable_eval: bool | None = typer.Option(
+        None,
         "--eval/--no-eval",
         help="Add an 'eval' transport so the bot is runnable with `-t eval` for "
         "behavioral evals (see `pipecat eval`). Off by default.",
@@ -214,9 +214,10 @@ def init_command(
                 observability = observability or file_data.get(
                     "observability", file_data.get("enable_observability", False)
                 )
-                enable_eval = enable_eval or file_data.get(
-                    "enable_eval", file_data.get("eval", False)
-                )
+                # Tri-state: an explicit --eval/--no-eval always beats the file value;
+                # the file only applies when the flag was omitted.
+                if enable_eval is None:
+                    enable_eval = file_data.get("enable_eval", file_data.get("eval", False))
 
             try:
                 project_config = validate_and_build_config(
@@ -240,7 +241,7 @@ def init_command(
                     deploy_to_cloud=deploy_to_cloud,
                     enable_krisp=enable_krisp,
                     observability=observability,
-                    enable_eval=enable_eval,
+                    enable_eval=bool(enable_eval),
                 )
             except ConfigValidationError as e:
                 console.print(f"\n[red]{e}[/red]")

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -92,3 +92,25 @@ class TestFlagPrecedence:
         config_path = _write_config(tmp_path)  # no observability key -> defaults off
         resolved = _dry_run(["--config", str(config_path), "--observability"])
         assert resolved["enable_observability"] is True
+
+    def test_no_eval_flag_disables_over_file_value(self, tmp_path):
+        """An explicit --no-eval beats "enable_eval": true in the config file."""
+        config_path = _write_config(tmp_path, enable_eval=True)
+        resolved = _dry_run(["--config", str(config_path), "--no-eval"])
+        assert resolved["enable_eval"] is False
+
+    def test_eval_flag_enables_over_file_value(self, tmp_path):
+        """An explicit --eval beats "enable_eval": false in the config file."""
+        config_path = _write_config(tmp_path, enable_eval=False)
+        resolved = _dry_run(["--config", str(config_path), "--eval"])
+        assert resolved["enable_eval"] is True
+
+    def test_eval_file_value_applies_when_flag_omitted(self, tmp_path):
+        config_path = _write_config(tmp_path, enable_eval=True)
+        resolved = _dry_run(["--config", str(config_path)])
+        assert resolved["enable_eval"] is True
+
+    def test_eval_defaults_off_without_flag_or_file_key(self, tmp_path):
+        config_path = _write_config(tmp_path)
+        resolved = _dry_run(["--config", str(config_path)])
+        assert resolved["enable_eval"] is False


### PR DESCRIPTION
## Summary

Follow-up to #4689, reworking the surviving piece of pipecat-ai/pipecat-cli#96 per @markbackman's feedback there (the scenario scaffolding was dropped; the eval transport scaffolding already landed in #4689).

With `enable_eval` declared as a plain `bool` defaulting to `False`, an explicit `--no-eval` is indistinguishable from an omitted flag. The or-merge in `init_command` then lets `"enable_eval": true` in a `--config` file silently override an explicit `--no-eval`:

```bash
pipecat init --config saved.json --no-eval   # before: evals still enabled
```

This matters because `--dry-run` output (which includes `enable_eval`) is designed to be fed back via `--config`.

## Fix

- `--eval/--no-eval` now defaults to `None` (tri-state)
- The config-file value only applies when the flag was omitted
- The resolved value is coerced back to a real `bool` before `validate_and_build_config`, so `ProjectConfig`/JSON never see `None`

## Testing

- New dry-run precedence tests in `tests/cli/test_init_command.py`: `--no-eval` beats a true file value, `--eval` beats a false file value, file value applies when the flag is omitted, and everything defaults off
- `uv run pytest tests/cli/`: 273 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)