### PR TITLE
Fix DeepgramSageMakerSTTService ignoring runtime settings updates

### DIFF
--- a/changelog/4737.fixed.md
+++ b/changelog/4737.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect so the updated configuration takes effect immediately.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -211,7 +211,7 @@ class DeepgramSageMakerSTTService(STTService):
         return True
 
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
-        """Apply a settings delta and warn about unhandled changes."""
+        """Apply a settings delta and reconnect to apply updated settings."""
         changed = await super()._update_settings(delta)
 
         if not changed:
@@ -221,12 +221,7 @@ class DeepgramSageMakerSTTService(STTService):
         if isinstance(self._settings, self.Settings):
             self._settings._sync_extra_to_fields()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._request_reconnect()
 
         return changed
 
@@ -375,6 +370,10 @@ class DeepgramSageMakerSTTService(STTService):
 
             logger.debug("Disconnected from Deepgram on SageMaker")
             await self._call_event_handler("on_disconnected")
+
+    async def _do_reconnect(self):
+        await self._disconnect()
+        await self._connect()
 
     async def _send_keepalive(self):
         """Send periodic KeepAlive messages to maintain the connection.


### PR DESCRIPTION
Fixes #4737

## Summary

- `_update_settings()` now calls `_request_reconnect()` after applying the delta, so updated settings take effect immediately on the next connection
- Added `_do_reconnect()` override that calls `_disconnect()` + `_connect()` — required because this service extends `STTService` directly rather than `WebsocketSTTService`, which already provides this override
- Removed the `_warn_unhandled_updated_settings()` call since settings are now actually applied

## How it works

`_request_reconnect()` (defined in `STTService`) defers the reconnect until after the current user turn if the user is speaking — consistent with the pattern used by `DeepgramSTTService` and the recently fixed `GladiaSTTService`. On reconnect, `_build_query_string()` reads `self._settings` (already updated) and submits the new configuration to the SageMaker endpoint.

## Test plan

- [ ] Verify that sending `STTUpdateSettingsFrame` mid-session causes a reconnect and the new query string (e.g. different `language` or `model`) is sent to the endpoint
- [ ] Verify reconnect is deferred when user is speaking and triggers immediately after `UserStoppedSpeakingFrame`
- [ ] Verify no reconnect occurs when the settings delta produces no changes