### PR TITLE
feat(smallest): migrate SmallestSTTService to latest STT endpoint

### DIFF
--- a/changelog/4730.changed.md
+++ b/changelog/4730.changed.md
@@ -1,1 +1,0 @@
-- `SmallestSTTService` updated to use the Waves v4 STT endpoint (`/waves/v1/stt/live?model=pulse`). The termination signal has changed from `finalize` to `close_stream`; the service now handles the new `is_last` response field and reconnects automatically after each session.

--- a/changelog/4730.changed.md
+++ b/changelog/4730.changed.md
@@ -1,0 +1,1 @@
+- `SmallestSTTService` updated to use the Waves v4 STT endpoint (`/waves/v1/stt/live?model=pulse`). The termination signal has changed from `finalize` to `close_stream`; the service now handles the new `is_last` response field and reconnects automatically after each session.

--- a/changelog/4747.changed.md
+++ b/changelog/4747.changed.md
@@ -1,0 +1,1 @@
+- `SmallestSTTService` now uses the Waves v4 STT endpoint (`/waves/v1/stt/live`) and sends `finalize` per utterance to keep the WebSocket session alive across turns.

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -6,7 +6,7 @@
 
 """Smallest AI speech-to-text service implementation.
 
-This module provides a STT service using Smallest AI's Waves v4 API:
+This module provides a STT service using Smallest AI's Waves API:
 
 - ``SmallestSTTService``: WebSocket-based real-time STT using the Pulse model.
   Streams audio continuously and receives interim/final transcripts with low

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -8,11 +8,8 @@
 
 This module provides a STT service using Smallest AI's Waves API:
 
-- ``SmallestSTTService``: WebSocket-based real-time STT using the Pulse model.
-  Streams audio continuously and receives interim/final transcripts with low
-  latency. Each utterance opens a session; sending ``close_stream`` flushes the
-  final transcript and the server closes the session. The service reconnects
-  automatically for the next utterance.
+- ``SmallestSTTService``: WebSocket-based real-time STT. Streams audio
+  continuously and receives interim/final transcripts with low latency.
 """
 
 import asyncio

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -6,10 +6,13 @@
 
 """Smallest AI speech-to-text service implementation.
 
-This module provides a STT service using Smallest AI's Waves API:
+This module provides a STT service using Smallest AI's Waves v4 API:
 
-- ``SmallestSTTService``: WebSocket-based real-time STT. Streams audio
-  continuously and receives interim/final transcripts with low latency.
+- ``SmallestSTTService``: WebSocket-based real-time STT using the Pulse model.
+  Streams audio continuously and receives interim/final transcripts with low
+  latency. Each utterance opens a session; sending ``close_stream`` flushes the
+  final transcript and the server closes the session. The service reconnects
+  automatically for the next utterance.
 """
 
 import asyncio
@@ -129,7 +132,11 @@ class SmallestSTTService(WebsocketSTTService):
     for real-time voice applications where immediate feedback is needed.
 
     Uses Pipecat's VAD to detect when the user stops speaking and sends
-    a finalize message to flush the final transcript.
+    a ``close_stream`` message to flush the final transcript. The server
+    closes the session after the final response; the service reconnects
+    automatically for the next utterance.
+
+    Connects to ``wss://api.smallest.ai/waves/v1/stt/live?model=pulse``.
 
     Example::
 
@@ -237,9 +244,18 @@ class SmallestSTTService(WebsocketSTTService):
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             if self._websocket and self._websocket.state is State.OPEN:
                 try:
-                    await self._websocket.send(json.dumps({"type": "finalize"}))
+                    # Mark as intentionally disconnecting before sending close_stream.
+                    # The v4 API closes the session after the final transcript, which
+                    # would look like a quick-failure to WebsocketService's reconnect
+                    # guard (_MIN_STABLE_CONNECTION_DURATION). Setting _disconnecting=True
+                    # makes _maybe_try_reconnect treat it as a clean exit rather than an
+                    # error, breaking the receive loop instead of incrementing the failure
+                    # counter. _connect() resets _disconnecting=False on reconnect.
+                    self._disconnecting = True
+                    await self._websocket.send(json.dumps({"type": "close_stream"}))
                 except Exception as e:
-                    logger.warning(f"{self} failed to send finalize: {e}")
+                    self._disconnecting = False
+                    logger.warning(f"{self} failed to send close_stream: {e}")
 
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame | None, None]:
         """Send audio to the Smallest Pulse WebSocket for transcription.
@@ -280,6 +296,11 @@ class SmallestSTTService(WebsocketSTTService):
             await self._connect_websocket()
             await super()._connect()
 
+            # After close_stream the server closes the session; the receive task
+            # exits naturally. Clear it so we can create a fresh one on reconnect.
+            if self._receive_task is not None and self._receive_task.done():
+                self._receive_task = None
+
             if self._websocket and not self._receive_task:
                 self._receive_task = self.create_task(
                     self._receive_task_handler(self._report_error)
@@ -297,7 +318,7 @@ class SmallestSTTService(WebsocketSTTService):
         await self._disconnect_websocket()
 
     async def _connect_websocket(self):
-        """Establish WebSocket connection to the Smallest Pulse STT API."""
+        """Establish WebSocket connection to the Smallest Pulse STT API (v4)."""
         try:
             if self._websocket and self._websocket.state is State.OPEN:
                 return
@@ -305,6 +326,7 @@ class SmallestSTTService(WebsocketSTTService):
             logger.debug("Connecting to Smallest STT")
 
             query_params = {
+                "model": self._settings.model,
                 "language": self._settings.language,
                 "encoding": self._encoding,
                 "sample_rate": str(self.sample_rate),
@@ -317,7 +339,7 @@ class SmallestSTTService(WebsocketSTTService):
                 "diarize": str(self._settings.diarize).lower(),
             }
 
-            ws_url = f"{self._base_url}/waves/v1/pulse/get_text?{urlencode(query_params)}"
+            ws_url = f"{self._base_url}/waves/v1/stt/live?{urlencode(query_params)}"
 
             self._websocket = await websocket_connect(
                 ws_url,
@@ -363,13 +385,26 @@ class SmallestSTTService(WebsocketSTTService):
                 logger.error(f"{self} error processing message: {e}")
 
     async def _process_response(self, data: dict):
-        """Process a transcription response from the Pulse API.
+        """Process a transcription response from the Pulse API (v4).
 
         Args:
             data: Parsed JSON response containing transcript data.
+
+        The response contains:
+            - ``transcript``: The recognized text.
+            - ``is_final``: Whether this is a final (vs. interim) result.
+            - ``is_last``: Whether this is the final message of the session.
+              When ``True`` the server closes the WebSocket; the service
+              reconnects automatically for the next utterance.
+            - ``language``: The detected or specified language.
+            - ``session_id``: Unique identifier for the WebSocket session.
         """
         is_final = data.get("is_final", False)
+        is_last = data.get("is_last", False)
         text = data.get("transcript", "").strip()
+
+        if is_last:
+            logger.debug(f"{self} received is_last; server will close session")
 
         if not text:
             return

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -129,9 +129,8 @@ class SmallestSTTService(WebsocketSTTService):
     for real-time voice applications where immediate feedback is needed.
 
     Uses Pipecat's VAD to detect when the user stops speaking and sends
-    a ``close_stream`` message to flush the final transcript. The server
-    closes the session after the final response; the service reconnects
-    automatically for the next utterance.
+    a ``finalize`` message to flush the final transcript while keeping the
+    session alive for the next utterance.
 
     Connects to ``wss://api.smallest.ai/waves/v1/stt/live?model=pulse``.
 
@@ -241,18 +240,9 @@ class SmallestSTTService(WebsocketSTTService):
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             if self._websocket and self._websocket.state is State.OPEN:
                 try:
-                    # Mark as intentionally disconnecting before sending close_stream.
-                    # The v4 API closes the session after the final transcript, which
-                    # would look like a quick-failure to WebsocketService's reconnect
-                    # guard (_MIN_STABLE_CONNECTION_DURATION). Setting _disconnecting=True
-                    # makes _maybe_try_reconnect treat it as a clean exit rather than an
-                    # error, breaking the receive loop instead of incrementing the failure
-                    # counter. _connect() resets _disconnecting=False on reconnect.
-                    self._disconnecting = True
-                    await self._websocket.send(json.dumps({"type": "close_stream"}))
+                    await self._websocket.send(json.dumps({"type": "finalize"}))
                 except Exception as e:
-                    self._disconnecting = False
-                    logger.warning(f"{self} failed to send close_stream: {e}")
+                    logger.warning(f"{self} failed to send finalize: {e}")
 
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame | None, None]:
         """Send audio to the Smallest Pulse WebSocket for transcription.
@@ -292,11 +282,6 @@ class SmallestSTTService(WebsocketSTTService):
         try:
             await self._connect_websocket()
             await super()._connect()
-
-            # After close_stream the server closes the session; the receive task
-            # exits naturally. Clear it so we can create a fresh one on reconnect.
-            if self._receive_task is not None and self._receive_task.done():
-                self._receive_task = None
 
             if self._websocket and not self._receive_task:
                 self._receive_task = self.create_task(
@@ -390,9 +375,8 @@ class SmallestSTTService(WebsocketSTTService):
         The response contains:
             - ``transcript``: The recognized text.
             - ``is_final``: Whether this is a final (vs. interim) result.
-            - ``is_last``: Whether this is the final message of the session.
-              When ``True`` the server closes the WebSocket; the service
-              reconnects automatically for the next utterance.
+            - ``is_last``: Whether this is the last message of the session.
+              Only ``True`` after ``close_stream`` is sent at call end.
             - ``language``: The detected or specified language.
             - ``session_id``: Unique identifier for the WebSocket session.
         """

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -318,7 +318,7 @@ class SmallestSTTService(WebsocketSTTService):
         await self._disconnect_websocket()
 
     async def _connect_websocket(self):
-        """Establish WebSocket connection to the Smallest Pulse STT API (v4)."""
+        """Establish WebSocket connection to the Smallest Pulse STT API."""
         try:
             if self._websocket and self._websocket.state is State.OPEN:
                 return

--- a/src/pipecat/services/smallest/stt.py
+++ b/src/pipecat/services/smallest/stt.py
@@ -385,7 +385,7 @@ class SmallestSTTService(WebsocketSTTService):
                 logger.error(f"{self} error processing message: {e}")
 
     async def _process_response(self, data: dict):
-        """Process a transcription response from the Pulse API (v4).
+        """Process a transcription response from the Pulse API.
 
         Args:
             data: Parsed JSON response containing transcript data.


### PR DESCRIPTION
## Summary

- Updates `SmallestSTTService` to use the Waves v4 STT WebSocket endpoint (`wss://api.smallest.ai/waves/v1/stt/live?model=pulse`) replacing the legacy `/waves/v1/pulse/get_text` path.
- Changes the utterance-end signal from `{"type": "finalize"}` to `{"type": "close_stream"}` as required by the new API.
- Handles the new `is_last` response field (signals the server will close the session after the final transcript) and clears the completed `_receive_task` so the service reconnects automatically for the next utterance.

**API changes (Waves v4):**
| | Old | New |
|---|---|---|
| Endpoint | `/waves/v1/pulse/get_text` | `/waves/v1/stt/live?model=pulse` |
| End-of-utterance signal | `{"type": "finalize"}` | `{"type": "close_stream"}` |
| Response | `transcript`, `is_final` | `transcript`, `is_final`, `is_last`, `session_id` |

Docs reference: https://docs.smallest.ai/waves/v-4-0-0/documentation/speech-to-text-pulse/realtime-web-socket/quickstart

## Test plan

- [x] 11 new unit tests in `tests/test_smallest_stt.py` covering:
  - WebSocket URL uses new v4 path and includes `model=pulse`
  - `close_stream` is sent (not `finalize`) on `VADUserStoppedSpeakingFrame`
  - Interim and final transcripts produce correct frame types
  - `is_last` field is handled without errors
  - `_connect` clears a completed `_receive_task` to allow reconnection
- [x] Existing `tests/test_smallest_tts.py` (6 tests) — all pass
- [x] `ruff check` + `ruff format --check` — clean