### PR TITLE
fix: GladiaSTTService silently ignores runtime settings updates (#4719)

### DIFF
--- a/changelog/4719.fixed.md
+++ b/changelog/4719.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GladiaSTTService` silently ignoring runtime settings updates. Settings are now applied by clearing the current session and triggering a safe reconnect via `_request_reconnect()`, which defers until after the current user turn if the user is speaking.

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -419,9 +419,13 @@ class GladiaSTTService(WebsocketSTTService):
         await self._connect()
 
     async def _update_settings(self, delta: Settings) -> dict[str, Any]:
-        """Apply settings delta.
+        """Apply settings delta and reconnect with new settings.
 
-        Settings are stored but not applied to the active session.
+        Clears the current Gladia session so that ``_connect()`` initialises a
+        fresh session (via ``POST /v2/live``) with the updated configuration,
+        then triggers a reconnect via the safe ``_request_reconnect()`` path,
+        which defers the reconnect until after the current user turn if the
+        user is speaking.
 
         Args:
             delta: A settings delta.
@@ -434,14 +438,9 @@ class GladiaSTTService(WebsocketSTTService):
         if not changed:
             return changed
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # self._session_url = None
-        # self._session_id = None
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        self._session_url = None
+        self._session_id = None
+        await self._request_reconnect()
 
         return changed
 

--- a/tests/test_gladia_stt.py
+++ b/tests/test_gladia_stt.py
@@ -28,18 +28,10 @@ async def test_update_settings_triggers_reconnect():
     service._settings = GladiaSTTService.Settings(model="solaria-1")
     service._session_url = "wss://fake-session.gladia.io/live/abc123"
     service._session_id = "abc123"
+    service._request_reconnect = AsyncMock()
 
-    reconnect_called = False
-
-    async def fake_request_reconnect():
-        nonlocal reconnect_called
-        reconnect_called = True
-
-    service._request_reconnect = fake_request_reconnect
-
-    with patch.object(
-        GladiaSTTService.__bases__[0],
-        "_update_settings",
+    with patch(
+        "pipecat.services.stt_service.STTService._update_settings",
         new_callable=AsyncMock,
         return_value={"model": "old-model"},
     ):
@@ -47,7 +39,7 @@ async def test_update_settings_triggers_reconnect():
 
     assert service._session_url is None, "session_url should be cleared on settings change"
     assert service._session_id is None, "session_id should be cleared on settings change"
-    assert reconnect_called, "_request_reconnect() should be called on settings change"
+    service._request_reconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -58,18 +50,10 @@ async def test_update_settings_no_reconnect_when_nothing_changed():
     service._settings = GladiaSTTService.Settings(model="solaria-1")
     service._session_url = "wss://fake-session.gladia.io/live/abc123"
     service._session_id = "abc123"
+    service._request_reconnect = AsyncMock()
 
-    reconnect_called = False
-
-    async def fake_request_reconnect():
-        nonlocal reconnect_called
-        reconnect_called = True
-
-    service._request_reconnect = fake_request_reconnect
-
-    with patch.object(
-        GladiaSTTService.__bases__[0],
-        "_update_settings",
+    with patch(
+        "pipecat.services.stt_service.STTService._update_settings",
         new_callable=AsyncMock,
         return_value={},  # empty dict → nothing changed
     ):
@@ -77,4 +61,4 @@ async def test_update_settings_no_reconnect_when_nothing_changed():
 
     assert service._session_url == "wss://fake-session.gladia.io/live/abc123"
     assert service._session_id == "abc123"
-    assert not reconnect_called, "_request_reconnect() should NOT be called when nothing changed"
+    service._request_reconnect.assert_not_awaited()

--- a/tests/test_gladia_stt.py
+++ b/tests/test_gladia_stt.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.services.gladia.stt import GladiaSTTService
+
+
+@pytest.mark.asyncio
+async def test_update_settings_triggers_reconnect():
+    """Regression test for issue #4719.
+
+    Runtime settings updates were silently ignored because _update_settings()
+    stored the new settings but never reconnected. Gladia bakes all config into
+    the session at POST /v2/live time, so a new session must be created for any
+    settings change to take effect.
+
+    After the fix, _update_settings() clears the session URL/ID and calls
+    _request_reconnect(), following the same pattern as DeepgramSTTService.
+    """
+    service = GladiaSTTService.__new__(GladiaSTTService)
+    service._name = "GladiaSTTService"
+    service._settings = GladiaSTTService.Settings(model="solaria-1")
+    service._session_url = "wss://fake-session.gladia.io/live/abc123"
+    service._session_id = "abc123"
+
+    reconnect_called = False
+
+    async def fake_request_reconnect():
+        nonlocal reconnect_called
+        reconnect_called = True
+
+    service._request_reconnect = fake_request_reconnect
+
+    with patch.object(
+        GladiaSTTService.__bases__[0],
+        "_update_settings",
+        new_callable=AsyncMock,
+        return_value={"model": "old-model"},
+    ):
+        await service._update_settings(GladiaSTTService.Settings(model="accurate"))
+
+    assert service._session_url is None, "session_url should be cleared on settings change"
+    assert service._session_id is None, "session_id should be cleared on settings change"
+    assert reconnect_called, "_request_reconnect() should be called on settings change"
+
+
+@pytest.mark.asyncio
+async def test_update_settings_no_reconnect_when_nothing_changed():
+    """When settings delta produces no change, _request_reconnect() must not be called."""
+    service = GladiaSTTService.__new__(GladiaSTTService)
+    service._name = "GladiaSTTService"
+    service._settings = GladiaSTTService.Settings(model="solaria-1")
+    service._session_url = "wss://fake-session.gladia.io/live/abc123"
+    service._session_id = "abc123"
+
+    reconnect_called = False
+
+    async def fake_request_reconnect():
+        nonlocal reconnect_called
+        reconnect_called = True
+
+    service._request_reconnect = fake_request_reconnect
+
+    with patch.object(
+        GladiaSTTService.__bases__[0],
+        "_update_settings",
+        new_callable=AsyncMock,
+        return_value={},  # empty dict → nothing changed
+    ):
+        await service._update_settings(GladiaSTTService.Settings(model="solaria-1"))
+
+    assert service._session_url == "wss://fake-session.gladia.io/live/abc123"
+    assert service._session_id == "abc123"
+    assert not reconnect_called, "_request_reconnect() should NOT be called when nothing changed"


### PR DESCRIPTION
## Summary

Fixes #4719.

`GladiaSTTService._update_settings()` was storing the settings delta in `self._settings` but never reconnecting, so any runtime settings change (language, model, VAD config, endpointing) sent via `STTUpdateSettingsFrame` had no effect on the live transcription session.

Gladia bakes all configuration into the session at `POST /v2/live` time and provides no mid-session update API, so a settings change requires creating a fresh session. The fix:

1. Clears `_session_url` and `_session_id` so `_connect()` will `POST /v2/live` with the updated settings on the next connection
2. Calls `_request_reconnect()` which safely defers the reconnect until after the current user turn if the user is speaking — matching the pattern already used by `DeepgramSTTService`

The existing TODO comment in the code described exactly this approach; this PR implements it.

## Changes

- `src/pipecat/services/gladia/stt.py` — replace TODO with the reconnect logic; update docstring
- `tests/test_gladia_stt.py` — two new unit tests:
  - `test_update_settings_triggers_reconnect` — verifies session is cleared and reconnect is requested on settings change
  - `test_update_settings_no_reconnect_when_nothing_changed` — verifies no reconnect when delta produces no change
- `changelog/4719.fixed.md` — changelog fragment

## Test plan

- [x] `uv run pytest tests/test_gladia_stt.py -v` — both tests pass