### PR TITLE
Drop the unused fixtures field from eval scenarios

### DIFF
--- a/src/pipecat/cli/commands/eval.py
+++ b/src/pipecat/cli/commands/eval.py
@@ -139,9 +139,8 @@ def _record_path(record_dir: str | None, scenario_name: str) -> str | None:
 def _build_scenario_runs(paths: list[Path], bot_url: str) -> list[EvalRun]:
     """Build an EvalRun per scenario YAML, each run against ``bot_url`` (no spawn).
 
-    A scenario's ``fixtures.bot_url`` overrides the URL. A scenario that fails to
-    load becomes an EvalRun already marked done with an error, so it shows in the
-    dashboard and the final tally like any other failure.
+    A scenario that fails to load becomes an EvalRun already marked done with an
+    error, so it shows in the dashboard and the final tally like any other failure.
     """
     runs: list[EvalRun] = []
     for path in paths:
@@ -153,8 +152,9 @@ def _build_scenario_runs(paths: list[Path], bot_url: str) -> list[EvalRun]:
             run.error = f"failed to load: {e}"
             runs.append(run)
             continue
-        url = scenario.fixtures.get("bot_url") or bot_url
-        runs.append(EvalRun(bot=url, scenario=scenario.name, scenario_path=path, bot_url=url))
+        runs.append(
+            EvalRun(bot=bot_url, scenario=scenario.name, scenario_path=path, bot_url=bot_url)
+        )
     return runs
 
 
@@ -267,8 +267,7 @@ def run(
     bot_url: str = typer.Option(
         "ws://localhost:7860",
         "--bot-url",
-        help="WebSocket URL of the bot's eval transport. "
-        "Overridden per-scenario by fixtures.bot_url.",
+        help="WebSocket URL of the bot's eval transport.",
     ),
     verbose: bool = typer.Option(
         False,

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -90,7 +90,6 @@ Top-level optional fields:
             ``audio`` makes the bot speak and judges the transcription of its
             actual audio (``tts_response``); ``text`` (the default) skips TTS and
             judges the LLM text (``llm_response``), which is faster and silent.
-    fixtures: free-form mapping (e.g. ``bot_url:``).
 
 Any value can be pulled from a separate file with ``!include``, resolved
 relative to the scenario file's directory. This is handy for sharing the
@@ -240,7 +239,6 @@ class EvalScenario:
             to the bot, exercising its STT for real. Mapping with ``service``,
             ``voice``, and optional ``model`` / ``sample_rate`` /
             ``api_key``. Omit for text-only evals (default).
-        fixtures: Optional fixtures dict (e.g. ``bot_url:``).
         source_path: Path the scenario was loaded from, for error messages.
     """
 
@@ -251,7 +249,6 @@ class EvalScenario:
     bot_audio: bool = False
     transcriber: dict | None = None
     user_audio: dict | None = None
-    fixtures: dict = field(default_factory=dict)
     source_path: Path | None = None
 
     @classmethod
@@ -326,7 +323,6 @@ class EvalScenario:
             bot_audio=bot_audio,
             transcriber=transcriber,
             user_audio=user_audio,
-            fixtures=data.get("fixtures") or {},
             source_path=path,
         )
 

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -231,7 +231,7 @@ class TestEvalsScenarioParser(unittest.TestCase):
         self.assertIsNone(s.turns[0].user)
         self.assertEqual(s.turns[0].expect[0].event, "llm_response")
 
-    def test_judge_eval_and_fixtures_preserved(self):
+    def test_judge_eval_preserved(self):
         s = EvalScenario.load(
             _write(
                 """
@@ -241,8 +241,6 @@ class TestEvalsScenarioParser(unittest.TestCase):
                     service: openai
                     model: gpt-4o-mini
                     endpoint: http://custom-endpoint
-                fixtures:
-                  bot_url: ws://localhost:9000
                 turns:
                   - user: "hi"
                     expect: [{event: user_stopped_speaking}]
@@ -253,7 +251,6 @@ class TestEvalsScenarioParser(unittest.TestCase):
             s.judge,
             {"service": "openai", "model": "gpt-4o-mini", "endpoint": "http://custom-endpoint"},
         )
-        self.assertEqual(s.fixtures, {"bot_url": "ws://localhost:9000"})
 
     def test_judge_block_defaults_to_ollama(self):
         s = EvalScenario.load(


### PR DESCRIPTION
## Summary

The scenario schema's free-form `fixtures:` mapping had exactly one consumer and one key ever used: `pipecat eval run` let `fixtures.bot_url` pin the bot URL a scenario runs against, overriding `--bot-url`.

Removing it because:

- It welds a *reusable* scenario to a deployment detail, against the design everywhere else (one shared scenario covers many bots; the whole release suite reuses `capital_question` across ~50 bots).
- The need is served elsewhere: per-bot runs pass `--bot-url`, and the suite manifest owns the bot-to-scenario mapping.
- No in-tree scenario used it; "free-form mapping" was speculative generality.

## Changes

- `evals/scenario.py`: remove the `fixtures` field, its parse line, and both docstring mentions.
- `cli/commands/eval.py`: remove the per-scenario URL override in `_build_scenario_runs` and the `--bot-url` help-text mention.
- `tests/test_evals_scenario.py`: trim the fixtures assertion from the parse test (now `test_judge_eval_preserved`).

## Test plan

- [x] `tests/test_evals_scenario.py` + `tests/test_evals_harness.py` — 71 passed
- [x] `ruff check` clean
- [x] No `fixtures` references remain in `src/`, `tests/`, or `scripts/release-evals/`
