### PR TITLE
Rename process_assistant_turn to _process_assistant_turn in STT service.

### DIFF
--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -727,7 +727,7 @@ class AssemblyAISTTService(WebsocketSTTService):
         self._settings.agent_context = text
         await self._send_update_configuration(agent_context=text)
 
-    async def process_assistant_turn(self, text: str) -> None:
+    async def _process_assistant_turn(self, text: str) -> None:
         """Feed the assistant's completed reply to AssemblyAI as carryover context.
 
         Called automatically when the assistant's turn ends.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -276,7 +276,7 @@ class STTService(AIService):
         """
         return Language(language)
 
-    async def process_assistant_turn(self, text: str) -> None:
+    async def _process_assistant_turn(self, text: str) -> None:
         """Called when the assistant's turn completes with the aggregated reply text.
 
         Override in subclasses to react to each completed bot reply — for
@@ -449,7 +449,7 @@ class STTService(AIService):
             await self._reset_stt_ttfb_state()
             await self.push_frame(frame, direction)
         elif isinstance(frame, LLMContextAssistantTurnFrame):
-            await self.process_assistant_turn(frame.text)
+            await self._process_assistant_turn(frame.text)
             await self.push_frame(frame, direction)
         else:
             await self.push_frame(frame, direction)

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -511,5 +511,6 @@ def test__process_assistant_turn_noop_when_carryover_disabled():
 
     assert sent == []
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -463,10 +463,10 @@ def test_update_settings_mixed_delta_reconnects_without_update_configuration():
     assert "agent_context" in service._build_ws_url()
 
 
-# --- process_assistant_turn ---
+# --- _process_assistant_turn ---
 
 
-def test_process_assistant_turn_delegates_to_update_agent_context():
+def test__process_assistant_turn_delegates_to_update_agent_context():
     service = AssemblyAISTTService(api_key="test-key")
     sent = []
 
@@ -474,13 +474,13 @@ def test_process_assistant_turn_delegates_to_update_agent_context():
         sent.append(fields)
 
     service._send_update_configuration = fake_send
-    asyncio.run(service.process_assistant_turn("Hello there."))
+    asyncio.run(service._process_assistant_turn("Hello there."))
 
     assert sent == [{"agent_context": "Hello there."}]
     assert service._settings.agent_context == "Hello there."
 
 
-def test_process_assistant_turn_noop_for_non_u3():
+def test__process_assistant_turn_noop_for_non_u3():
     service = AssemblyAISTTService(
         api_key="test-key",
         settings=AssemblyAISTTService.Settings(model="universal-streaming-english"),
@@ -491,12 +491,12 @@ def test_process_assistant_turn_noop_for_non_u3():
         sent.append(fields)
 
     service._send_update_configuration = fake_send
-    asyncio.run(service.process_assistant_turn("Hello."))
+    asyncio.run(service._process_assistant_turn("Hello."))
 
     assert sent == []
 
 
-def test_process_assistant_turn_noop_when_carryover_disabled():
+def test__process_assistant_turn_noop_when_carryover_disabled():
     service = AssemblyAISTTService(
         api_key="test-key",
         settings=AssemblyAISTTService.Settings(previous_context_n_turns=0),
@@ -507,6 +507,9 @@ def test_process_assistant_turn_noop_when_carryover_disabled():
         sent.append(fields)
 
     service._send_update_configuration = fake_send
-    asyncio.run(service.process_assistant_turn("Hello."))
+    asyncio.run(service._process_assistant_turn("Hello."))
 
     assert sent == []
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rename process_assistant_turn to _process_assistant_turn in STT service
  
It's an internal method not intended for external use, so the leading underscore signals that clearly. Simple and accurate.