### PR TITLE
Fix DeepgramSageMakerTTSService ignoring runtime settings updates

### DIFF
--- a/changelog/4737.fixed.md
+++ b/changelog/4737.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect so the updated configuration takes effect immediately.

--- a/changelog/4739.fixed.md
+++ b/changelog/4739.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerTTSService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect so the updated configuration takes effect immediately.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -211,7 +211,7 @@ class DeepgramSageMakerSTTService(STTService):
         return True
 
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
-        """Apply a settings delta and warn about unhandled changes."""
+        """Apply a settings delta and reconnect to apply updated settings."""
         changed = await super()._update_settings(delta)
 
         if not changed:
@@ -221,12 +221,7 @@ class DeepgramSageMakerSTTService(STTService):
         if isinstance(self._settings, self.Settings):
             self._settings._sync_extra_to_fields()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._request_reconnect()
 
         return changed
 
@@ -375,6 +370,10 @@ class DeepgramSageMakerSTTService(STTService):
 
             logger.debug("Disconnected from Deepgram on SageMaker")
             await self._call_event_handler("on_disconnected")
+
+    async def _do_reconnect(self):
+        await self._disconnect()
+        await self._connect()
 
     async def _send_keepalive(self):
         """Send periodic KeepAlive messages to maintain the connection.

--- a/src/pipecat/services/deepgram/sagemaker/tts.py
+++ b/src/pipecat/services/deepgram/sagemaker/tts.py
@@ -217,7 +217,7 @@ class DeepgramSageMakerTTSService(TTSService):
             await self._call_event_handler("on_disconnected")
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
-        """Apply a settings delta and reconnect if necessary.
+        """Apply a settings delta and reconnect to apply updated settings.
 
         Since all settings are part of the SageMaker session query string,
         any setting change requires reconnecting to apply the new values.
@@ -232,12 +232,8 @@ class DeepgramSageMakerTTSService(TTSService):
             self._settings.model = self._settings.voice
             self._sync_model_name_to_metrics()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._disconnect()
+        await self._connect()
 
         return changed
 


### PR DESCRIPTION
Fixes #4739

## Summary

- `_update_settings()` now calls `_disconnect()` then `_connect()` after applying the delta, so updated settings take effect immediately on the next connection
- Removed the `_warn_unhandled_updated_settings()` call since settings are now actually applied
- No `_do_reconnect()` override needed here — `TTSService` has no reconnect infrastructure, so a direct disconnect + connect is the appropriate pattern (consistent with other TTS services like `GradiumTTSService`)

## How it works

`_connect()` builds the query string fresh from `self._settings.voice`, `self._encoding`, and `self.sample_rate` on every call. After `super()._update_settings(delta)` stores the change, the reconnect submits the updated configuration to the SageMaker endpoint.

Unlike the STT counterpart (#4738), TTS has no VAD deferral concern, so the reconnect is immediate.

## Test plan

- [ ] Verify that sending `TTSUpdateSettingsFrame` mid-session causes a reconnect and the new query string (e.g. different `voice`) is sent to the endpoint
- [ ] Verify no reconnect occurs when the settings delta produces no changes