### PR TITLE
fix(cli): explicit init flags always beat --config file values

### DIFF
--- a/changelog/4698.fixed.md
+++ b/changelog/4698.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `pipecat init` ignoring explicit `--no-*` flags (e.g. `--no-eval`, `--no-recording`, `--no-transcription`) when a `--config` file enabled the same setting. Explicit CLI flags now always take precedence over config-file values, for every setting — so a saved/`--dry-run` config can be reused as a template and overridden one flag at a time.

--- a/src/pipecat/cli/commands/init.py
+++ b/src/pipecat/cli/commands/init.py
@@ -44,6 +44,7 @@ def _list_options_callback(value: bool):
 
 
 def init_command(
+    ctx: typer.Context,
     target: str | None = typer.Argument(
         None,
         help="Target directory; use '.' to scaffold into the current directory "
@@ -186,37 +187,53 @@ def init_command(
             # Load from config file if provided
             if config is not None:
                 file_data = load_config_from_file(config)
-                # CLI flags override file values
-                name = name or file_data.get("name") or file_data.get("project_name")
-                bot_type = bot_type or file_data.get("bot_type")
-                transport = transport or file_data.get("transports") or file_data.get("transport")
-                mode = mode or file_data.get("mode")
-                stt = stt or file_data.get("stt") or file_data.get("stt_service")
-                llm = llm or file_data.get("llm") or file_data.get("llm_service")
-                tts = tts or file_data.get("tts") or file_data.get("tts_service")
-                realtime = (
-                    realtime or file_data.get("realtime") or file_data.get("realtime_service")
+
+                # Merge file values with CLI flags. An explicit CLI flag always wins;
+                # the file value only applies when the flag was omitted.
+                def from_cli(param):
+                    """True only if the user typed this flag (vs. falling back to its default).
+
+                    Compares the parameter source by enum member name rather than identity:
+                    Typer vendors its own copy of Click, so the ``ParameterSource`` returned
+                    here is a different enum object than ``click.core.ParameterSource``.
+                    """
+                    source = ctx.get_parameter_source(param)
+                    return source is not None and source.name == "COMMANDLINE"
+
+                def pick(value, param, *file_keys):
+                    """Explicit CLI flag wins; else first file key present; else the flag's default."""
+                    if from_cli(param):
+                        return value
+                    for key in file_keys:
+                        if key in file_data:
+                            return file_data[key]
+                    return value
+
+                name = pick(name, "name", "name", "project_name")
+                bot_type = pick(bot_type, "bot_type", "bot_type")
+                transport = pick(transport, "transport", "transports", "transport")
+                mode = pick(mode, "mode", "mode")
+                stt = pick(stt, "stt", "stt", "stt_service")
+                llm = pick(llm, "llm", "llm", "llm_service")
+                tts = pick(tts, "tts", "tts", "tts_service")
+                realtime = pick(realtime, "realtime", "realtime", "realtime_service")
+                video = pick(video, "video", "video", "video_service")
+                client_framework = pick(client_framework, "client_framework", "client_framework")
+                client_server = pick(client_server, "client_server", "client_server")
+                daily_pstn_mode = pick(daily_pstn_mode, "daily_pstn_mode", "daily_pstn_mode")
+                twilio_daily_sip_mode = pick(
+                    twilio_daily_sip_mode, "twilio_daily_sip_mode", "twilio_daily_sip_mode"
                 )
-                video = video or file_data.get("video") or file_data.get("video_service")
-                client_framework = client_framework or file_data.get("client_framework")
-                client_server = client_server or file_data.get("client_server")
-                daily_pstn_mode = daily_pstn_mode or file_data.get("daily_pstn_mode")
-                twilio_daily_sip_mode = twilio_daily_sip_mode or file_data.get(
-                    "twilio_daily_sip_mode"
+                recording = pick(recording, "recording", "recording")
+                transcription = pick(transcription, "transcription", "transcription")
+                video_input = pick(video_input, "video_input", "video_input")
+                video_output = pick(video_output, "video_output", "video_output")
+                deploy_to_cloud = pick(deploy_to_cloud, "deploy_to_cloud", "deploy_to_cloud")
+                enable_krisp = pick(enable_krisp, "enable_krisp", "enable_krisp")
+                observability = pick(
+                    observability, "observability", "observability", "enable_observability"
                 )
-                recording = recording or file_data.get("recording", False)
-                transcription = transcription or file_data.get("transcription", False)
-                video_input = video_input or file_data.get("video_input", False)
-                video_output = video_output or file_data.get("video_output", False)
-                if "deploy_to_cloud" in file_data:
-                    deploy_to_cloud = file_data["deploy_to_cloud"]
-                enable_krisp = enable_krisp or file_data.get("enable_krisp", False)
-                observability = observability or file_data.get(
-                    "observability", file_data.get("enable_observability", False)
-                )
-                enable_eval = enable_eval or file_data.get(
-                    "enable_eval", file_data.get("eval", False)
-                )
+                enable_eval = pick(enable_eval, "enable_eval", "enable_eval", "eval")
 
             try:
                 project_config = validate_and_build_config(

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -13,6 +13,7 @@ generating any files — exercising the merge logic in ``init_command`` end to e
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from pipecat.cli.main import app
@@ -92,3 +93,38 @@ class TestFlagPrecedence:
         config_path = _write_config(tmp_path)  # no observability key -> defaults off
         resolved = _dry_run(["--config", str(config_path), "--observability"])
         assert resolved["enable_observability"] is True
+
+    # Negatable booleans default to False, so an explicit --no-<flag> looks identical
+    # to an omitted flag by value alone. These prove the explicit flag still beats a
+    # file value that enabled the setting — the general fix, not just for --eval.
+    @pytest.mark.parametrize(
+        "flag, file_key, output_key",
+        [
+            ("--no-eval", "enable_eval", "enable_eval"),
+            ("--no-recording", "recording", "recording"),
+            ("--no-transcription", "transcription", "transcription"),
+            ("--no-observability", "enable_observability", "enable_observability"),
+        ],
+    )
+    def test_negated_flag_disables_over_file_value(self, tmp_path, flag, file_key, output_key):
+        config_path = _write_config(tmp_path, **{file_key: True})
+        resolved = _dry_run(["--config", str(config_path), flag])
+        assert resolved[output_key] is False
+
+    def test_no_deploy_to_cloud_flag_disables_over_file_value(self, tmp_path):
+        """The True-default flag can be disabled even when the file enables it."""
+        config_path = _write_config(tmp_path, deploy_to_cloud=True)
+        resolved = _dry_run(["--config", str(config_path), "--no-deploy-to-cloud"])
+        assert resolved["deploy_to_cloud"] is False
+
+    def test_enable_krisp_flag_enables_over_file_value(self, tmp_path):
+        # Krisp requires deploy_to_cloud (config_validator cross-field rule).
+        config_path = _write_config(tmp_path, enable_krisp=False, deploy_to_cloud=True)
+        resolved = _dry_run(["--config", str(config_path), "--enable-krisp"])
+        assert resolved["enable_krisp"] is True
+
+    def test_boolean_file_value_applies_when_flag_omitted(self, tmp_path):
+        """With no flag, the file value still drives the setting — it's the flag that flips it."""
+        config_path = _write_config(tmp_path, enable_eval=True)
+        resolved = _dry_run(["--config", str(config_path)])
+        assert resolved["enable_eval"] is True


### PR DESCRIPTION
## Summary

Supersedes #4693 with a general fix. `pipecat init` merged `--config` file values with CLI flags using `flag or file_data.get(...)`, which can't distinguish an omitted flag from an explicit `--no-<flag>`: a plain `bool` default of `False` looks identical either way. So a config file's `"enable_eval": true` silently overrode an explicit `--no-eval` — and the same bug affected **every** negatable boolean (`recording`, `transcription`, `video_input`, `video_output`, `enable_krisp`, `observability`).

This matters because `--dry-run` emits a resolved config that's designed to be fed back via `--config` (config-as-template / round-trip), so overriding one knob on the command line is a normal workflow.

#4693 fixed only `enable_eval` by making it tri-state (`bool | None`). Rather than tri-state each flag one at a time, this resolves the precedence rule **generally**.

## Fix

- Add `ctx: typer.Context` to `init_command` and ask Click via `ctx.get_parameter_source()` whether each parameter actually came from the command line, instead of inferring it from the value.
- Replace the ~30-line `or`-merge block with a single `pick(value, param, *file_keys)` helper applied uniformly to all settings: **explicit flag wins; else first file key present; else the flag default**. `enable_eval` stays a plain `bool = False` (no tri-state needed).
- Compare the parameter source by enum member *name* (`.name == "COMMANDLINE"`): Typer vendors its own copy of Click, so the returned `ParameterSource` is a different enum object than `click.core.ParameterSource` and an identity/`==` comparison silently fails.

## Testing

- New parametrized precedence tests in `tests/cli/test_init_command.py`: `--no-*` beats a true file value across `enable_eval`/`recording`/`transcription`/`observability`, `--no-deploy-to-cloud` overrides the True-default case, `--enable-krisp` wins over a false file value, and the file value still applies when no flag is passed.
- `uv run pytest tests/cli/`: 276 passed.
- `uv run ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)