### PR TITLE
docs(agents): correct interruption pattern and stale class references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,14 +87,14 @@ Runnable examples live in `examples/multi-worker/` (local handoff, distributed h
 
 ### Important Patterns
 
-- **Context Aggregation**: `LLMContext` accumulates messages for LLM calls; `UserResponse` aggregates user input
+- **Context Aggregation**: `LLMContext` accumulates messages for LLM calls; the aggregators created by `LLMContextAggregatorPair` keep it updated with user and assistant turns
 
 - **Turn Management**: Turn management is done through `LLMUserAggregator` and
   `LLMAssistantAggregator`, created with `LLMContextAggregatorPair`
 
 - **User turn strategies**: Detection of when the user starts and stops speaking is done via user turn start/stop strategies. They push `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` respectively.
 
-- **Interruptions**: Interruptions are usually triggered by a user turn start strategy (e.g. `VADUserTurnStartStrategy`) but they can be triggered by other processors as well, in which case the user turn start strategies don't need to. An `InterruptionFrame` carries an optional `asyncio.Event` that is set when the frame reaches the pipeline sink. If a processor stops an `InterruptionFrame` from propagating downstream (i.e., doesn't push it), it **must** call `frame.complete()` to avoid stalling `push_interruption_task_frame_and_wait()` callers.
+- **Interruptions**: Interruptions are usually triggered by a user turn start strategy (e.g. `VADUserTurnStartStrategy`), but any processor can trigger one by calling `await self.broadcast_interruption()`, which broadcasts an `InterruptionFrame` both upstream and downstream. The old `push_interruption_task_frame_and_wait()` is deprecated and delegates to `broadcast_interruption()`.
 
 - **Uninterruptible Frames**: These are frames that will not be removed from internal queues even if there's an interruption. For example, `EndFrame` and `StopFrame`.
 
@@ -122,6 +122,11 @@ Runnable examples live in `examples/multi-worker/` (local handoff, distributed h
 | `src/pipecat/observers/`   | Pipeline observers for monitoring frame flow       |
 | `src/pipecat/audio/`       | VAD, filters, mixers, turn detection, DTMF         |
 | `src/pipecat/turns/`       | User turn management                               |
+| `src/pipecat/adapters/`    | LLM provider adapters (context/tools conversion)   |
+| `src/pipecat/runner/`      | Development runner (multi-transport bot hosting)   |
+| `src/pipecat/cli/`         | `pipecat` CLI (`init`, `eval`)                     |
+| `src/pipecat/evals/`       | Behavioral eval framework (run via `pipecat eval`) |
+| `src/pipecat/metrics/`     | Metrics data models                                |
 
 ## Code Style
 


### PR DESCRIPTION
I had Fable take a look at AGENTS.md and update. Just small additions/changes.

## Summary

Reviewed `AGENTS.md` against the current codebase and fixed three stale/incorrect items. The rest of the file (workers/bus/jobs, commands, deprecation notes, example directories) was verified accurate and left unchanged.

- **Interruptions pattern was outdated** — `InterruptionFrame` is now a plain marker frame (`frames.py:971`); it no longer carries an `asyncio.Event` and has no `complete()` method, so the "must call `frame.complete()`" guidance was misleading. The current API is `FrameProcessor.broadcast_interruption()` (`frame_processor.py:718`), which broadcasts the frame both upstream and downstream. `push_interruption_task_frame_and_wait()` is deprecated and delegates to it.
- **`UserResponse` doesn't exist** anywhere in the codebase — replaced that mention in the Context Aggregation bullet with the aggregator pair that actually keeps `LLMContext` updated.
- **Key Directories table was missing newer modules** — added `adapters/`, `runner/`, `cli/`, `evals/`, and `metrics/`.

## Test plan

Docs-only change. No code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)