### PR TITLE
fix(logging): truncate verbose LLM context in debug logs

### DIFF
--- a/changelog/4661.changed.md
+++ b/changelog/4661.changed.md
@@ -1,0 +1,3 @@
+- `AnthropicLLMService` and `AWSBedrockLLMService` now log a short summary
+  (message count plus the last message) instead of the full LLM context
+  in their `Generating chat from context` debug log line.

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -41,6 +41,7 @@ from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
 from pipecat.services.settings import NOT_GIVEN as _NOT_GIVEN
 from pipecat.services.settings import LLMSettings, _NotGiven, assert_given, is_given
 from pipecat.utils.deprecation import deprecated
+from pipecat.utils.string import summarize_messages_for_logging
 from pipecat.utils.tracing.service_decorators import traced_llm
 
 try:
@@ -364,7 +365,10 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
 
             adapter = self.get_llm_adapter()
             messages_for_logging = adapter.get_messages_for_logging(context)
-            logger.debug(f"{self}: Generating chat from context {messages_for_logging}")
+            logger.debug(
+                f"{self}: Generating chat from context "
+                f"{summarize_messages_for_logging(messages_for_logging)}"
+            )
 
             await self.start_ttfb_metrics()
 

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -39,6 +39,7 @@ from pipecat.services.aws.utils import resolve_credentials
 from pipecat.services.llm_service import LLMService
 from pipecat.services.settings import NOT_GIVEN, LLMSettings, _NotGiven, assert_given
 from pipecat.utils.deprecation import deprecated
+from pipecat.utils.string import summarize_messages_for_logging
 from pipecat.utils.tracing.service_decorators import traced_llm
 
 try:
@@ -489,7 +490,10 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
             # Log request params with messages redacted for logging
             adapter = self.get_llm_adapter()
             messages_for_logging = adapter.get_messages_for_logging(context)
-            logger.debug(f"{self}: Generating chat from context {messages_for_logging}")
+            logger.debug(
+                f"{self}: Generating chat from context "
+                f"{summarize_messages_for_logging(messages_for_logging)}"
+            )
 
             async with self._aws_session.create_client(
                 service_name="bedrock-runtime", **self._aws_params

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -20,6 +20,7 @@ Dependencies:
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import nltk
 from loguru import logger
@@ -301,3 +302,24 @@ def concatenate_aggregated_text(text_parts: list[TextPartForConcatenation]) -> s
     result = result.strip()
 
     return result
+
+
+def summarize_messages_for_logging(messages: Sequence[Any], tail: int = 1) -> str:
+    """Summarize a list of LLM context messages for debug logging.
+
+    Logging an entire LLM context on every inference call is extremely
+    verbose for long-running sessions. This returns a short summary
+    consisting of the total message count plus the last ``tail``
+    message(s), which is usually enough to debug what's being sent
+    without dumping the full conversation history.
+
+    Args:
+        messages: The list of messages (e.g. from
+            :meth:`~pipecat.adapters.base_llm_adapter.BaseLLMAdapter.get_messages_for_logging`).
+        tail: The number of trailing messages to include in full.
+
+    Returns:
+        A string of the form ``"<N> messages, last <tail>: [...]"``.
+    """
+    last = list(messages[-tail:]) if tail > 0 else []
+    return f"{len(messages)} messages, last {len(last)}: {last}"


### PR DESCRIPTION
## Summary

- `AnthropicLLMService` and `AWSBedrockLLMService` log the full LLM context (`messages_for_logging`) on every inference call via `logger.debug(f\"{self}: Generating chat from context {messages_for_logging}\")`. For long-running sessions with debug logging enabled, this dumps the entire conversation history repeatedly and makes logs very noisy.
- Adds `summarize_messages_for_logging()` in `pipecat.utils.string`, which returns the message count plus the last message instead of the full list, and uses it in both services' debug logs.

Closes #4661

## Test plan

- [x] `ruff check` / `ruff format --check` pass on changed files
- [x] Manually verified `summarize_messages_for_logging()` produces a short summary (`"<N> messages, last 1: [...]"`) instead of the full context dump