### PR TITLE
Add raw VAD speaking events and incomplete-turn eval scenarios

### DIFF
--- a/changelog/4785.added.md
+++ b/changelog/4785.added.md
@@ -1,0 +1,6 @@
+- `RTVIObserver` can now emit raw VAD user speaking events
+  (`vad-user-started-speaking` / `vad-user-stopped-speaking`), driven directly by
+  the VAD signal and independent of turn finalization (unlike
+  `user-started-speaking` / `user-stopped-speaking`, which a turn strategy may
+  gate or defer). Enable with `RTVIObserverParams(vad_user_speaking_enabled=True)`
+  (off by default), or at runtime via `RTVIConfigureObserverFrame`.

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -251,3 +251,7 @@ suite:
   #
   - bot: turn-management/turn-management-filter-incomplete-turns.py
     scenarios: [filter_incomplete_turns]
+  - bot: turn-management/turn-management-filter-incomplete-turns-function-calling.py
+    scenarios: [filter_incomplete_turns_function_calling]
+  - bot: turn-management/turn-management-filter-incomplete-turns-function-calling.py
+    scenarios: [filter_incomplete_turns]

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -243,3 +243,11 @@ suite:
   - bot: vision/vision-moondream.py
     runner_body: scenarios/vision-cat.json
     scenarios: [vision_describe]
+
+  #
+  # Turn management: the user trails off mid-thought, then completes it after a
+  # pause. The bot's incomplete-turn detection must hold the turn open and
+  # respond only to the finished thought (anchored on the raw VAD stop signal).
+  #
+  - bot: turn-management/turn-management-filter-incomplete-turns.py
+    scenarios: [filter_incomplete_turns]

--- a/scripts/release-evals/scenarios/filter_incomplete_turns.yaml
+++ b/scripts/release-evals/scenarios/filter_incomplete_turns.yaml
@@ -1,0 +1,37 @@
+name: filter_incomplete_turns
+
+# Audio modality. The user trails off mid-thought ("Let me think about it...")
+# and the bot's incomplete-turn detection should hold the turn open instead of
+# responding. After a short pause the user finishes the sentence; only then
+# should the bot answer — to the *complete* thought, not the trailing fragment.
+#
+# We anchor the completion off the raw VAD stop signal (vad_user_stopped_speaking):
+# the turn-level user_stopped_speaking is deliberately deferred while the turn is
+# held open, so it can't be used here, but the VAD signal still fires on the pause.
+
+user: !include user_audio.yaml
+
+judge: !include judge_audio.yaml
+
+turns:
+  # Wait for the bot's on-connect greeting/question before speaking.
+  - expect:
+      - event: response
+        eval: "the bot opens the conversation in some way (a greeting, an introduction, or a question inviting the user to respond)"
+
+  # The user trails off mid-thought. VAD detects the pause (vad_user_stopped_speaking
+  # fires), but the bot should mark the turn incomplete and keep it open rather than
+  # respond.
+  - user: "Let me think about it, hmmm"
+    expect:
+      - event: vad_user_stopped_speaking
+
+  # ~3s later (under the 5s incomplete-short timeout), the user finishes the
+  # thought. Now the turn completes and the bot should respond to the whole answer.
+  - user: "I think I'd go to Japan, to see the temples and try the food."
+    send_after:
+      event: vad_user_stopped_speaking
+      delay_ms: 3000
+    expect:
+      - event: response
+        eval: "the response engages with the user's answer about visiting Japan (acknowledging or responding to it), rather than asking the user to continue or finish their thought"

--- a/scripts/release-evals/scenarios/filter_incomplete_turns_function_calling.yaml
+++ b/scripts/release-evals/scenarios/filter_incomplete_turns_function_calling.yaml
@@ -1,0 +1,42 @@
+name: filter_incomplete_turns_function_calling
+
+# Audio modality. Like filter_incomplete_turns, but the completed thought is a
+# weather question that requires a tool call. The user trails off mid-question
+# ("What's the weather in... hmmmm") and finishes it after a pause; the bot's
+# incomplete-turn detection must hold the turn open and call get_current_weather
+# only once the location is actually given.
+#
+# The completion turn is anchored on the raw VAD stop signal
+# (vad_user_stopped_speaking): the turn-level user_stopped_speaking is deferred
+# while the turn is held open, but the VAD signal still fires on the pause.
+
+user: !include user_audio.yaml
+
+judge: !include judge_audio.yaml
+
+turns:
+  # Wait for the bot's on-connect greeting before speaking.
+  - expect:
+      - event: response
+        eval: "the bot opens the conversation in some way (a greeting, an introduction, or an offer to help)"
+
+  # The user trails off mid-question. VAD detects the pause, but the bot should
+  # mark the turn incomplete and not call the tool yet (the location is missing).
+  - user: "What's the weather in... hmmm"
+    expect:
+      - event: vad_user_stopped_speaking
+
+  # ~3s later (under the 5s incomplete-short timeout), the user supplies the
+  # location. Now the turn completes and the bot calls the weather tool.
+  - user: "in Los Angeles, California?"
+    send_after:
+      event: vad_user_stopped_speaking
+      delay_ms: 3000
+    expect:
+      # Name only: the stub ignores location and the LLM phrases it
+      # unpredictably, so asserting args would be flaky.
+      - event: function_call
+        calls:
+          - name: get_current_weather
+      - event: response
+        eval: "the response reports the current weather for Los Angeles, mentioning the city and its conditions or temperature"

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -18,20 +18,22 @@ models (:mod:`pipecat.processors.frameworks.rtvi.models`) and translates the
 RTVI server messages it receives back into a small set of friendly event names
 the scenario files assert on:
 
-==========================  ==============================================
-scenario ``event:``         RTVI server message(s)
-==========================  ==============================================
-``user_started_speaking``   ``user-started-speaking``
-``user_stopped_speaking``   ``user-stopped-speaking``
-``user_transcription``      ``user-transcription`` (final only)
-``llm_started``             ``bot-llm-started``
-``llm_response``            the LLM text: ``bot-llm-text`` joined at ``bot-llm-stopped``
-``tts_response``            the TTS's spoken text: one segment per ``bot-tts-text``
-                            (audio modality only)
-``response``                local-STT transcription of the bot's actual audio
-                            (audio modality only); ``llm_response`` in text modality
-``function_call``           ``llm-function-call-in-progress``
-==========================  ==============================================
+==========================      ==============================================
+scenario ``event:``             RTVI server message(s)
+==========================      ==============================================
+``user_started_speaking``       ``user-started-speaking``
+``user_stopped_speaking``       ``user-stopped-speaking``
+``vad_user_started_speaking``   ``vad-user-started-speaking`` (raw VAD, ungated by turn detection)
+``vad_user_stopped_speaking``   ``vad-user-stopped-speaking`` (raw VAD, ungated by turn detection)
+``user_transcription``          ``user-transcription`` (final only)
+``llm_started``                 ``bot-llm-started``
+``llm_response``                the LLM text: ``bot-llm-text`` joined at ``bot-llm-stopped``
+``tts_response``                the TTS's spoken text: one segment per ``bot-tts-text``
+                                (audio modality only)
+``response``                    local-STT transcription of the bot's actual audio
+                                (audio modality only); ``llm_response`` in text modality
+``function_call``               ``llm-function-call-in-progress``
+==========================      ==============================================
 
 Matching semantics: expected events must appear in the specified order, but
 unmatched events may appear between them (so a scenario doesn't have to
@@ -595,6 +597,21 @@ class EvalSession:
                         needs_name = True
         return "name" if needs_name else None
 
+    def _needs_vad_events(self) -> bool:
+        """Whether the scenario references raw VAD speaking events.
+
+        These (``vad_user_started_speaking`` / ``vad_user_stopped_speaking``) are
+        off by default; the harness asks the bot's RTVIObserver to emit them only
+        when a scenario asserts on or schedules from them.
+        """
+        vad_events = {"vad_user_started_speaking", "vad_user_stopped_speaking"}
+        for turn in self._scenario.turns:
+            if turn.send_after is not None and turn.send_after.event in vad_events:
+                return True
+            if any(exp.event in vad_events for exp in turn.expect):
+                return True
+        return False
+
     async def _handshake(self) -> None:
         """Send client-ready, wait for bot-ready, then optionally seed context.
 
@@ -618,18 +635,23 @@ class EvalSession:
         # Hard gate — raises TimeoutError if the bot never announces readiness.
         await self._wait_for_event("bot_ready", BOT_READY_TIMEOUT_S)
 
-        # If the scenario asserts on function-call name/args, ask the bot's
-        # RTVIObserver to report them for the duration of this eval. Bots keep
-        # the secure NONE default; only the eval transport understands this.
+        # Ask the bot's RTVIObserver to expose what this scenario needs, for the
+        # duration of this eval only (bots keep their defaults; only the eval
+        # transport understands this): raise the function-call report level if it
+        # asserts on call name/args, and enable raw VAD speaking events if it uses
+        # them.
         level = self._required_report_level()
-        if level is not None:
+        vad = self._needs_vad_events()
+        if level is not None or vad:
+            config: dict = {}
+            if level is not None:
+                config["function_call_report_level"] = {"*": level}
+            if vad:
+                config["vad_user_speaking"] = True
             configure = RTVI.Message(
                 type="client-message",
                 id=self._message_id(),
-                data={
-                    "t": EVAL_CONFIGURE_MESSAGE_TYPE,
-                    "d": {"function_call_report_level": {"*": level}},
-                },
+                data={"t": EVAL_CONFIGURE_MESSAGE_TYPE, "d": config},
             )
             await self._send(configure)
 
@@ -781,6 +803,10 @@ class EvalSession:
                 return [{"type": "bot_interrupted"}]
             case "user-stopped-speaking":
                 return [{"type": "user_stopped_speaking"}]
+            case "vad-user-started-speaking":
+                return [{"type": "vad_user_started_speaking"}]
+            case "vad-user-stopped-speaking":
+                return [{"type": "vad_user_stopped_speaking"}]
             case "user-transcription":
                 if data.get("final"):
                     return [{"type": "user_transcription", "transcript": data.get("text", "")}]

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -22,9 +22,11 @@ the bot's eval transport over RTVI, drives each turn, collects the RTVI events
 the bot emits, and asserts on them in order.
 
 Event names are the friendly names the harness maps RTVI server messages onto:
-``user_started_speaking``, ``user_stopped_speaking``, ``user_transcription``,
-``llm_started``, ``response``, ``llm_response``, ``tts_response``,
-``function_call``.
+``user_started_speaking``, ``user_stopped_speaking``, ``vad_user_started_speaking``,
+``vad_user_stopped_speaking``, ``user_transcription``, ``llm_started``, ``response``,
+``llm_response``, ``tts_response``, ``function_call``. The ``vad_*`` events are the raw
+VAD signal, useful as a timing anchor when a turn-detection strategy gates or defers the
+turn-level ``user_stopped_speaking`` (e.g. filtering incomplete turns).
 
 The bot's reply can be asserted three ways:
     response       the transcription of the bot's *actual synthesized audio* (a

--- a/src/pipecat/evals/serializer.py
+++ b/src/pipecat/evals/serializer.py
@@ -239,9 +239,16 @@ class RTVIEvalSerializer(FrameSerializer):
         if not isinstance(data, dict) or data.get("t") != EVAL_CONFIGURE_MESSAGE_TYPE:
             return None
         payload = data.get("d") or {}
-        levels = payload.get("function_call_report_level") if isinstance(payload, dict) else None
+        if not isinstance(payload, dict):
+            payload = {}
+        levels = payload.get("function_call_report_level")
         report_level = None
         if isinstance(levels, dict):
             # Values arrive as strings ("none"/"name"/"full"); coerce to the enum.
             report_level = {k: RTVIFunctionCallReportLevel(v) for k, v in levels.items()}
-        return RTVIConfigureObserverFrame(function_call_report_level=report_level)
+        vad = payload.get("vad_user_speaking")
+        vad_user_speaking_enabled = bool(vad) if vad is not None else None
+        return RTVIConfigureObserverFrame(
+            function_call_report_level=report_level,
+            vad_user_speaking_enabled=vad_user_speaking_enabled,
+        )

--- a/src/pipecat/processors/frameworks/rtvi/frames.py
+++ b/src/pipecat/processors/frameworks/rtvi/frames.py
@@ -84,13 +84,19 @@ class RTVIConfigureObserverFrame(SystemFrame):
         function_call_report_level: Per-function report-level map to apply to the
             observer (e.g. ``{"*": RTVIFunctionCallReportLevel.FULL}``), or
             ``None`` to leave it unchanged.
+        vad_user_speaking_enabled: Whether the observer should emit raw VAD user
+            started/stopped speaking messages, or ``None`` to leave it unchanged.
     """
 
     function_call_report_level: dict[str, RTVIFunctionCallReportLevel] | None = None
+    vad_user_speaking_enabled: bool | None = None
 
     def __str__(self):
         """String representation of the observer-config frame."""
-        return f"{self.name}(function_call_report_level: {self.function_call_report_level})"
+        return (
+            f"{self.name}(function_call_report_level: {self.function_call_report_level}, "
+            f"vad_user_speaking_enabled: {self.vad_user_speaking_enabled})"
+        )
 
 
 @dataclass

--- a/src/pipecat/processors/frameworks/rtvi/models.py
+++ b/src/pipecat/processors/frameworks/rtvi/models.py
@@ -537,6 +537,28 @@ class UserStoppedSpeakingMessage(BaseModel):
     type: Literal["user-stopped-speaking"] = "user-stopped-speaking"
 
 
+class VADUserStartedSpeakingMessage(BaseModel):
+    """Message indicating VAD detected the user started speaking.
+
+    Raw VAD signal, emitted independently of turn finalization (unlike
+    ``user-started-speaking``, which a turn strategy may gate or defer).
+    """
+
+    label: MessageLiteral = MESSAGE_LABEL
+    type: Literal["vad-user-started-speaking"] = "vad-user-started-speaking"
+
+
+class VADUserStoppedSpeakingMessage(BaseModel):
+    """Message indicating VAD detected the user stopped speaking.
+
+    Raw VAD signal, emitted independently of turn finalization (unlike
+    ``user-stopped-speaking``, which a turn strategy may gate or defer).
+    """
+
+    label: MessageLiteral = MESSAGE_LABEL
+    type: Literal["vad-user-stopped-speaking"] = "vad-user-stopped-speaking"
+
+
 class UserMuteStartedMessage(BaseModel):
     """Message indicating user has been muted."""
 

--- a/src/pipecat/processors/frameworks/rtvi/observer.py
+++ b/src/pipecat/processors/frameworks/rtvi/observer.py
@@ -373,6 +373,11 @@ class RTVIObserver(BaseObserver):
             logger.debug(
                 f"{self}: function_call_report_level set to {frame.function_call_report_level}"
             )
+        if frame.vad_user_speaking_enabled is not None:
+            self._params.vad_user_speaking_enabled = frame.vad_user_speaking_enabled
+            logger.debug(
+                f"{self}: vad_user_speaking_enabled set to {frame.vad_user_speaking_enabled}"
+            )
 
     async def _logger_sink(self, message):
         """Logger sink so we can send system logs to RTVI clients."""

--- a/src/pipecat/processors/frameworks/rtvi/observer.py
+++ b/src/pipecat/processors/frameworks/rtvi/observer.py
@@ -50,6 +50,8 @@ from pipecat.frames.frames import (
     UserMuteStoppedFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
 )
 from pipecat.metrics.metrics import (
     LLMUsageMetricsData,
@@ -104,6 +106,10 @@ class RTVIObserverParams:
         bot_audio_level_enabled: Indicates if bot's audio level messages should be sent.
         user_llm_enabled: Indicates if the user's LLM input messages should be sent.
         user_speaking_enabled: Indicates if the user's started/stopped speaking messages should be sent.
+        vad_user_speaking_enabled: Indicates if raw VAD user started/stopped speaking messages
+            should be sent. These reflect the VAD signal directly, independent of turn
+            finalization (unlike ``user_speaking_enabled``, which a turn strategy may gate or
+            defer). Off by default. Defaults to False.
         user_transcription_enabled: Indicates if user's transcription messages should be sent.
         user_audio_level_enabled: Indicates if user's audio level messages should be sent.
         metrics_enabled: Indicates if metrics messages should be sent.
@@ -161,6 +167,7 @@ class RTVIObserverParams:
     bot_audio_level_enabled: bool = False
     user_llm_enabled: bool = True
     user_speaking_enabled: bool = True
+    vad_user_speaking_enabled: bool = False
     user_mute_enabled: bool = True
     user_transcription_enabled: bool = True
     user_audio_level_enabled: bool = False
@@ -425,6 +432,11 @@ class RTVIObserver(BaseObserver):
         ):
             await self._handle_interruptions(frame)
         elif (
+            isinstance(frame, (VADUserStartedSpeakingFrame, VADUserStoppedSpeakingFrame))
+            and self._params.vad_user_speaking_enabled
+        ):
+            await self._handle_vad_speaking(frame)
+        elif (
             isinstance(frame, (UserMuteStartedFrame, UserMuteStoppedFrame))
             and self._params.user_mute_enabled
         ):
@@ -575,6 +587,17 @@ class RTVIObserver(BaseObserver):
             message = RTVI.UserStartedSpeakingMessage()
         elif isinstance(frame, UserStoppedSpeakingFrame):
             message = RTVI.UserStoppedSpeakingMessage()
+
+        if message:
+            await self.send_rtvi_message(message)
+
+    async def _handle_vad_speaking(self, frame: Frame):
+        """Emit raw VAD user started/stopped speaking messages."""
+        message = None
+        if isinstance(frame, VADUserStartedSpeakingFrame):
+            message = RTVI.VADUserStartedSpeakingMessage()
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            message = RTVI.VADUserStoppedSpeakingMessage()
 
         if message:
             await self.send_rtvi_message(message)

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -232,6 +232,10 @@ class SingleClientWebsocketServerInputTransport(BaseInputTransport):
                     await self.broadcast_frame(InputTransportMessageFrame, message=frame.message)
                 else:
                     await self.push_frame(frame)
+        except websockets.ConnectionClosed:
+            # The client closed the connection (clean or abrupt). Normal end of a
+            # session, not an error.
+            logger.debug(f"{self}: client disconnected while receiving")
         except Exception as e:
             logger.error(f"{self} exception receiving data: {e.__class__.__name__} ({e})")
 
@@ -420,6 +424,10 @@ class SingleClientWebsocketServerOutputTransport(BaseOutputTransport):
             payload = await self._params.serializer.serialize(frame)
             if payload and self._websocket:
                 await self._websocket.send(payload)
+        except websockets.ConnectionClosed:
+            # The client went away mid-send (a normal race on disconnect, e.g.
+            # while still streaming TTS audio). Not an error.
+            logger.debug(f"{self}: client disconnected while sending")
         except Exception as e:
             logger.error(f"{self} exception sending data: {e.__class__.__name__} ({e})")
 

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -268,6 +268,37 @@ class TestRequiredReportLevel(unittest.TestCase):
         )
 
 
+class TestNeedsVadEvents(unittest.TestCase):
+    """The harness enables raw VAD events only when a scenario references them."""
+
+    def _needs(self, turn: EvalTurn) -> bool:
+        scenario = EvalScenario(name="t", turns=[turn])
+        return EvalSession(scenario, "ws://localhost:0")._needs_vad_events()
+
+    def test_false_without_vad_events(self):
+        self.assertFalse(
+            self._needs(EvalTurn(user="x", expect=[EvalExpectation(event="response")]))
+        )
+
+    def test_true_when_expected(self):
+        self.assertTrue(
+            self._needs(
+                EvalTurn(user="x", expect=[EvalExpectation(event="vad_user_started_speaking")])
+            )
+        )
+
+    def test_true_when_used_as_send_after_anchor(self):
+        self.assertTrue(
+            self._needs(
+                EvalTurn(
+                    user="x",
+                    expect=[EvalExpectation(event="response")],
+                    send_after=EvalSendAfter(event="vad_user_stopped_speaking", delay_ms=2000),
+                )
+            )
+        )
+
+
 class TestConnectURL(unittest.TestCase):
     """The harness signals skip-TTS via the connect URL in text mode."""
 

--- a/tests/test_evals_serializer.py
+++ b/tests/test_evals_serializer.py
@@ -89,6 +89,22 @@ class TestRTVIEvalSerializerDeserialize(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(frame, RTVIConfigureObserverFrame)
         self.assertEqual(frame.function_call_report_level, {"*": RTVIFunctionCallReportLevel.FULL})
 
+    async def test_eval_configure_enables_vad_user_speaking(self):
+        msg = {
+            "label": RTVI.MESSAGE_LABEL,
+            "type": "client-message",
+            "id": "8",
+            "data": {
+                "t": EVAL_CONFIGURE_MESSAGE_TYPE,
+                "d": {"vad_user_speaking": True},
+            },
+        }
+        frame = await self.serializer.deserialize(json.dumps(msg))
+        self.assertIsInstance(frame, RTVIConfigureObserverFrame)
+        self.assertTrue(frame.vad_user_speaking_enabled)
+        # Unset report level stays None, so it isn't disturbed.
+        self.assertIsNone(frame.function_call_report_level)
+
     async def test_eval_image_stored_and_not_forwarded(self):
         img = b"\x89PNG-fake-bytes"
         msg = {

--- a/tests/test_rtvi_observer_config.py
+++ b/tests/test_rtvi_observer_config.py
@@ -46,6 +46,16 @@ class TestRTVIConfigureObserver(unittest.TestCase):
             RTVIFunctionCallReportLevel.NAME,
         )
 
+    def test_enables_vad_user_speaking_at_runtime(self):
+        # Off by default; a config frame enables raw VAD speaking events live.
+        observer = RTVIObserver(params=RTVIObserverParams())
+        self.assertFalse(observer._params.vad_user_speaking_enabled)
+        observer._apply_config(RTVIConfigureObserverFrame(vad_user_speaking_enabled=True))
+        self.assertTrue(observer._params.vad_user_speaking_enabled)
+        # A None field leaves it unchanged.
+        observer._apply_config(RTVIConfigureObserverFrame(vad_user_speaking_enabled=None))
+        self.assertTrue(observer._params.vad_user_speaking_enabled)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds raw VAD speaking events to the RTVI observer so eval scenarios can anchor timing on the VAD signal even when a turn-detection strategy gates the turn-level events, and uses them to add two incomplete-turn eval scenarios. Also fixes a noisy disconnect log in the websocket server transport.

## Why

`FilterIncompleteUserTurnStrategies` deliberately defers the turn-level `user-stopped-speaking` until the LLM confirms the turn is complete. That's the feature — but it means an eval can't anchor a follow-up turn on `user_stopped_speaking` after an incomplete utterance (it never fires). The raw VAD stop signal does fire on the pause, so exposing it gives scenarios a reliable anchor.

## Changes

### Raw VAD speaking events (RTVI)
- `RTVIObserver` emits `vad-user-started-speaking` / `vad-user-stopped-speaking` from `VADUserStartedSpeakingFrame` / `VADUserStoppedSpeakingFrame`, gated by a new `RTVIObserverParams.vad_user_speaking_enabled` (**off by default** — production RTVI traffic is unchanged; clients ignore unknown messages anyway).

### Eval harness integration
- Extended `RTVIConfigureObserverFrame` + the `eval-configure` message with a `vad_user_speaking` flag. The harness enables it **per-connection, only when a scenario references** `vad_user_started_speaking` / `vad_user_stopped_speaking` (in `expect:` or `send_after:`), mirroring how it raises the function-call report level. Bots keep their defaults.
- Harness maps the new RTVI messages to friendly events.

### Eval scenarios
- `filter_incomplete_turns` — user trails off ("Let me think about it…"), finishes after a pause; bot must hold the turn open and answer only the complete thought.
- `filter_incomplete_turns_function_calling` — same, but the completed thought is a weather question; bot must call `get_current_weather` only once the location is given. Both wired into the manifest.

### Unrelated fix
- `SingleClientWebsocketServerTransport` no longer logs a clean client disconnect (`ConnectionClosed`) as an ERROR on the send/receive paths — it's a normal end-of-session race, now logged at debug.

## Test plan

- 184 rtvi/evals tests pass; `ruff check` / `ruff format` clean.
- New tests: VAD config apply (observer), `eval-configure` VAD parse (serializer), VAD-event detection (harness).
- Both scenarios parse against the real schema and resolve to valid manifest runs.

## Notes

- No changelog: the evals framework is unreleased. The VAD RTVI events are additive and off by default. The websocket-disconnect change is a log-level fix.
- The websocket-disconnect fix is independent of the VAD work; happy to split it into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)