### PR TITLE
Fix inconsistent ### Fixed header in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6082,7 +6082,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
   `@transport.output().event_handler("on_after_push_frame")` event handler or a
   custom processor.
 
-## Fixed
+### Fixed
 
 - Fixed an issue in `AWSBedrockLLMService` where timeout exceptions weren't
   being detected.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Pipecat Context Hub uses the changelog, so we need consistent formatting. This is not true with towncrier, but fixing one issue from the past.