### PR TITLE
Fix NvidiaSegmentedSTTService missing speaker_diarization and diarization_max_speakers defaults

### DIFF
--- a/changelog/4718.fixed.md
+++ b/changelog/4718.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `NvidiaSegmentedSTTService` not initializing `speaker_diarization` and `diarization_max_speakers` defaults, which left both fields as `NOT_GIVEN` after construction.

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -716,6 +716,8 @@ class NvidiaSegmentedSTTService(SegmentedSTTService):
             boosted_lm_score=4.0,
             max_alternatives=1,
             word_time_offsets=False,
+            speaker_diarization=False,
+            diarization_max_speakers=0,
         )
 
         # 2. (no deprecated direct args for this service)


### PR DESCRIPTION
## Summary

- `_NvidiaBaseSTTSettings` defines `speaker_diarization` and `diarization_max_speakers` fields shared by both NVIDIA STT services
- `NvidiaSTTService` correctly initializes both to `False`/`0` in `default_settings`
- `NvidiaSegmentedSTTService` was missing both fields, leaving them as `NOT_GIVEN` after construction — caught by `test_service_init.py::test_service_settings_complete`

## Changes

- Added `speaker_diarization=False` and `diarization_max_speakers=0` to the `default_settings` block in `NvidiaSegmentedSTTService.__init__`

## Test plan

- [x] `uv run pytest tests/test_service_init.py::test_service_settings_complete[NvidiaSegmentedSTTService]` now passes (was failing before)
- [x] Full test suite passes (2775 passed, no regressions)