### PR TITLE
fix: DeepgramSageMaker STT/TTS silently ignored runtime settings updates (#4737, #4739)

### DIFF
--- a/changelog/4737.fixed.md
+++ b/changelog/4737.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerSTTService` silently ignoring runtime settings updates. Added `_do_reconnect()` so the base-class reconnect machinery can tear down and re-establish the BiDi session. Settings changes now call `_request_reconnect()`, which defers the reconnect safely until after the current user turn if the user is speaking.

--- a/changelog/4739.fixed.md
+++ b/changelog/4739.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSageMakerTTSService` silently ignoring runtime settings updates. Settings changes now trigger an immediate disconnect and reconnect so the updated query string (voice, model, sample rate) is submitted to the SageMaker endpoint on the new connection.

--- a/src/pipecat/services/deepgram/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/sagemaker/stt.py
@@ -209,8 +209,30 @@ class DeepgramSageMakerSTTService(STTService):
         """
         return True
 
+    async def _do_reconnect(self):
+        """Disconnect and reconnect to apply updated settings.
+
+        Called by ``STTService._reconnect()`` inside the reconnecting guard.
+        Tears down the current BiDi session and re-establishes it with the
+        updated query string built from ``self._settings``.
+        """
+        await self._disconnect()
+        await self._connect()
+
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
-        """Apply a settings delta and warn about unhandled changes."""
+        """Apply a settings delta and reconnect so the new query string takes effect.
+
+        All STT settings are baked into the SageMaker query string at connection
+        time, so any change requires a fresh connection. Uses
+        ``_request_reconnect()`` which defers the reconnect until after the
+        current user turn if the user is speaking.
+
+        Args:
+            delta: Settings delta to apply.
+
+        Returns:
+            Dict mapping changed field names to their previous values.
+        """
         changed = await super()._update_settings(delta)
 
         if not changed:
@@ -220,12 +242,7 @@ class DeepgramSageMakerSTTService(STTService):
         if isinstance(self._settings, self.Settings):
             self._settings._sync_extra_to_fields()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._request_reconnect()
 
         return changed
 

--- a/src/pipecat/services/deepgram/sagemaker/tts.py
+++ b/src/pipecat/services/deepgram/sagemaker/tts.py
@@ -217,10 +217,16 @@ class DeepgramSageMakerTTSService(TTSService):
             await self._call_event_handler("on_disconnected")
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
-        """Apply a settings delta and reconnect if necessary.
+        """Apply a settings delta and reconnect so the new query string takes effect.
 
-        Since all settings are part of the SageMaker session query string,
-        any setting change requires reconnecting to apply the new values.
+        All TTS settings (voice, model, sample rate) are baked into the query
+        string at connection time, so any change requires a fresh connection.
+
+        Args:
+            delta: Settings delta to apply.
+
+        Returns:
+            Dict mapping changed field names to their previous values.
         """
         changed = await super()._update_settings(delta)
 
@@ -232,12 +238,8 @@ class DeepgramSageMakerTTSService(TTSService):
             self._settings.model = self._settings.voice
             self._sync_model_name_to_metrics()
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # await self._disconnect()
-        # await self._connect()
-
-        self._warn_unhandled_updated_settings(changed)
+        await self._disconnect()
+        await self._connect()
 
         return changed
 

--- a/tests/test_deepgram_sagemaker.py
+++ b/tests/test_deepgram_sagemaker.py
@@ -1,0 +1,128 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pipecat.services.deepgram.sagemaker.stt import DeepgramSageMakerSTTService
+from pipecat.services.deepgram.sagemaker.tts import DeepgramSageMakerTTSService
+
+# ---------------------------------------------------------------------------
+# TTS — issue #4739
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tts_update_settings_triggers_reconnect():
+    """Regression test for issue #4739.
+
+    _update_settings() previously stored new settings but never reconnected,
+    so voice/model changes were silently ignored. All TTS settings are baked
+    into the SageMaker query string at connect time, so a fresh connection is
+    required for any change to take effect.
+    """
+    service = DeepgramSageMakerTTSService.__new__(DeepgramSageMakerTTSService)
+    service._name = "DeepgramSageMakerTTSService"
+    service._settings = DeepgramSageMakerTTSService.Settings(voice="aura-2-helena-en")
+    service._disconnect = AsyncMock()
+    service._connect = AsyncMock()
+    service._sync_model_name_to_metrics = MagicMock()
+
+    with patch(
+        "pipecat.services.tts_service.TTSService._update_settings",
+        new_callable=AsyncMock,
+        return_value={"voice": "aura-2-helena-en"},
+    ):
+        await service._update_settings(
+            DeepgramSageMakerTTSService.Settings(voice="aura-2-arcas-en")
+        )
+
+    service._disconnect.assert_awaited_once()
+    service._connect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tts_update_settings_no_reconnect_when_nothing_changed():
+    """No reconnect when the settings delta produces no change."""
+    service = DeepgramSageMakerTTSService.__new__(DeepgramSageMakerTTSService)
+    service._name = "DeepgramSageMakerTTSService"
+    service._settings = DeepgramSageMakerTTSService.Settings(voice="aura-2-helena-en")
+    service._disconnect = AsyncMock()
+    service._connect = AsyncMock()
+
+    with patch(
+        "pipecat.services.tts_service.TTSService._update_settings",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        await service._update_settings(
+            DeepgramSageMakerTTSService.Settings(voice="aura-2-helena-en")
+        )
+
+    service._disconnect.assert_not_awaited()
+    service._connect.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# STT — issue #4737
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stt_do_reconnect_calls_disconnect_then_connect():
+    """_do_reconnect() must disconnect then reconnect so STTService._reconnect()
+    can use it as the connection-reset hook."""
+    service = DeepgramSageMakerSTTService.__new__(DeepgramSageMakerSTTService)
+    service._name = "DeepgramSageMakerSTTService"
+    service._disconnect = AsyncMock()
+    service._connect = AsyncMock()
+
+    await service._do_reconnect()
+
+    service._disconnect.assert_awaited_once()
+    service._connect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stt_update_settings_triggers_reconnect():
+    """Regression test for issue #4737.
+
+    _update_settings() previously stored new settings but never reconnected.
+    After the fix, it calls _request_reconnect() which defers the reconnect
+    until after the current user turn when the user is speaking.
+    """
+    service = DeepgramSageMakerSTTService.__new__(DeepgramSageMakerSTTService)
+    service._name = "DeepgramSageMakerSTTService"
+    service._settings = DeepgramSageMakerSTTService.Settings(model="nova-3")
+    service._request_reconnect = AsyncMock()
+
+    with patch(
+        "pipecat.services.stt_service.STTService._update_settings",
+        new_callable=AsyncMock,
+        return_value={"model": "nova-3"},
+    ):
+        await service._update_settings(DeepgramSageMakerSTTService.Settings(model="nova-2"))
+
+    service._request_reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stt_update_settings_no_reconnect_when_nothing_changed():
+    """No reconnect when the settings delta produces no change."""
+    service = DeepgramSageMakerSTTService.__new__(DeepgramSageMakerSTTService)
+    service._name = "DeepgramSageMakerSTTService"
+    service._settings = DeepgramSageMakerSTTService.Settings(model="nova-3")
+    service._request_reconnect = AsyncMock()
+
+    with patch(
+        "pipecat.services.stt_service.STTService._update_settings",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        await service._update_settings(DeepgramSageMakerSTTService.Settings(model="nova-3"))
+
+    service._request_reconnect.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #4737. Fixes #4739.

Both `DeepgramSageMakerTTSService` and `DeepgramSageMakerSTTService` had TODO comments acknowledging that settings changes require a reconnect, but the reconnect was never implemented — so any runtime settings change (voice, model, language) was silently discarded.

### DeepgramSageMakerTTSService (#4739)

All TTS settings are baked into the SageMaker query string at `_connect()` time. Fix: call `_disconnect()` then `_connect()` immediately after any settings change so the updated query string is submitted to the endpoint.

### DeepgramSageMakerSTTService (#4737)

Same root cause. Additionally, because this service extends `STTService` directly (not `WebsocketSTTService`), it had no `_do_reconnect()` override, leaving the base-class reconnect machinery as a no-op. Fix: add `_do_reconnect()` that tears down and re-establishes the BiDi session, then call `_request_reconnect()` in `_update_settings()` — which safely defers the reconnect until after the current user turn if the user is speaking, consistent with `DeepgramSTTService`.

## Changes

- `src/pipecat/services/deepgram/sagemaker/tts.py` — replace TODO with `_disconnect()` + `_connect()`
- `src/pipecat/services/deepgram/sagemaker/stt.py` — add `_do_reconnect()` override; replace TODO with `_request_reconnect()`
- `tests/test_deepgram_sagemaker.py` — 5 new unit tests covering both services
- `changelog/4737.fixed.md`, `changelog/4739.fixed.md` — changelog fragments

## Test plan

- [x] `uv run pytest tests/test_deepgram_sagemaker.py -v` — all 5 tests pass
- [x] `uv run ruff check` — no lint errors