### PR TITLE
Fix DeepgramSageMakerSTTService crash on construction

### DIFF
--- a/changelog/4786.fixed.md
+++ b/changelog/4786.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` raising `TypeError` on construction. Its default settings still passed `vad_events`, which was removed from `DeepgramSTTService.Settings`, so the service (and the `voice-deepgram-sagemaker` example) crashed on instantiation.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -144,7 +144,6 @@ class DeepgramSageMakerSTTService(STTService):
             search=None,
             smart_format=False,
             utterance_end_ms=None,
-            vad_events=False,
         )
 
         # 2. Apply live_options overrides — only if settings not provided


### PR DESCRIPTION
## Summary

- Fixed `DeepgramSageMakerSTTService` raising `TypeError` on construction — even with defaults — because its default-settings builder still passed `vad_events`, which was removed from the base `DeepgramSTTService.Settings` when `vad_events` support was deprecated.
- `vad_events` is no longer a supported Deepgram option, so the stale argument is simply dropped.
- This also unbreaks the `examples/voice/voice-deepgram-sagemaker.py` example, which constructs the service with no `settings=`.

## Testing

- `DeepgramSageMakerSTTService(endpoint_name="x", region="us-east-1")` now constructs cleanly (previously raised `TypeError`).
- Confirmed `vad_events` is no longer a field on the resulting settings.

## Fixes

- Fixes #4784

🤖 Generated with [Claude Code](https://claude.com/claude-code)