### PR TITLE
Log eval failure reasons to the eval log file

### DIFF
--- a/changelog/4811.fixed.md
+++ b/changelog/4811.fixed.md
@@ -1,0 +1,1 @@
+- Fixed eval failure reasons (a missing function call, a response timeout, an unsatisfied `eval:`, or a `send_after` that never fired) not being written to the per-scenario `.eval.log` file. They were only printed to the terminal during the run, so there was no record to debug failures after the fact.

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -1107,6 +1107,7 @@ class EvalSession:
                 # make; it completes only when all are found, in any order (a
                 # response arriving doesn't short-circuit it).
                 return await self._match_function_calls(expectation, deadline, turn_idx, exp_idx)
+            self._debug(f"match: waiting for {expectation.event!r}")
             event = await self._next_matching_event(expectation.event, deadline)
             payload_failure = self._check_payload(event, expectation, turn_idx, exp_idx)
             if payload_failure:
@@ -1139,8 +1140,7 @@ class EvalSession:
                 event = await self._next_matching_event(expectation.event, deadline)
             except TimeoutError:
                 if not seen_any:
-                    self._debug(f"match: timeout, no {expectation.event!r} event arrived")
-                    raise  # no response at all → "no matching event arrived"
+                    raise  # no response at all → caller logs "no matching event arrived"
                 self._debug(f"eval: timeout, not satisfied: {last_reason}")
                 return fail(f"not satisfied within {budget_ms}ms: {last_reason}")
 
@@ -1201,8 +1201,16 @@ class EvalSession:
         def fail(reason: str) -> EvalAssertionFailure:
             return EvalAssertionFailure(turn_idx, exp_idx, expectation.event, reason)
 
+        def spec_sig(spec) -> str:
+            name = spec.name or "any function"
+            if not spec.args:
+                return name
+            args = ", ".join(f"{k}={v!r}" for k, v in spec.args.items())
+            return f"{name}({args})"
+
         matched: list[str] = []
         for spec in expectation.calls or []:
+            self._debug(f"match: waiting for {expectation.event!r} ({spec_sig(spec)})")
             try:
                 event = await self._next_function_call(spec.name, deadline)
             except TimeoutError:

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -906,6 +906,7 @@ class EvalSession:
                         reason=f"send_after never fired: {e}",
                     )
                 )
+                self._debug(f"FAIL: {turn.send_after.event}: {failures[-1].reason}")
                 self._progress(
                     EvalTurnProgress(
                         turn_idx, -1, turn.send_after.event, "timeout", failures[-1].reason
@@ -953,6 +954,7 @@ class EvalSession:
                         reason=reason,
                     )
                 )
+                self._debug(f"FAIL: {expectation.event}: {reason}")
                 self._progress(
                     EvalTurnProgress(turn_idx, exp_idx, expectation.event, "timeout", reason)
                 )
@@ -960,6 +962,7 @@ class EvalSession:
 
             if failure:
                 failures.append(failure)
+                self._debug(f"FAIL: {expectation.event}: {failure.reason}")
                 self._progress(
                     EvalTurnProgress(turn_idx, exp_idx, expectation.event, "failed", failure.reason)
                 )
@@ -1127,7 +1130,7 @@ class EvalSession:
             )
             if val is not None
         )
-        self._debug(f"match: aggregating {expectation.event!r} ({check})")
+        self._debug(f"match: waiting for {expectation.event!r} ({check})")
         aggregate = ""
         last_reason = ""
         seen_any = False


### PR DESCRIPTION
## Summary

Eval expectation failures (a missing function call, a response timeout, an unsatisfied `eval:`, or a `send_after` that never fired) were only sent to the `on_progress` callback and surfaced in the terminal. They were never written to the per-scenario `.eval.log` file, so once a run finished there was no record of *why* an expectation failed, which made after-the-fact debugging impossible.

This PR makes the eval log self-explanatory: it shows what each expectation is waiting for, then either the received events or a `FAIL:` line with the reason.

- Write each failure reason to the debug log so it lands in the `.eval.log` file (send_after timeout, expectation timeout, and returned assertion failures).
- Emit a `match: waiting for ...` line up front for every expectation type (single event, aggregating text, and function calls), so the log clearly states what is expected. The expected function call line includes its args, and each expected call is printed on its own line.
- Reword the matcher's pre-wait debug line from `match: aggregating ...` to `match: waiting for ...` (it is emitted before any event is received) and drop the now-redundant `match: timeout, no event arrived` line, since the caller already logs the `FAIL:` reason.

## Example log output

```
match: waiting for 'function_call' (get_current_weather(location='San Francisco'))
match: waiting for 'function_call' (this_function_does_not_exist)
FAIL: function_call: function call 'this_function_does_not_exist' not seen (matched: get_current_weather)
```

## Test plan

Run a scenario with an expectation that cannot be satisfied (e.g. a function call the bot will not make) and confirm the `match: waiting for ...` lines and the `FAIL:` reason now appear in the generated `<scenario>.eval.log` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)