### PR TITLE
Add trigger_disconnect eval flag

### DIFF
--- a/src/pipecat/cli/agent_templates/AGENTS.md
+++ b/src/pipecat/cli/agent_templates/AGENTS.md
@@ -212,7 +212,7 @@ The dev runner wraps this in the eval transport + serializer when you pass `-t e
 - **Logs** — the bot logs to stdout (loguru). However you run it, keep the output durable and greppable — e.g. `uv run bot.py -t eval 2>&1 | tee /tmp/pipecat-output.txt` — so when a scenario fails you can grep the file for the traceback instead of re-running. If your harness captures background-process output natively, that works too.
 - **Clean boot** — `uv run bot.py -t eval` boots the bot as a headless eval WebSocket server (default `ws://localhost:7860`). No exceptions + pipeline assembled is your fastest "did I wire it right" signal.
 
-**The eval loop (where you live).** Boot the bot (`uv run bot.py -t eval`), then drive a scenario against it from a second terminal. The bot serves that one eval session and exits when the run finishes, so boot it fresh for each run as you iterate (or use `pipecat eval suite` to spawn a fresh bot per scenario from a manifest). Start in **text mode** (the default), the fast inner loop. A minimal scenario:
+**The eval loop (where you live).** Boot the bot (`uv run bot.py -t eval`), then drive a scenario against it from a second terminal. The eval transport keeps the bot alive between runs, so boot it once and drive scenario after scenario as you iterate — no re-boot per run. Start in **text mode** (the default), the fast inner loop. A minimal scenario:
 ```yaml
 name: capital_of_germany
 turns:
@@ -230,6 +230,8 @@ turns:
 uv run pipecat eval run my_scenario.yaml -v
 ```
 Text mode **bypasses STT, VAD, and TTS** (the `user:` turn is sent as text), so assert on what the bot *produced* (`response`, `function_call`), not on `user_*_speaking` events. Prefer the modality-agnostic `response` event — it resolves to the LLM text in text mode and to the bot's transcribed audio in audio mode. Exit code is non-zero if any non-skipped scenario fails. When a run fails in a confusing way, re-run with `-d` to also write `<scenario>.debug.log` — the harness's full logs for the eval STT, TTS, and LLM judge. Route run output to `eval-runs/` with `--logs-dir eval-runs` (and `--record-dir eval-runs` for `-a` recordings); `pipecat eval suite` writes runs to a timestamped `eval-runs/<timestamp>/`.
+
+**One bot serves many runs.** Because the bot stays up between runs, its context carries over — give a scenario a top-level `context:` (a list of LLM messages) to start that run from a known context, or boot fresh / use `pipecat eval suite` (a fresh bot per scenario from a manifest) when you want each run fully isolated. Its `on_client_disconnected` handler (which usually cancels the pipeline) also won't fire during a normal eval; to exercise that path — cleanup, or a goodbye on hang-up — pass `--trigger-disconnect` to `pipecat eval run`, or set `trigger_disconnect: true` on a single scenario. If the handler cancels the pipeline the bot exits, so treat that as a terminal run.
 
 **Escalate to audio mode** for the full round trip. Set `user: {modality: audio, speech: {service: kokoro, voice: af_heart}}` and the harness synthesizes the user's speech, so the bot's **real VAD + STT** run; set `judge: {modality: audio}` (with a `transcription:` block) so the bot **speaks** and the harness transcribes that audio into the `response` event. Kokoro (user TTS) and Moonshine (bot transcription) run **locally with no API key** — audio mode is slower but free. Add `-a` to save the conversation to `<record-dir>/<scenario>.wav` for a human to listen back and confirm it sounds right.
 

--- a/src/pipecat/cli/commands/eval.py
+++ b/src/pipecat/cli/commands/eval.py
@@ -169,6 +169,7 @@ async def _execute_scenario(
     logs_dir: str,
     debug: bool,
     stop_bot: bool,
+    trigger_disconnect: bool,
     on_progress,
 ) -> None:
     """Run one scenario against its ``bot_url``, updating ``run`` in place.
@@ -194,6 +195,7 @@ async def _execute_scenario(
                 cache_dir=cache_dir,
                 use_cache=use_cache,
                 stop_bot=stop_bot,
+                trigger_disconnect=trigger_disconnect,
             ).run()
         if run.result.debug_log:
             Path(logs_dir).mkdir(parents=True, exist_ok=True)
@@ -227,6 +229,7 @@ async def _run_scenarios_all(
     verbose: bool,
     debug: bool,
     stop_bot: bool,
+    trigger_disconnect: bool,
     started: float,
 ) -> None:
     """Run scenarios sequentially against a fixed bot, with the suite's display.
@@ -246,6 +249,7 @@ async def _run_scenarios_all(
             logs_dir=logs_dir,
             debug=debug,
             stop_bot=stop_bot,
+            trigger_disconnect=trigger_disconnect,
             on_progress=on_progress,
         )
 
@@ -320,6 +324,13 @@ def run(
         help="Cancel the bot's pipeline (exit it) after the run. By default the "
         "bot is left running so it can serve more scenarios.",
     ),
+    trigger_disconnect: bool = typer.Option(
+        False,
+        "--trigger-disconnect",
+        help="Fire the bot's on_client_disconnected handler when the eval client "
+        "disconnects. Bots often cancel their pipeline there, so it's off by "
+        "default. A scenario's 'trigger_disconnect:' field opts in on its own.",
+    ),
 ) -> None:
     """Run one or more evals against an already-running bot.
 
@@ -348,6 +359,7 @@ def run(
             verbose=verbose,
             debug=debug,
             stop_bot=stop_bot,
+            trigger_disconnect=trigger_disconnect,
             started=started,
         )
     )

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -198,6 +198,7 @@ class EvalSession:
         on_progress: Callable[[EvalTurnProgress], None] | None = None,
         record_path: str | None = None,
         stop_bot: bool = False,
+        trigger_disconnect: bool = False,
         judge: EvalJudge | None = None,
         speech: EvalSpeech | None = None,
         transcriber: EvalTranscriber | None = None,
@@ -224,6 +225,11 @@ class EvalSession:
             stop_bot: When True, ask the bot to cancel its pipeline (and exit) on
                 teardown via ``eval-cancel``. The suite enables it to clean up
                 each spawned bot.
+            trigger_disconnect: When True (or when the scenario sets
+                ``trigger_disconnect``), ask the eval transport to fire the bot's
+                ``on_client_disconnected`` handler when this connection ends.
+                Bots often cancel their pipeline there, so it is off by default
+                to avoid that between scenarios.
             judge: The :class:`~pipecat.evals.judge.EvalJudge` for ``eval:``
                 assertions, or ``None`` if the scenario has none.
             speech: The :class:`~pipecat.evals.speech.EvalSpeech` for synthesizing
@@ -240,6 +246,8 @@ class EvalSession:
         self._on_progress = on_progress
         self._record_path = record_path
         self._stop_bot = stop_bot
+        # Either the run-wide CLI flag or the scenario's own field opts in.
+        self._trigger_disconnect = trigger_disconnect or scenario.trigger_disconnect
 
         self._ws: ClientConnection | None = None
         self._queue: asyncio.Queue = asyncio.Queue()
@@ -300,6 +308,7 @@ class EvalSession:
         cache_dir: str | None = None,
         use_cache: bool = True,
         stop_bot: bool = False,
+        trigger_disconnect: bool = False,
         judge: EvalJudge | None = None,
         speech: EvalSpeech | None = None,
         transcriber: EvalTranscriber | None = None,
@@ -329,6 +338,9 @@ class EvalSession:
                 (no cache reads or writes). Defaults to True.
             stop_bot: When True, ask the bot to cancel its pipeline (and exit) on
                 teardown. Leave False to keep it running for more scenarios.
+            trigger_disconnect: When True, fire the bot's ``on_client_disconnected``
+                handler when the connection ends (the scenario's own
+                ``trigger_disconnect`` field also opts in). Off by default.
             judge: Override the judge (default: built from ``scenario.judge`` when the
                 scenario has ``eval:`` assertions).
             speech: Override the user-audio generator (default: built from
@@ -363,6 +375,7 @@ class EvalSession:
             on_progress=on_progress,
             record_path=record_path,
             stop_bot=stop_bot,
+            trigger_disconnect=trigger_disconnect,
             judge=judge,
             speech=speech,
             transcriber=transcriber,
@@ -535,7 +548,9 @@ class EvalSession:
         mic at all, so a text-mode scenario never feeds silence into the bot's
         STT. ``capture_bot_audio`` makes the bot forward its synthesized audio for
         ``tts_response`` transcription. ``record`` asks the eval transport to
-        record the conversation audio (audio mode only).
+        record the conversation audio (audio mode only). ``trigger_disconnect``
+        asks the transport to fire the bot's ``on_client_disconnected`` handler
+        when the connection ends (off by default, since bots often cancel there).
         """
         from urllib.parse import quote
 
@@ -548,6 +563,8 @@ class EvalSession:
             flags.append("capture_bot_audio=true")
         if self._record_path and self._scenario.bot_audio:
             flags.append(f"record={quote(self._record_path, safe='')}")
+        if self._trigger_disconnect:
+            flags.append("trigger_disconnect=true")
         if not flags:
             return self._bot_url
         sep = "&" if "?" in self._bot_url else "?"

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -241,6 +241,12 @@ class EvalScenario:
             to the bot, exercising its STT for real. Mapping with ``service``,
             ``voice``, and optional ``model`` / ``sample_rate`` /
             ``api_key``. Omit for text-only evals (default).
+        trigger_disconnect: Whether the harness fires the bot's
+            ``on_client_disconnected`` handler when this scenario's connection
+            ends. Bots often cancel their pipeline there, so this is False by
+            default to avoid that between scenarios; set True to exercise the
+            bot's disconnect path. Independent of ``--stop-bot``, which tears the
+            bot down via ``eval-cancel`` regardless of the handler.
         source_path: Path the scenario was loaded from, for error messages.
     """
 
@@ -251,6 +257,7 @@ class EvalScenario:
     bot_audio: bool = False
     transcriber: dict | None = None
     user_audio: dict | None = None
+    trigger_disconnect: bool = False
     source_path: Path | None = None
 
     @classmethod
@@ -325,6 +332,7 @@ class EvalScenario:
             bot_audio=bot_audio,
             transcriber=transcriber,
             user_audio=user_audio,
+            trigger_disconnect=bool(data.get("trigger_disconnect", False)),
             source_path=path,
         )
 

--- a/src/pipecat/evals/transport.py
+++ b/src/pipecat/evals/transport.py
@@ -75,6 +75,7 @@ SKIP_TTS_QUERY_PARAM = "skip_tts"
 USER_AUDIO_QUERY_PARAM = "user_audio"
 CAPTURE_AUDIO_QUERY_PARAM = "capture_bot_audio"
 RECORD_QUERY_PARAM = "record"
+TRIGGER_DISCONNECT_QUERY_PARAM = "trigger_disconnect"
 
 # One virtual-mic frame per tick — the granularity a live transport delivers and
 # what VAD/turn models consume.
@@ -416,3 +417,16 @@ class EvalTransport(SingleClientWebsocketServerTransport):
             self._record_path = None
 
         await super()._on_client_disconnected(websocket)
+
+    async def _emit_client_disconnected(self, websocket):
+        """Fire ``on_client_disconnected`` only when the harness asks for it.
+
+        Bots often cancel their pipeline in ``on_client_disconnected``, so the
+        event is suppressed by default to avoid that between eval scenarios. The
+        harness sets ``?trigger_disconnect=true`` (via a scenario's
+        ``trigger_disconnect`` field or ``pipecat eval run --trigger-disconnect``)
+        to exercise the bot's disconnect path. Independent of ``--stop-bot``,
+        which tears the bot down reliably via ``eval-cancel``.
+        """
+        if _query_flag(websocket, TRIGGER_DISCONNECT_QUERY_PARAM):
+            await super()._emit_client_disconnected(websocket)

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -539,9 +539,17 @@ class SingleClientWebsocketServerTransport(BaseTransport):
         """Handle client disconnection events."""
         if self._output:
             await self._output.set_client_connection(None)
-            await self._call_event_handler("on_client_disconnected", websocket)
+            await self._emit_client_disconnected(websocket)
         else:
             logger.error("A SingleClientWebsocketServerTransport output is missing in the pipeline")
+
+    async def _emit_client_disconnected(self, websocket):
+        """Fire the ``on_client_disconnected`` event.
+
+        Split from the connection teardown above so subclasses can suppress the
+        event without skipping that teardown.
+        """
+        await self._call_event_handler("on_client_disconnected", websocket)
 
     async def _on_session_timeout(self, websocket):
         """Handle client session timeout events."""


### PR DESCRIPTION
## Summary

Bots often cancel their pipeline in their `on_client_disconnected` handler. During evals that tears the bot down on every scenario disconnect, so the eval transport now **suppresses that event by default**. A new `trigger_disconnect` flag lets the harness fire it on demand to exercise the bot's disconnect path.

## Changes

- **Base transport** (`SingleClientWebsocketServerTransport`): extracted the `on_client_disconnected` event firing into an overridable `_emit_client_disconnected()` seam, so subclasses can suppress the event while keeping connection teardown. No behavior change.
- **Eval transport**: `EvalTransport._emit_client_disconnected` fires `on_client_disconnected` only when the connection carries `?trigger_disconnect=true`. Default off; the recording flush and `set_client_connection(None)` still run.
- **Scenario schema**: top-level `trigger_disconnect: bool = False` field, so a single scenario can opt in mid-suite.
- **Harness**: `EvalSession` accepts `trigger_disconnect` (OR'd with the scenario field) and appends the query flag in `_connect_url`.
- **CLI**: `pipecat eval run --trigger-disconnect`.
- **Docs** (`agent_templates/AGENTS.md` §6): the bot now stays alive between runs, so boot once and iterate; documented `--trigger-disconnect` / `trigger_disconnect:` for exercising the disconnect path, plus a note that context carries over (reset per run with `context:`).

## Relationship to `--stop-bot`

These are orthogonal and both kept:

| | mechanism | guarantees teardown? | runs bot's handler? |
|---|---|---|---|
| `--stop-bot` | `eval-cancel` → `CancelWorkerFrame` | yes | no |
| `--trigger-disconnect` | fire `on_client_disconnected` | no (handler's choice) | yes |

`--stop-bot` was deliberately not reused as the trigger, because its contract ("the bot reliably stops") can only be guaranteed by `eval-cancel`, which bypasses the handler.

## Test plan

- Eval/scenario/websocket + CLI tests pass; `ruff check` / `ruff format` clean.
- `pipecat eval run --help` shows `--trigger-disconnect`; `_query_flag` reads `?trigger_disconnect=true` → `True` (absent → `False`).

## Notes

- No changelog: the evals framework is unreleased, and the base-transport change is a private, behavior-preserving extract-method.
- Rebased on `main` (now includes the `context:` rename, #4781).

🤖 Generated with [Claude Code](https://claude.com/claude-code)