### PR TITLE
Fix pyright errors in frame_processor and rime/tts

### DIFF
--- a/changelog/4755.fixed.md
+++ b/changelog/4755.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `RimeTTSService.SPELL()` and `RimeTTSService.PAUSE_TAG()` helpers, which are now static methods. Previously they were defined as instance methods without a `self` parameter, so calling them on a service instance bound the instance to the first argument and produced incorrect output.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -35,7 +35,6 @@
     "src/pipecat/services/nvidia/tts.py",
     "src/pipecat/services/openai/base_llm.py",
     "src/pipecat/services/openai/realtime/llm.py",
-    "src/pipecat/services/rime/tts.py",
     "src/pipecat/services/sambanova/llm.py",
     "src/pipecat/services/sarvam/stt.py",
     "src/pipecat/services/simli/video.py",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -12,7 +12,6 @@
     "src/pipecat/audio/turn/smart_turn/local_smart_turn_v3.py",
     "src/pipecat/audio/vad/silero.py",
     "src/pipecat/processors/aggregators/llm_response_universal.py",
-    "src/pipecat/processors/frame_processor.py",
     "src/pipecat/processors/frameworks/rtvi/observer.py",
     "src/pipecat/services/anthropic/llm.py",
     "src/pipecat/services/aws/llm.py",

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -133,7 +133,7 @@ class FrameProcessorQueue(asyncio.PriorityQueue):
         self.__high_counter = 0
         self.__low_counter = 0
 
-    async def put(self, item: tuple[Frame, FrameDirection, FrameCallback]):
+    async def put(self, item: tuple[Frame, FrameDirection, FrameCallback | None]):
         """Put an item into the priority queue.
 
         System frames (`SystemFrame`) have higher priority than any other

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -372,10 +372,12 @@ class RimeTTSService(WebsocketTTSService):
         return params
 
     # A set of Rime-specific helpers for text transformations
+    @staticmethod
     def SPELL(text: str) -> str:
         """Wrap text in Rime spell function."""
         return f"spell({text})"
 
+    @staticmethod
     def PAUSE_TAG(seconds: float) -> str:
         """Convenience method to create a pause tag."""
         return f"<{seconds * 1000}>"


### PR DESCRIPTION
## Summary

Two small, self-contained pyright fixes that clear all errors in their files, letting both come off the `pyrightconfig.json` ignore list and stay enforced going forward.

### `FrameProcessor` queue callback type
`FrameProcessorQueue.put` declared its item tuple as `tuple[Frame, FrameDirection, FrameCallback]`, but `queue_frame()` forwards an *optional* callback into the queue and the downstream consumer (`__process_frame`) already types it `FrameCallback | None`. Widened the annotation to match. Pure type-correctness change, no runtime behavior change.

### Rime `SPELL` / `PAUSE_TAG` static helpers
`SPELL` and `PAUSE_TAG` take no `self` and are pure text transformations, but were defined as instance methods — so calling them on an instance (e.g. `service.SPELL("hi")`) would bind the instance to the first argument. Marked them `@staticmethod`, which fixes that latent self-binding bug and clears the pyright errors/warnings.

## Test plan
- `uv run pyright` passes clean with both files removed from the ignore list.
- Pre-commit hooks pass (ruff, deprecation registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
