### PR TITLE
Fix Silero VAD high-dimensional input errors

### DIFF
--- a/changelog/4808.fixed.md
+++ b/changelog/4808.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Silero VAD input validation for high-dimensional NumPy audio chunks.

--- a/src/pipecat/audio/vad/silero.py
+++ b/src/pipecat/audio/vad/silero.py
@@ -61,10 +61,11 @@ class SileroOnnxModel:
 
     def _validate_input(self, x, sr: int):
         """Validate and preprocess input audio data."""
-        if np.ndim(x) == 1:
+        input_dims = np.ndim(x)
+        if input_dims == 1:
             x = np.expand_dims(x, 0)
-        if np.ndim(x) > 2:
-            raise ValueError(f"Too many dimensions for input audio chunk {x.dim()}")
+        if input_dims > 2:
+            raise ValueError(f"Too many dimensions for input audio chunk {input_dims}")
 
         if sr not in self.sample_rates:
             raise ValueError(

--- a/tests/test_silero_vad.py
+++ b/tests/test_silero_vad.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Unit tests for Silero VAD."""
+
+import numpy as np
+import pytest
+
+from pipecat.audio.vad.silero import SileroOnnxModel
+
+
+def test_validate_input_rejects_high_dimensional_numpy_audio():
+    model = SileroOnnxModel.__new__(SileroOnnxModel)
+    model.sample_rates = [8000, 16000]
+
+    audio = np.zeros((1, 1, 512), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Too many dimensions for input audio chunk 3"):
+        model._validate_input(audio, 16000)


### PR DESCRIPTION
## Summary
- cache the NumPy input dimension count in Silero VAD validation
- raise the intended ValueError for high-dimensional NumPy audio chunks instead of calling the PyTorch-only dim() method
- add a focused regression test and changelog fragment for #4808

## Testing
- uv run pytest tests/test_silero_vad.py -q
- uv run pytest tests/test_silero_vad.py tests/test_vad_controller.py tests/test_vad_processor.py -q
- uv run ruff check src/pipecat/audio/vad/silero.py tests/test_silero_vad.py
- uv run ruff format --check src/pipecat/audio/vad/silero.py tests/test_silero_vad.py
- uv run python -m compileall -q src/pipecat/audio/vad/silero.py tests/test_silero_vad.py
- git diff --check

Fixes #4808
