### PR TITLE
Make docs-sync workflow generic and auto-assign the docs PR

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -32,6 +32,17 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+          owner: pipecat-ai
+          repositories: |
+            pipecat
+            docs
+
       - name: Checkout pipecat
         uses: actions/checkout@v4
         with:
@@ -41,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: pipecat-ai/docs
-          token: ${{ secrets.DOCS_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: _docs
 
       - name: Resolve PR number
@@ -53,10 +64,35 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine assignee
+        id: assignee
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_AUTHOR=$(gh pr view ${{ steps.pr.outputs.number }} \
+            --repo pipecat-ai/pipecat --json author --jq '.author.login')
+
+          # Assign the PR author only if they're a maintainer (== member of the
+          # pipecat-ai org). Org members all have at least read access to the docs
+          # repo, so they're assignable there; the assignees probe guards against
+          # future access changes. Otherwise leave the PR unassigned for triage.
+          ASSIGNEE=""
+          if gh api "orgs/pipecat-ai/members/$PR_AUTHOR" --silent 2>/dev/null \
+            && gh api "repos/pipecat-ai/docs/assignees/$PR_AUTHOR" --silent 2>/dev/null; then
+            ASSIGNEE="$PR_AUTHOR"
+          fi
+
+          echo "login=$ASSIGNEE" >> "$GITHUB_OUTPUT"
+          if [ -n "$ASSIGNEE" ]; then
+            echo "Docs PR will be assigned to: $ASSIGNEE"
+          else
+            echo "PR author is not an org member; docs PR will be left unassigned."
+          fi
+
       - name: Update documentation
         uses: anthropics/claude-code-action@v1
         env:
-          DOCS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
+          DOCS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +147,7 @@ jobs:
             ```bash
             cd _docs
             git push -u origin docs/pr-${{ steps.pr.outputs.number }}
-            GH_TOKEN=$DOCS_SYNC_TOKEN gh pr create \
+            GH_TOKEN=$DOCS_TOKEN gh pr create \
               --repo pipecat-ai/docs \
               --label auto-docs \
               --label pipecat \
@@ -141,8 +177,28 @@ jobs:
             - Only modify files inside `./_docs/` — never modify pipecat source code
             - Follow the conservative editing rules from SKILL.md Step 6
             - Read each doc page fully before editing (SKILL.md Guidelines)
-            - Use `GH_TOKEN=$DOCS_SYNC_TOKEN` for all `gh` commands targeting pipecat-ai/docs
+            - Use `GH_TOKEN=$DOCS_TOKEN` for all `gh` commands targeting pipecat-ai/docs
           claude_args: |
             --model claude-sonnet-4-5-20250929
             --max-turns 30
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash"
+
+      - name: Assign docs PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ASSIGNEE="${{ steps.assignee.outputs.login }}"
+          if [ -z "$ASSIGNEE" ]; then
+            echo "No assignee resolved; leaving docs PR unassigned."
+            exit 0
+          fi
+          PR_URL=$(gh pr list --repo pipecat-ai/docs \
+            --head docs/pr-${{ steps.pr.outputs.number }} \
+            --state open --json url --jq '.[0].url')
+          if [ -z "$PR_URL" ]; then
+            echo "No open docs PR for branch docs/pr-${{ steps.pr.outputs.number }}; nothing to assign."
+            exit 0
+          fi
+          gh pr edit "$PR_URL" --add-assignee "$ASSIGNEE"
+          echo "Assigned $PR_URL to $ASSIGNEE"


### PR DESCRIPTION
Previously, the docs were created with a PAT from my Github user. This means I can't approve my own PRs. Instead, I've created a GitHub App to create for us.

The other improvement is to auto-assign to the PR author. It's left blank if the author is not a member of the pipecat-ai GitHub org.

## Summary

Updates `.github/workflows/update-docs.yml` so the auto-generated documentation PR is no longer tied to an individual's personal access token, and is assigned to the right person.

- **Generic identity:** mint a GitHub App installation token (`actions/create-github-app-token`) instead of a personal PAT. The app is installed on `pipecat-ai` and scoped to `pipecat` + `docs`, so a single token covers the docs checkout, PR creation, and the new assignment step. The synced docs PR is now opened by a bot identity rather than an individual.
- **Maintainer-aware assignment:** the docs PR is assigned to the source PR's author when they're a `pipecat-ai` org member (and assignable on the docs repo); otherwise it's left unassigned for triage.

## Required secrets

Two repository secrets must exist on `pipecat-ai/pipecat` (Settings → Secrets and variables → Actions):

- `DOCS_BOT_APP_ID` — the GitHub App's numeric App ID
- `DOCS_BOT_PRIVATE_KEY` — the full contents of the App's generated `.pem`

The old `DOCS_SYNC_TOKEN` secret is no longer referenced and can be removed (and its PAT revoked) once a real run is verified.

## Testing

- Validated the workflow YAML parses cleanly.
- Recommend a `workflow_dispatch` run against a recent merged PR to confirm the app token has the access it needs (cross-repo push + org member read) before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)