### PR TITLE
fix(azure): omit output_modalities from Azure Realtime response.create

### DIFF
--- a/changelog/4762.fixed.md
+++ b/changelog/4762.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AzureRealtimeLLMService` sending unsupported `output_modalities` field in `response.create` events, which caused 400 errors from Azure OpenAI Realtime endpoints.

--- a/src/pipecat/services/azure/realtime/llm.py
+++ b/src/pipecat/services/azure/realtime/llm.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from loguru import logger
 from websockets.asyncio.client import connect as websocket_connect
 
+from pipecat.services.openai.realtime import events
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 
 
@@ -50,6 +51,9 @@ class AzureRealtimeLLMService(OpenAIRealtimeLLMService):
         super().__init__(base_url=base_url, api_key=api_key, **kwargs)
         self.api_key = api_key
         self.base_url = base_url
+
+    def _build_response_create_event(self) -> events.ResponseCreateEvent:
+        return events.ResponseCreateEvent()
 
     async def _connect(self):
         try:

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -1177,10 +1177,11 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         await self.push_frame(LLMFullResponseStartFrame())
         await self.start_processing_metrics()
         await self.start_ttfb_metrics()
-        await self.send_client_event(
-            events.ResponseCreateEvent(
-                response=events.ResponseProperties(output_modalities=self._get_enabled_modalities())
-            )
+        await self.send_client_event(self._build_response_create_event())
+
+    def _build_response_create_event(self) -> events.ResponseCreateEvent:
+        return events.ResponseCreateEvent(
+            response=events.ResponseProperties(output_modalities=self._get_enabled_modalities())
         )
 
     async def _process_completed_function_calls(self, send_new_results: bool):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Azure OpenAI Realtime endpoints reject `response.output_modalities` in `response.create` events with a 400 error. This field is specific to OpenAI's API and is not supported by Azure.

Closes #4106

**Root cause:** `OpenAIRealtimeLLMService._create_response()` always includes `output_modalities` in the `ResponseCreateEvent`. `AzureRealtimeLLMService` inherits this without the ability to opt out.

**Fix:** Extract a `_build_response_create_event()` hook in `OpenAIRealtimeLLMService` that `AzureRealtimeLLMService` overrides to return a bare `ResponseCreateEvent()` without the unsupported field.

**Before:**
```python
# Azure received: {"type": "response.create", "response": {"output_modalities": ["text", "audio"]}}
# → 400 Bad Request from Azure endpoint
```

**After:**
```python
# Azure receives: {"type": "response.create"}
# → Accepted by Azure endpoint
```