### PR TITLE
fix(azure): remove unsupported output_modalities from realtime requests

### DIFF
--- a/changelog/4763.fixed.md
+++ b/changelog/4763.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AzureRealtimeLLMService` sending unsupported `output_modalities` parameter in `session.update` and `response.create` requests, which caused Azure's Realtime API to reject the connection (#4106).

--- a/src/pipecat/services/azure/realtime/llm.py
+++ b/src/pipecat/services/azure/realtime/llm.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from loguru import logger
 from websockets.asyncio.client import connect as websocket_connect
 
+from pipecat.services.openai.realtime import events
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 
 
@@ -27,6 +28,10 @@ class AzureRealtimeLLMService(OpenAIRealtimeLLMService):
     Extends the OpenAI Realtime service to work with Azure OpenAI endpoints,
     using Azure's authentication headers and endpoint format. Provides the same
     real-time audio and text communication capabilities as the base OpenAI service.
+
+    Note: Azure's Realtime API does not support the ``output_modalities`` parameter
+    in either ``session.update`` or ``response.create`` requests. This class strips
+    that field from all outgoing payloads.
     """
 
     Settings = AzureRealtimeLLMSettings
@@ -50,6 +55,26 @@ class AzureRealtimeLLMService(OpenAIRealtimeLLMService):
         super().__init__(base_url=base_url, api_key=api_key, **kwargs)
         self.api_key = api_key
         self.base_url = base_url
+
+    async def send_client_event(self, event: events.ClientEvent):
+        """Send a client event, stripping output_modalities before transmission.
+
+        Azure's Realtime API rejects ``output_modalities`` in both
+        ``session.update`` and ``response.create`` requests. This override
+        removes the field from those events before forwarding them.
+        """
+        if isinstance(event, events.SessionUpdateEvent) and event.session.output_modalities:
+            event = event.model_copy(
+                update={"session": event.session.model_copy(update={"output_modalities": None})}
+            )
+        elif isinstance(event, events.ResponseCreateEvent) and event.response is not None:
+            if event.response.output_modalities is not None:
+                event = event.model_copy(
+                    update={
+                        "response": event.response.model_copy(update={"output_modalities": None})
+                    }
+                )
+        await super().send_client_event(event)
 
     async def _connect(self):
         try:

--- a/tests/test_azure_realtime_output_modalities.py
+++ b/tests/test_azure_realtime_output_modalities.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests verifying that AzureRealtimeLLMService omits output_modalities.
+
+Azure's Realtime API rejects the ``output_modalities`` parameter in both
+``session.update`` and ``response.create`` events. These tests confirm it is
+stripped before transmission, even when a caller explicitly configures it.
+"""
+
+import pytest
+
+from pipecat.services.azure.realtime.llm import AzureRealtimeLLMService
+from pipecat.services.openai.realtime import events
+
+
+def _make_service(**kwargs) -> AzureRealtimeLLMService:
+    defaults = dict(
+        api_key="test-key",
+        base_url="wss://example.openai.azure.com/openai/realtime?api-version=2025-04-01-preview&deployment=gpt-4o-realtime",
+    )
+    defaults.update(kwargs)
+    return AzureRealtimeLLMService(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# send_client_event: session.update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_update_omits_output_modalities_by_default():
+    """output_modalities must not appear in session.update when not configured."""
+    service = _make_service(
+        settings=AzureRealtimeLLMService.Settings(
+            model="gpt-4o-realtime-preview",
+            system_instruction="be helpful",
+            session_properties=events.SessionProperties(),
+        )
+    )
+
+    sent_events: list[events.ClientEvent] = []
+
+    # Capture what the base class would transmit by patching _ws_send.
+    async def _capture(payload):
+        sent_events.append(payload)
+
+    service._ws_send = _capture
+    await service.send_client_event(events.SessionUpdateEvent(session=events.SessionProperties()))
+
+    assert len(sent_events) == 1
+    assert "output_modalities" not in sent_events[0].get("session", {})
+
+
+@pytest.mark.asyncio
+async def test_session_update_strips_explicit_output_modalities():
+    """output_modalities must be stripped from session.update even when explicitly set."""
+    service = _make_service(
+        settings=AzureRealtimeLLMService.Settings(
+            model="gpt-4o-realtime-preview",
+            system_instruction="be helpful",
+            session_properties=events.SessionProperties(
+                output_modalities=["audio", "text"],
+            ),
+        )
+    )
+
+    sent_events: list[dict] = []
+
+    async def _capture(payload):
+        sent_events.append(payload)
+
+    service._ws_send = _capture
+    await service.send_client_event(
+        events.SessionUpdateEvent(
+            session=events.SessionProperties(output_modalities=["audio", "text"])
+        )
+    )
+
+    assert len(sent_events) == 1
+    assert "output_modalities" not in sent_events[0].get("session", {})
+
+    # The stored config is preserved — the strip only affects the wire payload.
+    assert service._settings.session_properties.output_modalities == ["audio", "text"]
+
+
+# ---------------------------------------------------------------------------
+# send_client_event: response.create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_create_omits_output_modalities():
+    """output_modalities must not appear in response.create payloads."""
+    service = _make_service()
+
+    sent_events: list[dict] = []
+
+    async def _capture(payload):
+        sent_events.append(payload)
+
+    service._ws_send = _capture
+    await service.send_client_event(
+        events.ResponseCreateEvent(response=events.ResponseProperties(output_modalities=["audio"]))
+    )
+
+    assert len(sent_events) == 1
+    response_payload = sent_events[0].get("response") or {}
+    assert "output_modalities" not in response_payload


### PR DESCRIPTION
## Summary

- Azure's Realtime API rejects the `output_modalities` parameter in both `session.update` and `response.create` requests, causing the connection to fail with an unsupported parameter error.
- Overrides `send_client_event` in `AzureRealtimeLLMService` to strip `output_modalities` from `SessionUpdateEvent` and `ResponseCreateEvent` before transmission, using `model_copy` so the stored configuration is unchanged.
- Adds a unit test verifying the field is absent from the serialized wire payload in both event types.

Closes #4106

## Test plan

- [ ] `python -m pytest tests/test_azure_realtime_output_modalities.py -v` -- 3 tests pass
- [ ] `python -m ruff check src/pipecat/services/azure/realtime/llm.py` -- no issues
- [ ] `python -m ruff format --check src/pipecat/services/azure/realtime/llm.py` -- already formatted