### PR TITLE
Apply 'Writing for Future Readers' guidance to update-docs skill

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -284,6 +284,7 @@ After all edits are complete, print a summary:
 
 ## Guidelines
 
+- **Write for a future reader, not the diff** — docs describe the API as it currently stands. Never narrate the change itself: no "newly added," "this replaces," "recently changed," or references to prior behavior. A reader landing on the page should see no sign that a PR just edited it. Match the weight of the prose to the feature — a routine new parameter gets a one-line description, not a paragraph.
 - **Be conservative** — only change what the diff warrants. Don't "improve" docs beyond what changed in source.
 - **Read before editing** — always read the full doc page before making changes so you understand the existing structure.
 - **Preserve voice** — match the writing style of the existing doc page, don't impose a different tone.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -285,6 +285,9 @@ After all edits are complete, print a summary:
 ## Guidelines
 
 - **Write for a future reader, not the diff** — docs describe the API as it currently stands. Never narrate the change itself: no "newly added," "this replaces," "recently changed," or references to prior behavior. A reader landing on the page should see no sign that a PR just edited it. Match the weight of the prose to the feature — a routine new parameter gets a one-line description, not a paragraph.
+- **Avoid LLM tells** — write plainly. Skip filler and AI-signalling phrases ("delve," "seamless," "leverage," "it is worth noting," "this underscores"), formulaic "not just X, but Y" contrasts, and overuse of em dashes or boldface. Never leave placeholder text (`[X]`, `{placeholder}`) or assistant meta ("I hope this helps") in a page — this skill runs unattended in CI, so nothing downstream will catch it.
+- **Keep code and prose in sync** — when a page names a parameter, class, or identifier, spell it in prose exactly as the source and the `<ParamField>`/table entry do. After editing a code example or renaming a param, re-read the surrounding prose for stale references.
+- **Backtick inline technical terms** — wrap parameter names, class names, filenames, env vars, and config keys in backticks when they appear in prose (Overview, Notes, descriptions). Structured elements like `<ParamField>` already format these inside tables.
 - **Be conservative** — only change what the diff warrants. Don't "improve" docs beyond what changed in source.
 - **Read before editing** — always read the full doc page before making changes so you understand the existing structure.
 - **Preserve voice** — match the writing style of the existing doc page, don't impose a different tone.


### PR DESCRIPTION
## Summary

Adds prose-quality guidelines to the `update-docs` skill's `## Guidelines` section. The skill is the shared source for both the manual `/update-docs` invocation and the `update-docs.yml` GitHub Action (which delegates to it), so these apply on both paths — including the unattended CI run.

New guidelines:
- **Write for a future reader, not the diff** — docs describe the API as it currently stands; never narrate the change.
- **Avoid LLM tells** — no filler/AI-signalling phrases, formulaic contrasts, or leftover placeholder/meta text.
- **Keep code and prose in sync** — prose must name params/identifiers exactly as the source and `<ParamField>`/table do.
- **Backtick inline technical terms** — params, class names, filenames, env vars, config keys in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)