### PR TITLE
Fix `SpeechmaticsSTTService` truncating trailing tokens at end of turn

### DIFF
--- a/changelog/4732.fixed.md
+++ b/changelog/4732.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SpeechmaticsSTTService` dropping the last words of a turn. When Pipecat's VAD signalled end-of-turn, `finalize()` was sent to the server immediately and truncated tokens it was still streaming; the service now waits a short aggregation delay so trailing segments are captured first.

--- a/src/pipecat/services/speechmatics/stt.py
+++ b/src/pipecat/services/speechmatics/stt.py
@@ -66,6 +66,12 @@ except ModuleNotFoundError as e:
 load_dotenv()
 
 
+# Speechmatics' server may still be streaming the final tokens of a turn when Pipecat's VAD reports
+# the user stopped speaking. Wait this many seconds for those trailing segments to arrive before
+# sending finalize(), which would otherwise truncate them. See issue #4484.
+TRANSCRIPT_AGGREGATION_DELAY = 0.1
+
+
 class TurnDetectionMode(StrEnum):
     """Endpoint and turn detection handling mode.
 
@@ -506,6 +512,7 @@ class SpeechmaticsSTTService(STTService):
 
         # Build SDK config from settings, set model name before calling super
         self._client: VoiceAgentClient | None = None
+        self._finalize_task: asyncio.Task | None = None
         self._audio_encoding = encoding
         self._config: VoiceAgentConfig = self._build_config(default_settings)
         default_settings.model = self._config.operating_point.value
@@ -680,6 +687,11 @@ class SpeechmaticsSTTService(STTService):
         - Disconnect the client
         - Emit on_disconnected event handler for clients
         """
+        # Cancel a pending finalize task
+        if self._finalize_task:
+            await self.cancel_task(self._finalize_task)
+            self._finalize_task = None
+
         # Cancel the message processing task
         if self._stt_msg_task:
             await self.cancel_task(self._stt_msg_task)
@@ -955,7 +967,24 @@ class SpeechmaticsSTTService(STTService):
                 )
             elif not self._enable_vad and self._client is not None:
                 self.request_finalize()
-                self._client.finalize()
+                # Defer finalize() so trailing tokens still being streamed by the server are
+                # captured instead of truncated. See _finalize_after_delay() and issue #4484.
+                if self._finalize_task is not None:
+                    await self.cancel_task(self._finalize_task)
+                self._finalize_task = self.create_task(
+                    self._finalize_after_delay(), "speechmatics_finalize"
+                )
+
+    async def _finalize_after_delay(self) -> None:
+        """Wait a short aggregation delay, then tell the server to finalize the turn.
+
+        Gives trailing tokens still in flight from the server time to arrive before finalize()
+        truncates them. See issue #4484.
+        """
+        await asyncio.sleep(TRANSCRIPT_AGGREGATION_DELAY)
+        if self._client is not None:
+            self._client.finalize()
+        self._finalize_task = None
 
     async def _send_frames(self, segments: list[dict[str, Any]], finalized: bool = False) -> None:
         """Send frames to the pipeline.

--- a/tests/test_speechmatics_stt.py
+++ b/tests/test_speechmatics_stt.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipecat.frames.frames import VADUserStoppedSpeakingFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.speechmatics.stt import SpeechmaticsSTTService
+from pipecat.services.stt_service import STTService
+
+
+@pytest.mark.asyncio
+async def test_vad_user_stopped_defers_finalize(monkeypatch):
+    """``finalize()`` must be deferred on ``VADUserStoppedSpeakingFrame``, not called immediately.
+
+    Speechmatics' server may still be delivering the final tokens of a turn when VAD reports the
+    user stopped. Calling ``finalize()`` right away truncates those trailing tokens (issue #4484),
+    so the service schedules the call after a short aggregation delay instead.
+    """
+    service = SpeechmaticsSTTService(api_key="test-key")
+    service._enable_vad = False
+    service._client = MagicMock()  # the real VoiceAgentClient.finalize() is synchronous
+    service._finalize_task = None
+
+    scheduled = []
+
+    def fake_create_task(coro, name=None):
+        scheduled.append(coro)
+        return MagicMock()
+
+    # The VAD branch is all we exercise here; skip the full FrameProcessor pipeline machinery.
+    async def noop_process_frame(self, frame, direction):
+        pass
+
+    monkeypatch.setattr(STTService, "process_frame", noop_process_frame, raising=False)
+    monkeypatch.setattr(service, "create_task", fake_create_task)
+    monkeypatch.setattr(service, "request_finalize", MagicMock())
+
+    await service.process_frame(VADUserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+
+    # The fix: finalize() is scheduled on a task, not invoked synchronously.
+    service._client.finalize.assert_not_called()
+    assert len(scheduled) == 1
+
+    # Running the deferred task waits the aggregation delay, then finalizes the turn.
+    await scheduled[0]
+    service._client.finalize.assert_called_once()


### PR DESCRIPTION
Fixes #4484.

### Problem

`SpeechmaticsSTTService` streaming transcripts drop the trailing tokens of a turn compared to Speechmatics' batch API on identical audio and config. On `VADUserStoppedSpeakingFrame`, `process_frame` called `self._client.finalize()` immediately. Speechmatics' WebSocket server is often still delivering the last segments of the turn at that moment, so the immediate `finalize()` truncates them — e.g. *"Mein Name ist Assad. Cassius."* is received as *"Name Paces."* (full repro and measurements in the issue).

### Fix

Mirror the approach merged for `GradiumSTTService` in #4066: instead of calling `finalize()` synchronously, schedule it after a short aggregation delay (`TRANSCRIPT_AGGREGATION_DELAY = 0.1`s) via `self.create_task`, so trailing segments still in flight are captured first. Repeated VAD stops debounce (the pending task is cancelled and rescheduled), and any pending finalize is cancelled on disconnect.

### Test

Added `tests/test_speechmatics_stt.py::test_vad_user_stopped_defers_finalize`, which asserts `finalize()` is scheduled (not called synchronously) on `VADUserStoppedSpeakingFrame` and is invoked after the delay. Fails on `main`, passes with this change. `ruff check` / `ruff format --check` are clean.

### Out of scope

The issue also notes that `include_partials=False` is silently overridden — that override lives in the upstream `speechmatics-voice-python` client (it hardcodes `enable_partials=True`), not in Pipecat, so it's out of scope here.

The reporter notes 100–150 ms works well in production (150 ms for telephony jitter); the 100 ms default matches #4066. Happy to expose it as a setting if telephony deployments want a longer delay.
