### PR TITLE
Rename eval scenario reset: keyword to context:

### DIFF
--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -86,8 +86,8 @@ from pipecat.evals.serializer import (
     EVAL_BOT_AUDIO_TYPE,
     EVAL_CANCEL_MESSAGE_TYPE,
     EVAL_CONFIGURE_MESSAGE_TYPE,
+    EVAL_CONTEXT_MESSAGE_TYPE,
     EVAL_IMAGE_MESSAGE_TYPE,
-    EVAL_RESET_MESSAGE_TYPE,
 )
 from pipecat.evals.speech import EvalSpeech
 from pipecat.evals.transcribe import EvalTranscriber
@@ -616,16 +616,17 @@ class EvalSession:
             )
             await self._send(configure)
 
-        # Only send a reset when the scenario actually asked for one. An implicit
-        # empty reset would race with bot startup flows (e.g. a greeting added in
-        # on_client_connected), wiping the bot's context right after it set it up.
-        if self._scenario.reset:
-            reset = RTVI.Message(
+        # Only send the eval-context when the scenario provides starting context.
+        # An implicit empty one would race with bot startup flows (e.g. a greeting
+        # added in on_client_connected), wiping the bot's context right after it
+        # set it up.
+        if self._scenario.context:
+            context_message = RTVI.Message(
                 type="client-message",
                 id=self._message_id(),
-                data={"t": EVAL_RESET_MESSAGE_TYPE, "d": {"messages": self._scenario.reset}},
+                data={"t": EVAL_CONTEXT_MESSAGE_TYPE, "d": {"messages": self._scenario.context}},
             )
-            await self._send(reset)
+            await self._send(context_message)
 
     async def _send(self, message: RTVI.Message) -> None:
         """Serialize and send an RTVI message over the WebSocket."""

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -61,8 +61,9 @@ relative to the scenario file) to register an image for the turn — when a
 function-calling-video bot requests a user image, the eval transport serves it.
 
 Top-level optional fields:
-    reset:  list of LLM messages the harness sends as a reset before driving
-            turns (default empty list, which clears the bot's context).
+    context: LLM messages the bot's context should start from. When given, the
+            harness sends them before driving turns (replacing the bot's
+            context); omit to leave the bot's own context untouched.
     user:   how user turns are delivered::
 
                 user:
@@ -216,12 +217,13 @@ class EvalScenario:
     Parameters:
         name: The eval name (from ``name:``).
         turns: Ordered list of turns.
-        reset: Messages to seed the bot's LLM context with before this eval
-            runs. Sent by the harness as an ``eval-reset`` client message right
-            after the bot-ready handshake (the eval serializer turns it into an
-            ``LLMMessagesUpdateFrame``). Empty list (the default) clears the
-            context entirely; bots without an LLM context aggregator ignore the
-            resulting frame.
+        context: LLM messages the bot's context should start from for this eval.
+            When non-empty, the harness sends them as an ``eval-context`` client
+            message right after the bot-ready handshake (the eval serializer
+            turns it into an ``LLMMessagesUpdateFrame``, which replaces the
+            context); bots without an LLM context aggregator ignore the frame.
+            Omitted or empty (the default): the harness sends nothing and the
+            bot keeps the context it set up itself.
         judge: Judge LLM configuration dict with keys ``service``, ``model``,
             and optional ``endpoint``. Defaults to
             ``{"service": "ollama", "model": "gemma2:9b"}``.
@@ -244,7 +246,7 @@ class EvalScenario:
 
     name: str
     turns: list[EvalTurn]
-    reset: list[dict] = field(default_factory=list)
+    context: list[dict] = field(default_factory=list)
     judge: dict = field(default_factory=lambda: {"service": "ollama", "model": "gemma2:9b"})
     bot_audio: bool = False
     transcriber: dict | None = None
@@ -292,13 +294,13 @@ class EvalScenario:
 
         turns = [_parse_turn(t, path, idx) for idx, t in enumerate(raw_turns)]
 
-        raw_reset = data.get("reset")
-        if raw_reset is None:
-            reset: list[dict] = []
-        elif isinstance(raw_reset, list):
-            reset = raw_reset
+        raw_context = data.get("context")
+        if raw_context is None:
+            context: list[dict] = []
+        elif isinstance(raw_context, list):
+            context = raw_context
         else:
-            raise ValueError(f"{path}: 'reset:' must be a list of message dicts")
+            raise ValueError(f"{path}: 'context:' must be a list of message dicts")
 
         # user: { modality: audio|text, speech: {...} }. Audio synthesizes each user
         # turn via TTS (exercising the bot's STT); text sends it as text. Stored
@@ -318,7 +320,7 @@ class EvalScenario:
         return cls(
             name=name,
             turns=turns,
-            reset=reset,
+            context=context,
             judge=judge,
             bot_audio=bot_audio,
             transcriber=transcriber,

--- a/src/pipecat/evals/serializer.py
+++ b/src/pipecat/evals/serializer.py
@@ -14,7 +14,7 @@ is the only glue needed:
   :class:`~pipecat.frames.frames.InputTransportMessageFrame` so the bot's
   ``RTVIProcessor`` parses and routes them (``send-text``, ``raw-audio``,
   ``client-ready``, ...). Two control messages are the exception: a
-  ``client-message`` with ``t = "eval-reset"`` is short-circuited into an
+  ``client-message`` with ``t = "eval-context"`` is short-circuited into an
   :class:`LLMMessagesUpdateFrame` (reseeding the bot's context), and one with
   ``t = "eval-configure"`` into an
   :class:`~pipecat.processors.frameworks.rtvi.frames.RTVIConfigureObserverFrame`
@@ -28,7 +28,7 @@ is the only glue needed:
   harness only asserts on semantic events.
 
 This lives under ``pipecat.evals`` rather than ``pipecat.serializers`` because
-it carries eval-specific behavior (the reset short-circuit, dropping audio) and
+it carries eval-specific behavior (the context short-circuit, dropping audio) and
 is not a general-purpose RTVI transport serializer.
 """
 
@@ -55,7 +55,7 @@ from pipecat.serializers.base_serializer import FrameSerializer
 # A ``client-message`` with this ``t`` is intercepted by the serializer and
 # turned into an ``LLMMessagesUpdateFrame`` instead of being forwarded to the
 # RTVIProcessor. Keeps per-eval context seeding out of the bot.
-EVAL_RESET_MESSAGE_TYPE = "eval-reset"
+EVAL_CONTEXT_MESSAGE_TYPE = "eval-context"
 
 # A ``client-message`` with this ``t`` is intercepted and turned into an
 # ``RTVIConfigureObserverFrame``. This is the trust boundary for raising the
@@ -153,7 +153,7 @@ class RTVIEvalSerializer(FrameSerializer):
             data: JSON text (or bytes) sent by the harness.
 
         Returns:
-            An ``LLMMessagesUpdateFrame`` for the eval-reset control message, an
+            An ``LLMMessagesUpdateFrame`` for the eval-context control message, an
             ``InputTransportMessageFrame`` wrapping any other RTVI message, or
             ``None`` if the payload is not a valid RTVI message.
         """
@@ -167,9 +167,9 @@ class RTVIEvalSerializer(FrameSerializer):
             logger.warning(f"RTVIEvalSerializer: ignoring non-RTVI message: {message!r}")
             return None
 
-        reset = self._maybe_reset_frame(message)
-        if reset is not None:
-            return reset
+        context = self._maybe_context_frame(message)
+        if context is not None:
+            return context
 
         configure = self._maybe_configure_frame(message)
         if configure is not None:
@@ -184,12 +184,12 @@ class RTVIEvalSerializer(FrameSerializer):
 
         return InputTransportMessageFrame(message=message)
 
-    def _maybe_reset_frame(self, message: dict) -> Frame | None:
-        """Return an ``LLMMessagesUpdateFrame`` for the eval-reset message, else None."""
+    def _maybe_context_frame(self, message: dict) -> Frame | None:
+        """Return an ``LLMMessagesUpdateFrame`` for the eval-context message, else None."""
         if message.get("type") != "client-message":
             return None
         data: Any = message.get("data") or {}
-        if not isinstance(data, dict) or data.get("t") != EVAL_RESET_MESSAGE_TYPE:
+        if not isinstance(data, dict) or data.get("t") != EVAL_CONTEXT_MESSAGE_TYPE:
             return None
         payload = data.get("d") or {}
         messages = payload.get("messages", []) if isinstance(payload, dict) else []

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -13,7 +13,7 @@ Two layers:
 - :class:`TestEvalsHarnessIntegration` runs scenarios via :meth:`EvalSession.from_scenario` against a fake
   RTVI WebSocket server that replies to ``client-ready``/``send-text`` with
   scripted RTVI server messages — exercising the handshake, send/receive, event
-  matching, and reset paths without a real bot pipeline.
+  matching, and context paths without a real bot pipeline.
 """
 
 import json
@@ -654,42 +654,43 @@ class TestEvalsHarnessIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(any("kokoro boom" in line for line in result.debug_log))
         self.assertTrue(any("Traceback" in line for line in result.debug_log))
 
-    async def test_reset_sends_eval_reset_message(self):
+    async def test_context_sends_eval_context_message(self):
         self.server.on_text("hi", _rtvi("bot-llm-started"), _rtvi("bot-llm-stopped"))
         scenario = EvalScenario(
-            name="reset",
+            name="context",
             turns=[
                 EvalTurn(user="hi", expect=[EvalExpectation(event="llm_started", within_ms=2000)])
             ],
-            reset=[{"role": "system", "content": "be terse"}],
+            context=[{"role": "system", "content": "be terse"}],
         )
         result = await EvalSession.from_scenario(scenario, self.server.url).run()
         self.assertTrue(result.passed, f"failures: {[str(f) for f in result.failures]}")
-        resets = [
+        context_messages = [
             m
             for m in self.server.received
-            if m.get("type") == "client-message" and m["data"].get("t") == "eval-reset"
+            if m.get("type") == "client-message" and m["data"].get("t") == "eval-context"
         ]
-        self.assertEqual(len(resets), 1)
+        self.assertEqual(len(context_messages), 1)
         self.assertEqual(
-            resets[0]["data"]["d"]["messages"], [{"role": "system", "content": "be terse"}]
+            context_messages[0]["data"]["d"]["messages"],
+            [{"role": "system", "content": "be terse"}],
         )
 
-    async def test_no_reset_when_not_requested(self):
+    async def test_no_eval_context_message_when_empty(self):
         self.server.on_text("hi", _rtvi("bot-llm-started"), _rtvi("bot-llm-stopped"))
         scenario = EvalScenario(
-            name="noreset",
+            name="nocontext",
             turns=[
                 EvalTurn(user="hi", expect=[EvalExpectation(event="llm_started", within_ms=2000)])
             ],
         )
         await EvalSession.from_scenario(scenario, self.server.url).run()
-        resets = [
+        context_messages = [
             m
             for m in self.server.received
-            if m.get("type") == "client-message" and m["data"].get("t") == "eval-reset"
+            if m.get("type") == "client-message" and m["data"].get("t") == "eval-context"
         ]
-        self.assertEqual(resets, [])
+        self.assertEqual(context_messages, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -361,18 +361,18 @@ class TestEvalsScenarioParser(unittest.TestCase):
             )
         self.assertIn("image", str(cm.exception))
 
-    def test_reset_defaults_to_empty(self):
+    def test_context_defaults_to_empty(self):
         s = EvalScenario.load(
             _write("name: e\nturns: [{user: hi, expect: [{event: user_stopped_speaking}]}]\n")
         )
-        self.assertEqual(s.reset, [])
+        self.assertEqual(s.context, [])
 
-    def test_reset_parsed_as_list(self):
+    def test_context_parsed_as_list(self):
         s = EvalScenario.load(
             _write(
                 """
-                name: with_reset
-                reset:
+                name: with_context
+                context:
                   - role: system
                     content: "You are a helpful assistant."
                 turns:
@@ -381,16 +381,18 @@ class TestEvalsScenarioParser(unittest.TestCase):
                 """
             )
         )
-        self.assertEqual(len(s.reset), 1)
-        self.assertEqual(s.reset[0]["role"], "system")
-        self.assertEqual(s.reset[0]["content"], "You are a helpful assistant.")
+        self.assertEqual(len(s.context), 1)
+        self.assertEqual(s.context[0]["role"], "system")
+        self.assertEqual(s.context[0]["content"], "You are a helpful assistant.")
 
-    def test_reset_non_list_rejected(self):
+    def test_context_non_list_rejected(self):
         with self.assertRaises(ValueError) as cm:
             EvalScenario.load(
-                _write("name: bad\nreset: not_a_list\nturns: [{user: hi, expect: [{event: x}]}]\n")
+                _write(
+                    "name: bad\ncontext: not_a_list\nturns: [{user: hi, expect: [{event: x}]}]\n"
+                )
             )
-        self.assertIn("'reset:'", str(cm.exception))
+        self.assertIn("'context:'", str(cm.exception))
 
     def test_include_resolves_judge_and_user_blocks(self):
         # `judge: !include ...` / `user: !include ...` let scenarios share config.

--- a/tests/test_evals_serializer.py
+++ b/tests/test_evals_serializer.py
@@ -13,8 +13,8 @@ import unittest
 import pipecat.processors.frameworks.rtvi.models as RTVI
 from pipecat.evals.serializer import (
     EVAL_CONFIGURE_MESSAGE_TYPE,
+    EVAL_CONTEXT_MESSAGE_TYPE,
     EVAL_IMAGE_MESSAGE_TYPE,
-    EVAL_RESET_MESSAGE_TYPE,
     RTVIEvalSerializer,
 )
 from pipecat.frames.frames import (
@@ -60,13 +60,13 @@ class TestRTVIEvalSerializerDeserialize(unittest.IsolatedAsyncioTestCase):
         frame = await self.serializer.deserialize(json.dumps(msg))
         self.assertIsInstance(frame, InputTransportMessageFrame)
 
-    async def test_eval_reset_short_circuits_to_messages_update(self):
+    async def test_eval_context_short_circuits_to_messages_update(self):
         msg = {
             "label": RTVI.MESSAGE_LABEL,
             "type": "client-message",
             "id": "4",
             "data": {
-                "t": EVAL_RESET_MESSAGE_TYPE,
+                "t": EVAL_CONTEXT_MESSAGE_TYPE,
                 "d": {"messages": [{"role": "system", "content": "be terse"}]},
             },
         }
@@ -104,7 +104,7 @@ class TestRTVIEvalSerializerDeserialize(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(await self.serializer.deserialize(json.dumps(msg)))
         self.assertEqual(self.serializer.get_user_image(), (img, "image/png"))
 
-    async def test_non_reset_client_message_is_forwarded(self):
+    async def test_non_context_client_message_is_forwarded(self):
         msg = {
             "label": RTVI.MESSAGE_LABEL,
             "type": "client-message",


### PR DESCRIPTION
## Summary

Renames the eval scenario's top-level `reset:` keyword to `context:`. It names what the field actually sets (the bot's starting LLM context) and aligns with pipecat's `LLMContext` vocabulary. The internal `eval-reset` wire message is renamed to `eval-context` to match.

## Changes

- **Scenario** (`scenario.py`): `reset:` keyword → `context:`; field `EvalScenario.reset` → `context`; parsing and error message updated.
- **Wire message** (`serializer.py`): `EVAL_RESET_MESSAGE_TYPE` / `eval-reset` → `EVAL_CONTEXT_MESSAGE_TYPE` / `eval-context`; helper `_maybe_reset_frame` → `_maybe_context_frame`.
- **Harness** (`harness.py`): reads `scenario.context`, sends the `eval-context` message.
- **Tests**: scenario, harness, and serializer tests updated (fields, YAML, wire-type strings, method/var names).

## Behavior

Unchanged. When `context:` is non-empty, the harness sends the messages before driving turns (an `LLMMessagesUpdateFrame` that **replaces** the bot's context); omitted or empty, it sends nothing and the bot keeps the context it set up itself.

## Doc fix

The old docstrings claimed an empty/default value *clears* the bot's context. That was wrong — the harness only sends the message when the field is non-empty (intentionally, to avoid racing the bot's startup, e.g. an on-connect greeting). The docs now say so.

Not renamed (unrelated): `EvalMicrophone.reset()`.

## Test plan

- 139 eval tests pass; `ruff check` / `ruff format` clean; no stray `eval-reset` / `EVAL_RESET` references.

## Notes

- No changelog: the evals framework is unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)