### PR TITLE
Flush the pipeline before gracefully ending or handing off

### DIFF
--- a/changelog/4706.deprecated.md
+++ b/changelog/4706.deprecated.md
@@ -1,0 +1,1 @@
+- ⚠️ Deprecated the `messages` and `result_callback` parameters of `LLMWorker.end()` and `LLMWorker.activate_worker()`. Call `params.result_callback(result)` before `end()` or `activate_worker()` instead; the LLM output triggered by the result is flushed automatically.

--- a/changelog/4706.fixed.md
+++ b/changelog/4706.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `PipelineWorker.end()` could tear down the pipeline before in-flight output (e.g. a final LLM turn triggered by a function call result) finished playing. `end()` now flushes the pipeline first.

--- a/examples/multi-worker/distributed-handoff/pgmq-handoff/llm.py
+++ b/examples/multi-worker/distributed-handoff/pgmq-handoff/llm.py
@@ -32,6 +32,7 @@ from loguru import logger
 from pgmq.async_queue import PGMQueue
 
 from pipecat.bus.network.pgmq import PgmqBus
+from pipecat.frames.frames import FunctionCallResultProperties
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.workers.llm import LLMWorker, LLMWorkerActivationArgs, tool
@@ -121,11 +122,11 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the user is being transferred.
         """
         logger.info(f"Task '{self.name}': transferring to '{agent}' ({reason})")
+        await params.result_callback(None, properties=FunctionCallResultProperties(run_llm=False))
         await self.activate_worker(
             agent,
             args=LLMWorkerActivationArgs(messages=[{"role": "developer", "content": reason}]),
             deactivate_self=True,
-            result_callback=params.result_callback,
         )
 
     @tool
@@ -136,11 +137,8 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the conversation is ending.
         """
         logger.info(f"Task '{self.name}': ending conversation ({reason})")
-        await self.end(
-            reason=reason,
-            messages=[{"role": "developer", "content": reason}],
-            result_callback=params.result_callback,
-        )
+        await params.result_callback(reason)
+        await self.end(reason=reason)
 
 
 async def main_async() -> None:

--- a/examples/multi-worker/distributed-handoff/redis-handoff/llm.py
+++ b/examples/multi-worker/distributed-handoff/redis-handoff/llm.py
@@ -29,6 +29,7 @@ from loguru import logger
 from redis.asyncio import Redis
 
 from pipecat.bus.network.redis import RedisBus
+from pipecat.frames.frames import FunctionCallResultProperties
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.workers.llm import LLMWorker, LLMWorkerActivationArgs, tool
@@ -103,11 +104,11 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the user is being transferred.
         """
         logger.info(f"Task '{self.name}': transferring to '{agent}' ({reason})")
+        await params.result_callback(None, properties=FunctionCallResultProperties(run_llm=False))
         await self.activate_worker(
             agent,
             args=LLMWorkerActivationArgs(messages=[{"role": "developer", "content": reason}]),
             deactivate_self=True,
-            result_callback=params.result_callback,
         )
 
     @tool
@@ -118,11 +119,8 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the conversation is ending.
         """
         logger.info(f"Task '{self.name}': ending conversation ({reason})")
-        await self.end(
-            reason=reason,
-            messages=[{"role": "developer", "content": reason}],
-            result_callback=params.result_callback,
-        )
+        await params.result_callback(reason)
+        await self.end(reason=reason)
 
 
 async def main_async() -> None:

--- a/examples/multi-worker/local-handoff/local-handoff-two-agents-tts.py
+++ b/examples/multi-worker/local-handoff/local-handoff-two-agents-tts.py
@@ -111,19 +111,13 @@ class AcmeTTSTask(LLMWorker):
             reason (str): Why the user is being transferred.
         """
         logger.info(f"Task '{self.name}': transferring to '{agent}' ({reason})")
+        await params.result_callback(f"Tell the user about the transfer ({reason}).")
         await self.activate_worker(
             agent,
-            messages=[
-                {
-                    "role": "developer",
-                    "content": f"Tell the user about the transfer ({reason}).",
-                }
-            ],
             args=LLMWorkerActivationArgs(
                 messages=[{"role": "developer", "content": reason}],
             ),
             deactivate_self=True,
-            result_callback=params.result_callback,
         )
 
     @tool
@@ -134,11 +128,8 @@ class AcmeTTSTask(LLMWorker):
             reason (str): Why the conversation is ending.
         """
         logger.info(f"Task '{self.name}': ending conversation ({reason})")
-        await self.end(
-            reason=reason,
-            messages=[{"role": "developer", "content": reason}],
-            result_callback=params.result_callback,
-        )
+        await params.result_callback(reason)
+        await self.end(reason=reason)
 
 
 def build_greeter() -> AcmeTTSTask:

--- a/examples/multi-worker/local-handoff/local-handoff-two-agents.py
+++ b/examples/multi-worker/local-handoff/local-handoff-two-agents.py
@@ -29,6 +29,7 @@ from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.bus import BusBridgeProcessor
+from pipecat.frames.frames import FunctionCallResultProperties
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -90,13 +91,13 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the user is being transferred.
         """
         logger.info(f"Task '{self.name}': transferring to '{agent}' ({reason})")
+        await params.result_callback(None, properties=FunctionCallResultProperties(run_llm=False))
         await self.activate_worker(
             agent,
             args=LLMWorkerActivationArgs(
                 messages=[{"role": "developer", "content": reason}],
             ),
             deactivate_self=True,
-            result_callback=params.result_callback,
         )
 
     @tool
@@ -107,11 +108,8 @@ class AcmeLLMTask(LLMWorker):
             reason (str): Why the conversation is ending.
         """
         logger.info(f"Task '{self.name}': ending conversation ({reason})")
-        await self.end(
-            reason=reason,
-            messages=[{"role": "developer", "content": reason}],
-            result_callback=params.result_callback,
-        )
+        await params.result_callback(reason)
+        await self.end(reason=reason)
 
 
 def build_greeter() -> AcmeLLMTask:

--- a/examples/multi-worker/remote-proxy-assistant/assistant.py
+++ b/examples/multi-worker/remote-proxy-assistant/assistant.py
@@ -70,11 +70,8 @@ class AcmeAssistant(LLMWorker):
             reason (str): Why the conversation is ending.
         """
         logger.info(f"Task '{self.name}': ending conversation ({reason})")
-        await self.end(
-            reason=reason,
-            messages=[{"role": "developer", "content": reason}],
-            result_callback=params.result_callback,
-        )
+        await params.result_callback(reason)
+        await self.end(reason=reason)
 
 
 @app.websocket("/ws")

--- a/src/pipecat/pipeline/worker.py
+++ b/src/pipecat/pipeline/worker.py
@@ -95,6 +95,11 @@ CANCEL_TIMEOUT_SECS = 20.0
 
 T = TypeVar("T")
 
+# Timeout for the pre-end pipeline flush. The flush may span a full LLM
+# completion and TTS synthesis (e.g. a final turn triggered by a function
+# call result), so it needs to be generous.
+END_FLUSH_TIMEOUT_SECS = 30.0
+
 
 class IdleFrameObserver(BaseObserver):
     """Idle timeout observer.
@@ -768,6 +773,20 @@ class PipelineWorker(BaseWorker):
         except TimeoutError:
             logger.warning(f"{self}: pipeline flush timed out after {timeout}s")
             return False
+
+    async def end(self, *, reason: str | None = None) -> None:
+        """Request a graceful end of the session.
+
+        Flushes the pipeline first so in-flight frames (e.g. a final LLM
+        response triggered by a function call result) are fully processed
+        before the end is requested.
+
+        Args:
+            reason: Optional human-readable reason for ending.
+        """
+        if not self._pipeline_end_event.is_set():
+            await self.flush_pipeline(timeout=END_FLUSH_TIMEOUT_SECS)
+        await super().end(reason=reason)
 
     async def on_bus_message(self, message: BusMessage) -> None:
         """Handle outbound bus messages: TTS playback and RTVI UI translation.

--- a/src/pipecat/workers/llm/llm_worker.py
+++ b/src/pipecat/workers/llm/llm_worker.py
@@ -11,6 +11,7 @@ pipeline and automatic tool registration.
 """
 
 import functools
+import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -25,7 +26,7 @@ from pipecat.frames.frames import (
     PipelineFlushFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.pipeline.worker import END_FLUSH_TIMEOUT_SECS, PipelineParams, PipelineWorker
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import LLMService
 from pipecat.workers.base_worker import WorkerActivationArgs
@@ -190,19 +191,32 @@ class LLMWorker(PipelineWorker):
     ) -> None:
         """Request a graceful end of the session.
 
-        When called from a ``@tool`` handler, pass ``params.result_callback`` to
-        ensure any pending LLM output is fully delivered before ending.
+        When called from a ``@tool`` handler, deliver the function call result
+        first with ``await params.result_callback(result)``: the LLM output it
+        triggers is flushed before the session ends.
 
         Args:
             reason: Optional human-readable reason for ending.
-            messages: Optional LLM messages to inject and speak before
-                ending. The LLM runs immediately so the output is
-                delivered before the session terminates.
-            result_callback: The ``result_callback`` from
-                `FunctionCallParams`.
+            messages: Optional LLM messages to inject and speak before ending.
+
+                .. deprecated:: 1.4.0
+                    Call ``params.result_callback(result)`` before ``end()``
+                    instead; the LLM responds to the function call result.
+            result_callback: The ``result_callback`` from `FunctionCallParams`.
+
+                .. deprecated:: 1.4.0
+                    Call ``params.result_callback(result)`` before ``end()``
+                    instead.
         """
         self._closing = True
-        await self._finish_function_call(result_callback, messages=messages)
+        if messages is not None or result_callback is not None:
+            warnings.warn(
+                "Passing messages or result_callback to LLMWorker.end() is deprecated, "
+                "call params.result_callback(result) before end() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            await self._finish_function_call(result_callback, messages=messages)
         await super().end(reason=reason)
 
     async def activate_worker(
@@ -214,11 +228,11 @@ class LLMWorker(PipelineWorker):
         messages: list | None = None,
         result_callback: FunctionCallResultCallback | None = None,
     ) -> None:
-        """Activate another worker, optionally finishing an in-progress tool call.
+        """Activate another worker, flushing this worker's pipeline first.
 
-        When called from a ``@tool`` handler, pass ``params.result_callback`` to
-        ensure any pending LLM output is fully delivered before the target is
-        activated.
+        When called from a ``@tool`` handler, deliver the function call result
+        first with ``await params.result_callback(result)``: the LLM output it
+        triggers is flushed before the target is activated.
 
         Args:
             worker_name: The name of the worker to activate.
@@ -227,11 +241,29 @@ class LLMWorker(PipelineWorker):
             deactivate_self: Whether to deactivate this worker before activating
                 the target.
             messages: Optional LLM messages to inject and speak before
-                activating the target. The LLM runs immediately so the output
-                is delivered before the transfer completes.
+                activating the target.
+
+                .. deprecated:: 1.4.0
+                    Call ``params.result_callback(result)`` before
+                    ``activate_worker()`` instead; the LLM responds to the
+                    function call result.
             result_callback: The ``result_callback`` from `FunctionCallParams`.
+
+                .. deprecated:: 1.4.0
+                    Call ``params.result_callback(result)`` before
+                    ``activate_worker()`` instead.
         """
-        await self._finish_function_call(result_callback, messages=messages)
+        if messages is not None or result_callback is not None:
+            warnings.warn(
+                "Passing messages or result_callback to LLMWorker.activate_worker() is "
+                "deprecated, call params.result_callback(result) before activate_worker() "
+                "instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            await self._finish_function_call(result_callback, messages=messages)
+        else:
+            await self.flush_pipeline(timeout=END_FLUSH_TIMEOUT_SECS)
         await super().activate_worker(worker_name, args=args, deactivate_self=deactivate_self)
 
     async def process_deferred_tool_frames(

--- a/src/pipecat/workers/llm/llm_worker.py
+++ b/src/pipecat/workers/llm/llm_worker.py
@@ -10,6 +10,7 @@ Provides the `LLMWorker` class that extends `PipelineWorker` with an LLM
 pipeline and automatic tool registration.
 """
 
+import asyncio
 import functools
 import warnings
 from collections import deque
@@ -17,10 +18,14 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from loguru import logger
+
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.frames.frames import (
     Frame,
     FunctionCallResultProperties,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
     LLMMessagesAppendFrame,
     LLMSetToolsFrame,
     PipelineFlushFrame,
@@ -100,6 +105,10 @@ class LLMWorker(PipelineWorker):
         self._tool_call_inflight: int = 0
         self._deferred_frames: deque[tuple[Frame, FrameDirection]] = deque()
         self._closing: bool = False
+        # Set when a tool delivers a final result that may trigger an LLM run;
+        # cleared (and the event set) when the response completes.
+        self._triggered_run_pending: bool = False
+        self._triggered_run_done = asyncio.Event()
 
         self._llm = llm
         self._register_tools(llm)
@@ -121,6 +130,9 @@ class LLMWorker(PipelineWorker):
         # PipelineWorker's __init__ doesn't accept active; configure after.
         self._active = active
         self._pending_activation = active
+
+        self.add_reached_downstream_filter((LLMFullResponseEndFrame,))
+        self.add_event_handler("on_frame_reached_downstream", self._on_frame_reached_downstream)
 
     @property
     def llm(self) -> LLMService:
@@ -159,14 +171,23 @@ class LLMWorker(PipelineWorker):
 
         When tool calls are in progress, the frame is held in an internal
         queue and delivered automatically once the last tool finishes.
-        When no tools are active, the frame is queued immediately.
+        When no tools are active, the frame is queued immediately. A context
+        frame triggered by a tool's own result (e.g. round-tripping back over
+        the bus from a bridged worker's context aggregator) is never deferred,
+        so the LLM can respond to the result while the tool is still running.
 
         Args:
             frame: Any ``Frame`` to deliver.
             direction: Direction the frame should travel. Defaults to
                 ``FrameDirection.DOWNSTREAM``.
         """
-        if self._defer_tool_frames and self._tool_call_inflight > 0 and not self._closing:
+        bypass = self._triggered_run_pending and isinstance(frame, LLMContextFrame)
+        if (
+            self._defer_tool_frames
+            and self._tool_call_inflight > 0
+            and not self._closing
+            and not bypass
+        ):
             self._deferred_frames.append((frame, direction))
         else:
             await super().queue_frame(frame, direction)
@@ -217,6 +238,8 @@ class LLMWorker(PipelineWorker):
                 stacklevel=2,
             )
             await self._finish_function_call(result_callback, messages=messages)
+        else:
+            await self._wait_for_triggered_run()
         await super().end(reason=reason)
 
     async def activate_worker(
@@ -263,6 +286,7 @@ class LLMWorker(PipelineWorker):
             )
             await self._finish_function_call(result_callback, messages=messages)
         else:
+            await self._wait_for_triggered_run()
             await self.flush_pipeline(timeout=END_FLUSH_TIMEOUT_SECS)
         await super().activate_worker(worker_name, args=args, deactivate_self=deactivate_self)
 
@@ -293,9 +317,45 @@ class LLMWorker(PipelineWorker):
                 timeout_secs=method._pipecat_timeout_secs,
             )
 
+    async def _on_frame_reached_downstream(self, worker, frame: Frame) -> None:
+        """Mark a tool-triggered LLM run as complete when its response ends."""
+        if isinstance(frame, LLMFullResponseEndFrame):
+            self._triggered_run_pending = False
+            self._triggered_run_done.set()
+
+    async def _wait_for_triggered_run(self) -> None:
+        """Wait for the LLM response triggered by a just-delivered tool result.
+
+        The result round-trips through the context aggregator (over the bus
+        when bridged) before the run starts, so a pipeline flush can't order
+        itself behind it; wait for the response-end frame instead. The timeout
+        is a safety net for runs the aggregator skips (e.g. the user is
+        speaking).
+        """
+        if not self._triggered_run_pending:
+            return
+        try:
+            await asyncio.wait_for(self._triggered_run_done.wait(), END_FLUSH_TIMEOUT_SECS)
+        except TimeoutError:
+            logger.warning(f"{self}: timed out waiting for the LLM response to a tool result")
+
     def _track_tool_call(self, method: Callable) -> Callable:
         @functools.wraps(method)
         async def wrapper(params, *args, **kwargs):
+            original_callback = params.result_callback
+
+            async def tracked_result_callback(result, *, properties=None):
+                is_final = properties.is_final if properties else True
+                run_llm = properties.run_llm if properties else None
+                if is_final and run_llm is not False:
+                    # The result may trigger an LLM run; end() and
+                    # activate_worker() wait for the response to complete.
+                    self._triggered_run_pending = True
+                    self._triggered_run_done.clear()
+                await original_callback(result, properties=properties)
+
+            params.result_callback = tracked_result_callback
+
             self._tool_call_inflight += 1
             try:
                 return await method(params, *args, **kwargs)

--- a/tests/test_llm_worker.py
+++ b/tests/test_llm_worker.py
@@ -6,9 +6,15 @@
 
 import asyncio
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-from pipecat.frames.frames import LLMMessagesAppendFrame, PipelineFlushFrame
+from pipecat.frames.frames import (
+    FunctionCallResultProperties,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
+    LLMMessagesAppendFrame,
+    PipelineFlushFrame,
+)
 from pipecat.pipeline.worker import PipelineWorker
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.workers.llm import LLMWorker, tool
@@ -257,6 +263,79 @@ class TestToolCallTracking(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(delivered), 2)
         self.assertIs(delivered[0][0], frame_a)
         self.assertIs(delivered[1][0], frame_b)
+
+    async def test_result_callback_marks_triggered_run_pending(self):
+        """A final tool result with default properties marks an LLM run as pending."""
+        task = self._track(_create_task())
+
+        @tool
+        async def reporting_tool(self, params):
+            """Delivers a result."""
+            await params.result_callback("done")
+
+        wrapped = task._track_tool_call(reporting_tool.__get__(task))
+        params = MagicMock()
+        original_callback = AsyncMock()
+        params.result_callback = original_callback
+        await wrapped(params)
+
+        self.assertTrue(task._triggered_run_pending)
+        self.assertFalse(task._triggered_run_done.is_set())
+        original_callback.assert_awaited_once()
+
+    async def test_silent_or_intermediate_results_not_pending(self):
+        """run_llm=False and is_final=False results don't mark a run as pending."""
+        task = self._track(_create_task())
+
+        for properties in (
+            FunctionCallResultProperties(run_llm=False),
+            FunctionCallResultProperties(is_final=False),
+        ):
+
+            @tool
+            async def silent_tool(self, params):
+                """Delivers a silent result."""
+                await params.result_callback("done", properties=properties)
+
+            wrapped = task._track_tool_call(silent_tool.__get__(task))
+            params = MagicMock()
+            params.result_callback = AsyncMock()
+            await wrapped(params)
+
+            self.assertFalse(task._triggered_run_pending)
+
+    async def test_context_frame_bypasses_deferral_when_run_pending(self):
+        """A context frame is not deferred while a tool-triggered run is pending."""
+        task = self._track(_create_task())
+        task._tool_call_inflight = 1
+        task._triggered_run_pending = True
+
+        context_frame = LLMContextFrame(context=MagicMock())
+        other_frame = _make_frame("deferred")
+        await task.queue_frame(context_frame)
+        await task.queue_frame(other_frame)
+
+        delivered = _get_delivered_frames(task)
+        self.assertEqual(len(delivered), 1)
+        self.assertIs(delivered[0][0], context_frame)
+        self.assertEqual(len(task._deferred_frames), 1)
+
+    async def test_wait_for_triggered_run_released_by_response_end(self):
+        """The wait returns immediately when idle and releases on LLMFullResponseEndFrame."""
+        task = self._track(_create_task())
+
+        # Nothing pending: returns immediately.
+        await asyncio.wait_for(task._wait_for_triggered_run(), timeout=1)
+
+        task._triggered_run_pending = True
+        task._triggered_run_done.clear()
+        waiter = asyncio.create_task(task._wait_for_triggered_run())
+        await asyncio.sleep(0)
+        self.assertFalse(waiter.done())
+
+        await task._on_frame_reached_downstream(task, LLMFullResponseEndFrame())
+        await asyncio.wait_for(waiter, timeout=1)
+        self.assertFalse(task._triggered_run_pending)
 
     async def test_tool_error_still_decrements_and_flushes(self):
         """If a tool raises, the counter still decrements and deferred frames flush."""


### PR DESCRIPTION
Fixes #4647.

`PipelineWorker.end()` now flushes the pipeline before requesting the end, so in-flight frames are fully processed and the final turn's audio plays out before teardown (`EndFrame` is uninterruptible and the output transport waits for playout).

For `LLMWorker`, a flush alone isn't enough: the LLM run triggered by a function call result round-trips through the context aggregator (over the bus when the worker is bridged) before it starts, so a flush probe drains an idle pipeline and the end or handoff races the response. Instead, the tool wrapper marks a pending run when a final result with `run_llm` not `False` is delivered, and `end()` / `activate_worker()` wait for the LLM's response-end frame; a timeout acts only as a safety net for runs the aggregator skips (e.g. the user is speaking). Context frames are exempt from tool-call deferral while a run is pending, so the trigger coming back over the bus isn't held up by the tool that caused it.

This makes ending or handing off from a `@tool` handler simple: deliver the result normally and the triggered LLM output is delivered before the worker acts.

```python
@tool
async def end_call(self, params, reason: str):
    await params.result_callback(reason)
    await self.end(reason=reason)
```

The `messages` and `result_callback` parameters of `LLMWorker.end()` and `LLMWorker.activate_worker()` are deprecated: the function call result is the steering mechanism, and the old `result_callback(None, run_llm=False)` path suppressed the LLM's natural response to it. Passing them still works and emits a `DeprecationWarning`.

The multi-worker examples (local handoff, distributed handoff via pgmq/redis, remote proxy assistant) are updated to the new pattern. Transfers that should stay silent call `params.result_callback(None, properties=FunctionCallResultProperties(run_llm=False))` before activating the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)