### PR TITLE
Fix GladiaSTTService silently ignoring runtime settings updates

### DIFF
--- a/changelog/4719.fixed.md
+++ b/changelog/4719.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GladiaSTTService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect with a fresh Gladia session so the updated configuration takes effect immediately.

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -417,9 +417,11 @@ class GladiaSTTService(WebsocketSTTService):
         await self._connect()
 
     async def _update_settings(self, delta: Settings) -> dict[str, Any]:
-        """Apply settings delta.
+        """Apply settings delta and reconnect with a new Gladia session.
 
-        Settings are stored but not applied to the active session.
+        Clears the current session so that the next connection initializes a
+        fresh session with the updated settings. Reconnection is deferred
+        until after the current user turn if the user is speaking.
 
         Args:
             delta: A settings delta.
@@ -432,14 +434,9 @@ class GladiaSTTService(WebsocketSTTService):
         if not changed:
             return changed
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # self._session_url = None
-        # self._session_id = None
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        self._session_url = None
+        self._session_id = None
+        await self._request_reconnect()
 
         return changed
 


### PR DESCRIPTION
Fixes #4719

## Summary

- `GladiaSTTService._update_settings()` was storing setting changes in `self._settings` but never applying them — the active Gladia session kept the original configuration
- All Gladia session config (model, language, endpointing, VAD, pre/post-processing) is submitted at HTTP session-init time, so applying changes requires a new session
- The code already had a TODO comment with the fix sketched out

## Changes

- Clear `_session_url` and `_session_id` on settings change to force a new Gladia HTTP session on reconnect
- Call `_request_reconnect()` which safely defers reconnection until after the current user turn and buffers audio during the transition
- Remove the TODO comment and update the docstring

## Pattern

Follows `DeepgramSTTService._update_settings`, which calls `_request_reconnect()` after applying the delta.

## Test plan

- [x] `uv run pytest tests/ -k "gladia" -v` — 3 passed, no regressions