### PR TITLE
fix: AWSBedrockLLMAdapter raises UnboundLocalError for image-before-text content (#4724)

### DIFF
--- a/changelog/4724.fixed.md
+++ b/changelog/4724.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AWSBedrockLLMAdapter` raising `UnboundLocalError` when a user message's content list places the image before the text (e.g. a `UserImageRawFrame` followed by a prompt). The reorder guard's `insert` call was incorrectly placed outside its `if` block, so image-first input would crash silently and drop the message.

--- a/changelog/4724.fixed.md
+++ b/changelog/4724.fixed.md
@@ -1,1 +1,0 @@
-- Fixed `AWSBedrockLLMAdapter` raising `UnboundLocalError` when a user message's content list places the image before the text (e.g. a `UserImageRawFrame` followed by a prompt). The reorder guard's `insert` call was incorrectly placed outside its `if` block, so image-first input would crash silently and drop the message.

--- a/changelog/4796.fixed.md
+++ b/changelog/4796.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AWSBedrockLLMAdapter` raising `UnboundLocalError` when a user message's content list places the image before the text (e.g. a `UserImageRawFrame` followed by a prompt).

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -333,7 +333,7 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
                 if img_idx > first_txt_idx:
                     # Move image before the first text
                     image_item = new_content.pop(img_idx)
-                new_content.insert(first_txt_idx, image_item)
+                    new_content.insert(first_txt_idx, image_item)
             return {"role": msg["role"], "content": new_content}
 
         return msg

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -1897,6 +1897,65 @@ class TestAWSBedrockGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(params["messages"][-1]["role"], "user")
         self.assertIn("toolResult", params["messages"][-1]["content"][0])
 
+    def test_image_before_text_does_not_raise_unbound_local_error(self):
+        """Regression test for issue #4724: image placed before text must not raise UnboundLocalError.
+
+        When a user message's content list places the image *before* the text (e.g. a
+        UserImageRawFrame followed by a prompt), _from_standard_message previously
+        raised ``UnboundLocalError: cannot access local variable 'image_item'``
+        because the ``new_content.insert(...)`` call was outside the
+        ``if img_idx > first_txt_idx:`` guard that assigns ``image_item``.
+        """
+        # Image appears FIRST (before text) — this is the failing shape from the issue.
+        message: LLMStandardMessage = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+                    },
+                },
+                {"type": "text", "text": "What do you see?"},
+            ],
+        }
+        context = LLMContext(messages=[message])
+
+        # Must not raise — previously threw UnboundLocalError.
+        params = self.adapter.get_llm_invocation_params(context)
+
+        user_msg = params["messages"][0]
+        self.assertEqual(user_msg["role"], "user")
+        content = user_msg["content"]
+        self.assertEqual(len(content), 2)
+        # Image was already first, so the adapter should leave it in place.
+        self.assertIn("image", content[0])
+        self.assertEqual(content[1]["text"], "What do you see?")
+
+    def test_image_after_text_reordered_to_first(self):
+        """Image placed after text is reordered to come before text (existing behaviour)."""
+        message: LLMStandardMessage = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What do you see?"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+                    },
+                },
+            ],
+        }
+        context = LLMContext(messages=[message])
+        params = self.adapter.get_llm_invocation_params(context)
+
+        user_msg = params["messages"][0]
+        content = user_msg["content"]
+        self.assertEqual(len(content), 2)
+        # Adapter should have moved the image before the text.
+        self.assertIn("image", content[0])
+        self.assertEqual(content[1]["text"], "What do you see?")
+
 
 class TestPerplexityGetLLMInvocationParams(unittest.TestCase):
     # Perplexity doesn't support the "developer" role, so PerplexityLLMService


### PR DESCRIPTION
## Summary

Fixes #4724.

`AWSBedrockLLMAdapter._from_standard_message` raised `UnboundLocalError: cannot access local variable 'image_item'` when a user message's content list placed the image **before** the text (a valid OpenAI shape, e.g. a `UserImageRawFrame` followed by a prompt). The error was caught silently by `_from_universal_context_messages`, which then returned empty `messages`, dropping the image and prompt from the Bedrock request.

**Root cause:** The `new_content.insert(first_txt_idx, image_item)` call at line 306 of `bedrock_adapter.py` was indented one level too shallow — it sat **outside** the `if img_idx > first_txt_idx:` guard that assigns `image_item`. When the image was already first (no reorder needed), the guard was skipped and `image_item` was never assigned, causing the `UnboundLocalError` on the subsequent `insert`.

**Fix:** Indent `new_content.insert(...)` into the `if` block so it only runs when a reorder is actually needed.

## Changes

- `src/pipecat/adapters/services/bedrock_adapter.py` — one-line indentation fix
- `tests/test_get_llm_invocation_params.py` — two new regression tests:
  - `test_image_before_text_does_not_raise_unbound_local_error` — the crash case
  - `test_image_after_text_reordered_to_first` — the existing reorder behaviour
- `changelog/4724.fixed.md` — changelog fragment

## Test plan

- [x] `uv run pytest tests/test_get_llm_invocation_params.py::TestAWSBedrockGetLLMInvocationParams -v` — all 14 tests pass (including 2 new)
- [x] Repro from issue confirmed fixed (no AWS credentials required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)