### PR TITLE
Annotate LLMContext re-exported types as explicit TypeAliases

### DIFF
--- a/src/pipecat/processors/aggregators/llm_context.py
+++ b/src/pipecat/processors/aggregators/llm_context.py
@@ -46,10 +46,10 @@ from pipecat.frames.frames import AudioRawFrame
 # and we want to continue supporting them). In the meantime, code at the
 # LLMContext/OpenAI boundary should use explicit casts rather than rely on
 # the aliasing.
-LLMStandardMessage = ChatCompletionMessageParam
-LLMContextToolChoice = ChatCompletionToolChoiceOptionParam
+LLMStandardMessage: TypeAlias = ChatCompletionMessageParam
+LLMContextToolChoice: TypeAlias = ChatCompletionToolChoiceOptionParam
 NOT_GIVEN = OPEN_AI_NOT_GIVEN
-NotGiven = OpenAINotGiven
+NotGiven: TypeAlias = OpenAINotGiven
 
 
 _T = TypeVar("_T")


### PR DESCRIPTION
Was not tripping up pyright but was getting flagged by VSCode. Simple fix is to specify the type.

## Summary

The re-exported "universal context" type aliases in `llm_context.py` were declared as bare assignments:

```python
LLMStandardMessage = ChatCompletionMessageParam
LLMContextToolChoice = ChatCompletionToolChoiceOptionParam
NotGiven = OpenAINotGiven
```

Pyright/Pylance normally infer `Name = SomeClass` as an implicit type alias, but in interactive editor sessions that inference can be flaky — surfacing a spurious `reportInvalidTypeForm` ("Variable not allowed in type expression") on uses like `from_standard_tools(...) -> list[Any] | NotGiven` in `base_llm_adapter.py`. The pyright CLI does not report the error, confirming it's an editor false positive rather than a real type problem.

This marks the three aliases with an explicit `TypeAlias` (already imported), declaring intent unambiguously so neither the CLI nor the editor second-guesses them. `NOT_GIVEN` is left as a plain assignment since it's a value (the sentinel instance), not a type.

## Testing

- `uv run pyright src/pipecat/processors/aggregators/llm_context.py src/pipecat/adapters/base_llm_adapter.py` → 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
