### PR TITLE
Fix TTS trace text for delayed and reused contexts

### DIFF
--- a/changelog/4627.fixed.md
+++ b/changelog/4627.fixed.md
@@ -1,0 +1,1 @@
+- Fixed TTS tracing spans missing `text` and `metrics.character_count` when a TTS service creates its audio context from inside `run_tts`.

--- a/src/pipecat/tests/utils.py
+++ b/src/pipecat/tests/utils.py
@@ -123,6 +123,7 @@ class QueuedFrameProcessor(FrameProcessor):
 async def run_test(
     processor: FrameProcessor,
     *,
+    enable_tracing: bool = False,
     enable_rtvi: bool = False,
     expected_down_frames: Sequence[type] | None = None,
     expected_up_frames: Sequence[type] | None = None,
@@ -141,6 +142,7 @@ async def run_test(
 
     Args:
         processor: The frame processor to test.
+        enable_tracing: Whether OpenTelemetry tracing should be enabled in this test.
         enable_rtvi: Whether RTVI should be enabled in this test.
         expected_down_frames: Expected frame types flowing downstream (optional).
         expected_up_frames: Expected frame types flowing upstream (optional).
@@ -180,6 +182,7 @@ async def run_test(
     worker = PipelineWorker(
         pipeline,
         cancel_on_idle_timeout=False,
+        enable_tracing=enable_tracing,
         enable_rtvi=enable_rtvi,
         observers=observers,
         params=pipeline_params,

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -258,6 +258,10 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 return
             service.__tts_tracing_patches_installed__ = True
             service._tts_spans = {}
+            # Holds one accumulated payload per context so text can be
+            # attached even if run_tts fires before the span is visible,
+            # and so later chunk writes don't collapse the span back to
+            # only the latest sentence.
             service._tts_pending_run_tts_attributes = {}
 
             orig_create = service.create_audio_context
@@ -284,7 +288,7 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                             settings=settings,
                             operation_name="tts",
                         )
-                        pending_attributes = service._tts_pending_run_tts_attributes.pop(
+                        pending_attributes = service._tts_pending_run_tts_attributes.get(
                             context_id, None
                         )
                         if pending_attributes:
@@ -373,23 +377,44 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
             owner.setup = patched_setup
 
         def attach_run_tts_attributes(service, text, args, kwargs):
-            """Attach text-specific attributes to the in-flight TTS span."""
+            """Attach accumulated text attributes to the in-flight TTS span."""
             if not getattr(service, "_tracing_enabled", False):
                 return
             try:
                 context_id = args[0] if args else kwargs.get("context_id")
-                if not context_id or not text:
+                if not context_id:
                     return
-                attributes = {"text": text, "metrics.character_count": len(text)}
+
+                pending = getattr(service, "_tts_pending_run_tts_attributes", None)
+                if pending is None:
+                    return
+
+                existing_payload = pending.get(context_id, {})
+                existing_text = str(existing_payload.get("text") or "")
+                if text and existing_text:
+                    separator = (
+                        " " if not existing_text[-1].isspace() and not text[0].isspace() else ""
+                    )
+                    combined_text = f"{existing_text}{separator}{text}"
+                elif text:
+                    combined_text = text
+                else:
+                    combined_text = existing_text
+
+                # Empty text means "re-apply what we already accumulated".
+                if not combined_text:
+                    return
+
+                attributes = {
+                    "text": combined_text,
+                    "metrics.character_count": len(combined_text),
+                }
+                pending[context_id] = attributes
+
                 entry = getattr(service, "_tts_spans", {}).get(context_id)
                 if entry:
                     for key, value in attributes.items():
                         entry["span"].set_attribute(key, value)
-                    getattr(service, "_tts_pending_run_tts_attributes", {}).pop(context_id, None)
-                else:
-                    pending = getattr(service, "_tts_pending_run_tts_attributes", None)
-                    if pending is not None:
-                        pending[context_id] = attributes
             except Exception as e:
                 logging.warning(f"Error attaching TTS text to span: {e}")
 
@@ -407,15 +432,23 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 @functools.wraps(f)
                 async def gen_wrapper(self, text, *args, **kwargs):
                     attach_run_tts_attributes(self, text, args, kwargs)
-                    async for item in f(self, text, *args, **kwargs):
-                        yield item
+                    try:
+                        async for item in f(self, text, *args, **kwargs):
+                            yield item
+                    finally:
+                        # Re-apply the accumulated payload for services that
+                        # open the span while run_tts is in progress.
+                        attach_run_tts_attributes(self, "", args, kwargs)
 
                 return gen_wrapper
 
             @functools.wraps(f)
             async def coro_wrapper(self, text, *args, **kwargs):
                 attach_run_tts_attributes(self, text, args, kwargs)
-                return await f(self, text, *args, **kwargs)
+                try:
+                    return await f(self, text, *args, **kwargs)
+                finally:
+                    attach_run_tts_attributes(self, "", args, kwargs)
 
             return coro_wrapper
 

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -207,6 +207,7 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
 
         def end_tts_span(service, context_id, *, interrupted=False):
             """End the TTS span for ``context_id`` if still open. Idempotent."""
+            getattr(service, "_tts_pending_run_tts_attributes", {}).pop(context_id, None)
             entry = service._tts_spans.pop(context_id, None)
             if not entry:
                 return
@@ -257,6 +258,7 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 return
             service.__tts_tracing_patches_installed__ = True
             service._tts_spans = {}
+            service._tts_pending_run_tts_attributes = {}
 
             orig_create = service.create_audio_context
             orig_append = service.append_to_audio_context
@@ -282,6 +284,12 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                             settings=settings,
                             operation_name="tts",
                         )
+                        pending_attributes = service._tts_pending_run_tts_attributes.pop(
+                            context_id, None
+                        )
+                        if pending_attributes:
+                            for key, value in pending_attributes.items():
+                                span.set_attribute(key, value)
                     except Exception as e:
                         logging.warning(f"Error opening TTS span: {e}")
                 return await orig_create(context_id)
@@ -319,6 +327,7 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                     logging.warning(f"Error recording TTS ttfb from MetricsFrame: {e}")
 
             async def traced_remove_audio_context(context_id):
+                getattr(service, "_tts_pending_run_tts_attributes", {}).pop(context_id, None)
                 entry = service._tts_spans.pop(context_id, None)
                 if entry:
                     try:
@@ -369,11 +378,18 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 return
             try:
                 context_id = args[0] if args else kwargs.get("context_id")
+                if not context_id or not text:
+                    return
+                attributes = {"text": text, "metrics.character_count": len(text)}
                 entry = getattr(service, "_tts_spans", {}).get(context_id)
-                if entry and text:
-                    span = entry["span"]
-                    span.set_attribute("text", text)
-                    span.set_attribute("metrics.character_count", len(text))
+                if entry:
+                    for key, value in attributes.items():
+                        entry["span"].set_attribute(key, value)
+                    getattr(service, "_tts_pending_run_tts_attributes", {}).pop(context_id, None)
+                else:
+                    pending = getattr(service, "_tts_pending_run_tts_attributes", None)
+                    if pending is not None:
+                        pending[context_id] = attributes
             except Exception as e:
                 logging.warning(f"Error attaching TTS text to span: {e}")
 
@@ -382,8 +398,9 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
 
             Span lifetime is owned by the audio-context patches. This
             wrapper only attaches the text and character count to the
-            span that was opened by ``create_audio_context`` just
-            before ``run_tts`` was invoked.
+            span that was opened by ``create_audio_context``, or stores
+            them until that span exists for services that open the
+            context from inside ``run_tts``.
             """
             if is_async_generator:
 

--- a/tests/test_tts_tracing.py
+++ b/tests/test_tts_tracing.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for TTS service tracing."""
+
+import threading
+from collections.abc import AsyncGenerator
+
+import pytest
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    HAS_OPENTELEMETRY = True
+except ImportError:
+    HAS_OPENTELEMETRY = False
+
+import pipecat.utils.tracing.service_decorators as tracing_decorators
+from pipecat.frames.frames import Frame, TTSAudioRawFrame, TTSSpeakFrame, TTSStartedFrame
+from pipecat.services.tts_service import TTSService
+from pipecat.tests.utils import run_test
+from pipecat.utils.tracing.service_decorators import traced_tts
+
+_FAKE_AUDIO = b"\x00\x01" * 320
+_SAMPLE_RATE = 16000
+
+
+if HAS_OPENTELEMETRY:
+
+    class _InMemorySpanExporter(SpanExporter):
+        """Simple in-memory span exporter for testing."""
+
+        def __init__(self):
+            """Initialize the exporter."""
+            self._spans = []
+            self._lock = threading.Lock()
+
+        def export(self, spans):
+            """Export spans to memory."""
+            with self._lock:
+                self._spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        def get_finished_spans(self):
+            """Return collected spans."""
+            with self._lock:
+                return list(self._spans)
+
+
+class _SelfStartTracedTTSService(TTSService):
+    """TTS service that opens its audio context from inside ``run_tts``."""
+
+    def __init__(self, **kwargs):
+        """Initialize the test service."""
+        super().__init__(
+            push_start_frame=False,
+            push_stop_frames=True,
+            push_text_frames=False,
+            sample_rate=_SAMPLE_RATE,
+            **kwargs,
+        )
+
+    def can_generate_metrics(self) -> bool:
+        """Return whether this service can generate metrics."""
+        return False
+
+    @traced_tts
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame | None, None]:
+        """Generate one synthetic audio frame."""
+        if not self.audio_context_available(context_id):
+            await self.create_audio_context(context_id)
+            yield TTSStartedFrame(context_id=context_id)
+        yield TTSAudioRawFrame(
+            audio=_FAKE_AUDIO,
+            sample_rate=_SAMPLE_RATE,
+            num_channels=1,
+            context_id=context_id,
+        )
+
+
+@pytest.mark.skipif(not HAS_OPENTELEMETRY, reason="opentelemetry not installed")
+@pytest.mark.asyncio
+async def test_traced_tts_attaches_text_when_context_created_in_run_tts(monkeypatch):
+    """TTS spans include text even when ``run_tts`` creates the audio context."""
+    exporter = _InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracing_decorators.trace, "get_tracer", provider.get_tracer)
+
+    text = "delayed span text"
+    try:
+        await run_test(
+            _SelfStartTracedTTSService(),
+            enable_tracing=True,
+            frames_to_send=[TTSSpeakFrame(text=text, append_to_context=False)],
+        )
+    finally:
+        provider.shutdown()
+
+    tts_spans = [span for span in exporter.get_finished_spans() if span.name == "tts"]
+    assert len(tts_spans) == 1
+    assert tts_spans[0].attributes["text"] == text
+    assert tts_spans[0].attributes["metrics.character_count"] == len(text)

--- a/tests/test_tts_tracing.py
+++ b/tests/test_tts_tracing.py
@@ -20,8 +20,16 @@ except ImportError:
     HAS_OPENTELEMETRY = False
 
 import pipecat.utils.tracing.service_decorators as tracing_decorators
-from pipecat.frames.frames import Frame, TTSAudioRawFrame, TTSSpeakFrame, TTSStartedFrame
-from pipecat.services.tts_service import TTSService
+from pipecat.frames.frames import (
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    TextFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+    TTSStartedFrame,
+)
+from pipecat.services.tts_service import TextAggregationMode, TTSService
 from pipecat.tests.utils import run_test
 from pipecat.utils.tracing.service_decorators import traced_tts
 
@@ -105,3 +113,35 @@ async def test_traced_tts_attaches_text_when_context_created_in_run_tts(monkeypa
     assert len(tts_spans) == 1
     assert tts_spans[0].attributes["text"] == text
     assert tts_spans[0].attributes["metrics.character_count"] == len(text)
+
+
+@pytest.mark.skipif(not HAS_OPENTELEMETRY, reason="opentelemetry not installed")
+@pytest.mark.asyncio
+async def test_traced_tts_accumulates_text_for_reused_context(monkeypatch):
+    """TTS spans include every synthesized chunk in a reused turn context."""
+    exporter = _InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracing_decorators.trace, "get_tracer", provider.get_tracer)
+
+    expected_text = "First sentence. Second sentence."
+    try:
+        await run_test(
+            _SelfStartTracedTTSService(text_aggregation_mode=TextAggregationMode.TOKEN),
+            enable_tracing=True,
+            frames_to_send=[
+                LLMFullResponseStartFrame(),
+                TextFrame("First"),
+                TextFrame("sentence."),
+                TextFrame("Second"),
+                TextFrame("sentence."),
+                LLMFullResponseEndFrame(),
+            ],
+        )
+    finally:
+        provider.shutdown()
+
+    tts_spans = [span for span in exporter.get_finished_spans() if span.name == "tts"]
+    assert len(tts_spans) == 1
+    assert tts_spans[0].attributes["text"] == expected_text
+    assert tts_spans[0].attributes["metrics.character_count"] == len(expected_text)


### PR DESCRIPTION
## Summary

- Fix `traced_tts` so `text` and `metrics.character_count` are preserved when a TTS service creates its audio context inside `run_tts`
- Keep accumulated span text for reused TTS contexts so later chunked `run_tts` calls do not overwrite earlier synthesized text
- Add focused tracing regression tests and test helper support for running TTS services with tracing enabled

## Testing

- `uv run pytest tests/test_tts_tracing.py`
- `uv run ruff check src/pipecat/utils/tracing/service_decorators.py tests/test_tts_tracing.py`
- `uv run ruff format --check src/pipecat/utils/tracing/service_decorators.py tests/test_tts_tracing.py`

## Fixes

- Fixes [#4627](https://github.com/pipecat-ai/pipecat/issues/4627)