### PR TITLE
fix(transports): keep mixer audio flowing across interruptions

### DIFF
--- a/changelog/4714.fixed.md
+++ b/changelog/4714.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an audible 200-300 ms gap in audio mixer output (e.g. `SoundfileMixer` background sound) on every interruption. The output transport now keeps the audio task running and drains the queue instead of cancelling and recreating it when a mixer is active.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -545,9 +545,13 @@ class BaseOutputTransport(FrameProcessor):
             await self._cancel_clock_task()
             await self._cancel_video_task()
 
-            if self._audio_queue.has_uninterruptible:
+            if self._audio_queue.has_uninterruptible or self._mixer:
                 # Keep the audio task running but drain all interruptible frames
-                # so the pending UninterruptibleFrames are still delivered.
+                # so the pending UninterruptibleFrames are still delivered. With
+                # a mixer, cancelling the task would also stop mixer-only output
+                # during the restart, causing an audible gap in the background
+                # audio (made worse by telephony serializers that clear the
+                # playout buffer on interruptions).
                 self._audio_queue.reset()
             else:
                 await self._cancel_audio_task()

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for interruption handling in :class:`BaseOutputTransport`."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
+from pipecat.clocks.system_clock import SystemClock
+from pipecat.frames.frames import (
+    CancelFrame,
+    InterruptionFrame,
+    MixerControlFrame,
+    OutputAudioRawFrame,
+    StartFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
+from pipecat.transports.base_output import BaseOutputTransport
+from pipecat.transports.base_transport import TransportParams
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+
+
+class _PassthroughMixer(BaseAudioMixer):
+    """Minimal mixer that returns the input audio unchanged."""
+
+    async def start(self, sample_rate: int):
+        pass
+
+    async def stop(self):
+        pass
+
+    async def process_frame(self, frame: MixerControlFrame):
+        pass
+
+    async def mix(self, audio: bytes) -> bytes:
+        return audio
+
+
+class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
+    async def _make_transport(self, mixer: BaseAudioMixer | None = None) -> BaseOutputTransport:
+        params = TransportParams(audio_out_enabled=True, audio_out_mixer=mixer)
+        transport = BaseOutputTransport(params)
+        transport.push_frame = AsyncMock()
+        transport.write_audio_frame = AsyncMock(return_value=True)
+
+        task_manager = TaskManager()
+        task_manager.setup(TaskManagerParams(loop=asyncio.get_event_loop()))
+        await transport.setup(
+            FrameProcessorSetup(
+                clock=SystemClock(),
+                task_manager=task_manager,
+                pipeline_worker=SimpleNamespace(app_resources=None),  # type: ignore[arg-type]
+            )
+        )
+        start_frame = StartFrame(audio_out_sample_rate=16000)
+        await transport.process_frame(start_frame, FrameDirection.DOWNSTREAM)
+        await transport.set_transport_ready(start_frame)
+        return transport
+
+    async def test_interruption_with_mixer_keeps_audio_task_and_mixer_output(self):
+        transport = await self._make_transport(mixer=_PassthroughMixer())
+        try:
+            sender = transport._media_senders[None]
+            task_before = sender._audio_task
+            self.assertIsNotNone(task_before)
+
+            # Mixer-only frames flow while the queue is empty.
+            await asyncio.sleep(0.1)
+            self.assertGreater(transport.write_audio_frame.call_count, 0)
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            # Same task object: not cancelled and not recreated.
+            self.assertIs(sender._audio_task, task_before)
+            self.assertFalse(task_before.cancelled())
+
+            # Mixer frames keep flowing across the interruption.
+            count_after_interruption = transport.write_audio_frame.call_count
+            await asyncio.sleep(0.1)
+            self.assertGreater(transport.write_audio_frame.call_count, count_after_interruption)
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_interruption_without_mixer_recreates_audio_task(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            task_before = sender._audio_task
+            self.assertIsNotNone(task_before)
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertIsNot(sender._audio_task, task_before)
+            self.assertIsNotNone(sender._audio_task)
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_interruption_with_mixer_still_discards_queued_bot_audio(self):
+        transport = await self._make_transport(mixer=_PassthroughMixer())
+        try:
+            sender = transport._media_senders[None]
+
+            # Pause the audio task by patching write_audio_frame with a slow
+            # write, so the queued bot audio can't be consumed before the
+            # interruption arrives.
+            write_started = asyncio.Event()
+            release_write = asyncio.Event()
+
+            async def slow_write(frame):
+                write_started.set()
+                await release_write.wait()
+                return True
+
+            transport.write_audio_frame = AsyncMock(side_effect=slow_write)
+            await write_started.wait()
+
+            # Queue bot audio (one full chunk) behind the in-flight write.
+            bot_audio = OutputAudioRawFrame(
+                audio=b"\x01\x02" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(bot_audio, FrameDirection.DOWNSTREAM)
+            self.assertFalse(sender._audio_queue.empty())
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            # The queued bot audio was dropped by the reset.
+            self.assertTrue(sender._audio_queue.empty())
+            release_write.set()
+        finally:
+            await transport.cancel(CancelFrame())


### PR DESCRIPTION
## Problem

When an output transport has an audio mixer (e.g. `SoundfileMixer` playing looping background sound), every `InterruptionFrame` causes an audible 200-300 ms gap in the mixed background audio.

Mechanism:
1. `MediaSender.handle_interruptions` cancels and recreates the audio task. The mixer only produces audio inside that task (`_next_frame.with_mixer` emits mixer-only frames when the queue is empty), so background audio stops during the restart.
2. Telephony serializers (Twilio, etc.) also send a `clear` on interruptions, wiping the playout buffer, which makes the gap clearly audible.

This was confirmed in production on a Twilio websocket transport: the recorded outbound channel shows 60-280 ms dropouts that line up with `InterruptionFrame` timestamps (e.g. a 260 ms gap matching an interruption that reached the output transport at pts 7.958s). Pipelines that broadcast interruptions on every user turn start hit this constantly, and downstream consumers that rely on a continuous background reference (e.g. VAD with background subtraction) break.

## Fix

Take the existing reset-queue path (already used when `has_uninterruptible` is true) whenever a mixer is set: keep the audio task alive and drain interruptible frames with `FrameQueue.reset()`, so mixer-only output continues without a gap. Queued bot audio is still discarded on interruption.

Notes:
- Scoped: senders without a mixer keep the cancel+recreate behavior.
- Shutdown safe: `EndFrame` is an `UninterruptibleFrame`, so `reset()` preserves it and the live task drains it; `stop()`'s `await self._audio_task` completes normally.
- Pre-existing tradeoff (same as the `has_uninterruptible` branch): one in-flight audio chunk may still be written after the interruption.

## Tests

New `tests/test_base_output_transport.py`:
- With a mixer, the audio task survives an interruption and mixer frames keep flowing.
- Without a mixer, the task is still recreated.
- With a mixer, queued bot audio is still discarded on interruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)