### PR TITLE
fix(cli): env.example comments are parsed as values by python-dotenv

### DIFF
--- a/changelog/4697.fixed.md
+++ b/changelog/4697.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `pipecat init` generating an `env.example` where inline comments on optional variables (e.g. `OPENAI_MODEL`, `CARTESIA_VOICE_ID`) were parsed by python-dotenv as the variable's value, causing the generated bot to fail on startup. Comments now sit on their own line.

--- a/src/pipecat/cli/templates/server/env.example.jinja2
+++ b/src/pipecat/cli/templates/server/env.example.jinja2
@@ -5,7 +5,8 @@
 # Daily (Transport)
 DAILY_API_KEY=
 {% if 'daily' in transports %}
-DAILY_ROOM_URL=  # Optional: leave empty to create a new room
+# Optional: leave empty to create a new room
+# DAILY_ROOM_URL=
 {% endif %}
 {% if 'daily_pstn_dialout' in transports or 'twilio_daily_sip_dialin' in transports or 'twilio_daily_sip_dialout' in transports %}
 
@@ -67,7 +68,8 @@ AWS_BEDROCK_MODEL=
 # AWS_SESSION_TOKEN= # Optional
 {% endif %}
 {% if tts_service == 'aws_polly_tts' or realtime_service == 'aws_nova_realtime' %}
-AWS_VOICE_ID= # "Joanna"
+# "Joanna"
+# AWS_VOICE_ID=
 {% endif %}
 {% if realtime_service == 'aws_nova_realtime' %}
 # AWS_SESSION_TOKEN=  # Optional
@@ -98,14 +100,16 @@ AZURE_REALTIME_BASE_URL=
 {% if tts_service == 'camb_tts' %}
 # Camb (TTS)
 CAMB_API_KEY=
-CAMB_VOICE_ID= # 147320
+# 147320
+# CAMB_VOICE_ID=
 
 {% endif %}
 {% if stt_service == 'cartesia_stt' or stt_service == 'cartesia_turns_stt' or tts_service == 'cartesia_tts' %}
 # Cartesia (STT/TTS)
 CARTESIA_API_KEY=
 {% if tts_service == 'cartesia_tts' %}
-CARTESIA_VOICE_ID= # Optional: defaults to "71a7ad14-091c-4e8e-a314-022ece01c121" (British Reading Lady)
+# Optional: defaults to "71a7ad14-091c-4e8e-a314-022ece01c121" (British Reading Lady)
+# CARTESIA_VOICE_ID=
 {% endif %}
 
 {% endif %}
@@ -113,7 +117,8 @@ CARTESIA_VOICE_ID= # Optional: defaults to "71a7ad14-091c-4e8e-a314-022ece01c121
 # Deepgram (STT/TTS)
 DEEPGRAM_API_KEY=
 {% if tts_service == 'deepgram_tts' %}
-DEEPGRAM_VOICE_ID= # "aura-2-helena-en"
+# "aura-2-helena-en"
+# DEEPGRAM_VOICE_ID=
 {% endif %}
 
 {% endif %}
@@ -133,7 +138,8 @@ DEEPGRAM_SAGEMAKER_STT_REGION=
 # Deepgram SageMaker (TTS)
 DEEPGRAM_SAGEMAKER_TTS_ENDPOINT_NAME=
 DEEPGRAM_SAGEMAKER_TTS_REGION=
-DEEPGRAM_SAGEMAKER_TTS_VOICE_ID= # "aura-2-helena-en"
+# "aura-2-helena-en"
+# DEEPGRAM_SAGEMAKER_TTS_VOICE_ID=
 
 {% endif %}
 {% if stt_service == 'elevenlabs_stt' or tts_service == 'elevenlabs_tts' %}
@@ -159,7 +165,8 @@ GLADIA_REGION=
 # Google (STT/LLM/TTS/Realtime)
 {% if stt_service == 'google_stt' or llm_service == 'google_gemini_llm' or tts_service == 'google_tts' or realtime_service == 'gemini_live_realtime' %}
 GOOGLE_API_KEY=
-GOOGLE_MODEL= # "gemini-2.5-flash"
+# "gemini-2.5-flash"
+# GOOGLE_MODEL=
 {% endif %}
 {% if stt_service == 'google_stt' or tts_service == 'google_tts' or llm_service == 'google_vertex_llm' or realtime_service == 'gemini_vertex_live_realtime' %}
 GOOGLE_APPLICATION_CREDENTIALS=path/to/credentials.json  # For service account
@@ -170,7 +177,8 @@ GOOGLE_PROJECT_ID=
 GOOGLE_MODEL=
 {% endif %}
 {% if tts_service == 'google_tts' or realtime_service == 'gemini_live_realtime' or realtime_service == 'gemini_vertex_live_realtime' %}
-GOOGLE_VOICE_ID= # "en-US-Chirp3-HD-Charon"
+# "en-US-Chirp3-HD-Charon"
+# GOOGLE_VOICE_ID=
 {% endif %}
 
 {% endif %}
@@ -178,16 +186,19 @@ GOOGLE_VOICE_ID= # "en-US-Chirp3-HD-Charon"
 # Gradium (STT/TTS)
 GRADIUM_API_KEY=
 {% if tts_service == 'gradium_tts' %}
-GRADIUM_VOICE_ID= # "YTpq7expH9539ERJ"
+# "YTpq7expH9539ERJ"
+# GRADIUM_VOICE_ID=
 {% endif %}
 
 {% endif %}
 {% if stt_service == 'groq_stt' or llm_service == 'groq_llm' or tts_service == 'groq_tts' %}
 # Groq (STT/LLM/TTS)
 GROQ_API_KEY=
-GROQ_MODEL= # "whisper-large-v3-turbo"
+# "whisper-large-v3-turbo"
+# GROQ_MODEL=
 {% if tts_service == 'groq_tts' %}
-GROQ_VOICE_ID= # "autumn"
+# "autumn"
+# GROQ_VOICE_ID=
 {% endif %}
 
 {% endif %}
@@ -206,18 +217,22 @@ NVIDIA_SAGEMAKER_STT_ENDPOINT_NAME=
 {% if tts_service == 'nvidia_sagemaker_tts' %}
 # NVIDIA SageMaker (TTS)
 NVIDIA_SAGEMAKER_TTS_ENDPOINT_NAME=
-NVIDIA_SAGEMAKER_TTS_VOICE_ID= # "Magpie-Multilingual.EN-US.Isabella"
+# "Magpie-Multilingual.EN-US.Isabella"
+# NVIDIA_SAGEMAKER_TTS_VOICE_ID=
 
 {% endif %}
 {% if stt_service == 'openai_stt' or stt_service == 'openai_realtime_stt' or llm_service == 'openai_llm' or llm_service == 'openai_responses_llm' or tts_service == 'openai_tts' or realtime_service == 'openai_realtime' %}
 # OpenAI (STT/LLM/TTS/Realtime)
 OPENAI_API_KEY=
-OPENAI_MODEL= # Optional: defaults to "gpt-4.1"
+# Optional: defaults to "gpt-4.1"
+# OPENAI_MODEL=
 {% if tts_service == 'openai_tts' %}
-OPENAI_VOICE_ID= # "alloy"
+# "alloy"
+# OPENAI_VOICE_ID=
 {% endif %}
 {% if realtime_service == 'openai_realtime' %}
-OPENAI_INSTRUCTIONS=  # Optional: Custom system instructions
+# Optional: Custom system instructions
+# OPENAI_INSTRUCTIONS=
 {% endif %}
 
 {% endif %}
@@ -251,44 +266,52 @@ OPENAI_API_KEY=
 {% if llm_service == 'anthropic_llm' %}
 # Anthropic Claude (LLM)
 ANTHROPIC_API_KEY=
-ANTHROPIC_MODEL= # "claude-sonnet-4-5-20250929"
+# "claude-sonnet-4-5-20250929"
+# ANTHROPIC_MODEL=
 
 {% endif %}
 {% if llm_service == 'cerebras_llm' %}
 # Cerebras (LLM)
 CEREBRAS_API_KEY=
-CEREBRAS_MODEL= # "gpt-oss-120b"
+# "gpt-oss-120b"
+# CEREBRAS_MODEL=
 
 {% endif %}
 {% if llm_service == 'deepseek_llm' %}
 # DeepSeek (LLM)
 DEEPSEEK_API_KEY=
-DEEPSEEK_MODEL= # "deepseek-chat"
+# "deepseek-chat"
+# DEEPSEEK_MODEL=
 
 {% endif %}
 {% if llm_service == 'fireworks_llm' %}
 # Fireworks (LLM)
 FIREWORKS_API_KEY= 
-FIREWORKS_MODEL= # "accounts/fireworks/models/firefunction-v2"
+# "accounts/fireworks/models/firefunction-v2"
+# FIREWORKS_MODEL=
 
 {% endif %}
 {% if llm_service == 'inception_llm' %}
 # Inception (LLM)
 INCEPTION_API_KEY= 
-INCEPTION_MODEL= # "mercury-2"
+# "mercury-2"
+# INCEPTION_MODEL=
 
 {% endif %}
 {% if llm_service == 'xai_llm' or tts_service == 'xai_tts' or realtime_service == 'xai_realtime' %}
 # XAI / Grok (LLM/TTS/Realtime)
 XAI_API_KEY=
 {% if llm_service == 'xai_llm' %}
-XAI_MODEL= # "grok-3-beta"
+# "grok-3-beta"
+# XAI_MODEL=
 {% endif %}
 {% if tts_service == 'xai_tts' or realtime_service == 'xai_realtime' %}
-XAI_VOICE_ID= # "Ara"
+# "Ara"
+# XAI_VOICE_ID=
 {% endif %}
 {% if realtime_service == 'xai_realtime' %}
-XAI_INSTRUCTIONS=  # Optional: Custom system instructions
+# Optional: Custom system instructions
+# XAI_INSTRUCTIONS=
 {% endif %}
 
 {% endif %}
@@ -301,7 +324,8 @@ NOVITA_MODEL=
 {% if llm_service == 'mistral_llm' %}
 # Mistral (LLM)
 MISTRAL_API_KEY=
-MISTRAL_MODEL= # "mistral-small-latest"
+# "mistral-small-latest"
+# MISTRAL_MODEL=
 
 {% endif %}
 {% if llm_service == 'ollama_llm' %}
@@ -312,25 +336,29 @@ OLLAMA_MODEL=
 {% if llm_service == 'openrouter_llm' %}
 # OpenRouter (LLM)
 OPENROUTER_API_KEY=
-OPENROUTER_MODEL= # "openai/gpt-4.1"
+# "openai/gpt-4.1"
+# OPENROUTER_MODEL=
 
 {% endif %}
 {% if llm_service == 'perplexity_llm' %}
 # Perplexity (LLM)
 PERPLEXITY_API_KEY=
-PERPLEXITY_MODEL= # "sonar"
+# "sonar"
+# PERPLEXITY_MODEL=
 
 {% endif %}
 {% if llm_service == 'qwen_llm' %}
 # Qwen (LLM)
 QWEN_API_KEY=
-QWEN_MODEL= # "qwen-plus"
+# "qwen-plus"
+# QWEN_MODEL=
 
 {% endif %}
 {% if llm_service == 'together_llm' %}
 # Together (LLM)
 TOGETHER_API_KEY=
-TOGETHER_MODEL= # "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+# "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
+# TOGETHER_MODEL=
 
 {% endif %}
 {% if tts_service == 'asyncai_tts' %}
@@ -354,7 +382,8 @@ HUME_VOICE_ID=
 {% if tts_service == 'inworld_tts' %}
 # Inworld (TTS)
 INWORLD_API_KEY=
-INWORLD_VOICE_ID= # "Ashley"
+# "Ashley"
+# INWORLD_VOICE_ID=
 
 {% endif %}
 {% if tts_service == 'lmnt_tts' %}
@@ -367,7 +396,8 @@ LMNT_VOICE_ID=
 # MiniMax (TTS)
 MINIMAX_API_KEY=
 MINIMAX_GROUP_ID=
-MINIMAX_VOICE_ID= # "Calm_Woman"
+# "Calm_Woman"
+# MINIMAX_VOICE_ID=
 
 {% endif %}
 {% if tts_service == 'mistral_tts' %}
@@ -379,12 +409,14 @@ MISTRAL_VOICE_ID=
 {% if tts_service == 'neuphonic_tts' %}
 # Neuphonic (TTS)
 NEUPHONIC_API_KEY=
-NEUPHONIC_VOICE_ID= # optional
+# optional
+# NEUPHONIC_VOICE_ID=
 
 {% endif %}
 {% if tts_service == 'piper_tts' %}
 # Piper (TTS)
-PIPER_VOICE_ID= # 'en_US-ryan-high'
+# 'en_US-ryan-high'
+# PIPER_VOICE_ID=
 
 {% endif %}
 {% if tts_service == 'resemble_tts' %}
@@ -442,6 +474,7 @@ TAVUS_REPLICA_ID=
 {% if video_service == 'simli_video' %}
 # Simli (Video Avatar)
 SIMLI_API_KEY=
-SIMLI_FACE_ID= # optional
+# optional
+# SIMLI_FACE_ID=
 
 {% endif %}


### PR DESCRIPTION
Hey folks

As I was running through the quickstart (a `pipecat init` cascade project with OpenAI + Cartesia), the bot died on the first run with:

```
WebSocket API error: The requested model '# Optional: defaults to "gpt-4.1"' does not exist.
```

Turns out the model name was literally the comment from `env.example`. The generated file puts hints on the value side of empty optional vars:

```
OPENAI_MODEL= # Optional: defaults to "gpt-4.1"
```

python-dotenv only strips an inline comment when a real value precedes it; with an empty value the `#…` becomes the value, so `os.getenv("OPENAI_MODEL")` returns the comment string. The default in `os.getenv("OPENAI_MODEL", "gpt-4.1")` doesn't save it either — that only applies when the key is fully absent. Same trap on ~33 optional vars across providers (Cartesia voice, Anthropic/Google/Groq/Mistral/xAI models, etc.).

This PR comments the optional vars out and moves each hint to its own line, so the var is genuinely unset and the existing `os.getenv(..., default)` fallbacks work:

```
# Optional: defaults to "gpt-4.1"
# OPENAI_MODEL=
```

One file changed, no code changes. Confirmed locally that `OPENAI_MODEL` is now absent and the bot uses `gpt-4.1`.

Closes #4696.