### PR TITLE
feat(nvidia): add per-sentence TTS mode and zero-shot prompt support

### DIFF
--- a/changelog/4742.added.md
+++ b/changelog/4742.added.md
@@ -1,0 +1,1 @@
+- Added per-sentence synthesis mode and zero-shot audio prompt support to `NvidiaTTSService`, letting NVIDIA TTS users choose between stitched and per-request synthesis flows and configure voice-cloning prompts for supported models.

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -65,7 +65,7 @@ class NvidiaTTSSynthesisMode(StrEnum):
     Parameters:
         PER_SENTENCE: Open a separate ``SynthesizeOnline`` call for each
             ``run_tts`` invocation. This is the default mode and can be used
-            with all supported NVIDIA TTS models, including Chatterbox,
+            with all supported NVIDIA TTS NIMs, including Chatterbox,
             Magpie multilingual, and Magpie zero-shot. Text may still be
             chunked within that call to satisfy model request length limits.
         STITCHED: Reuse one ``SynthesizeOnline`` stream across multiple

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -98,22 +98,16 @@ class NvidiaTTSSettings(TTSSettings):
 
 
 @dataclass
-class _SynthesisState:
-    """Runtime state for the active synthesis manager."""
+class _SynthesisStreamState:
+    """Runtime state for one active synthesis stream."""
 
     context_id: str
-    mode: NvidiaTTSSynthesisMode
     text_queue: queue.Queue
     response_queue: asyncio.Queue
     stop_event: threading.Event
     rpc_call: Any = None
     synth_task: asyncio.Task | None = None
     response_task: asyncio.Task | None = None
-
-
-_RECONNECT = object()
-_CLOSE_STREAM = object()
-_REQUEST_DONE = object()
 
 
 class NvidiaTTSService(TTSService):
@@ -262,8 +256,10 @@ class NvidiaTTSService(TTSService):
         self._service = None
         self._config = None
 
-        # Runtime state for the active synthesis manager.
-        self._synthesis_state: _SynthesisState | None = None
+        # Runtime state for the active streaming turn.
+        self._stream_state: _SynthesisStreamState | None = None
+        # In-flight gRPC call for per-sentence mode (used for cancellation).
+        self._per_sentence_rpc_call: Any = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate metrics.
@@ -376,12 +372,8 @@ class NvidiaTTSService(TTSService):
         Args:
             frame: The end frame.
         """
-        context_ids = self._active_context_ids()
-        await self._abort_all_synthesis()
-        for context_id in context_ids:
-            if self.audio_context_available(context_id):
-                await self.remove_audio_context(context_id)
         await super().stop(frame)
+        await self._abort_synthesis_stream()
         self._close_client()
 
     async def cancel(self, frame: CancelFrame):
@@ -390,54 +382,32 @@ class NvidiaTTSService(TTSService):
         Args:
             frame: The cancel frame.
         """
-        context_ids = self._active_context_ids()
-        await self._abort_all_synthesis()
-        for context_id in context_ids:
-            if self.audio_context_available(context_id):
-                await self.remove_audio_context(context_id)
         await super().cancel(frame)
+        await self._abort_synthesis_stream()
         self._close_client()
 
-    def _active_context_ids(self) -> tuple[str, ...]:
-        """Return the active audio context IDs owned by in-flight synthesis."""
-        if self._synthesis_state is None:
-            return ()
-        return (self._synthesis_state.context_id,)
+    def _start_synthesis_stream(self, context_id: str):
+        """Start a persistent gRPC synthesis stream for the current turn.
 
-    def _start_synthesis_state(self, context_id: str, mode: NvidiaTTSSynthesisMode):
-        """Start the active synthesis manager for the requested mode."""
-        state = _SynthesisState(
+        Creates a queue-backed generator that feeds text to
+        ``synthesize_online``. The gRPC stream stays open until a ``None``
+        sentinel is pushed into the queue.
+        """
+        state = _SynthesisStreamState(
             context_id=context_id,
-            mode=mode,
             text_queue=queue.Queue(),
             response_queue=asyncio.Queue(),
             stop_event=threading.Event(),
         )
-        self._synthesis_state = state
-        logger.debug(f"{self}: starting {mode} synthesis state")
+        self._stream_state = state
+        logger.debug(f"{self}: starting synthesis stream")
 
         state.synth_task = self.create_task(
-            asyncio.to_thread(self._synthesis_handler, state),
-            name="nvidia-tts-synth",
+            self._synth_task_handler(state), name="nvidia-tts-synth"
         )
-        if mode == NvidiaTTSSynthesisMode.STITCHED:
-            state.response_task = self.create_task(
-                self._process_stitched_responses(state), name="nvidia-tts-response"
-            )
-
-    async def _ensure_synthesis_state(
-        self, context_id: str, mode: NvidiaTTSSynthesisMode
-    ) -> _SynthesisState:
-        """Return an active synthesis manager for the given context and mode."""
-        state = self._synthesis_state
-        if state is not None and state.context_id == context_id and state.mode == mode:
-            return state
-
-        await self._abort_all_synthesis()
-        self._start_synthesis_state(context_id, mode)
-
-        assert self._synthesis_state is not None
-        return self._synthesis_state
+        state.response_task = self.create_task(
+            self._process_responses(state), name="nvidia-tts-response"
+        )
 
     def _build_base_request(self) -> rtts.SynthesizeSpeechRequest:
         """Build a reusable ``SynthesizeSpeechRequest`` with current settings."""
@@ -460,26 +430,29 @@ class NvidiaTTSService(TTSService):
             req.zero_shot_data.quality = int(zero_shot_quality)
         return req
 
-    def _run_synthesis_call(
-        self,
-        requests: Any,
-        state: _SynthesisState,
-    ):
-        """Run one blocking ``SynthesizeOnline`` gRPC call.
+    def _synthesis_handler(self, state: _SynthesisStreamState):
+        """Run ``SynthesizeOnline`` gRPC stream in a blocking call.
 
-        Args:
-            requests: Blocking iterator of ``SynthesizeSpeechRequest`` objects.
-            state: Runtime state owning the active RPC call and response queue.
+        Uses a queue-backed generator to feed text chunks into a single
+        ``SynthesizeOnline`` call, enabling Magpie's cross-sentence stitching.
+        Audio responses are forwarded to the async response queue.
         """
         event_loop = self.get_event_loop()
-        error_label = (
-            "gRPC stitched synthesis stream error"
-            if state.mode == NvidiaTTSSynthesisMode.STITCHED
-            else "gRPC per-sentence synthesis request error"
-        )
+        base_req = self._build_base_request()
+
+        def request_generator():
+            while True:
+                if state.stop_event.is_set():
+                    break
+                text = state.text_queue.get()
+                if text is None or state.stop_event.is_set():
+                    break
+                base_req.text = text
+                yield base_req
+
         try:
             call = self._service.stub.SynthesizeOnline(
-                requests,
+                request_generator(),
                 metadata=self._service.auth.get_auth_metadata(),
             )
             state.rpc_call = call
@@ -490,62 +463,24 @@ class NvidiaTTSService(TTSService):
                 asyncio.run_coroutine_threadsafe(state.response_queue.put(resp), event_loop)
         except Exception as e:
             if not state.stop_event.is_set():
-                logger.error(f"{self} {error_label}: {e}")
+                logger.error(f"{self} gRPC synthesis stream error: {e}")
                 asyncio.run_coroutine_threadsafe(state.response_queue.put(e), event_loop)
         finally:
             state.rpc_call = None
-            asyncio.run_coroutine_threadsafe(state.response_queue.put(_REQUEST_DONE), event_loop)
-
-    def _synthesis_handler(self, state: _SynthesisState):
-        """Process queued synthesis requests for stitched or per-sentence mode."""
-        try:
-            while not state.stop_event.is_set():
-                first_item = state.text_queue.get()
-                if first_item is _CLOSE_STREAM or state.stop_event.is_set():
-                    break
-                if first_item is _RECONNECT:
-                    continue
-
-                base_req = self._build_base_request()
-                close_reason = {"value": _RECONNECT}
-
-                def request_generator():
-                    current_item: str | object = first_item
-                    while True:
-                        if state.stop_event.is_set():
-                            close_reason["value"] = _CLOSE_STREAM
-                            return
-                        if current_item is _RECONNECT:
-                            close_reason["value"] = _RECONNECT
-                            return
-                        if current_item is _CLOSE_STREAM:
-                            close_reason["value"] = _CLOSE_STREAM
-                            return
-
-                        base_req.text = current_item
-                        yield base_req
-                        current_item = state.text_queue.get()
-
-                self._run_synthesis_call(request_generator(), state)
-                if close_reason["value"] is _CLOSE_STREAM:
-                    break
-        finally:
-            event_loop = self.get_event_loop()
             asyncio.run_coroutine_threadsafe(state.response_queue.put(None), event_loop)
 
-    def _cancel_rpc_call(self, state: _SynthesisState):
-        """Best-effort cancellation of an in-flight gRPC call."""
+    async def _synth_task_handler(self, state: _SynthesisStreamState):
+        """Wrap ``_synthesis_handler`` as an asyncio-managed task."""
+        await asyncio.to_thread(self._synthesis_handler, state)
+
+    def _cancel_stream_call(self, state: _SynthesisStreamState):
+        """Best-effort cancellation of in-flight gRPC call."""
         call = state.rpc_call
-        cancel_label = (
-            "stitched gRPC call"
-            if state.mode == NvidiaTTSSynthesisMode.STITCHED
-            else "per-sentence gRPC call"
-        )
         if call is not None and hasattr(call, "cancel"):
             try:
                 call.cancel()
             except Exception as e:
-                logger.debug(f"{self}: failed to cancel {cancel_label}: {e}")
+                logger.debug(f"{self}: failed to cancel gRPC stream call: {e}")
 
     def _close_client(self):
         """Close the underlying gRPC channel and release client references."""
@@ -560,12 +495,10 @@ class NvidiaTTSService(TTSService):
         self._service = None
         self._config = None
 
-    async def _process_stitched_responses(self, state: _SynthesisState):
+    async def _process_responses(self, state: _SynthesisStreamState):
         """Consume gRPC responses and append audio to the active audio context."""
         while True:
             item = await state.response_queue.get()
-            if item is _REQUEST_DONE:
-                continue
             if item is None:
                 if self.audio_context_available(state.context_id):
                     await self.remove_audio_context(state.context_id)
@@ -575,15 +508,12 @@ class NvidiaTTSService(TTSService):
                 # SynthesizeOnline raises, no further reliable audio is expected.
                 # Ignore stale or interruption-driven exceptions to avoid noisy
                 # errors during handoff to a new stream.
-                if self._synthesis_state is state and not state.stop_event.is_set():
+                if self._stream_state is state and not state.stop_event.is_set():
                     await self.push_error(f"{self} synthesis error: {item}")
-                    if self.audio_context_available(state.context_id):
-                        await self.remove_audio_context(state.context_id)
-                    self._synthesis_state = None
                 break
 
             # Stale stream responses must never leak into a newer stream context.
-            if self._synthesis_state is not state:
+            if self._stream_state is not state:
                 continue
 
             await self.stop_ttfb_metrics()
@@ -596,12 +526,23 @@ class NvidiaTTSService(TTSService):
             await self.append_to_audio_context(state.context_id, frame)
 
         # Finalize ownership once the stream drains naturally.
-        if self._synthesis_state is state and not state.stop_event.is_set():
-            self._synthesis_state = None
+        if self._stream_state is state and not state.stop_event.is_set():
+            self._stream_state = None
 
-    async def _abort_all_synthesis(self):
-        """Abort any active synthesis work."""
-        state = self._synthesis_state
+    def _signal_synthesis_close(self, state: _SynthesisStreamState):
+        """Signal the active synthesis request generator to close."""
+        state.text_queue.put(None)
+
+    async def _abort_synthesis_stream(self):
+        """Abort the active gRPC synthesis stream immediately.
+
+        Cancels the response task first to stop delivering audio, then
+        drains the text queue and signals the synthesis handler to stop.
+        Pending audio is discarded.
+        """
+        self._cancel_per_sentence_call()
+
+        state = self._stream_state
         if state is None:
             return
 
@@ -616,25 +557,26 @@ class NvidiaTTSService(TTSService):
                 state.text_queue.get_nowait()
             except queue.Empty:
                 break
-        state.text_queue.put(_CLOSE_STREAM)
+        self._signal_synthesis_close(state)
 
-        self._cancel_rpc_call(state)
+        self._cancel_stream_call(state)
 
         if state.synth_task is not None:
             await self.cancel_task(state.synth_task)
             state.synth_task = None
 
-        if self._synthesis_state is state:
-            self._synthesis_state = None
+        if self._stream_state is state:
+            self._stream_state = None
 
-    async def _ensure_audio_context_started(self, context_id: str) -> TTSStartedFrame | None:
-        """Create the audio context if needed and start TTFB metrics once."""
-        if self.audio_context_available(context_id):
-            return None
-
-        await self.create_audio_context(context_id)
-        await self.start_ttfb_metrics()
-        return TTSStartedFrame(context_id=context_id)
+    def _cancel_per_sentence_call(self):
+        """Best-effort cancellation of an in-flight per-sentence gRPC call."""
+        call = self._per_sentence_rpc_call
+        if call is not None and hasattr(call, "cancel"):
+            try:
+                call.cancel()
+            except Exception as e:
+                logger.debug(f"{self}: failed to cancel per-sentence gRPC call: {e}")
+        self._per_sentence_rpc_call = None
 
     async def flush_audio(self, context_id: str | None = None):
         """Flush any pending audio and finalize the current context.
@@ -643,9 +585,9 @@ class NvidiaTTSService(TTSService):
             context_id: The specific context to flush. If None, falls back to the
                 currently active context.
         """
-        state = self._synthesis_state
+        state = self._stream_state
         if state is not None:
-            state.text_queue.put(_CLOSE_STREAM)
+            self._signal_synthesis_close(state)
         await super().flush_audio(context_id)
 
     async def on_audio_context_interrupted(self, context_id: str):
@@ -655,7 +597,7 @@ class NvidiaTTSService(TTSService):
             context_id: The ID of the audio context that was interrupted.
         """
         await self.stop_all_metrics()
-        await self._abort_all_synthesis()
+        await self._abort_synthesis_stream()
         await super().on_audio_context_interrupted(context_id)
 
     @staticmethod
@@ -686,18 +628,23 @@ class NvidiaTTSService(TTSService):
     async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame | None, None]:
         """Generate speech from text using NVIDIA TTS.
 
-        Uses the configured synthesis mode to either yield audio directly
-        (``per_sentence``) or queue text for asynchronous delivery
-        (``stitched``).
+        On the first call for a turn, starts a persistent ``synthesize_online``
+        gRPC stream. Subsequent calls within the same turn feed text into the
+        existing stream, enabling Magpie's cross-sentence stitching.
+
+        Text is split into chunks respecting Magpie's per-request limits. Each chunk becomes
+        a separate request in the gRPC stream, stitched seamlessly by Magpie.
+
+        In ``per_sentence`` mode, opens a fresh ``SynthesizeOnline`` call per
+        invocation and yields audio directly before returning.
 
         Args:
             text: The text to synthesize into speech.
             context_id: The context ID for tracking audio frames.
 
         Yields:
-            ``TTSAudioRawFrame`` objects in ``per_sentence`` mode, ``None`` in
-            ``stitched`` mode once text has been queued for asynchronous
-            delivery, or ``ErrorFrame`` on failure.
+            None on success in ``stitched`` mode. ``TTSAudioRawFrame`` objects
+                in ``per_sentence`` mode. ``ErrorFrame`` on failure.
         """
         text = text.strip()
         if not text or not any(c.isalnum() for c in text):
@@ -705,39 +652,43 @@ class NvidiaTTSService(TTSService):
 
         try:
             assert self._service is not None, "TTS service not initialized"
-            if self._settings.synthesis_mode == NvidiaTTSSynthesisMode.STITCHED:
-                async for frame in self._run_tts_stitched(text, context_id):
-                    yield frame
-            else:
+            if self._settings.synthesis_mode == NvidiaTTSSynthesisMode.PER_SENTENCE:
                 async for frame in self._run_tts_per_sentence(text, context_id):
                     yield frame
+                return
+
+            # First call for this turn: create audio context and start gRPC stream
+            if not self.audio_context_available(context_id):
+                await self.create_audio_context(context_id)
+                await self.start_ttfb_metrics()
+                yield TTSStartedFrame(context_id=context_id)
+                self._start_synthesis_stream(context_id)
+                logger.trace(f"{self}: Started synthesis stream for context {context_id}")
+
+            logger.debug(f"{self}: Generating TTS [{text}]")
+
+            state = self._stream_state
+            if state is None:
+                raise RuntimeError("Synthesis stream not started")
+
+            for chunk in self._split_text_into_chunks(text):
+                if any(c.isalnum() for c in chunk):
+                    state.text_queue.put(chunk)
+
+            await self.start_tts_usage_metrics(text)
+            yield None
         except Exception as e:
             logger.error(f"{self} exception: {e}")
             yield ErrorFrame(error=f"{self} error: {e}")
 
-    async def _run_tts_stitched(
-        self, text: str, context_id: str
-    ) -> AsyncGenerator[Frame | None, None]:
-        """Send text through one turn-scoped stitched synthesis stream."""
-        if start_frame := await self._ensure_audio_context_started(context_id):
-            yield start_frame
-
-        logger.debug(f"{self}: Generating TTS [{text}]")
-        state = await self._ensure_synthesis_state(context_id, NvidiaTTSSynthesisMode.STITCHED)
-
-        for chunk in self._split_text_into_chunks(text):
-            if any(c.isalnum() for c in chunk):
-                state.text_queue.put(chunk)
-
-        await self.start_tts_usage_metrics(text)
-        yield None
-
     async def _run_tts_per_sentence(
         self, text: str, context_id: str
     ) -> AsyncGenerator[Frame | None, None]:
-        """Open one synthesis request per queued chunk and yield audio directly."""
-        if start_frame := await self._ensure_audio_context_started(context_id):
-            yield start_frame
+        """Open one fresh ``SynthesizeOnline`` call per split chunk."""
+        if not self.audio_context_available(context_id):
+            await self.create_audio_context(context_id)
+            await self.start_ttfb_metrics()
+            yield TTSStartedFrame(context_id=context_id)
 
         logger.debug(f"{self}: Generating TTS [{text}]")
 
@@ -747,32 +698,52 @@ class NvidiaTTSService(TTSService):
         if not chunks:
             return
 
-        state = await self._ensure_synthesis_state(
-            context_id, NvidiaTTSSynthesisMode.PER_SENTENCE
-        )
-        request_count = 0
-        for chunk in chunks:
-            state.text_queue.put(chunk)
-            state.text_queue.put(_RECONNECT)
-            request_count += 1
+        await self.start_tts_usage_metrics(text)
 
-        try:
-            await self.start_tts_usage_metrics(text)
-            completed_requests = 0
-            while completed_requests < request_count:
-                item = await state.response_queue.get()
-                if item is _REQUEST_DONE:
-                    completed_requests += 1
-                    continue
-                if item is None:
-                    if state.stop_event.is_set():
+        response_queue: asyncio.Queue = asyncio.Queue()
+        event_loop = self.get_event_loop()
+        stop_event = threading.Event()
+
+        def run_grpc():
+            try:
+                for chunk in chunks:
+                    if stop_event.is_set():
                         break
-                    raise RuntimeError("Synthesis stream closed unexpectedly")
-                if self._synthesis_state is not state:
+
+                    base_req = self._build_base_request()
+
+                    def request_gen():
+                        base_req.text = chunk
+                        yield base_req
+
+                    call = self._service.stub.SynthesizeOnline(
+                        request_gen(),
+                        metadata=self._service.auth.get_auth_metadata(),
+                    )
+                    self._per_sentence_rpc_call = call
+                    try:
+                        for resp in call:
+                            if stop_event.is_set():
+                                break
+                            asyncio.run_coroutine_threadsafe(response_queue.put(resp), event_loop)
+                    finally:
+                        if self._per_sentence_rpc_call is call:
+                            self._per_sentence_rpc_call = None
+            except Exception as e:
+                if not stop_event.is_set():
+                    asyncio.run_coroutine_threadsafe(response_queue.put(e), event_loop)
+            finally:
+                self._per_sentence_rpc_call = None
+                asyncio.run_coroutine_threadsafe(response_queue.put(None), event_loop)
+
+        grpc_task = self.create_task(asyncio.to_thread(run_grpc), name="nvidia-tts-per-sentence")
+        try:
+            while True:
+                item = await response_queue.get()
+                if item is None:
                     break
                 if isinstance(item, Exception):
                     raise item
-
                 await self.stop_ttfb_metrics()
                 yield TTSAudioRawFrame(
                     audio=item.audio,
@@ -781,5 +752,6 @@ class NvidiaTTSService(TTSService):
                     context_id=context_id,
                 )
         finally:
-            if self._synthesis_state is state and state.mode == NvidiaTTSSynthesisMode.PER_SENTENCE:
-                await self._abort_all_synthesis()
+            stop_event.set()
+            self._cancel_per_sentence_call()
+            await self.cancel_task(grpc_task)

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -20,11 +20,11 @@ import os
 import queue
 import textwrap
 import threading
-from collections.abc import AsyncGenerator, Iterable, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any
 
 from pipecat.utils.tracing.service_decorators import traced_tts
 
@@ -98,10 +98,11 @@ class NvidiaTTSSettings(TTSSettings):
 
 
 @dataclass
-class _StitchedSynthesisState:
-    """Runtime state for one active stitched synthesis stream."""
+class _SynthesisState:
+    """Runtime state for the active synthesis manager."""
 
     context_id: str
+    mode: NvidiaTTSSynthesisMode
     text_queue: queue.Queue
     response_queue: asyncio.Queue
     stop_event: threading.Event
@@ -110,27 +111,16 @@ class _StitchedSynthesisState:
     response_task: asyncio.Task | None = None
 
 
-@dataclass
-class _PerSentenceSynthesisState:
-    """Runtime state for one per-sentence synthesis request."""
-
-    context_id: str
-    response_queue: asyncio.Queue
-    stop_event: threading.Event
-    rpc_call: Any = None
-    synth_task: asyncio.Task | None = None
-
-
-_SynthesisCallState: TypeAlias = _StitchedSynthesisState | _PerSentenceSynthesisState
+_RECONNECT = object()
+_CLOSE_STREAM = object()
+_REQUEST_DONE = object()
 
 
 class NvidiaTTSService(TTSService):
     """NVIDIA TTS service.
 
-    Provides high-quality text-to-speech synthesis using NVIDIA TTS
-    cloud-based models. Supports multiple voices, languages, and configurable
+    Provides high-quality text-to-speech synthesis using both locally deployed and cloud-based NVIDIA TTS models. Supports multiple voices, languages, and configurable
     quality settings.
-
     """
 
     Settings = NvidiaTTSSettings
@@ -272,9 +262,8 @@ class NvidiaTTSService(TTSService):
         self._service = None
         self._config = None
 
-        # Runtime state for the active streaming turn.
-        self._stitched_stream_state: _StitchedSynthesisState | None = None
-        self._per_sentence_state: _PerSentenceSynthesisState | None = None
+        # Runtime state for the active synthesis manager.
+        self._synthesis_state: _SynthesisState | None = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate metrics.
@@ -411,50 +400,44 @@ class NvidiaTTSService(TTSService):
 
     def _active_context_ids(self) -> tuple[str, ...]:
         """Return the active audio context IDs owned by in-flight synthesis."""
-        context_ids: list[str] = []
-        if self._stitched_stream_state is not None:
-            context_ids.append(self._stitched_stream_state.context_id)
-        if self._per_sentence_state is not None:
-            context_ids.append(self._per_sentence_state.context_id)
-        return tuple(dict.fromkeys(context_ids))
+        if self._synthesis_state is None:
+            return ()
+        return (self._synthesis_state.context_id,)
 
-    def _start_synthesis_stream(self, context_id: str):
-        """Start a persistent gRPC synthesis stream for the current turn.
-
-        Creates a queue-backed generator that feeds text to
-        ``synthesize_online``. The gRPC stream stays open until a ``None``
-        sentinel is pushed into the queue.
-        """
-        state = _StitchedSynthesisState(
+    def _start_synthesis_state(self, context_id: str, mode: NvidiaTTSSynthesisMode):
+        """Start the active synthesis manager for the requested mode."""
+        state = _SynthesisState(
             context_id=context_id,
+            mode=mode,
             text_queue=queue.Queue(),
             response_queue=asyncio.Queue(),
             stop_event=threading.Event(),
         )
-        self._stitched_stream_state = state
-        logger.debug(f"{self}: starting synthesis stream")
+        self._synthesis_state = state
+        logger.debug(f"{self}: starting {mode} synthesis state")
 
         state.synth_task = self.create_task(
-            self._stitched_synth_task_handler(state), name="nvidia-tts-synth"
+            asyncio.to_thread(self._synthesis_handler, state),
+            name="nvidia-tts-synth",
         )
-        state.response_task = self.create_task(
-            self._process_stitched_responses(state), name="nvidia-tts-response"
-        )
+        if mode == NvidiaTTSSynthesisMode.STITCHED:
+            state.response_task = self.create_task(
+                self._process_stitched_responses(state), name="nvidia-tts-response"
+            )
 
-    def _request_generator_from_texts(
-        self, texts: Iterable[str], stop_event: threading.Event
-    ) -> Any:
-        """Create a blocking generator of synthesis requests for gRPC threads."""
-        base_req = self._build_base_request()
+    async def _ensure_synthesis_state(
+        self, context_id: str, mode: NvidiaTTSSynthesisMode
+    ) -> _SynthesisState:
+        """Return an active synthesis manager for the given context and mode."""
+        state = self._synthesis_state
+        if state is not None and state.context_id == context_id and state.mode == mode:
+            return state
 
-        def request_generator():
-            for text in texts:
-                if stop_event.is_set():
-                    break
-                base_req.text = text
-                yield base_req
+        await self._abort_all_synthesis()
+        self._start_synthesis_state(context_id, mode)
 
-        return request_generator()
+        assert self._synthesis_state is not None
+        return self._synthesis_state
 
     def _build_base_request(self) -> rtts.SynthesizeSpeechRequest:
         """Build a reusable ``SynthesizeSpeechRequest`` with current settings."""
@@ -480,20 +463,18 @@ class NvidiaTTSService(TTSService):
     def _run_synthesis_call(
         self,
         requests: Any,
-        state: _SynthesisCallState,
-        mode: NvidiaTTSSynthesisMode,
+        state: _SynthesisState,
     ):
         """Run one blocking ``SynthesizeOnline`` gRPC call.
 
         Args:
             requests: Blocking iterator of ``SynthesizeSpeechRequest`` objects.
             state: Runtime state owning the active RPC call and response queue.
-            mode: Whether this call belongs to stitched or per-sentence synthesis.
         """
         event_loop = self.get_event_loop()
         error_label = (
             "gRPC stitched synthesis stream error"
-            if mode == NvidiaTTSSynthesisMode.STITCHED
+            if state.mode == NvidiaTTSSynthesisMode.STITCHED
             else "gRPC per-sentence synthesis request error"
         )
         try:
@@ -513,52 +494,51 @@ class NvidiaTTSService(TTSService):
                 asyncio.run_coroutine_threadsafe(state.response_queue.put(e), event_loop)
         finally:
             state.rpc_call = None
+            asyncio.run_coroutine_threadsafe(state.response_queue.put(_REQUEST_DONE), event_loop)
+
+    def _synthesis_handler(self, state: _SynthesisState):
+        """Process queued synthesis requests for stitched or per-sentence mode."""
+        try:
+            while not state.stop_event.is_set():
+                first_item = state.text_queue.get()
+                if first_item is _CLOSE_STREAM or state.stop_event.is_set():
+                    break
+                if first_item is _RECONNECT:
+                    continue
+
+                base_req = self._build_base_request()
+                close_reason = {"value": _RECONNECT}
+
+                def request_generator():
+                    current_item: str | object = first_item
+                    while True:
+                        if state.stop_event.is_set():
+                            close_reason["value"] = _CLOSE_STREAM
+                            return
+                        if current_item is _RECONNECT:
+                            close_reason["value"] = _RECONNECT
+                            return
+                        if current_item is _CLOSE_STREAM:
+                            close_reason["value"] = _CLOSE_STREAM
+                            return
+
+                        base_req.text = current_item
+                        yield base_req
+                        current_item = state.text_queue.get()
+
+                self._run_synthesis_call(request_generator(), state)
+                if close_reason["value"] is _CLOSE_STREAM:
+                    break
+        finally:
+            event_loop = self.get_event_loop()
             asyncio.run_coroutine_threadsafe(state.response_queue.put(None), event_loop)
 
-    def _stitched_synthesis_handler(self, state: _StitchedSynthesisState):
-        """Run the stitched ``SynthesizeOnline`` gRPC stream in a blocking call.
-
-        Uses a queue-backed generator to feed text chunks into a single
-        ``SynthesizeOnline`` call, enabling Magpie's cross-sentence stitching.
-        The explicit ``state`` argument keeps the handler bound to the stream
-        instance that spawned it, even if service-level state changes later.
-        """
-        base_req = self._build_base_request()
-
-        def request_generator():
-            while True:
-                if state.stop_event.is_set():
-                    break
-                text = state.text_queue.get()
-                if text is None or state.stop_event.is_set():
-                    break
-                base_req.text = text
-                yield base_req
-
-        self._run_synthesis_call(
-            request_generator(),
-            state,
-            mode=NvidiaTTSSynthesisMode.STITCHED,
-        )
-
-    async def _stitched_synth_task_handler(self, state: _StitchedSynthesisState):
-        """Wrap ``_stitched_synthesis_handler`` as an asyncio-managed task."""
-        await asyncio.to_thread(self._stitched_synthesis_handler, state)
-
-    def _per_sentence_synthesis_handler(self, texts: list[str], state: _PerSentenceSynthesisState):
-        """Run one blocking ``SynthesizeOnline`` call for a per-sentence request."""
-        self._run_synthesis_call(
-            self._request_generator_from_texts(texts, state.stop_event),
-            state,
-            mode=NvidiaTTSSynthesisMode.PER_SENTENCE,
-        )
-
-    def _cancel_rpc_call(self, state: _SynthesisCallState, mode: NvidiaTTSSynthesisMode):
+    def _cancel_rpc_call(self, state: _SynthesisState):
         """Best-effort cancellation of an in-flight gRPC call."""
         call = state.rpc_call
         cancel_label = (
             "stitched gRPC call"
-            if mode == NvidiaTTSSynthesisMode.STITCHED
+            if state.mode == NvidiaTTSSynthesisMode.STITCHED
             else "per-sentence gRPC call"
         )
         if call is not None and hasattr(call, "cancel"):
@@ -580,10 +560,12 @@ class NvidiaTTSService(TTSService):
         self._service = None
         self._config = None
 
-    async def _process_stitched_responses(self, state: _StitchedSynthesisState):
+    async def _process_stitched_responses(self, state: _SynthesisState):
         """Consume gRPC responses and append audio to the active audio context."""
         while True:
             item = await state.response_queue.get()
+            if item is _REQUEST_DONE:
+                continue
             if item is None:
                 if self.audio_context_available(state.context_id):
                     await self.remove_audio_context(state.context_id)
@@ -593,15 +575,15 @@ class NvidiaTTSService(TTSService):
                 # SynthesizeOnline raises, no further reliable audio is expected.
                 # Ignore stale or interruption-driven exceptions to avoid noisy
                 # errors during handoff to a new stream.
-                if self._stitched_stream_state is state and not state.stop_event.is_set():
+                if self._synthesis_state is state and not state.stop_event.is_set():
                     await self.push_error(f"{self} synthesis error: {item}")
                     if self.audio_context_available(state.context_id):
                         await self.remove_audio_context(state.context_id)
-                    self._stitched_stream_state = None
+                    self._synthesis_state = None
                 break
 
             # Stale stream responses must never leak into a newer stream context.
-            if self._stitched_stream_state is not state:
+            if self._synthesis_state is not state:
                 continue
 
             await self.stop_ttfb_metrics()
@@ -614,50 +596,36 @@ class NvidiaTTSService(TTSService):
             await self.append_to_audio_context(state.context_id, frame)
 
         # Finalize ownership once the stream drains naturally.
-        if self._stitched_stream_state is state and not state.stop_event.is_set():
-            self._stitched_stream_state = None
-
-    def _signal_stitched_synthesis_close(self, state: _StitchedSynthesisState):
-        """Signal the active synthesis request generator to close."""
-        state.text_queue.put(None)
+        if self._synthesis_state is state and not state.stop_event.is_set():
+            self._synthesis_state = None
 
     async def _abort_all_synthesis(self):
-        """Abort any active stitched or per-sentence synthesis work."""
-        stitched_state = self._stitched_stream_state
-        if stitched_state is not None:
-            stitched_state.stop_event.set()
+        """Abort any active synthesis work."""
+        state = self._synthesis_state
+        if state is None:
+            return
 
-            if stitched_state.response_task is not None:
-                await self.cancel_task(stitched_state.response_task)
-                stitched_state.response_task = None
+        state.stop_event.set()
 
-            while not stitched_state.text_queue.empty():
-                try:
-                    stitched_state.text_queue.get_nowait()
-                except queue.Empty:
-                    break
-            self._signal_stitched_synthesis_close(stitched_state)
+        if state.response_task is not None:
+            await self.cancel_task(state.response_task)
+            state.response_task = None
 
-            self._cancel_rpc_call(stitched_state, NvidiaTTSSynthesisMode.STITCHED)
+        while not state.text_queue.empty():
+            try:
+                state.text_queue.get_nowait()
+            except queue.Empty:
+                break
+        state.text_queue.put(_CLOSE_STREAM)
 
-            if stitched_state.synth_task is not None:
-                await self.cancel_task(stitched_state.synth_task)
-                stitched_state.synth_task = None
+        self._cancel_rpc_call(state)
 
-            if self._stitched_stream_state is stitched_state:
-                self._stitched_stream_state = None
+        if state.synth_task is not None:
+            await self.cancel_task(state.synth_task)
+            state.synth_task = None
 
-        per_sentence_state = self._per_sentence_state
-        if per_sentence_state is not None:
-            per_sentence_state.stop_event.set()
-            self._cancel_rpc_call(per_sentence_state, NvidiaTTSSynthesisMode.PER_SENTENCE)
-
-            if per_sentence_state.synth_task is not None:
-                await self.cancel_task(per_sentence_state.synth_task)
-                per_sentence_state.synth_task = None
-
-            if self._per_sentence_state is per_sentence_state:
-                self._per_sentence_state = None
+        if self._synthesis_state is state:
+            self._synthesis_state = None
 
     async def _ensure_audio_context_started(self, context_id: str) -> TTSStartedFrame | None:
         """Create the audio context if needed and start TTFB metrics once."""
@@ -675,9 +643,9 @@ class NvidiaTTSService(TTSService):
             context_id: The specific context to flush. If None, falls back to the
                 currently active context.
         """
-        state = self._stitched_stream_state
+        state = self._synthesis_state
         if state is not None:
-            self._signal_stitched_synthesis_close(state)
+            state.text_queue.put(_CLOSE_STREAM)
         await super().flush_audio(context_id)
 
     async def on_audio_context_interrupted(self, context_id: str):
@@ -754,15 +722,8 @@ class NvidiaTTSService(TTSService):
         if start_frame := await self._ensure_audio_context_started(context_id):
             yield start_frame
 
-        if self._stitched_stream_state is None:
-            self._start_synthesis_stream(context_id)
-            logger.trace(f"{self}: Started synthesis stream for context {context_id}")
-
         logger.debug(f"{self}: Generating TTS [{text}]")
-
-        state = self._stitched_stream_state
-        if state is None:
-            raise RuntimeError("Synthesis stream not started")
+        state = await self._ensure_synthesis_state(context_id, NvidiaTTSSynthesisMode.STITCHED)
 
         for chunk in self._split_text_into_chunks(text):
             if any(c.isalnum() for c in chunk):
@@ -774,7 +735,7 @@ class NvidiaTTSService(TTSService):
     async def _run_tts_per_sentence(
         self, text: str, context_id: str
     ) -> AsyncGenerator[Frame | None, None]:
-        """Open one synthesis request per ``run_tts`` call and yield audio directly."""
+        """Open one synthesis request per queued chunk and yield audio directly."""
         if start_frame := await self._ensure_audio_context_started(context_id):
             yield start_frame
 
@@ -786,22 +747,28 @@ class NvidiaTTSService(TTSService):
         if not chunks:
             return
 
-        state = _PerSentenceSynthesisState(
-            context_id=context_id,
-            response_queue=asyncio.Queue(),
-            stop_event=threading.Event(),
+        state = await self._ensure_synthesis_state(
+            context_id, NvidiaTTSSynthesisMode.PER_SENTENCE
         )
-        state.synth_task = self.create_task(
-            asyncio.to_thread(self._per_sentence_synthesis_handler, chunks, state),
-            name="nvidia-tts-single-synth",
-        )
-        self._per_sentence_state = state
+        request_count = 0
+        for chunk in chunks:
+            state.text_queue.put(chunk)
+            state.text_queue.put(_RECONNECT)
+            request_count += 1
 
         try:
             await self.start_tts_usage_metrics(text)
-            while True:
+            completed_requests = 0
+            while completed_requests < request_count:
                 item = await state.response_queue.get()
+                if item is _REQUEST_DONE:
+                    completed_requests += 1
+                    continue
                 if item is None:
+                    if state.stop_event.is_set():
+                        break
+                    raise RuntimeError("Synthesis stream closed unexpectedly")
+                if self._synthesis_state is not state:
                     break
                 if isinstance(item, Exception):
                     raise item
@@ -814,10 +781,5 @@ class NvidiaTTSService(TTSService):
                     context_id=context_id,
                 )
         finally:
-            state.stop_event.set()
-            self._cancel_rpc_call(state, NvidiaTTSSynthesisMode.PER_SENTENCE)
-            if state.synth_task is not None:
-                await state.synth_task
-                state.synth_task = None
-            if self._per_sentence_state is state:
-                self._per_sentence_state = None
+            if self._synthesis_state is state and state.mode == NvidiaTTSSynthesisMode.PER_SENTENCE:
+                await self._abort_all_synthesis()

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""NVIDIA Nemotron Speech text-to-speech service implementation.
+"""NVIDIA text-to-speech service implementation.
 
-This module provides integration with NVIDIA Nemotron Speech's TTS services through
+This module provides integration with NVIDIA TTS through
 gRPC API for high-quality speech synthesis.
 
 Refer to the NVIDIA TTS NIM documentation for usage, customization,
@@ -20,9 +20,11 @@ import os
 import queue
 import textwrap
 import threading
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, TypeAlias
 
 from pipecat.utils.tracing.service_decorators import traced_tts
 
@@ -41,7 +43,7 @@ from pipecat.frames.frames import (
     TTSAudioRawFrame,
     TTSStartedFrame,
 )
-from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, is_given
 from pipecat.services.tts_service import TTSService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.deprecation import deprecated
@@ -54,9 +56,32 @@ try:
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error(
-        'In order to use NVIDIA Nemotron Speech TTS, you need to `uv add "pipecat-ai[nvidia]"`.'
+        'In order to use NVIDIA TTS, you need to `uv add "pipecat-ai[nvidia]"`.'
     )
     raise ImportError(f"Missing module: {e}") from e
+
+
+class NvidiaTTSSynthesisMode(StrEnum):
+    """Controls how text is sent to NVIDIA TTS.
+
+    Parameters:
+        PER_SENTENCE: Open a separate ``SynthesizeOnline`` call for each
+            ``run_tts`` invocation. This is the default mode and can be used
+            with all supported NVIDIA TTS models, including Chatterbox,
+            Magpie multilingual, and Magpie zero-shot. Text may still be
+            chunked within that call to satisfy model request length limits.
+        STITCHED: Reuse one ``SynthesizeOnline`` stream across multiple
+            ``run_tts`` calls within the same LLM response. Enable this only
+            for models with cross-sentence stitching support, such as Magpie
+            multilingual and Magpie zero-shot v1.7.0 or later. Compatible
+            models can still use ``per_sentence``, but ``stitched`` can improve
+            multi-sentence synthesis quality. Individual ``run_tts`` inputs may
+            still be chunked within the shared stream to satisfy model request
+            length limits.
+    """
+
+    PER_SENTENCE = "per_sentence"
+    STITCHED = "stitched"
 
 
 @dataclass
@@ -64,15 +89,19 @@ class NvidiaTTSSettings(TTSSettings):
     """Settings for NvidiaTTSService.
 
     Parameters:
-        quality: Audio quality setting (0-100).
+        quality: Audio quality setting (0-100). For Magpie zero-shot, NVIDIA
+            expects values in the range ``1`` to ``40``.
+        synthesis_mode: Whether to synthesize one sentence per request or stitch
+            multiple sentences across a single streaming request.
     """
 
     quality: int | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    synthesis_mode: NvidiaTTSSynthesisMode = NvidiaTTSSynthesisMode.PER_SENTENCE
 
 
 @dataclass
-class _SynthesisStreamState:
-    """Runtime state for one active synthesis stream."""
+class _StitchedSynthesisState:
+    """Runtime state for one active stitched synthesis stream."""
 
     context_id: str
     text_queue: queue.Queue
@@ -83,12 +112,27 @@ class _SynthesisStreamState:
     response_task: asyncio.Task | None = None
 
 
-class NvidiaTTSService(TTSService):
-    """NVIDIA Nemotron Speech text-to-speech service.
+@dataclass
+class _PerSentenceSynthesisState:
+    """Runtime state for one per-sentence synthesis request."""
 
-    Provides high-quality text-to-speech synthesis using NVIDIA Nemotron Speech's
-    cloud-based TTS models. Supports multiple voices, languages, and
-    configurable quality settings.
+    context_id: str
+    response_queue: asyncio.Queue
+    stop_event: threading.Event
+    rpc_call: Any = None
+    synth_task: asyncio.Task | None = None
+
+
+_SynthesisCallState: TypeAlias = _StitchedSynthesisState | _PerSentenceSynthesisState
+
+
+class NvidiaTTSService(TTSService):
+    """NVIDIA TTS service.
+
+    Provides high-quality text-to-speech synthesis using NVIDIA TTS
+    cloud-based models. Supports multiple voices, languages, and configurable
+    quality settings.
+
     """
 
     Settings = NvidiaTTSSettings
@@ -100,7 +144,7 @@ class NvidiaTTSService(TTSService):
         "Use `NvidiaTTSService.Settings` instead."
     )
     class InputParams(BaseModel):
-        """Input parameters for Nemotron Speech TTS configuration.
+        """Input parameters for NVIDIA TTS configuration.
 
         .. deprecated:: 0.0.105
             Use ``NvidiaTTSService.Settings`` directly via the ``settings`` parameter instead.
@@ -108,7 +152,8 @@ class NvidiaTTSService(TTSService):
 
         Parameters:
             language: Language code for synthesis. Defaults to US English.
-            quality: Audio quality setting (0-100). Defaults to 20.
+            quality: Audio quality setting (0-100). For Magpie zero-shot,
+                NVIDIA expects values in the range ``1`` to ``40``. Defaults to 20.
         """
 
         language: Language | None = Language.EN_US
@@ -129,10 +174,12 @@ class NvidiaTTSService(TTSService):
         settings: Settings | None = None,
         use_ssl: bool = True,
         custom_dictionary: dict | None = None,
+        zero_shot_audio_prompt_file: str | os.PathLike[str] | None = None,
+        audio_prompt_encoding: AudioEncoding | None = AudioEncoding.ENCODING_UNSPECIFIED,
         encoding: AudioEncoding | None = AudioEncoding.LINEAR_PCM,
         **kwargs,
     ):
-        """Initialize the NVIDIA Nemotron Speech TTS service.
+        """Initialize the NVIDIA TTS service.
 
         Args:
             api_key: NVIDIA API key for authentication. Required when using the
@@ -153,8 +200,8 @@ class NvidiaTTSService(TTSService):
                     Use ``settings=NvidiaTTSService.Settings(...)`` instead.
                     Will be removed in 2.0.0.
 
-            settings: Runtime-updatable settings. When provided alongside deprecated
-                parameters, ``settings`` values take precedence.
+            settings: Runtime-updatable settings. When provided alongside
+                deprecated parameters, ``settings`` values take precedence.
             use_ssl: Whether to use SSL for the gRPC connection. Defaults to True
                 for the NVIDIA cloud endpoint. Set to False for local deployments.
             custom_dictionary: Custom pronunciation dictionary mapping words
@@ -162,6 +209,15 @@ class NvidiaTTSService(TTSService):
                 e.g. ``{"NVIDIA": "ɛn.vɪ.diː.ʌ"}``. See
                 https://docs.nvidia.com/nim/speech/latest/tts/phoneme-support.html
                 for the list of supported IPA phonemes.
+            zero_shot_audio_prompt_file: Optional audio prompt file for Magpie
+                zero-shot voice cloning. NVIDIA recommends a 16-bit mono WAV
+                prompt, sample rate 22.05 kHz or higher, and duration 3 to 10
+                seconds. Access to NVIDIA's hosted zero-shot models requires
+                approval through:
+                https://developer.nvidia.com/riva-tts-zeroshot-models
+            audio_prompt_encoding: Audio encoding for ``zero_shot_audio_prompt_file``.
+                Use this when the server expects a specific prompt encoding for
+                Magpie zero-shot voice cloning.
             encoding: Output audio encoding format. Defaults to ``AudioEncoding.LINEAR_PCM``.
             **kwargs: Additional arguments passed to parent TTSService.
         """
@@ -208,13 +264,19 @@ class NvidiaTTSService(TTSService):
         if custom_dictionary:
             entries = [f"{k}  {v}" for k, v in custom_dictionary.items()]
             self._custom_dictionary = ",".join(entries)
+        self._zero_shot_audio_prompt_file: Path | None = None
+        self._zero_shot_audio_prompt_data: bytes | None = None
+        if zero_shot_audio_prompt_file is not None:
+            self._zero_shot_audio_prompt_file = Path(zero_shot_audio_prompt_file).expanduser()
+        self._audio_prompt_encoding = audio_prompt_encoding
         self._encoding = encoding
 
         self._service = None
         self._config = None
 
         # Runtime state for the active streaming turn.
-        self._stream_state: _SynthesisStreamState | None = None
+        self._stitched_stream_state: _StitchedSynthesisState | None = None
+        self._per_sentence_state: _PerSentenceSynthesisState | None = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate metrics.
@@ -232,8 +294,7 @@ class NvidiaTTSService(TTSService):
         """Set the TTS model.
 
         .. deprecated:: 0.0.104
-            No replacement. Model cannot be changed after initialization for NVIDIA Nemotron
-            Speech TTS; set model and function id in the constructor instead.
+            No replacement.
             Will be removed in 2.0.0.
 
             Example::
@@ -246,6 +307,7 @@ class NvidiaTTSService(TTSService):
         Args:
             model: The model name to set.
         """
+        return None
 
     async def _update_settings(self, delta: Settings) -> dict[str, Any]:
         """Apply a settings delta.
@@ -263,10 +325,11 @@ class NvidiaTTSService(TTSService):
         if self._service is not None:
             return
 
-        metadata = [
-            ["function-id", self._function_id],
-            ["authorization", f"Bearer {self._api_key}"],
-        ]
+        metadata = []
+        if self._function_id:
+            metadata.append(["function-id", self._function_id])
+        if self._api_key:
+            metadata.append(["authorization", f"Bearer {self._api_key}"])
         auth = riva.client.Auth(None, self._use_ssl, self._server, metadata)
 
         self._service = riva.client.SpeechSynthesisService(auth)
@@ -291,8 +354,22 @@ class NvidiaTTSService(TTSService):
                 f"{self}: startup failed while fetching synthesis config (gRPC {status})"
             ) from e
 
+    def _load_zero_shot_audio_prompt(self):
+        """Load and cache zero-shot prompt audio bytes, if configured."""
+        if self._zero_shot_audio_prompt_file is None or self._zero_shot_audio_prompt_data is not None:
+            return
+
+        try:
+            with self._zero_shot_audio_prompt_file.open("rb") as prompt_file:
+                self._zero_shot_audio_prompt_data = prompt_file.read()
+        except OSError as e:
+            raise RuntimeError(
+                f"{self}: failed to read zero-shot audio prompt file "
+                f"{self._zero_shot_audio_prompt_file}"
+            ) from e
+
     async def start(self, frame: StartFrame):
-        """Start the NVIDIA Nemotron Speech TTS service.
+        """Start the NVIDIA TTS service.
 
         Args:
             frame: The start frame containing initialization parameters.
@@ -300,25 +377,45 @@ class NvidiaTTSService(TTSService):
         await super().start(frame)
         self._initialize_client()
         self._config = self._create_synthesis_config()
+        self._load_zero_shot_audio_prompt()
         logger.debug(f"Initialized NvidiaTTSService with model: {self._settings.model}")
 
     async def stop(self, frame: EndFrame):
-        """Stop the NVIDIA Nemotron Speech TTS service.
+        """Stop the NVIDIA TTS service.
 
         Args:
             frame: The end frame.
         """
+        context_ids = self._active_context_ids()
+        await self._abort_all_synthesis()
+        for context_id in context_ids:
+            if self.audio_context_available(context_id):
+                await self.remove_audio_context(context_id)
         await super().stop(frame)
-        await self._abort_synthesis_stream()
+        self._close_client()
 
     async def cancel(self, frame: CancelFrame):
-        """Cancel the NVIDIA Nemotron Speech TTS service.
+        """Cancel the NVIDIA TTS service.
 
         Args:
             frame: The cancel frame.
         """
+        context_ids = self._active_context_ids()
+        await self._abort_all_synthesis()
+        for context_id in context_ids:
+            if self.audio_context_available(context_id):
+                await self.remove_audio_context(context_id)
         await super().cancel(frame)
-        await self._abort_synthesis_stream()
+        self._close_client()
+
+    def _active_context_ids(self) -> tuple[str, ...]:
+        """Return the active audio context IDs owned by in-flight synthesis."""
+        context_ids: list[str] = []
+        if self._stitched_stream_state is not None:
+            context_ids.append(self._stitched_stream_state.context_id)
+        if self._per_sentence_state is not None:
+            context_ids.append(self._per_sentence_state.context_id)
+        return tuple(dict.fromkeys(context_ids))
 
     def _start_synthesis_stream(self, context_id: str):
         """Start a persistent gRPC synthesis stream for the current turn.
@@ -327,21 +424,36 @@ class NvidiaTTSService(TTSService):
         ``synthesize_online``. The gRPC stream stays open until a ``None``
         sentinel is pushed into the queue.
         """
-        state = _SynthesisStreamState(
+        state = _StitchedSynthesisState(
             context_id=context_id,
             text_queue=queue.Queue(),
             response_queue=asyncio.Queue(),
             stop_event=threading.Event(),
         )
-        self._stream_state = state
+        self._stitched_stream_state = state
         logger.debug(f"{self}: starting synthesis stream")
 
         state.synth_task = self.create_task(
-            self._synth_task_handler(state), name="nvidia-tts-synth"
+            self._stitched_synth_task_handler(state), name="nvidia-tts-synth"
         )
         state.response_task = self.create_task(
-            self._process_responses(state), name="nvidia-tts-response"
+            self._process_stitched_responses(state), name="nvidia-tts-response"
         )
+
+    def _request_generator_from_texts(
+        self, texts: Iterable[str], stop_event: threading.Event
+    ) -> Any:
+        """Create a blocking generator of synthesis requests for gRPC threads."""
+        base_req = self._build_base_request()
+
+        def request_generator():
+            for text in texts:
+                if stop_event.is_set():
+                    break
+                base_req.text = text
+                yield base_req
+
+        return request_generator()
 
     def _build_base_request(self) -> rtts.SynthesizeSpeechRequest:
         """Build a reusable ``SynthesizeSpeechRequest`` with current settings."""
@@ -356,16 +468,60 @@ class NvidiaTTSService(TTSService):
             req.voice_name = voice
         if self._custom_dictionary:
             req.custom_dictionary = self._custom_dictionary
+        if self._zero_shot_audio_prompt_data is not None:
+            req.zero_shot_data.audio_prompt = self._zero_shot_audio_prompt_data
+            if self._audio_prompt_encoding is not None:
+                req.zero_shot_data.encoding = self._audio_prompt_encoding
+            zero_shot_quality = self._settings.quality if is_given(self._settings.quality) else 20
+            req.zero_shot_data.quality = int(zero_shot_quality)
         return req
 
-    def _synthesis_handler(self, state: _SynthesisStreamState):
-        """Run ``SynthesizeOnline`` gRPC stream in a blocking call.
+    def _run_synthesis_call(
+        self,
+        requests: Any,
+        state: _SynthesisCallState,
+        mode: NvidiaTTSSynthesisMode,
+    ):
+        """Run one blocking ``SynthesizeOnline`` gRPC call.
+
+        Args:
+            requests: Blocking iterator of ``SynthesizeSpeechRequest`` objects.
+            state: Runtime state owning the active RPC call and response queue.
+            mode: Whether this call belongs to stitched or per-sentence synthesis.
+        """
+        event_loop = self.get_event_loop()
+        error_label = (
+            "gRPC stitched synthesis stream error"
+            if mode == NvidiaTTSSynthesisMode.STITCHED
+            else "gRPC per-sentence synthesis request error"
+        )
+        try:
+            call = self._service.stub.SynthesizeOnline(
+                requests,
+                metadata=self._service.auth.get_auth_metadata(),
+            )
+            state.rpc_call = call
+
+            for resp in call:
+                if state.stop_event.is_set():
+                    break
+                asyncio.run_coroutine_threadsafe(state.response_queue.put(resp), event_loop)
+        except Exception as e:
+            if not state.stop_event.is_set():
+                logger.error(f"{self} {error_label}: {e}")
+                asyncio.run_coroutine_threadsafe(state.response_queue.put(e), event_loop)
+        finally:
+            state.rpc_call = None
+            asyncio.run_coroutine_threadsafe(state.response_queue.put(None), event_loop)
+
+    def _stitched_synthesis_handler(self, state: _StitchedSynthesisState):
+        """Run the stitched ``SynthesizeOnline`` gRPC stream in a blocking call.
 
         Uses a queue-backed generator to feed text chunks into a single
         ``SynthesizeOnline`` call, enabling Magpie's cross-sentence stitching.
-        Audio responses are forwarded to the async response queue.
+        The explicit ``state`` argument keeps the handler bound to the stream
+        instance that spawned it, even if service-level state changes later.
         """
-        event_loop = self.get_event_loop()
         base_req = self._build_base_request()
 
         def request_generator():
@@ -378,56 +534,75 @@ class NvidiaTTSService(TTSService):
                 base_req.text = text
                 yield base_req
 
-        try:
-            call = self._service.stub.SynthesizeOnline(
-                request_generator(),
-                metadata=self._service.auth.get_auth_metadata(),
-            )
-            state.rpc_call = call
+        self._run_synthesis_call(
+            request_generator(),
+            state,
+            mode=NvidiaTTSSynthesisMode.STITCHED,
+        )
 
-            for resp in call:
-                if state.stop_event.is_set():
-                    break
-                asyncio.run_coroutine_threadsafe(state.response_queue.put(resp), event_loop)
-        except Exception as e:
-            if not state.stop_event.is_set():
-                logger.error(f"{self} gRPC synthesis stream error: {e}")
-                asyncio.run_coroutine_threadsafe(state.response_queue.put(e), event_loop)
-        finally:
-            state.rpc_call = None
-            asyncio.run_coroutine_threadsafe(state.response_queue.put(None), event_loop)
+    async def _stitched_synth_task_handler(self, state: _StitchedSynthesisState):
+        """Wrap ``_stitched_synthesis_handler`` as an asyncio-managed task."""
+        await asyncio.to_thread(self._stitched_synthesis_handler, state)
 
-    async def _synth_task_handler(self, state: _SynthesisStreamState):
-        """Wrap ``_synthesis_handler`` as an asyncio-managed task."""
-        await asyncio.to_thread(self._synthesis_handler, state)
+    def _per_sentence_synthesis_handler(
+        self, texts: list[str], state: _PerSentenceSynthesisState
+    ):
+        """Run one blocking ``SynthesizeOnline`` call for a per-sentence request."""
+        self._run_synthesis_call(
+            self._request_generator_from_texts(texts, state.stop_event),
+            state,
+            mode=NvidiaTTSSynthesisMode.PER_SENTENCE,
+        )
 
-    def _cancel_stream_call(self, state: _SynthesisStreamState):
-        """Best-effort cancellation of in-flight gRPC call."""
+    def _cancel_rpc_call(self, state: _SynthesisCallState, mode: NvidiaTTSSynthesisMode):
+        """Best-effort cancellation of an in-flight gRPC call."""
         call = state.rpc_call
+        cancel_label = (
+            "stitched gRPC call"
+            if mode == NvidiaTTSSynthesisMode.STITCHED
+            else "per-sentence gRPC call"
+        )
         if call is not None and hasattr(call, "cancel"):
             try:
                 call.cancel()
             except Exception as e:
-                logger.debug(f"{self}: failed to cancel gRPC stream call: {e}")
+                logger.debug(f"{self}: failed to cancel {cancel_label}: {e}")
 
-    async def _process_responses(self, state: _SynthesisStreamState):
+    def _close_client(self):
+        """Close the underlying gRPC channel and release client references."""
+        auth = getattr(self._service, "auth", None)
+        channel = getattr(auth, "channel", None)
+        if channel is not None and hasattr(channel, "close"):
+            try:
+                channel.close()
+            except Exception as e:
+                logger.debug(f"{self}: failed to close gRPC channel: {e}")
+
+        self._service = None
+        self._config = None
+
+    async def _process_stitched_responses(self, state: _StitchedSynthesisState):
         """Consume gRPC responses and append audio to the active audio context."""
         while True:
             item = await state.response_queue.get()
             if item is None:
-                await self.remove_audio_context(state.context_id)
+                if self.audio_context_available(state.context_id):
+                    await self.remove_audio_context(state.context_id)
                 break
             if isinstance(item, Exception):
                 # Treat stream exceptions as terminal for this stream. Once
                 # SynthesizeOnline raises, no further reliable audio is expected.
                 # Ignore stale or interruption-driven exceptions to avoid noisy
                 # errors during handoff to a new stream.
-                if self._stream_state is state and not state.stop_event.is_set():
+                if self._stitched_stream_state is state and not state.stop_event.is_set():
                     await self.push_error(f"{self} synthesis error: {item}")
+                    if self.audio_context_available(state.context_id):
+                        await self.remove_audio_context(state.context_id)
+                    self._stitched_stream_state = None
                 break
 
             # Stale stream responses must never leak into a newer stream context.
-            if self._stream_state is not state:
+            if self._stitched_stream_state is not state:
                 continue
 
             await self.stop_ttfb_metrics()
@@ -440,45 +615,59 @@ class NvidiaTTSService(TTSService):
             await self.append_to_audio_context(state.context_id, frame)
 
         # Finalize ownership once the stream drains naturally.
-        if self._stream_state is state and not state.stop_event.is_set():
-            self._stream_state = None
+        if self._stitched_stream_state is state and not state.stop_event.is_set():
+            self._stitched_stream_state = None
 
-    def _signal_synthesis_close(self, state: _SynthesisStreamState):
+    def _signal_stitched_synthesis_close(self, state: _StitchedSynthesisState):
         """Signal the active synthesis request generator to close."""
         state.text_queue.put(None)
 
-    async def _abort_synthesis_stream(self):
-        """Abort the active gRPC synthesis stream immediately.
+    async def _abort_all_synthesis(self):
+        """Abort any active stitched or per-sentence synthesis work."""
+        stitched_state = self._stitched_stream_state
+        if stitched_state is not None:
+            stitched_state.stop_event.set()
 
-        Cancels the response task first to stop delivering audio, then
-        drains the text queue and signals the synthesis handler to stop.
-        Pending audio is discarded.
-        """
-        state = self._stream_state
-        if state is None:
-            return
+            if stitched_state.response_task is not None:
+                await self.cancel_task(stitched_state.response_task)
+                stitched_state.response_task = None
 
-        state.stop_event.set()
+            while not stitched_state.text_queue.empty():
+                try:
+                    stitched_state.text_queue.get_nowait()
+                except queue.Empty:
+                    break
+            self._signal_stitched_synthesis_close(stitched_state)
 
-        if state.response_task is not None:
-            await self.cancel_task(state.response_task)
-            state.response_task = None
+            self._cancel_rpc_call(stitched_state, NvidiaTTSSynthesisMode.STITCHED)
 
-        while not state.text_queue.empty():
-            try:
-                state.text_queue.get_nowait()
-            except queue.Empty:
-                break
-        self._signal_synthesis_close(state)
+            if stitched_state.synth_task is not None:
+                await self.cancel_task(stitched_state.synth_task)
+                stitched_state.synth_task = None
 
-        self._cancel_stream_call(state)
+            if self._stitched_stream_state is stitched_state:
+                self._stitched_stream_state = None
 
-        if state.synth_task is not None:
-            await self.cancel_task(state.synth_task)
-            state.synth_task = None
+        per_sentence_state = self._per_sentence_state
+        if per_sentence_state is not None:
+            per_sentence_state.stop_event.set()
+            self._cancel_rpc_call(per_sentence_state, NvidiaTTSSynthesisMode.PER_SENTENCE)
 
-        if self._stream_state is state:
-            self._stream_state = None
+            if per_sentence_state.synth_task is not None:
+                await self.cancel_task(per_sentence_state.synth_task)
+                per_sentence_state.synth_task = None
+
+            if self._per_sentence_state is per_sentence_state:
+                self._per_sentence_state = None
+
+    async def _ensure_audio_context_started(self, context_id: str) -> TTSStartedFrame | None:
+        """Create the audio context if needed and start TTFB metrics once."""
+        if self.audio_context_available(context_id):
+            return None
+
+        await self.create_audio_context(context_id)
+        await self.start_ttfb_metrics()
+        return TTSStartedFrame(context_id=context_id)
 
     async def flush_audio(self, context_id: str | None = None):
         """Flush any pending audio and finalize the current context.
@@ -487,9 +676,9 @@ class NvidiaTTSService(TTSService):
             context_id: The specific context to flush. If None, falls back to the
                 currently active context.
         """
-        state = self._stream_state
+        state = self._stitched_stream_state
         if state is not None:
-            self._signal_synthesis_close(state)
+            self._signal_stitched_synthesis_close(state)
         await super().flush_audio(context_id)
 
     async def on_audio_context_interrupted(self, context_id: str):
@@ -499,7 +688,7 @@ class NvidiaTTSService(TTSService):
             context_id: The ID of the audio context that was interrupted.
         """
         await self.stop_all_metrics()
-        await self._abort_synthesis_stream()
+        await self._abort_all_synthesis()
         await super().on_audio_context_interrupted(context_id)
 
     @staticmethod
@@ -528,22 +717,20 @@ class NvidiaTTSService(TTSService):
 
     @traced_tts
     async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame | None, None]:
-        """Generate speech from text using NVIDIA Nemotron Speech TTS.
+        """Generate speech from text using NVIDIA TTS.
 
-        On the first call for a turn, starts a persistent ``synthesize_online``
-        gRPC stream. Subsequent calls within the same turn feed text into the
-        existing stream, enabling Magpie's cross-sentence stitching.
-
-        Text is split into chunks respecting Magpie's per-request limits. Each chunk becomes
-        a separate request in the gRPC stream, stitched seamlessly by Magpie.
+        Uses the configured synthesis mode to either yield audio directly
+        (``per_sentence``) or queue text for asynchronous delivery
+        (``stitched``).
 
         Args:
             text: The text to synthesize into speech.
             context_id: The context ID for tracking audio frames.
 
         Yields:
-            None on success. Audio is delivered asynchronously via the
-                response consumer. ErrorFrame on failure.
+            ``TTSAudioRawFrame`` objects in ``per_sentence`` mode, ``None`` in
+            ``stitched`` mode once text has been queued for asynchronous
+            delivery, or ``ErrorFrame`` on failure.
         """
         text = text.strip()
         if not text or not any(c.isalnum() for c in text):
@@ -551,27 +738,87 @@ class NvidiaTTSService(TTSService):
 
         try:
             assert self._service is not None, "TTS service not initialized"
-
-            # First call for this turn: create audio context and start gRPC stream
-            if not self.audio_context_available(context_id):
-                await self.create_audio_context(context_id)
-                await self.start_ttfb_metrics()
-                yield TTSStartedFrame(context_id=context_id)
-                self._start_synthesis_stream(context_id)
-                logger.trace(f"{self}: Started synthesis stream for context {context_id}")
-
-            logger.debug(f"{self}: Generating TTS [{text}]")
-
-            state = self._stream_state
-            if state is None:
-                raise RuntimeError("Synthesis stream not started")
-
-            for chunk in self._split_text_into_chunks(text):
-                if any(c.isalnum() for c in chunk):
-                    state.text_queue.put(chunk)
-
-            await self.start_tts_usage_metrics(text)
-            yield None
+            if self._settings.synthesis_mode == NvidiaTTSSynthesisMode.STITCHED:
+                async for frame in self._run_tts_stitched(text, context_id):
+                    yield frame
+            else:
+                async for frame in self._run_tts_per_sentence(text, context_id):
+                    yield frame
         except Exception as e:
             logger.error(f"{self} exception: {e}")
             yield ErrorFrame(error=f"{self} error: {e}")
+
+    async def _run_tts_stitched(
+        self, text: str, context_id: str
+    ) -> AsyncGenerator[Frame | None, None]:
+        """Send text through one turn-scoped stitched synthesis stream."""
+        if start_frame := await self._ensure_audio_context_started(context_id):
+            yield start_frame
+
+        if self._stitched_stream_state is None:
+            self._start_synthesis_stream(context_id)
+            logger.trace(f"{self}: Started synthesis stream for context {context_id}")
+
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        state = self._stitched_stream_state
+        if state is None:
+            raise RuntimeError("Synthesis stream not started")
+
+        for chunk in self._split_text_into_chunks(text):
+            if any(c.isalnum() for c in chunk):
+                state.text_queue.put(chunk)
+
+        await self.start_tts_usage_metrics(text)
+        yield None
+
+    async def _run_tts_per_sentence(
+        self, text: str, context_id: str
+    ) -> AsyncGenerator[Frame | None, None]:
+        """Open one synthesis request per ``run_tts`` call and yield audio directly."""
+        if start_frame := await self._ensure_audio_context_started(context_id):
+            yield start_frame
+
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        chunks = [
+            chunk for chunk in self._split_text_into_chunks(text) if any(c.isalnum() for c in chunk)
+        ]
+        if not chunks:
+            return
+
+        state = _PerSentenceSynthesisState(
+            context_id=context_id,
+            response_queue=asyncio.Queue(),
+            stop_event=threading.Event(),
+        )
+        state.synth_task = self.create_task(
+            asyncio.to_thread(self._per_sentence_synthesis_handler, chunks, state),
+            name="nvidia-tts-single-synth",
+        )
+        self._per_sentence_state = state
+
+        try:
+            await self.start_tts_usage_metrics(text)
+            while True:
+                item = await state.response_queue.get()
+                if item is None:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+
+                await self.stop_ttfb_metrics()
+                yield TTSAudioRawFrame(
+                    audio=item.audio,
+                    sample_rate=self.sample_rate,
+                    num_channels=1,
+                    context_id=context_id,
+                )
+        finally:
+            state.stop_event.set()
+            self._cancel_rpc_call(state, NvidiaTTSSynthesisMode.PER_SENTENCE)
+            if state.synth_task is not None:
+                await state.synth_task
+                state.synth_task = None
+            if self._per_sentence_state is state:
+                self._per_sentence_state = None

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -55,9 +55,7 @@ try:
     from riva.client.proto.riva_audio_pb2 import AudioEncoding
 except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
-    logger.error(
-        'In order to use NVIDIA TTS, you need to `uv add "pipecat-ai[nvidia]"`.'
-    )
+    logger.error('In order to use NVIDIA TTS, you need to `uv add "pipecat-ai[nvidia]"`.')
     raise ImportError(f"Missing module: {e}") from e
 
 
@@ -356,7 +354,10 @@ class NvidiaTTSService(TTSService):
 
     def _load_zero_shot_audio_prompt(self):
         """Load and cache zero-shot prompt audio bytes, if configured."""
-        if self._zero_shot_audio_prompt_file is None or self._zero_shot_audio_prompt_data is not None:
+        if (
+            self._zero_shot_audio_prompt_file is None
+            or self._zero_shot_audio_prompt_data is not None
+        ):
             return
 
         try:
@@ -544,9 +545,7 @@ class NvidiaTTSService(TTSService):
         """Wrap ``_stitched_synthesis_handler`` as an asyncio-managed task."""
         await asyncio.to_thread(self._stitched_synthesis_handler, state)
 
-    def _per_sentence_synthesis_handler(
-        self, texts: list[str], state: _PerSentenceSynthesisState
-    ):
+    def _per_sentence_synthesis_handler(self, texts: list[str], state: _PerSentenceSynthesisState):
         """Run one blocking ``SynthesizeOnline`` call for a per-sentence request."""
         self._run_synthesis_call(
             self._request_generator_from_texts(texts, state.stop_event),


### PR DESCRIPTION
## Summary

This PR updates `NvidiaTTSService` to support both stitched and per-sentence synthesis flows, while also adding support for zero-shot audio prompt input for NVIDIA TTS models.

## What changed

- added `NvidiaTTSSynthesisMode` with:
  - `per_sentence`
  - `stitched`
- added `synthesis_mode` to `NvidiaTTSSettings`
- refactored synthesis runtime state to handle:
  - stitched streaming requests
  - per-sentence requests
- added optional zero-shot prompt support via:
  - `zero_shot_audio_prompt_file`
  - `audio_prompt_encoding`
- load and cache zero-shot prompt audio during service startup
- attach zero-shot prompt data to TTS requests when configured
- improved shutdown/cancel cleanup for active NVIDIA TTS synthesis work
- updated NVIDIA TTS docs/comments to reflect the broader NVIDIA TTS support rather than only Nemotron Speech wording

## Notes

- `stitched` mode is intended for models that support cross-sentence stitching.
- `per_sentence` mode remains the safer default for broad model compatibility.
- `synthesis_mode` updates are intended to apply on the next turn, not as a mid-turn behavior switch.

## Testing

- validated module compiles successfully
- manually reviewed the diff against current `main`