### PR TITLE
Add mode (latency/accuracy preset) param to AssemblyAI STT

### DIFF
--- a/changelog/4810.added.md
+++ b/changelog/4810.added.md
@@ -1,0 +1,1 @@
+- Added a `mode` streaming parameter to `AssemblyAISTTService`, exposing AssemblyAI's U3 Pro latency/accuracy preset (`min_latency`, `balanced`, or `max_accuracy`). It trades transcription accuracy against turn-finalization latency and is only applicable to U3 Pro models, where the server defaults to `balanced`.

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -159,6 +159,11 @@ class AssemblyAISTTSettings(STTSettings):
             Float in [0.0, 1.0]; higher values suppress more. Only takes effect
             when ``voice_focus`` is set. Only applicable to U3 Pro models.
             Defaults to None (use the server default).
+        mode: Latency/accuracy preset, trading transcription accuracy against
+            turn-finalization latency. One of "min_latency", "balanced", or
+            "max_accuracy". Only applicable to U3 Pro models; the server defaults
+            to "balanced" and rejects this parameter for other models. Defaults
+            to None (not sent).
     """
 
     formatted_finals: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -185,6 +190,9 @@ class AssemblyAISTTSettings(STTSettings):
         default_factory=lambda: NOT_GIVEN
     )
     voice_focus_threshold: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    mode: Literal["min_latency", "balanced", "max_accuracy"] | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
 
 
 class AssemblyAISTTService(WebsocketSTTService):
@@ -290,6 +298,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             previous_context_n_turns=None,
             voice_focus=None,
             voice_focus_threshold=None,
+            mode=None,
         )
 
         # 2. Apply direct init arg overrides (deprecated)
@@ -399,6 +408,14 @@ class AssemblyAISTTService(WebsocketSTTService):
             logger.warning(
                 "voice_focus_threshold has no effect unless voice_focus is set "
                 "(to 'near-field' or 'far-field')."
+            )
+
+        # mode (latency/accuracy preset) is U3 Pro-only; the server rejects it
+        # for other models.
+        if not is_u3_pro and default_settings.mode is not None:
+            logger.warning(
+                "mode is only supported by U3 Pro models and will be ignored "
+                f"for model '{default_settings.model}'."
             )
 
         # 6. Configure pipecat turn mode (mutates default_settings)
@@ -630,14 +647,15 @@ class AssemblyAISTTService(WebsocketSTTService):
         }
 
         # continuous_partials, interruption_delay, agent_context,
-        # previous_context_n_turns, and voice_focus(_threshold) only apply to
-        # the U3 Pro family.
+        # previous_context_n_turns, voice_focus(_threshold), and mode only apply
+        # to the U3 Pro family.
         if is_u3_pro_model(s.model):
             optional_fields["continuous_partials"] = s.continuous_partials
             optional_fields["interruption_delay"] = s.interruption_delay
             optional_fields["previous_context_n_turns"] = s.previous_context_n_turns
             optional_fields["voice_focus"] = s.voice_focus
             optional_fields["voice_focus_threshold"] = s.voice_focus_threshold
+            optional_fields["mode"] = s.mode
             # isinstance narrows away None/NOT_GIVEN for the typed clip call.
             if isinstance(s.agent_context, str):
                 optional_fields["agent_context"] = self._clip_agent_context(s.agent_context)

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -352,6 +352,51 @@ def test_voice_focus_threshold_out_of_range_raises(value):
         )
 
 
+# --- mode (latency/accuracy preset) ---
+
+
+def test_mode_omitted_by_default():
+    service = AssemblyAISTTService(api_key="test-key")
+    assert "mode" not in _query(service)
+
+
+def test_mode_sent_for_u3_rt_pro():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(mode="max_accuracy"),
+    )
+    assert _query(service)["mode"] == ["max_accuracy"]
+
+
+def test_mode_sent_for_universal_3_5_pro():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(model="universal-3-5-pro", mode="min_latency"),
+    )
+    assert _query(service)["mode"] == ["min_latency"]
+
+
+def test_mode_omitted_for_universal_streaming():
+    # mode is a U3 Pro-only parameter.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(
+            model="universal-streaming-english",
+            mode="max_accuracy",
+        ),
+    )
+    assert "mode" not in _query(service)
+
+
+@pytest.mark.parametrize("value", ["min_latency", "balanced", "max_accuracy"])
+def test_mode_values_accepted(value):
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(mode=value),
+    )
+    assert _query(service)["mode"] == [value]
+
+
 # --- update_agent_context() ---
 
 


### PR DESCRIPTION
## Description

Adds the `mode` streaming connection parameter to `AssemblyAISTTService`, exposing AssemblyAI's U3 Pro latency/accuracy preset.

`mode` is one of:
- `min_latency`
- `balanced` — AssemblyAI's server-side default
- `max_accuracy`

It trades transcription accuracy against turn-finalization latency. Like the other U3 Pro-only streaming params (`voice_focus`, `interruption_delay`, `previous_context_n_turns`, …), it is sent as a WebSocket query parameter only for U3 Pro family models (`u3-rt-pro*`, `universal-3-5-pro*`). The server rejects it for other models, so the plugin omits it and logs a warning when it is set on a non-U3-Pro model.

## Usage

```python
from pipecat.services.assemblyai.stt import AssemblyAISTTService

stt = AssemblyAISTTService(
    api_key=...,
    settings=AssemblyAISTTService.Settings(mode="max_accuracy"),
)
```

## Tests

Added unit tests in `tests/test_assemblyai_stt.py`: omitted by default, sent for `u3-rt-pro` and `universal-3-5-pro`, omitted for `universal-streaming-*`, and all three preset values accepted. The full test file passes (58 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)