### PR TITLE
fix(text-filter): strip markdown headers before newline collapse

### DIFF
--- a/changelog/4708.fixed.md
+++ b/changelog/4708.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `MarkdownTextFilter` leaking raw `#` markers into TTS output for second-level (and deeper) markdown headers. Headers are now normalized to plain text before the newline-collapse step that previously broke header recognition by `md.convert`. This also handles closed ATX headers (e.g. `## Title ##`) while preserving trailing whitespace needed for word-by-word streaming.

--- a/src/pipecat/utils/text/markdown_text_filter.py
+++ b/src/pipecat/utils/text/markdown_text_filter.py
@@ -77,11 +77,23 @@ class MarkdownTextFilter(BaseTextFilter):
             The filtered text with Markdown formatting removed or converted.
         """
         if self._settings.enable_text_filter:
-            # Strip markdown header markers along with any preceding blank lines
-            # (headers require # at column 0, but the newline collapse below
-            # would inject a space that breaks header recognition by md.convert)
-            filtered_text = re.sub(r"(\n\s*\n)(#{1,6}\s+)", r"\n", text, flags=re.MULTILINE)
-            filtered_text = re.sub(r"^#{1,6}\s+", "", filtered_text, flags=re.MULTILINE)
+            # Strip markdown headers to plain text before the newline collapse
+            # below. md.convert can't recognize a header once the collapse
+            # injects a leading space, so we normalize headers ourselves.
+            # First, drop blank lines before a header (keeping the marker) so
+            # the collapse doesn't turn them into a leading space.
+            filtered_text = re.sub(r"\n\s*\n(#{1,6}[ \t])", r"\n\1", text)
+            # Then strip the leading marker and any "closed" trailing marker
+            # (e.g. ## Title ##), leaving just the header text. The trailing
+            # marker's surrounding spaces are absorbed only when the marker is
+            # present, so genuine trailing whitespace (needed for word-by-word
+            # streaming) is preserved on open headers.
+            filtered_text = re.sub(
+                r"^#{1,6}[ \t]+(.*?)(?:[ \t]+#+[ \t]*)?$",
+                r"\1",
+                filtered_text,
+                flags=re.MULTILINE,
+            )
 
             # Remove newlines and replace with a space only when there's no text before or after
             filtered_text = re.sub(r"^\s*\n", " ", filtered_text, flags=re.MULTILINE)

--- a/src/pipecat/utils/text/markdown_text_filter.py
+++ b/src/pipecat/utils/text/markdown_text_filter.py
@@ -77,8 +77,14 @@ class MarkdownTextFilter(BaseTextFilter):
             The filtered text with Markdown formatting removed or converted.
         """
         if self._settings.enable_text_filter:
+            # Strip markdown header markers along with any preceding blank lines
+            # (headers require # at column 0, but the newline collapse below
+            # would inject a space that breaks header recognition by md.convert)
+            filtered_text = re.sub(r"(\n\s*\n)(#{1,6}\s+)", r"\n", text, flags=re.MULTILINE)
+            filtered_text = re.sub(r"^#{1,6}\s+", "", filtered_text, flags=re.MULTILINE)
+
             # Remove newlines and replace with a space only when there's no text before or after
-            filtered_text = re.sub(r"^\s*\n", " ", text, flags=re.MULTILINE)
+            filtered_text = re.sub(r"^\s*\n", " ", filtered_text, flags=re.MULTILINE)
 
             # Remove backticks from inline code, but not from code blocks
             filtered_text = re.sub(r"(?<!`)`([^`\n]+)`(?!`)", r"\1", filtered_text)

--- a/tests/test_markdown_text_filter.py
+++ b/tests/test_markdown_text_filter.py
@@ -20,14 +20,14 @@ class TestMarkdownTextFilter(unittest.IsolatedAsyncioTestCase):
             **Bold text** and *italic text*
             1. Numbered list item
             - Bullet point
-            Some `inline code` here
+            Some `inline code` here\n\n## Subtitle
         """
 
         expected_text = """
             Bold text and italic text
             1. Numbered list item
             - Bullet point
-            Some inline code here
+            Some inline code here\nSubtitle
         """
 
         result = await self.filter.filter(input_text)
@@ -258,6 +258,26 @@ class TestMarkdownTextFilter(unittest.IsolatedAsyncioTestCase):
             await filter.filter(input_text),
             "bold and italic",
             "Text filtering should be re-enabled",
+        )
+
+    async def test_header_stripping(self):
+        """Test that markdown headers are stripped to plain text."""
+        input_text = (
+            "# Title\n"  # fmt: skip
+            "\n"
+            "## Subtitle\n"
+        )
+        expected = (
+            "Title\n"  # fmt: skip
+            "Subtitle"
+        )
+
+        result = await self.filter.filter(input_text)
+
+        self.assertEqual(
+            result.strip(),
+            expected,
+            f"Header stripping failed.\nInput:\n{input_text}\nExpected:\n{expected}\nGot:\n{result.strip()}",
         )
 
 

--- a/tests/test_markdown_text_filter.py
+++ b/tests/test_markdown_text_filter.py
@@ -280,6 +280,57 @@ class TestMarkdownTextFilter(unittest.IsolatedAsyncioTestCase):
             f"Header stripping failed.\nInput:\n{input_text}\nExpected:\n{expected}\nGot:\n{result.strip()}",
         )
 
+    async def test_closed_atx_header_stripping(self):
+        """Test that closed ATX headers (## Title ##) strip both markers."""
+        test_cases = {
+            "## Subtitle ##": "Subtitle",  # Symmetric closing run
+            "### Deep ###": "Deep",
+            "## Done ###": "Done",  # Asymmetric closing run
+            "# Title\n\n## Subtitle ##": "Title\nSubtitle",  # Closed header after a blank line
+        }
+
+        for input_text, expected in test_cases.items():
+            result = await self.filter.filter(input_text)
+            self.assertEqual(
+                result.strip(),
+                expected,
+                f"Closed ATX header stripping failed for: {input_text!r}\nGot: {result!r}",
+            )
+
+    async def test_header_trailing_space_preserved(self):
+        """Test that open headers keep trailing whitespace.
+
+        Trailing spaces matter for word-by-word streaming in bot-tts-text, so
+        only a closing marker's surrounding spaces are absorbed.
+        """
+        result = await self.filter.filter("## Trailing   ")
+        self.assertEqual(
+            result, "Trailing   ", f"Header trailing space not preserved.\nGot: {result!r}"
+        )
+
+    async def test_header_levels(self):
+        """Test that all six ATX header levels are reduced to their text."""
+        for n in range(1, 7):
+            input_text = f"{'#' * n} Heading"
+            result = await self.filter.filter(input_text)
+            self.assertEqual(result.strip(), "Heading", f"h{n} header failed.\nGot: {result!r}")
+
+    async def test_hash_in_content_not_treated_as_header(self):
+        """Test that a '#' that isn't a leading ATX marker is left in the text."""
+        test_cases = {
+            "C# is great": "C# is great",  # No leading marker
+            "## Issue #42 today": "Issue #42 today",  # '#' mid-content, not a closing run
+            "## C# matters": "C# matters",  # Content starts with a hash word
+        }
+
+        for input_text, expected in test_cases.items():
+            result = await self.filter.filter(input_text)
+            self.assertEqual(
+                result.strip(),
+                expected,
+                f"Hash-in-content handling failed for: {input_text!r}\nGot: {result!r}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When text containing markdown headers is streamed word-by-word through `MarkdownTextFilter`, second-level (and deeper) headers are not properly stripped — the raw `##` markers leak into the TTS output.

## Example

**Input text:**
```
# Title

## Subtitle
```

**Before this fix:**
```
Title
 ## Subtitle 
```
The first `# Title` is correctly recognized (it starts at column 0), but the blank line between the headers gets collapsed into a space by the newline-to-space substitution. This prepends a `§` (space marker) before `## Subtitle`, so `md.convert()` no longer recognizes it as a header and leaves the raw `##` in the output.

**After this fix:**
```
Title
Subtitle 
```
Headers are stripped before the newline collapse runs, so all header levels are properly removed from the plain-text output.

## Changes

- `markdown_text_filter.py`: Added two `re.sub()` calls at the top of `filter()` to strip header markers (and preceding blank lines) before the existing newline collapse logic.
- `test_markdown_text_filter.py`: Updated `test_basic_markdown_removal` to include a header, and added a dedicated `test_header_stripping` test case.