### PR TITLE
Revert deprecation of WebsocketServerTransport

### DIFF
--- a/changelog/4716.deprecated.md
+++ b/changelog/4716.deprecated.md
@@ -1,1 +1,0 @@
-- `WebsocketServerTransport` is now deprecated. It was intended for development and testing only and has a critical limitation: it only supports a single client at a time. Use `FastAPIWebsocketTransport` instead.

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -14,7 +14,6 @@ handling, and frame serialization.
 import asyncio
 import io
 import time
-import warnings
 import wave
 from collections.abc import Awaitable, Callable
 
@@ -431,13 +430,6 @@ class WebsocketServerTransport(BaseTransport):
     output transports, client connection management, and event handling for
     real-time audio and data streaming applications.
 
-    .. deprecated:: 1.4.0
-        :class:`WebsocketServerTransport` was intended for development and testing
-        only. It has a critical limitation: it only supports a single client at a
-        time. Use
-        :class:`~pipecat.transports.websocket.fastapi.FastAPIWebsocketTransport`
-        instead for production use.
-
     Event handlers available:
 
     - on_client_connected(transport, websocket): Client WebSocket connected
@@ -469,14 +461,6 @@ class WebsocketServerTransport(BaseTransport):
             input_name: Optional name for the input processor.
             output_name: Optional name for the output processor.
         """
-        warnings.warn(
-            "WebsocketServerTransport is deprecated and will be removed in a future version. "
-            "It was intended for development and testing only and has a critical limitation: "
-            "it only supports a single client at a time. "
-            "Use FastAPIWebsocketTransport instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(input_name=input_name, output_name=output_name)
         self._host = host
         self._port = port


### PR DESCRIPTION
## Summary

Reverts #4716, which deprecated `WebsocketServerTransport`.

This restores `WebsocketServerTransport` as a non-deprecated, supported transport:
- Removes the runtime `DeprecationWarning` emitted on instantiation
- Removes the `.. deprecated:: 1.4.0` Sphinx directive from the class docstring
- Deletes the `changelog/4716.deprecated.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)