### PR TITLE
Allow adding origin restrictions to WebSocket transports and the runner.

### DIFF
--- a/changelog/4704.security.md
+++ b/changelog/4704.security.md
@@ -1,4 +1,4 @@
 - Added origin restriction support to `WebsocketServerTransport`, `FastAPIWebsocketTransport`, and the development runner to mitigate Cross-Site WebSocket Hijacking (CSWSH). When `allowed_origins` is configured, connections with a missing or disallowed `Origin` header are rejected before the WebSocket handshake completes.
   - `WebsocketServerParams` and `FastAPIWebsocketParams` gain an `allowed_origins: list[str]` field. `FastAPIWebsocketTransport` raises `ValueError` at construction time if the origin is not allowed.
-  - The runner gains `--allowed-origins` CLI flag and `PIPECAT_WEBSOCKET_ALLOWED_ORIGINS` environment variable (comma-separated). Both also control the transport params default, so a single env var covers all WebSocket transports uniformly.
+  - The runner gains `--allowed-origins` CLI flag and `PIPECAT_ALLOWED_ORIGINS` environment variable (comma-separated). Both also control the transport params default, so a single env var covers all WebSocket transports uniformly.
   - Default is empty (allow all) — no behaviour change for existing deployments.

--- a/changelog/4704.security.md
+++ b/changelog/4704.security.md
@@ -1,0 +1,4 @@
+- Added origin restriction support to `WebsocketServerTransport`, `FastAPIWebsocketTransport`, and the development runner to mitigate Cross-Site WebSocket Hijacking (CSWSH). When `allowed_origins` is configured, connections with a missing or disallowed `Origin` header are rejected before the WebSocket handshake completes.
+  - `WebsocketServerParams` and `FastAPIWebsocketParams` gain an `allowed_origins: list[str]` field. `FastAPIWebsocketTransport` raises `ValueError` at construction time if the origin is not allowed.
+  - The runner gains `--allowed-origins` CLI flag and `PIPECAT_WEBSOCKET_ALLOWED_ORIGINS` environment variable (comma-separated). Both also control the transport params default, so a single env var covers all WebSocket transports uniformly.
+  - Default is empty (allow all) — no behaviour change for existing deployments.

--- a/env.example
+++ b/env.example
@@ -241,3 +241,8 @@ XAI_API_KEY=...
 # unauthorized session starts. Mirrors the websocket_auth = "token" setting in
 # Pipecat Cloud deployment config (pcc-deploy.toml). Valid values: none | token.
 #PIPECAT_WEBSOCKET_AUTH=none
+
+# Comma-separated list of allowed WebSocket origins. When set, the runner and
+# WebSocket transports reject any connection whose Origin header is missing or
+# not in this list. Leave unset or empty to allow all origins.
+#PIPECAT_WEBSOCKET_ALLOWED_ORIGINS=

--- a/env.example
+++ b/env.example
@@ -242,7 +242,7 @@ XAI_API_KEY=...
 # Pipecat Cloud deployment config (pcc-deploy.toml). Valid values: none | token.
 #PIPECAT_WEBSOCKET_AUTH=none
 
-# Comma-separated list of allowed WebSocket origins. When set, the runner and
+# Comma-separated list of allowed origins. When set, the runner and
 # WebSocket transports reject any connection whose Origin header is missing or
 # not in this list. Leave unset or empty to allow all origins.
-#PIPECAT_WEBSOCKET_ALLOWED_ORIGINS=
+#PIPECAT_ALLOWED_ORIGINS=

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -314,14 +314,14 @@ def _extract_ws_token(websocket) -> str | None:
     return websocket.query_params.get("token")
 
 
-def _print_ws_security_status(args: argparse.Namespace):
-    """Print WebSocket security status lines (auth + origin restriction)."""
+def _print_security_status(args: argparse.Namespace):
+    """Print security status lines (auth + origin restriction)."""
     if args.ws_auth == "token":
-        print("   → WebSocket auth:    token (HMAC, call /start to obtain a token)")
+        print("   → WebSocket auth:  token (HMAC, call /start to obtain a token)")
     if args.allowed_origins:
-        print(f"   → WebSocket origins: {', '.join(args.allowed_origins)}")
+        print(f"   → Allowed origins: {', '.join(args.allowed_origins)}")
     else:
-        print("   → WebSocket origins: all (no restriction)")
+        print("   → Allowed origins: all (no restriction)")
 
 
 def _print_startup_message(args: argparse.Namespace):
@@ -334,7 +334,7 @@ def _print_startup_message(args: argparse.Namespace):
         print(f"   → Enabled transports: {_format_transport_status(enabled)}")
         if disabled:
             print(f"   → Disabled transports: {_format_transport_status(disabled)}")
-        _print_ws_security_status(args)
+        _print_security_status(args)
     elif args.transport == "webrtc":
         if args.esp32:
             print("🚀 Bot ready! (ESP32 mode)")
@@ -367,7 +367,7 @@ def _print_startup_message(args: argparse.Namespace):
             if args.proxy:
                 print(f"   → XML webhook: http://{args.host}:{args.port}/")
             print(f"   → WebSocket:   ws://{args.host}:{args.port}/ws")
-            _print_ws_security_status(args)
+            _print_security_status(args)
     elif args.transport == "websocket":
         print("🚀 Bot ready! (WebSocket)")
         if not _transport_routes_enabled("websocket"):
@@ -376,7 +376,7 @@ def _print_startup_message(args: argparse.Namespace):
             print(f"   → Open: {_runner_url(args)}")
             scheme = "wss" if args.host != "localhost" else "ws"
             print(f"   → WebSocket:   {scheme}://{args.host}:{args.port}/ws-client")
-            _print_ws_security_status(args)
+            _print_security_status(args)
     elif args.transport == "vonage":
         print()
         print("🚀 Bot ready!")
@@ -1503,9 +1503,8 @@ def main(parser: argparse.ArgumentParser | None = None):
         nargs="*",
         default=_env_origins,
         help=(
-            "Allowed WebSocket origins (e.g. https://example.com). "
-            "Omit or leave empty to allow all origins. Non-browser clients "
-            "(no Origin header) are always allowed. "
+            "Allowed origins for HTTP and WebSocket connections (e.g. https://example.com). "
+            "Omit or leave empty to allow all origins. "
             "Defaults to the PIPECAT_ALLOWED_ORIGINS environment variable "
             "(comma-separated)."
         ),

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -498,7 +498,7 @@ def _configure_server_app(args: argparse.Namespace):
     """Configure the module-level FastAPI app with routes for all transports."""
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=args.allowed_origins or ["*"],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -1495,9 +1495,7 @@ def main(parser: argparse.ArgumentParser | None = None):
         ),
     )
     _env_origins = [
-        o.strip()
-        for o in os.getenv("PIPECAT_WEBSOCKET_ALLOWED_ORIGINS", "").split(",")
-        if o.strip()
+        o.strip() for o in os.getenv("PIPECAT_ALLOWED_ORIGINS", "").split(",") if o.strip()
     ]
     parser.add_argument(
         "--allowed-origins",
@@ -1508,7 +1506,7 @@ def main(parser: argparse.ArgumentParser | None = None):
             "Allowed WebSocket origins (e.g. https://example.com). "
             "Omit or leave empty to allow all origins. Non-browser clients "
             "(no Origin header) are always allowed. "
-            "Defaults to the PIPECAT_WEBSOCKET_ALLOWED_ORIGINS environment variable "
+            "Defaults to the PIPECAT_ALLOWED_ORIGINS environment variable "
             "(comma-separated)."
         ),
     )

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -119,6 +119,7 @@ from pipecat.runner.types import (
     WebSocketRunnerArguments,
 )
 from pipecat.runner.vonage import configure as configure_vonage
+from pipecat.utils.security.allowed_origins import is_origin_allowed
 
 try:
     import uvicorn
@@ -464,6 +465,11 @@ def _setup_websocket_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
                 logger.warning("WebSocket connection rejected: invalid or missing token")
                 await websocket.close(code=4003)
                 return
+        origin = websocket.headers.get("origin", "")
+        if not is_origin_allowed(origin, args.allowed_origins):
+            logger.warning(f"WebSocket connection rejected: origin '{origin}' not allowed")
+            await websocket.close(code=4003)
+            return
         await websocket.accept()
         logger.debug("Plain WebSocket connection accepted")
         await _run_websocket_bot(websocket, args)
@@ -1247,6 +1253,11 @@ def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
                 logger.warning("WebSocket connection rejected: invalid or missing token")
                 await websocket.close(code=4003)
                 return
+        origin = websocket.headers.get("origin", "")
+        if not is_origin_allowed(origin, args.allowed_origins):
+            logger.warning(f"WebSocket connection rejected: origin '{origin}' not allowed")
+            await websocket.close(code=4003)
+            return
         await websocket.accept()
         logger.debug("WebSocket connection accepted")
         await _run_telephony_bot(websocket, args)
@@ -1472,6 +1483,24 @@ def main(parser: argparse.ArgumentParser | None = None):
             "and obtain a signed HMAC session token before connecting to /ws or "
             "/ws-client. Defaults to the PIPECAT_WEBSOCKET_AUTH environment variable "
             "or 'none'."
+        ),
+    )
+    _env_origins = [
+        o.strip()
+        for o in os.getenv("PIPECAT_WEBSOCKET_ALLOWED_ORIGINS", "").split(",")
+        if o.strip()
+    ]
+    parser.add_argument(
+        "--allowed-origins",
+        dest="allowed_origins",
+        nargs="*",
+        default=_env_origins,
+        help=(
+            "Allowed WebSocket origins (e.g. https://example.com). "
+            "Omit or leave empty to allow all origins. Non-browser clients "
+            "(no Origin header) are always allowed. "
+            "Defaults to the PIPECAT_WEBSOCKET_ALLOWED_ORIGINS environment variable "
+            "(comma-separated)."
         ),
     )
 

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -314,6 +314,16 @@ def _extract_ws_token(websocket) -> str | None:
     return websocket.query_params.get("token")
 
 
+def _print_ws_security_status(args: argparse.Namespace):
+    """Print WebSocket security status lines (auth + origin restriction)."""
+    if args.ws_auth == "token":
+        print("   → WebSocket auth:    token (HMAC, call /start to obtain a token)")
+    if args.allowed_origins:
+        print(f"   → WebSocket origins: {', '.join(args.allowed_origins)}")
+    else:
+        print("   → WebSocket origins: all (no restriction)")
+
+
 def _print_startup_message(args: argparse.Namespace):
     """Print connection information for the development runner."""
     print()
@@ -324,6 +334,7 @@ def _print_startup_message(args: argparse.Namespace):
         print(f"   → Enabled transports: {_format_transport_status(enabled)}")
         if disabled:
             print(f"   → Disabled transports: {_format_transport_status(disabled)}")
+        _print_ws_security_status(args)
     elif args.transport == "webrtc":
         if args.esp32:
             print("🚀 Bot ready! (ESP32 mode)")
@@ -356,8 +367,7 @@ def _print_startup_message(args: argparse.Namespace):
             if args.proxy:
                 print(f"   → XML webhook: http://{args.host}:{args.port}/")
             print(f"   → WebSocket:   ws://{args.host}:{args.port}/ws")
-            if args.ws_auth == "token":
-                print("   → WebSocket auth: token (HMAC, call /start to obtain a token)")
+            _print_ws_security_status(args)
     elif args.transport == "websocket":
         print("🚀 Bot ready! (WebSocket)")
         if not _transport_routes_enabled("websocket"):
@@ -366,8 +376,7 @@ def _print_startup_message(args: argparse.Namespace):
             print(f"   → Open: {_runner_url(args)}")
             scheme = "wss" if args.host != "localhost" else "ws"
             print(f"   → WebSocket:   {scheme}://{args.host}:{args.port}/ws-client")
-            if args.ws_auth == "token":
-                print("   → WebSocket auth: token (HMAC, call /start to obtain a token)")
+            _print_ws_security_status(args)
     elif args.transport == "vonage":
         print()
         print("🚀 Bot ready!")

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -61,7 +61,7 @@ class FastAPIWebsocketParams(TransportParams):
         session_timeout: Session timeout in seconds, None for no timeout.
         fixed_audio_packet_size: Optional fixed-size packetization for raw PCM audio payloads.
             Useful when the remote WebSocket media endpoint requires strict audio framing.
-        allowed_origins: List of allowed WebSocket origins. Empty list allows all
+        allowed_origins: List of allowed origins. Empty list allows all
             origins. When set, connections with a missing or disallowed Origin header
             are rejected. Defaults to ``PIPECAT_ALLOWED_ORIGINS`` env var
             (comma-separated).

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -19,7 +19,7 @@ import wave
 from collections.abc import Awaitable, Callable
 
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -39,6 +39,7 @@ from pipecat.serializers.base_serializer import FrameSerializer
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.utils.security.allowed_origins import default_allowed_origins, is_origin_allowed
 
 try:
     from fastapi import WebSocket
@@ -60,12 +61,17 @@ class FastAPIWebsocketParams(TransportParams):
         session_timeout: Session timeout in seconds, None for no timeout.
         fixed_audio_packet_size: Optional fixed-size packetization for raw PCM audio payloads.
             Useful when the remote WebSocket media endpoint requires strict audio framing.
+        allowed_origins: List of allowed WebSocket origins. Empty list allows all
+            origins. When set, connections with a missing or disallowed Origin header
+            are rejected. Defaults to ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var
+            (comma-separated).
     """
 
     add_wav_header: bool = False
     serializer: FrameSerializer | None = None
     session_timeout: int | None = None
     fixed_audio_packet_size: int | None = None
+    allowed_origins: list[str] = Field(default_factory=default_allowed_origins)
 
 
 class FastAPIWebsocketCallbacks(BaseModel):
@@ -557,12 +563,21 @@ class FastAPIWebsocketTransport(BaseTransport):
     ):
         """Initialize the FastAPI WebSocket transport.
 
+        Raises ``ValueError`` if ``params.allowed_origins`` is set and the
+        connection's Origin header is missing or not in the allowed list. The
+        caller is responsible for closing the WebSocket in that case.
+
         Args:
             websocket: The FastAPI WebSocket connection.
             params: Transport configuration parameters.
             input_name: Optional name for the input processor.
             output_name: Optional name for the output processor.
         """
+        if params.allowed_origins:
+            origin = websocket.headers.get("origin", "")
+            if not is_origin_allowed(origin, params.allowed_origins):
+                raise ValueError(f"WebSocket connection rejected: origin '{origin}' not allowed")
+
         super().__init__(input_name=input_name, output_name=output_name)
 
         self._params = params

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -63,7 +63,7 @@ class FastAPIWebsocketParams(TransportParams):
             Useful when the remote WebSocket media endpoint requires strict audio framing.
         allowed_origins: List of allowed WebSocket origins. Empty list allows all
             origins. When set, connections with a missing or disallowed Origin header
-            are rejected. Defaults to ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var
+            are rejected. Defaults to ``PIPECAT_ALLOWED_ORIGINS`` env var
             (comma-separated).
     """
 

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -52,7 +52,7 @@ class WebsocketServerParams(TransportParams):
         add_wav_header: Whether to add WAV headers to audio frames.
         serializer: Frame serializer for message encoding/decoding.
         session_timeout: Timeout in seconds for client sessions.
-        allowed_origins: List of allowed WebSocket origins. Empty list allows all
+        allowed_origins: List of allowed origins. Empty list allows all
             origins. When set, connections with a missing or disallowed Origin header
             are rejected. Defaults to ``PIPECAT_ALLOWED_ORIGINS`` env var
             (comma-separated).

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -19,7 +19,7 @@ from collections.abc import Awaitable, Callable
 
 import websockets
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from websockets.asyncio.server import serve as websocket_serve
 from websockets.protocol import State
 
@@ -42,6 +42,7 @@ from pipecat.serializers.base_serializer import FrameSerializer
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.utils.security.allowed_origins import default_allowed_origins
 
 
 class WebsocketServerParams(TransportParams):
@@ -51,11 +52,16 @@ class WebsocketServerParams(TransportParams):
         add_wav_header: Whether to add WAV headers to audio frames.
         serializer: Frame serializer for message encoding/decoding.
         session_timeout: Timeout in seconds for client sessions.
+        allowed_origins: List of allowed WebSocket origins. Empty list allows all
+            origins. When set, connections with a missing or disallowed Origin header
+            are rejected. Defaults to ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var
+            (comma-separated).
     """
 
     add_wav_header: bool = False
     serializer: FrameSerializer | None = None
     session_timeout: int | None = None
+    allowed_origins: list[str] = Field(default_factory=default_allowed_origins)
 
 
 class WebsocketServerCallbacks(BaseModel):
@@ -176,7 +182,10 @@ class WebsocketServerInputTransport(BaseInputTransport):
     async def _server_task_handler(self):
         """Handle WebSocket server startup and client connections."""
         logger.info(f"Starting websocket server on {self._host}:{self._port}")
-        async with websocket_serve(self._client_handler, self._host, self._port) as server:
+        origins = self._params.allowed_origins or None
+        async with websocket_serve(
+            self._client_handler, self._host, self._port, origins=origins
+        ) as server:
             await self._callbacks.on_websocket_ready()
             await self._stop_server_event.wait()
 

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -54,7 +54,7 @@ class WebsocketServerParams(TransportParams):
         session_timeout: Timeout in seconds for client sessions.
         allowed_origins: List of allowed WebSocket origins. Empty list allows all
             origins. When set, connections with a missing or disallowed Origin header
-            are rejected. Defaults to ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var
+            are rejected. Defaults to ``PIPECAT_ALLOWED_ORIGINS`` env var
             (comma-separated).
     """
 

--- a/src/pipecat/utils/security/allowed_origins.py
+++ b/src/pipecat/utils/security/allowed_origins.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""WebSocket origin validation utilities."""
+
+import os
+
+
+def default_allowed_origins() -> list[str]:
+    """Return allowed origins from the ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var.
+
+    Parses a comma-separated list of origin strings. Returns an empty list
+    (allow all) when the variable is unset or empty.
+    """
+    val = os.getenv("PIPECAT_WEBSOCKET_ALLOWED_ORIGINS", "")
+    return [o.strip() for o in val.split(",") if o.strip()]
+
+
+def is_origin_allowed(origin: str, allowed_origins: list[str]) -> bool:
+    """Return whether ``origin`` is permitted by ``allowed_origins``.
+
+    Args:
+        origin: The value of the ``Origin`` header, or an empty string if absent.
+        allowed_origins: List of allowed origin strings. An empty list allows
+            all origins. When non-empty, a missing or disallowed origin is
+            rejected.
+    """
+    if not allowed_origins:
+        return True
+    return origin.lower() in {o.lower() for o in allowed_origins}

--- a/src/pipecat/utils/security/allowed_origins.py
+++ b/src/pipecat/utils/security/allowed_origins.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""WebSocket origin validation utilities."""
+"""Origin validation utilities."""
 
 import os
 

--- a/src/pipecat/utils/security/allowed_origins.py
+++ b/src/pipecat/utils/security/allowed_origins.py
@@ -10,12 +10,12 @@ import os
 
 
 def default_allowed_origins() -> list[str]:
-    """Return allowed origins from the ``PIPECAT_WEBSOCKET_ALLOWED_ORIGINS`` env var.
+    """Return allowed origins from the ``PIPECAT_ALLOWED_ORIGINS`` env var.
 
     Parses a comma-separated list of origin strings. Returns an empty list
     (allow all) when the variable is unset or empty.
     """
-    val = os.getenv("PIPECAT_WEBSOCKET_ALLOWED_ORIGINS", "")
+    val = os.getenv("PIPECAT_ALLOWED_ORIGINS", "")
     return [o.strip() for o in val.split(",") if o.strip()]
 
 

--- a/tests/test_runner_run.py
+++ b/tests/test_runner_run.py
@@ -253,7 +253,9 @@ class TestRunnerRun(unittest.TestCase):
         )
 
     def test_startup_message_all_transports_shows_open_url_and_transport_status(self):
-        args = argparse.Namespace(transport=None, host="localhost", port=7860)
+        args = argparse.Namespace(
+            transport=None, host="localhost", port=7860, ws_auth="none", allowed_origins=[]
+        )
 
         def routes_enabled(transport: str) -> bool:
             return transport in {"telephony", "websocket"}
@@ -270,12 +272,15 @@ class TestRunnerRun(unittest.TestCase):
                 "   → Enabled transports: telephony, websocket\n"
                 "   → Disabled transports: daily (install pipecat-ai[daily]), "
                 "webrtc (install pipecat-ai[webrtc])\n"
+                "   → WebSocket origins: all (no restriction)\n"
                 "\n"
             ),
         )
 
     def test_startup_message_all_transports_omits_disabled_status_when_all_enabled(self):
-        args = argparse.Namespace(transport=None, host="localhost", port=7860)
+        args = argparse.Namespace(
+            transport=None, host="localhost", port=7860, ws_auth="none", allowed_origins=[]
+        )
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
             output = self._capture_startup_message(args)
@@ -287,6 +292,7 @@ class TestRunnerRun(unittest.TestCase):
                 "🚀 Bot ready!\n"
                 "   → Open: http://localhost:7860\n"
                 "   → Enabled transports: daily, webrtc, telephony, websocket\n"
+                "   → WebSocket origins: all (no restriction)\n"
                 "\n"
             ),
         )
@@ -318,6 +324,7 @@ class TestRunnerRun(unittest.TestCase):
             port=7860,
             proxy="example.ngrok.io",
             ws_auth="none",
+            allowed_origins=[],
         )
 
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
@@ -501,7 +508,7 @@ class TestWsAuthConnectionBehavior(unittest.TestCase):
 
     def _make_ws_client_app(self, ws_auth: str) -> tuple[FastAPI, set]:
         app = FastAPI()
-        args = argparse.Namespace(ws_auth=ws_auth)
+        args = argparse.Namespace(ws_auth=ws_auth, allowed_origins=[])
         used: set[str] = set()
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
             _setup_websocket_routes(app, args, used)
@@ -509,7 +516,7 @@ class TestWsAuthConnectionBehavior(unittest.TestCase):
 
     def _make_telephony_app(self, ws_auth: str) -> tuple[FastAPI, set]:
         app = FastAPI()
-        args = argparse.Namespace(ws_auth=ws_auth, transport=None)
+        args = argparse.Namespace(ws_auth=ws_auth, transport=None, allowed_origins=[])
         used: set[str] = set()
         with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
             _setup_telephony_routes(app, args, used)
@@ -580,6 +587,108 @@ class TestWsAuthConnectionBehavior(unittest.TestCase):
         app, _ = self._make_telephony_app(ws_auth="none")
         with patch("pipecat.runner.run._run_telephony_bot", new=AsyncMock()):
             with TestClient(app).websocket_connect("/ws"):
+                pass
+
+
+class TestAllowedOriginsUtil(unittest.TestCase):
+    """Unit tests for the is_origin_allowed utility."""
+
+    def setUp(self):
+        from pipecat.utils.security.allowed_origins import is_origin_allowed
+
+        self.is_origin_allowed = is_origin_allowed
+
+    def test_empty_list_allows_any_origin(self):
+        self.assertTrue(self.is_origin_allowed("https://example.com", []))
+
+    def test_empty_list_allows_missing_origin(self):
+        self.assertTrue(self.is_origin_allowed("", []))
+
+    def test_matching_origin_is_allowed(self):
+        self.assertTrue(self.is_origin_allowed("https://example.com", ["https://example.com"]))
+
+    def test_non_matching_origin_is_rejected(self):
+        self.assertFalse(self.is_origin_allowed("https://evil.com", ["https://example.com"]))
+
+    def test_missing_origin_is_rejected_when_origins_configured(self):
+        self.assertFalse(self.is_origin_allowed("", ["https://example.com"]))
+
+    def test_matching_is_case_insensitive(self):
+        self.assertTrue(self.is_origin_allowed("https://Example.COM", ["https://example.com"]))
+
+    def test_multiple_allowed_origins(self):
+        allowed = ["https://a.com", "https://b.com"]
+        self.assertTrue(self.is_origin_allowed("https://a.com", allowed))
+        self.assertTrue(self.is_origin_allowed("https://b.com", allowed))
+        self.assertFalse(self.is_origin_allowed("https://c.com", allowed))
+
+
+class TestWsOriginConnectionBehavior(unittest.TestCase):
+    """WebSocket connection tests verifying origin enforcement at the ASGI layer."""
+
+    def _make_ws_client_app(self, allowed_origins: list) -> FastAPI:
+        app = FastAPI()
+        args = argparse.Namespace(ws_auth="none", allowed_origins=allowed_origins)
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_websocket_routes(app, args, set())
+        return app
+
+    def _make_telephony_app(self, allowed_origins: list) -> FastAPI:
+        app = FastAPI()
+        args = argparse.Namespace(ws_auth="none", transport=None, allowed_origins=allowed_origins)
+        with patch("pipecat.runner.run._transport_routes_enabled", return_value=True):
+            _setup_telephony_routes(app, args, set())
+        return app
+
+    # /ws-client (plain WebSocket)
+
+    def test_plain_ws_rejects_disallowed_origin(self):
+        app = self._make_ws_client_app(allowed_origins=["https://allowed.com"])
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect(
+                "/ws-client", headers={"Origin": "https://evil.com"}
+            ):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_plain_ws_rejects_missing_origin_when_origins_configured(self):
+        app = self._make_ws_client_app(allowed_origins=["https://allowed.com"])
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect("/ws-client"):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_plain_ws_accepts_allowed_origin(self):
+        app = self._make_ws_client_app(allowed_origins=["https://allowed.com"])
+        with patch("pipecat.runner.run._run_websocket_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(
+                "/ws-client", headers={"Origin": "https://allowed.com"}
+            ):
+                pass
+
+    def test_plain_ws_allows_any_origin_when_origins_not_configured(self):
+        app = self._make_ws_client_app(allowed_origins=[])
+        with patch("pipecat.runner.run._run_websocket_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(
+                "/ws-client", headers={"Origin": "https://anyone.com"}
+            ):
+                pass
+
+    # /ws (telephony WebSocket)
+
+    def test_telephony_ws_rejects_disallowed_origin(self):
+        app = self._make_telephony_app(allowed_origins=["https://allowed.com"])
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with TestClient(app).websocket_connect("/ws", headers={"Origin": "https://evil.com"}):
+                pass
+        self.assertEqual(cm.exception.code, 4003)
+
+    def test_telephony_ws_accepts_allowed_origin(self):
+        app = self._make_telephony_app(allowed_origins=["https://allowed.com"])
+        with patch("pipecat.runner.run._run_telephony_bot", new=AsyncMock()):
+            with TestClient(app).websocket_connect(
+                "/ws", headers={"Origin": "https://allowed.com"}
+            ):
                 pass
 
 

--- a/tests/test_runner_run.py
+++ b/tests/test_runner_run.py
@@ -272,7 +272,7 @@ class TestRunnerRun(unittest.TestCase):
                 "   → Enabled transports: telephony, websocket\n"
                 "   → Disabled transports: daily (install pipecat-ai[daily]), "
                 "webrtc (install pipecat-ai[webrtc])\n"
-                "   → WebSocket origins: all (no restriction)\n"
+                "   → Allowed origins: all (no restriction)\n"
                 "\n"
             ),
         )
@@ -292,7 +292,7 @@ class TestRunnerRun(unittest.TestCase):
                 "🚀 Bot ready!\n"
                 "   → Open: http://localhost:7860\n"
                 "   → Enabled transports: daily, webrtc, telephony, websocket\n"
-                "   → WebSocket origins: all (no restriction)\n"
+                "   → Allowed origins: all (no restriction)\n"
                 "\n"
             ),
         )


### PR DESCRIPTION
## Summary
  
  - Added origin restriction support to `WebsocketServerTransport`, `FastAPIWebsocketTransport`, and the development runner to mitigate Cross-Site WebSocket Hijacking (CSWSH)
  - New allowed_origins: list[str] field on `WebsocketServerParams` and `FastAPIWebsocketParams`; defaults to the
  `PIPECAT_ALLOWED_ORIGINS` env var (comma-separated)
  - `FastAPIWebsocketTransport` raises `ValueError` at construction if the connection's Origin header is missing or disallowed
  - Runner gains `--allowed-origins` CLI flag backed by `PIPECAT_ALLOWED_ORIGINS`; a single env var now covers all WebSocket transports uniformly
  - Startup message now always shows WebSocket security status (auth mode and origin restriction)
  - Default is an empty list (allow all origins) — no behavior change for existing deployments

## Testing

  Set the env var and test that connections from unlisted origins are rejected:

```
  PIPECAT_ALLOWED_ORIGINS=https://example.com uv run python your_bot.py
  # Connection from an unlisted origin should receive close code 4003
```

  Or pass the flag directly to the runner:

  `uv run python -m pipecat.runner.run --allowed-origins https://example.com`
