### PR TITLE
fix(dtmf): key cached DTMF audio by sample rate, not just button

### DIFF
--- a/changelog/4766.fixed.md
+++ b/changelog/4766.fixed.md
@@ -1,0 +1,1 @@
+- Fixed cached DTMF audio being returned at the wrong sample rate. `load_dtmf_audio()` keyed its in-memory cache by button only, so the first sample rate a button was loaded at was reused for every later request. The cache is now keyed by `(button, sample_rate)`.

--- a/src/pipecat/audio/dtmf/utils.py
+++ b/src/pipecat/audio/dtmf/utils.py
@@ -23,7 +23,7 @@ from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler
 from pipecat.audio.utils import create_file_resampler
 
 __DTMF_LOCK__ = asyncio.Lock()
-__DTMF_AUDIO__: dict[KeypadEntry, bytes] = {}
+__DTMF_AUDIO__: dict[tuple[KeypadEntry, int], bytes] = {}
 __DTMF_RESAMPLER__: BaseAudioResampler | None = None
 
 __DTMF_FILE_NAME = {
@@ -45,8 +45,9 @@ async def load_dtmf_audio(button: KeypadEntry, *, sample_rate: int = 8000) -> by
     global __DTMF_AUDIO__, __DTMF_RESAMPLER__
 
     async with __DTMF_LOCK__:
-        if button in __DTMF_AUDIO__:
-            return __DTMF_AUDIO__[button]
+        cache_key = (button, sample_rate)
+        if cache_key in __DTMF_AUDIO__:
+            return __DTMF_AUDIO__[cache_key]
 
         if not __DTMF_RESAMPLER__:
             __DTMF_RESAMPLER__ = create_file_resampler()
@@ -66,6 +67,6 @@ async def load_dtmf_audio(button: KeypadEntry, *, sample_rate: int = 8000) -> by
                 resampled_audio = await __DTMF_RESAMPLER__.resample(
                     audio, in_sample_rate, sample_rate
                 )
-                __DTMF_AUDIO__[button] = resampled_audio
+                __DTMF_AUDIO__[cache_key] = resampled_audio
 
-    return __DTMF_AUDIO__[button]
+    return __DTMF_AUDIO__[cache_key]

--- a/tests/test_dtmf_utils.py
+++ b/tests/test_dtmf_utils.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+
+from pipecat.audio.dtmf import utils
+from pipecat.audio.dtmf.types import KeypadEntry
+from pipecat.audio.dtmf.utils import load_dtmf_audio
+
+
+class TestLoadDTMFAudio(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        # The module caches decoded/resampled audio in process-global state.
+        # Reset it so each test starts from a clean cache.
+        utils.__DTMF_AUDIO__.clear()
+        utils.__DTMF_RESAMPLER__ = None
+
+    async def test_cache_is_keyed_by_sample_rate(self):
+        """Different sample rates for the same button must not collide in the cache."""
+        audio_8k = await load_dtmf_audio(KeypadEntry.ONE, sample_rate=8000)
+        audio_16k = await load_dtmf_audio(KeypadEntry.ONE, sample_rate=16000)
+
+        # 16 kHz PCM of the same tone has roughly twice the bytes of 8 kHz. With a
+        # button-only cache key the 8 kHz audio was returned for the 16 kHz request,
+        # so the lengths matched and this assertion failed.
+        self.assertGreater(len(audio_16k), len(audio_8k) * 1.8)
+
+    async def test_cached_rate_returns_identical_bytes(self):
+        """Re-requesting a previously loaded sample rate returns the same bytes."""
+        first = await load_dtmf_audio(KeypadEntry.ONE, sample_rate=8000)
+        # Load a different rate in between; it must not clobber the 8 kHz entry.
+        await load_dtmf_audio(KeypadEntry.ONE, sample_rate=16000)
+        again = await load_dtmf_audio(KeypadEntry.ONE, sample_rate=8000)
+        self.assertEqual(first, again)


### PR DESCRIPTION
## What

`load_dtmf_audio()` caches decoded/resampled tones in a process-global dict keyed only by the button. The sample rate determines how the audio is produced but is not part of the cache key, so the first rate a button is requested at wins for the rest of the process.

So if a process first loads a tone at 8 kHz and later asks for the same button at 16 kHz, it gets the cached 8 kHz audio back. A transport running at a different rate than the first caller ends up emitting wrong-rate DTMF (wrong pitch/duration), which downstream telephony providers may not detect.

## Fix

Key the cache by `(button, sample_rate)` instead of just `button`. No behavior change for single-rate processes; multi-rate processes now get audio resampled correctly per rate. About four lines touched.

## Verifying

Added `tests/test_dtmf_utils.py`. The main test loads button `1` at 8 kHz then 16 kHz and asserts the 16 kHz buffer is roughly twice the bytes:

- Before: the 16 kHz request returns the cached 8 kHz buffer (8000 bytes), assertion fails.
- After: the 16 kHz request returns ~16000 bytes, passes. Re-fetching 8 kHz still returns the cached 8 kHz bytes.

```
python -m pytest tests/test_dtmf_utils.py tests/test_dtmf_aggregator.py -q
```

9 passed. `ruff check` and `ruff format --check` are clean on the touched files.
