### PR TITLE
Add word timestamps to AWSPollyTTSService via Polly SpeechMarks (#1015)

### DIFF
--- a/changelog/4730.added.md
+++ b/changelog/4730.added.md
@@ -1,0 +1,1 @@
+- Added word-level timestamp support to `AWSPollyTTSService` via Amazon Polly SpeechMarks, emitting one timestamped `TTSTextFrame` per word when `word_timestamps` is enabled (default). Set `word_timestamps=False` to skip the extra request.

--- a/src/pipecat/services/aws/tts.py
+++ b/src/pipecat/services/aws/tts.py
@@ -7,9 +7,12 @@
 """AWS Polly text-to-speech service implementation.
 
 This module provides integration with Amazon Polly for text-to-speech synthesis,
-supporting multiple languages, voices, and SSML features.
+supporting multiple languages, voices, SSML features, and per-word timestamps
+via Polly SpeechMarks.
 """
 
+import asyncio
+import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 
@@ -18,10 +21,16 @@ from pydantic import BaseModel
 
 from pipecat.audio.utils import create_stream_resampler
 from pipecat.frames.frames import (
+    AggregationType,
     ErrorFrame,
     Frame,
+    InterruptionFrame,
+    StartFrame,
     TTSAudioRawFrame,
+    TTSStoppedFrame,
+    TTSTextFrame,
 )
+from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.aws.utils import resolve_credentials
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import TTSService
@@ -148,6 +157,11 @@ class AWSPollyTTSService(TTSService):
     Provides text-to-speech synthesis using Amazon Polly with support for
     multiple languages, voices, SSML features, and voice customization
     options including prosody controls.
+
+    When ``word_timestamps`` is enabled (the default), the service makes a
+    second Polly call requesting word SpeechMarks and emits one timestamped
+    ``TTSTextFrame`` per word, the same behaviour timestamp-capable services
+    such as ElevenLabs provide.
     """
 
     Settings = AWSPollyTTSSettings
@@ -184,6 +198,7 @@ class AWSPollyTTSService(TTSService):
         region: str | None = None,
         voice_id: str | None = None,
         sample_rate: int | None = None,
+        word_timestamps: bool = True,
         params: InputParams | None = None,
         settings: Settings | None = None,
         **kwargs,
@@ -204,6 +219,12 @@ class AWSPollyTTSService(TTSService):
                     Use ``settings=AWSPollyTTSService.Settings(voice=...)`` instead.
 
             sample_rate: Audio sample rate. If None, uses service default.
+            word_timestamps: Whether to emit per-word timestamped TTSTextFrames
+                using Polly SpeechMarks. Defaults to True. When True the service
+                makes a second (concurrent) Polly call to fetch word timing.
+                Set to False to skip that extra call (e.g. to reduce request
+                cost), in which case the base class emits a single whole-sentence
+                TTSTextFrame with no timing.
             params: Additional input parameters for voice customization.
 
                 .. deprecated:: 0.0.105
@@ -247,6 +268,10 @@ class AWSPollyTTSService(TTSService):
 
         super().__init__(
             sample_rate=sample_rate,
+            # push_text_frames=False activates the base word-timestamp path
+            # (per-word TTSTextFrames). When word timestamps are disabled we let
+            # the base push a single whole-sentence TTSTextFrame instead.
+            push_text_frames=not word_timestamps,
             push_start_frame=True,
             push_stop_frames=True,
             settings=default_settings,
@@ -265,6 +290,12 @@ class AWSPollyTTSService(TTSService):
 
         self._resampler = create_stream_resampler()
 
+        self._word_timestamps = word_timestamps
+        # Cumulative time offset (seconds) so each sentence's word timestamps
+        # land after the previous sentence on the shared turn timeline. Reset at
+        # the start of the service and on interruption / end of turn.
+        self._cumulative_time = 0.0
+
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
 
@@ -272,6 +303,28 @@ class AWSPollyTTSService(TTSService):
             True, as AWS Polly service supports metrics generation.
         """
         return True
+
+    async def start(self, frame: StartFrame):
+        """Start the service.
+
+        Args:
+            frame: The start frame.
+        """
+        await super().start(frame)
+        self._cumulative_time = 0.0
+
+    async def push_frame(self, frame: Frame, direction: FrameDirection = FrameDirection.DOWNSTREAM):
+        """Push a frame downstream and reset timing state on interruption or stop.
+
+        Args:
+            frame: The frame to push.
+            direction: The direction to push the frame.
+        """
+        await super().push_frame(frame, direction)
+        if isinstance(frame, (InterruptionFrame, TTSStoppedFrame)):
+            # Reset the cumulative offset at end of turn / on barge-in so the
+            # next turn's word timestamps start from zero.
+            self._cumulative_time = 0.0
 
     def language_to_service_language(self, language: Language) -> str | None:
         """Convert a Language enum to AWS Polly language format.
@@ -317,9 +370,75 @@ class AWSPollyTTSService(TTSService):
 
         return ssml
 
+    async def _fetch_word_marks(self, polly, base_params: dict) -> list[tuple[str, float]]:
+        """Fetch per-word SpeechMarks from Polly for the same utterance.
+
+        Makes a second ``synthesize_speech`` call with ``OutputFormat="json"``
+        and ``SpeechMarkTypes=["word"]``. Polly's ``OutputFormat`` is
+        single-valued, so audio and marks cannot come from one call. The marks
+        arrive as newline-delimited JSON in the ``AudioStream`` body.
+
+        This never raises: on any failure it returns an empty list so audio is
+        unaffected and the caller can fall back to whole-text output.
+
+        Args:
+            polly: An open aiobotocore Polly client.
+            base_params: The shared synthesis parameters (Text, VoiceId, etc.).
+
+        Returns:
+            A list of ``(word, start_seconds_within_this_utterance)`` tuples.
+        """
+        marks_params = {**base_params, "OutputFormat": "json", "SpeechMarkTypes": ["word"]}
+        # SampleRate does not apply to JSON marks.
+        marks_params.pop("SampleRate", None)
+        try:
+            response = await polly.synthesize_speech(**marks_params)
+            if "AudioStream" not in response:
+                return []
+            raw = await response["AudioStream"].read()
+            word_times: list[tuple[str, float]] = []
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                mark = json.loads(line)
+                if mark.get("type") == "word":
+                    # Polly reports the start time in milliseconds.
+                    word_times.append((mark["value"], mark["time"] / 1000.0))
+            return word_times
+        except (BotoCoreError, ClientError, ValueError, KeyError) as error:
+            logger.warning(f"{self}: Polly speech marks fetch failed: {error}")
+            return []
+
+    async def _push_fallback_text(self, text: str, context_id: str):
+        """Push the full text when no word marks were returned.
+
+        Without timestamps no per-word ``TTSTextFrame`` is emitted, so push the
+        whole text directly to keep the assistant conversation context in sync
+        with what was spoken (committed even if the turn is later interrupted).
+
+        Args:
+            text: The text that was synthesized.
+            context_id: The context ID for this TTS request.
+        """
+        text_clean = text.rstrip()
+        if not text_clean:
+            return
+        logger.debug(f"{self}: No speech marks received, pushing fallback text: [{text_clean}]")
+        fallback = TTSTextFrame(
+            text_clean, aggregated_by=AggregationType.SENTENCE, context_id=context_id
+        )
+        ctx = self._tts_contexts.get(context_id)
+        fallback.append_to_context = ctx.append_to_context if ctx else True
+        await self.push_frame(fallback)
+
     @traced_tts
     async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
         """Generate speech from text using AWS Polly.
+
+        When word timestamps are enabled, a concurrent second Polly call fetches
+        word SpeechMarks; the parsed timings are fed to the base class via
+        ``add_word_timestamps`` so it can emit one timestamped ``TTSTextFrame``
+        per word, aligned to the audio.
 
         Args:
             text: The text to synthesize into speech.
@@ -330,50 +449,74 @@ class AWSPollyTTSService(TTSService):
         """
         logger.debug(f"{self}: Generating TTS [{text}]")
 
+        ssml = self._construct_ssml(text)
+
+        # Parameters shared by the audio call and the marks call. Both must use
+        # identical Text/Voice/Engine so the word timings line up with the audio.
+        base_params = {
+            "Text": ssml,
+            "TextType": "ssml",
+            "VoiceId": self._settings.voice,
+            "Engine": self._settings.engine,
+            # AWS only supports 8000 and 16000 for PCM. We select 16000.
+            "SampleRate": "16000",
+            "LexiconNames": self._settings.lexicon_names,
+        }
+        # Filter out None values
+        base_params = {k: v for k, v in base_params.items() if v is not None}
+
+        marks_future = None
         try:
-            # Construct the parameters dictionary
-            ssml = self._construct_ssml(text)
-
-            params = {
-                "Text": ssml,
-                "TextType": "ssml",
-                "OutputFormat": "pcm",
-                "VoiceId": self._settings.voice,
-                "Engine": self._settings.engine,
-                # AWS only supports 8000 and 16000 for PCM. We select 16000.
-                "SampleRate": "16000",
-                "LexiconNames": self._settings.lexicon_names,
-            }
-
-            # Filter out None values
-            filtered_params = {k: v for k, v in params.items() if v is not None}
-
             async with self._aws_session.create_client(  # pyright: ignore[reportGeneralTypeIssues]
                 "polly",
                 **self._aws_params,  # pyright: ignore[reportArgumentType]
             ) as polly:
-                response = await polly.synthesize_speech(**filtered_params)  # pyright: ignore[reportGeneralTypeIssues]
-                if "AudioStream" in response:
-                    # Get the streaming body and read it
-                    stream = response["AudioStream"]
-                    audio_data = await stream.read()
-                else:
+                # Kick off the marks call so it overlaps audio synthesis and
+                # adds no latency on the critical path (TTFB).
+                if self._word_timestamps:
+                    marks_future = asyncio.ensure_future(self._fetch_word_marks(polly, base_params))
+
+                audio_params = {**base_params, "OutputFormat": "pcm"}
+                response = await polly.synthesize_speech(**audio_params)  # pyright: ignore[reportGeneralTypeIssues]
+                if "AudioStream" not in response:
                     logger.error(f"{self} No audio stream in response")
                     return
 
-                audio_data = await self._resampler.resample(audio_data, 16000, self.sample_rate)
+                pcm = await response["AudioStream"].read()
+                # Marks carry only start times, so derive the utterance duration
+                # from the PCM length (16-bit mono at 16000 Hz).
+                utterance_seconds = len(pcm) / (16000 * 2)
+
+                audio = await self._resampler.resample(pcm, 16000, self.sample_rate)
 
                 await self.start_tts_usage_metrics(text)
 
-                CHUNK_SIZE = self.chunk_size
-
-                for i in range(0, len(audio_data), CHUNK_SIZE):
-                    chunk = audio_data[i : i + CHUNK_SIZE]
+                # Yield audio first so the first chunk stops TTFB and anchors the
+                # word-timestamp baseline.
+                for i in range(0, len(audio), self.chunk_size):
+                    chunk = audio[i : i + self.chunk_size]
                     if len(chunk) > 0:
                         await self.stop_ttfb_metrics()
-                        frame = TTSAudioRawFrame(chunk, self.sample_rate, 1, context_id=context_id)
-                        yield frame
+                        yield TTSAudioRawFrame(chunk, self.sample_rate, 1, context_id=context_id)
+
+                # Feed the word marks (already in flight) and advance the offset.
+                if marks_future is not None:
+                    word_marks = await marks_future
+                    marks_future = None
+                    if word_marks:
+                        word_times = [
+                            (word, self._cumulative_time + start) for word, start in word_marks
+                        ]
+                        await self.add_word_timestamps(word_times, context_id)
+                    else:
+                        await self._push_fallback_text(text, context_id)
+                    # Offset the next sentence by this utterance's audio duration.
+                    self._cumulative_time += utterance_seconds
 
         except (BotoCoreError, ClientError) as error:
-            error_message = f"AWS Polly TTS error: {str(error)}"
-            yield ErrorFrame(error=error_message)
+            yield ErrorFrame(error=f"AWS Polly TTS error: {str(error)}")
+        finally:
+            # Make sure a still-pending marks call doesn't dangle if the audio
+            # call failed or the generator was closed early (e.g. interruption).
+            if marks_future is not None:
+                marks_future.cancel()

--- a/tests/test_aws_tts.py
+++ b/tests/test_aws_tts.py
@@ -1,0 +1,292 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for AWSPollyTTSService word-timestamp handling (issue #1015).
+
+All Polly calls are mocked, so no live AWS credentials are needed.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from pipecat.frames.frames import TTSStoppedFrame, TTSTextFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.aws.tts import AWSPollyTTSService
+from pipecat.services.tts_service import TTSContext, TTSService
+
+CTX = "ctx-1"
+
+# A live SpeechMarks response (newline-delimited JSON) captured from Polly for
+# "Hello world from Pipecat". `time` is the word start offset in milliseconds;
+# `start`/`end` are byte offsets into the input text (unused).
+MARKS_SAMPLE = (
+    b'{"time":6,"type":"word","start":0,"end":5,"value":"Hello"}\n'
+    b'{"time":273,"type":"word","start":6,"end":11,"value":"world"}\n'
+    b'{"time":612,"type":"word","start":12,"end":16,"value":"from"}\n'
+    b'{"time":794,"type":"word","start":17,"end":24,"value":"Pipecat"}\n'
+)
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles for the aiobotocore Polly client
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStream:
+    """Stands in for a Polly StreamingBody with an async read()."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakePolly:
+    """Fake Polly client: returns marks for json output, audio otherwise."""
+
+    def __init__(self, pcm: bytes = b"", marks: bytes = b""):
+        self._pcm = pcm
+        self._marks = marks
+        self.calls: list[dict] = []
+
+    async def synthesize_speech(self, **params):
+        self.calls.append(params)
+        if params.get("OutputFormat") == "json":
+            return {"AudioStream": _FakeStream(self._marks)}
+        return {"AudioStream": _FakeStream(self._pcm)}
+
+
+class _FakeClientCtx:
+    """Async context manager returned by session.create_client()."""
+
+    def __init__(self, polly):
+        self._polly = polly
+
+    async def __aenter__(self):
+        return self._polly
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Fake aiobotocore session whose create_client yields a fake Polly."""
+
+    def __init__(self, polly):
+        self._polly = polly
+
+    def create_client(self, *args, **kwargs):
+        return _FakeClientCtx(self._polly)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_service(**kwargs) -> AWSPollyTTSService:
+    # Explicit credentials short-circuit the botocore chain (no network).
+    return AWSPollyTTSService(
+        api_key="test-secret",
+        aws_access_key_id="test-key",
+        region="us-east-1",
+        **kwargs,
+    )
+
+
+def _pcm(seconds: float, sample_rate: int = 16000) -> bytes:
+    """Return `seconds` of 16-bit mono silence at the given sample rate."""
+    return b"\x00" * int(seconds * sample_rate * 2)
+
+
+def _ndjson(words: list[tuple[str, int]]) -> bytes:
+    """Build newline-delimited Polly word marks from (value, time_ms) pairs."""
+    lines = [json.dumps({"time": t, "type": "word", "value": w}).encode() for w, t in words]
+    return b"\n".join(lines) + b"\n"
+
+
+def _stub_for_run_tts(service: AWSPollyTTSService):
+    """Stub sample rate, resampler and metrics so run_tts can run offline."""
+    service._sample_rate = 16000
+
+    async def _aresample(data, in_rate, out_rate):
+        return data
+
+    async def _anoop(*args, **kwargs):
+        pass
+
+    service._resampler.resample = _aresample
+    service.start_tts_usage_metrics = _anoop
+    service.stop_ttfb_metrics = _anoop
+
+
+def _capture_word_timestamps(service: AWSPollyTTSService) -> list:
+    """Replace add_word_timestamps with a capturing stub; return the capture."""
+    captured: list = []
+
+    async def _fake(word_times, context_id=None, **kwargs):
+        captured.extend(word_times)
+
+    service.add_word_timestamps = _fake
+    return captured
+
+
+async def _drain(service: AWSPollyTTSService, text: str):
+    return [frame async for frame in service.run_tts(text, CTX)]
+
+
+# --------------------------------------------------------------------------- #
+# Constructor wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_word_timestamps_enabled_by_default():
+    """Word timestamps are on by default and activate the per-word path."""
+    service = _make_service()
+    assert service._word_timestamps is True
+    # Word events produce the TTSTextFrames, so the base must not push whole text.
+    assert service._push_text_frames is False
+    assert service._cumulative_time == 0.0
+
+
+def test_word_timestamps_disabled_pushes_whole_text():
+    """Disabling word timestamps flips the service back to whole-text frames."""
+    service = _make_service(word_timestamps=False)
+    assert service._word_timestamps is False
+    assert service._push_text_frames is True
+
+
+# --------------------------------------------------------------------------- #
+# Speech-marks fetch + parse
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fetch_word_marks_parses_ndjson():
+    """Newline-delimited Polly marks parse into (word, start_seconds) pairs."""
+    service = _make_service()
+    polly = _FakePolly(marks=MARKS_SAMPLE)
+
+    result = await service._fetch_word_marks(
+        polly, {"Text": "x", "VoiceId": "Joanna", "SampleRate": "16000"}
+    )
+
+    assert result == [
+        ("Hello", pytest.approx(0.006)),
+        ("world", pytest.approx(0.273)),
+        ("from", pytest.approx(0.612)),
+        ("Pipecat", pytest.approx(0.794)),
+    ]
+    # The marks call asks for json word marks and drops SampleRate.
+    sent = polly.calls[0]
+    assert sent["OutputFormat"] == "json"
+    assert sent["SpeechMarkTypes"] == ["word"]
+    assert "SampleRate" not in sent
+
+
+@pytest.mark.asyncio
+async def test_fetch_word_marks_returns_empty_on_failure():
+    """A Polly error or a missing AudioStream yields [] and never raises."""
+    service = _make_service()
+
+    class _RaisingPolly:
+        async def synthesize_speech(self, **params):
+            raise ClientError({"Error": {"Code": "Boom", "Message": "boom"}}, "SynthesizeSpeech")
+
+    class _NoStreamPolly:
+        async def synthesize_speech(self, **params):
+            return {}
+
+    assert await service._fetch_word_marks(_RaisingPolly(), {}) == []
+    assert await service._fetch_word_marks(_NoStreamPolly(), {}) == []
+
+
+# --------------------------------------------------------------------------- #
+# run_tts behaviour
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cumulative_offset_across_sentences():
+    """A later sentence in the same turn is offset by the prior audio duration."""
+    service = _make_service()
+    _stub_for_run_tts(service)
+    captured = _capture_word_timestamps(service)
+
+    # Sentence 1: 1.0s of audio (32000 bytes), word "Hello" at 0 ms.
+    service._aws_session = _FakeSession(_FakePolly(pcm=_pcm(1.0), marks=_ndjson([("Hello", 0)])))
+    await _drain(service, "Hello")
+
+    # Sentence 2: word "World" at 100 ms -> 0.1 + 1.0 (prior duration) = 1.1s.
+    service._aws_session = _FakeSession(_FakePolly(pcm=_pcm(0.5), marks=_ndjson([("World", 100)])))
+    await _drain(service, "World")
+
+    assert captured == [("Hello", pytest.approx(0.0)), ("World", pytest.approx(1.1))]
+
+
+@pytest.mark.asyncio
+async def test_no_marks_pushes_fallback_text():
+    """Empty marks emit a single whole-text frame and add no word timestamps."""
+    service = _make_service()
+    _stub_for_run_tts(service)
+    captured = _capture_word_timestamps(service)
+    service._tts_contexts[CTX] = TTSContext(append_to_context=True)
+
+    pushed: list = []
+
+    async def _fake_push(frame, direction=FrameDirection.DOWNSTREAM):
+        pushed.append(frame)
+
+    service.push_frame = _fake_push
+    service._aws_session = _FakeSession(_FakePolly(pcm=_pcm(0.5), marks=b""))
+
+    await _drain(service, "Hello world")
+
+    assert captured == []
+    text_frames = [f for f in pushed if isinstance(f, TTSTextFrame)]
+    assert len(text_frames) == 1
+    assert text_frames[0].text == "Hello world"
+    assert text_frames[0].append_to_context is True
+
+
+@pytest.mark.asyncio
+async def test_word_timestamps_disabled_skips_marks_call():
+    """With word timestamps off, run_tts never makes the json marks call."""
+    service = _make_service(word_timestamps=False)
+    _stub_for_run_tts(service)
+    captured = _capture_word_timestamps(service)
+    polly = _FakePolly(pcm=_pcm(0.5), marks=MARKS_SAMPLE)
+    service._aws_session = _FakeSession(polly)
+
+    await _drain(service, "Hello world")
+
+    assert captured == []
+    assert all(call.get("OutputFormat") != "json" for call in polly.calls)
+
+
+# --------------------------------------------------------------------------- #
+# Offset reset
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cumulative_time_resets_on_tts_stopped():
+    """A TTSStoppedFrame (end of turn) clears the accumulated offset."""
+    service = _make_service()
+
+    async def _noop_super(self, frame, direction=FrameDirection.DOWNSTREAM):
+        pass
+
+    service._cumulative_time = 5.0
+    # Stub the parent push so the override runs without a wired pipeline.
+    with patch.object(TTSService, "push_frame", _noop_super):
+        await service.push_frame(TTSStoppedFrame(context_id=CTX))
+
+    assert service._cumulative_time == 0.0


### PR DESCRIPTION
## Summary

Closes #1015.

`AWSPollyTTSService` produced audio but no per-word timing, so downstream
consumers (captions, RTVI bot-output events, assistant context) got nothing,
unlike timestamp-capable services such as ElevenLabs. Amazon Polly exposes word
timing via SpeechMarks, but the service never requested it. This PR adds per-word
timestamps using Polly SpeechMarks.

## Approach

- Pass `push_text_frames=False` so the base `TTSService` word-timestamp path is
  active, and feed it via `add_word_timestamps()`.
- Polly's `OutputFormat` is single-valued, so audio (PCM) and word marks (JSON)
  need two calls. The marks call runs concurrently with the audio call, so
  time-to-first-byte is unaffected.
- Parse the newline-delimited SpeechMarks JSON into `(word, start_seconds)` and
  apply a cumulative offset so multiple sentences in one turn stay monotonic on
  the shared turn timeline; the offset resets on interruption / stop.
- Word marks carry only start times, so utterance duration is derived from the
  PCM byte length.
- When no marks are returned, fall back to a whole-text `TTSTextFrame` so the
  assistant context still records what was spoken (matching
  `InworldHttpTTSService`).
- New `word_timestamps: bool = True` constructor flag; set `False` to skip the
  extra SpeechMarks call (e.g. to reduce cost), following the `SmallestTTSService`
  precedent.

Follows the HTTP word-timestamp patterns of `HumeTTSService` and
`InworldHttpTTSService`, and uses only base `TTSService` methods (no base changes).

## Testing

- `tests/test_aws_tts.py`: 8 unit tests with mocked Polly (no live AWS in CI),
  covering constructor wiring, marks parsing, error / no-marks handling, the
  cumulative offset across sentences, the fallback, the disabled-flag path, and
  the offset reset.
- Live reproduction against Polly: a 9-word sentence now yields 9 timestamped
  `TTSTextFrame`s with monotonically increasing pts (before: a single
  whole-sentence frame with pts unset).
- Manually verified word and audio alignment in the Pipecat Prebuilt UI (SmallWebRTC transport, Karaoke caption view). With a multi-sentence Polly utterance, words highlight in time with the audio and stay correctly ordered across sentence boundaries. Interruption and offset reset are covered by the unit tests.

## Notes

- The issue's class names (`WordTTSService`, `PollyTTSService`) are outdated; the
  current class is `AWSPollyTTSService`.
- Changelog fragment included as changelog/4730.added.md