### PR TITLE
docs(agents): document the behavioral eval framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ uv run pytest tests/test_name.py::test_function_name
 # Preview changelog
 uv run towncrier build --draft --version Unreleased
 
+# Run a behavioral eval scenario against a running bot (bot started with `-t eval`)
+pipecat eval run scenarios/<name>.yaml --bot-url ws://localhost:7860
+
+# Run the full release-eval suite (spawns bots from a manifest, runs scenarios in parallel)
+pipecat eval suite scripts/release-evals/manifest.yaml -p <bot-pattern> -s <scenario>
+
 # Lint and format check
 uv run ruff check
 uv run ruff format --check
@@ -204,4 +210,13 @@ When adding a new service:
 
 ## Testing
 
-Test utilities live in `src/pipecat/tests/utils.py`. Use `run_test()` to send frames through a pipeline and assert expected output frames in each direction. Use `SleepFrame(sleep=N)` to add delays between frames.
+**Unit tests.** Test utilities live in `src/pipecat/tests/utils.py`. Use `run_test()` to send frames through a pipeline and assert expected output frames in each direction. Use `SleepFrame(sleep=N)` to add delays between frames.
+
+**Behavioral evals.** `pipecat.evals` (`src/pipecat/evals/`) is a behavioral eval framework that drives a *real bot* end-to-end and asserts on its behavior — use it to confirm a feature works (interruptions, function calls, vision, multi-turn, transcription) rather than only checking frame plumbing. The harness connects to a bot's **eval transport** as an RTVI client, plays scripted user turns (synthesizing audio in audio mode), and checks each expectation (latency, `text_contains`, an expected `function_call`, or an LLM judge of the bot's reply).
+
+A scenario is a YAML file of `turns` with `expect:` assertions; scenarios are reusable across bots. To confirm a behavior while developing:
+
+1. Run the bot with its eval transport: `python bot.py -t eval --port 7860`
+2. Run a scenario against it: `pipecat eval run scenarios/<name>.yaml --bot-url ws://localhost:7860 -v`
+
+For many bots at once, `pipecat eval suite <manifest.yaml>` spawns each bot and runs its scenarios in parallel. Reusable scenarios and the pre-release validation manifest live in `scripts/release-evals/` — see its `README.md` for the full workflow (prerequisites: a local Ollama judge `gemma2:9b`, plus Kokoro/Moonshine for audio mode) and the `pipecat.evals.scenario` module docstring for the complete scenario file format.


### PR DESCRIPTION
Updates to the Pipecat framework's AGENTS.md, so that Claude and Codex can use evals for _our_ development on Pipecat.

## Summary

Adds guidance to `AGENTS.md` so coding agents (Claude, Codex) know they can use the `pipecat.evals` behavioral eval framework to drive a real bot end-to-end and confirm a feature's behavior — not just write frame-level unit tests.

- **Common Commands**: adds `pipecat eval run` (single scenario against a running bot) and `pipecat eval suite` (manifest-driven, parallel) entries.
- **Testing**: splits the section into "Unit tests" (existing `run_test()` guidance) and a new "Behavioral evals" subsection with the two-step dev loop (`python bot.py -t eval --port 7860` → `pipecat eval run ...`), pointing to `scripts/release-evals/README.md` and the `pipecat.evals.scenario` docstring for full detail.

Docs-only; points to the authoritative sources rather than duplicating the scenario schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)