### PR TITLE
Fix GeminiLiveLLMService ignoring runtime settings updates

### DIFF
--- a/changelog/4737.fixed.md
+++ b/changelog/4737.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect so the updated configuration takes effect immediately.

--- a/changelog/4739.fixed.md
+++ b/changelog/4739.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerTTSService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect so the updated configuration takes effect immediately.

--- a/changelog/4744.fixed.md
+++ b/changelog/4744.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GeminiLiveLLMService` silently ignoring runtime settings updates. Settings changes now trigger a reconnect with a fresh `LiveConnectConfig` so the updated configuration takes effect immediately.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -211,7 +211,7 @@ class DeepgramSageMakerSTTService(STTService):
         return True
 
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
-        """Apply a settings delta and warn about unhandled changes."""
+        """Apply a settings delta and reconnect to apply updated settings."""
         changed = await super()._update_settings(delta)
 
         if not changed:
@@ -221,12 +221,7 @@ class DeepgramSageMakerSTTService(STTService):
         if isinstance(self._settings, self.Settings):
             self._settings._sync_extra_to_fields()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._request_reconnect()
 
         return changed
 
@@ -375,6 +370,10 @@ class DeepgramSageMakerSTTService(STTService):
 
             logger.debug("Disconnected from Deepgram on SageMaker")
             await self._call_event_handler("on_disconnected")
+
+    async def _do_reconnect(self):
+        await self._disconnect()
+        await self._connect()
 
     async def _send_keepalive(self):
         """Send periodic KeepAlive messages to maintain the connection.

--- a/src/pipecat/services/deepgram/sagemaker/tts.py
+++ b/src/pipecat/services/deepgram/sagemaker/tts.py
@@ -217,7 +217,7 @@ class DeepgramSageMakerTTSService(TTSService):
             await self._call_event_handler("on_disconnected")
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
-        """Apply a settings delta and reconnect if necessary.
+        """Apply a settings delta and reconnect to apply updated settings.
 
         Since all settings are part of the SageMaker session query string,
         any setting change requires reconnecting to apply the new values.
@@ -232,12 +232,8 @@ class DeepgramSageMakerTTSService(TTSService):
             self._settings.model = self._settings.voice
             self._sync_model_name_to_metrics()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._disconnect()
+        await self._connect()
 
         return changed
 

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -655,21 +655,13 @@ class GeminiLiveLLMService(LLMService[GeminiLLMAdapter]):
         return True
 
     async def _update_settings(self, delta: LLMSettings) -> dict[str, Any]:
-        """Apply a settings delta.
-
-        Settings are stored but not applied to the active connection.
-        """
+        """Apply a settings delta and reconnect to apply updated settings."""
         changed = await super()._update_settings(delta)
 
         if not changed:
             return changed
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._reconnect()
 
         return changed
 


### PR DESCRIPTION
Fixes #4744

## Summary

- `_update_settings()` now calls `await self._reconnect()` after applying the delta, so the updated `LiveConnectConfig` is submitted to the Gemini Live API on the next connection
- Removed the `_warn_unhandled_updated_settings()` call since settings are now actually applied

## How it works

`_connect()` builds `LiveConnectConfig` entirely from `self._settings` (temperature, voice, model, VAD config, context window compression, etc.) on every call. After `super()._update_settings(delta)` stores the change, calling `_reconnect()` disconnects and reconnects with a fresh config reflecting the new values.

`_reconnect()` passes `self._session_resumption_handle` to `_connect()`, so if Gemini issued a resumption token for the current session, the new session resumes from there — preserving conversation state across the settings change. This is the same mechanism already used when `_handle_context()` triggers a reconnect on system instruction or tool changes.

## Test plan

- [ ] Verify that sending `LLMUpdateSettingsFrame` mid-session (e.g. changing `temperature` or `voice`) causes a reconnect and the updated config is sent to Gemini Live
- [ ] Verify session resumption handle is reused where available
- [ ] Verify no reconnect occurs when the settings delta produces no changes