### PR TITLE
feat(aws-nova-sonic): report LLM token usage metrics

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -37,6 +37,7 @@ jobs:
           uv sync --group dev \
             --extra anthropic \
             --extra aws \
+            --extra aws-nova-sonic \
             --extra azure \
             --extra cli \
             --extra daily \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
           uv sync --group dev \
             --extra anthropic \
             --extra aws \
+            --extra aws-nova-sonic \
             --extra azure \
             --extra cli \
             --extra daily \

--- a/changelog/4783.added.md
+++ b/changelog/4783.added.md
@@ -1,0 +1,1 @@
+- Added token usage metrics to `AWSNovaSonicLLMService`, which now emits `LLMUsageMetricsData` from Nova Sonic's `usageEvent`. Each event reports its token delta, with speech and text tokens combined into `prompt_tokens` and `completion_tokens`, so metrics summed over a session match the session total.

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -52,6 +52,7 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
+from pipecat.metrics.metrics import LLMTokenUsage
 from pipecat.processors.aggregators import async_tool_messages
 from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
 from pipecat.processors.frame_processor import FrameDirection
@@ -524,6 +525,14 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
         await super().cancel(frame)
         self._wants_connection = False
         await self._disconnect()
+
+    def can_generate_metrics(self) -> bool:
+        """Check if the service can generate usage metrics.
+
+        Returns:
+            True if metrics generation is supported.
+        """
+        return True
 
     #
     # conversation resetting
@@ -1327,6 +1336,9 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
                         elif "completionEnd" in event_json:
                             # Handle the LLM completion ending
                             await self._handle_completion_end_event(event_json)
+                        elif "usageEvent" in event_json:
+                            # Handle token usage reporting
+                            await self._handle_usage_event(event_json)
         except Exception as e:
             if self._disconnecting:
                 return
@@ -1514,6 +1526,28 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
         # Session continuation: completionEnd is a fallback completion signal
         if self._sc.on_completion_end():
             self.create_task(self._run_sc_handoff(), name="sc_handoff")
+
+    async def _handle_usage_event(self, event_json):
+        # Nova Sonic reports incremental token usage in details.delta, split into
+        # speech/text buckets for input and output. We report the delta (not the
+        # cumulative details.total) so usage stays incremental per event, matching
+        # the convention of the other speech-to-speech services. Pipecat's
+        # LLMTokenUsage does not separate modalities, so collapse speech + text
+        # into prompt/completion totals.
+        delta = event_json["usageEvent"].get("details", {}).get("delta", {})
+        input_tokens = delta.get("input", {})
+        output_tokens = delta.get("output", {})
+        prompt_tokens = input_tokens.get("speechTokens", 0) + input_tokens.get("textTokens", 0)
+        completion_tokens = output_tokens.get("speechTokens", 0) + output_tokens.get(
+            "textTokens", 0
+        )
+        if prompt_tokens or completion_tokens:
+            tokens = LLMTokenUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            )
+            await self.start_llm_usage_metrics(tokens)
 
     #
     # assistant response reporting

--- a/tests/test_nova_sonic_usage_metrics.py
+++ b/tests/test_nova_sonic_usage_metrics.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""AWS Nova Sonic reports token usage from its ``usageEvent`` stream events.
+
+Nova Sonic emits a ``usageEvent`` whose ``details.delta`` carries the tokens
+consumed since the previous event, split into speech/text buckets for input and
+output. The service collapses those buckets into the modality-agnostic
+``LLMTokenUsage`` (``prompt_tokens`` / ``completion_tokens``) and reports the
+*delta* — not the cumulative ``details.total`` — so usage stays incremental per
+event, matching the other speech-to-speech services.
+
+The service is imported with ``pytest.importorskip`` so the suite is skipped
+rather than failing collection when the optional AWS dependencies aren't
+installed.
+"""
+
+import unittest
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.metrics.metrics import LLMTokenUsage
+
+
+class TestAWSNovaSonicUsageMetrics(unittest.IsolatedAsyncioTestCase):
+    def _service(self):
+        mod = pytest.importorskip("pipecat.services.aws.nova_sonic.llm")
+        return mod.AWSNovaSonicLLMService(
+            secret_access_key="test", access_key_id="test", region="us-east-1"
+        )
+
+    def test_can_generate_metrics(self):
+        # Without this, start_llm_usage_metrics is a no-op and nothing is emitted.
+        service = self._service()
+        self.assertTrue(service.can_generate_metrics())
+
+    async def test_usage_event_reports_collapsed_delta(self):
+        service = self._service()
+        service.start_llm_usage_metrics = AsyncMock()
+
+        # A real usageEvent: delta is the increment for this event, total is the
+        # cumulative session count. We report the delta, collapsing speech + text.
+        await service._handle_usage_event(
+            {
+                "usageEvent": {
+                    "details": {
+                        "delta": {
+                            "input": {"speechTokens": 0, "textTokens": 3},
+                            "output": {"speechTokens": 20, "textTokens": 0},
+                        },
+                        "total": {
+                            "input": {"speechTokens": 288, "textTokens": 3443},
+                            "output": {"speechTokens": 694, "textTokens": 203},
+                        },
+                    },
+                }
+            }
+        )
+
+        service.start_llm_usage_metrics.assert_awaited_once()
+        (tokens,) = service.start_llm_usage_metrics.await_args.args
+        self.assertIsInstance(tokens, LLMTokenUsage)
+        self.assertEqual(tokens.prompt_tokens, 3)  # 0 speech + 3 text
+        self.assertEqual(tokens.completion_tokens, 20)  # 20 speech + 0 text
+        self.assertEqual(tokens.total_tokens, 23)
+
+    async def test_usage_event_with_no_tokens_is_skipped(self):
+        # A zero-token delta (e.g. an event carrying no new usage) must not emit
+        # an empty metrics frame.
+        service = self._service()
+        service.start_llm_usage_metrics = AsyncMock()
+
+        await service._handle_usage_event(
+            {
+                "usageEvent": {
+                    "details": {
+                        "delta": {
+                            "input": {"speechTokens": 0, "textTokens": 0},
+                            "output": {"speechTokens": 0, "textTokens": 0},
+                        },
+                    },
+                }
+            }
+        )
+
+        service.start_llm_usage_metrics.assert_not_awaited()
+
+    async def test_usage_event_with_missing_details_is_safe(self):
+        # A malformed/partial usageEvent must not raise and must not emit.
+        service = self._service()
+        service.start_llm_usage_metrics = AsyncMock()
+
+        await service._handle_usage_event({"usageEvent": {}})
+
+        service.start_llm_usage_metrics.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AWS Nova Sonic emits a `usageEvent` on its stream, but the service never routed it, so it was the only speech-to-speech service that reported no token usage (its inherited `can_generate_metrics()` returned `False` and the event was silently dropped by the receive loop's `if/elif`).

Override `can_generate_metrics()` and handle `usageEvent`: report the incremental `details.delta` (not the cumulative `details.total`) so usage stays per-event, consistent with the other realtime services (OpenAI/xAI/Inworld emit incrementally per response). Collapse Nova Sonic's speech/text buckets into prompt/completion totals, since `LLMTokenUsage` does not separate modalities (same approach OpenAI Realtime already takes).

## The usageEvent payload

Captured from a live call:

```json
{
  "usageEvent": {
    "details": {
      "delta": {
        "input":  { "speechTokens": 0,  "textTokens": 3 },
        "output": { "speechTokens": 20, "textTokens": 0 }
      },
      "total": {
        "input":  { "speechTokens": 288, "textTokens": 3443 },
        "output": { "speechTokens": 694, "textTokens": 203 }
      }
    },
    "totalTokens": 4628
  }
}
```

`total` is cumulative across the session; `delta` is the per-event increment. Reporting `delta` means summing the frames downstream yields the correct session total, matching how the other realtime services behave.

## Testing

- **Unit tests** (`tests/test_nova_sonic_usage_metrics.py`): cover `can_generate_metrics()`, the collapsed delta mapping, the zero-token guard, and safe handling of a partial payload. `pytest` → 4 passed.
- **Integration**: ran a real Nova Sonic call. Before this change the pipeline emitted 0 usage metrics; after, it emitted 41 `LLMUsageMetricsData` frames with real token counts (model `amazon.nova-2-sonic-v1:0`), incremental per event as expected.
- `ruff check` + `ruff format` pass.
