### PR TITLE
fix(silero): use NumPy API in VAD input handling

### DIFF
--- a/changelog/4820.fixed.md
+++ b/changelog/4820.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SileroOnnxModel` raising a confusing `AttributeError` instead of a `ValueError` when given an input audio chunk with too many dimensions. The validation error message called `x.dim()` (a PyTorch method) on a NumPy array; it now uses `x.ndim` and surfaces the intended "Too many dimensions" message.

--- a/src/pipecat/audio/vad/silero.py
+++ b/src/pipecat/audio/vad/silero.py
@@ -64,7 +64,7 @@ class SileroOnnxModel:
         if np.ndim(x) == 1:
             x = np.expand_dims(x, 0)
         if np.ndim(x) > 2:
-            raise ValueError(f"Too many dimensions for input audio chunk {x.dim()}")
+            raise ValueError(f"Too many dimensions for input audio chunk {x.ndim}")
 
         if sr not in self.sample_rates:
             raise ValueError(
@@ -207,7 +207,7 @@ class SileroVADAnalyzer(VADAnalyzer):
         try:
             audio_int16 = np.frombuffer(buffer, np.int16)
             # Divide by 32768 because we have signed 16-bit data.
-            audio_float32 = np.frombuffer(audio_int16, dtype=np.int16).astype(np.float32) / 32768.0
+            audio_float32 = audio_int16.astype(np.float32) / 32768.0
             new_confidence = self._model(audio_float32, self.sample_rate)[0]
 
             # We need to reset the model from time to time because it doesn't

--- a/tests/test_silero_vad.py
+++ b/tests/test_silero_vad.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+
+import numpy as np
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+
+
+class TestSileroVAD(unittest.TestCase):
+    """Tests for the Silero VAD analyzer and its ONNX model wrapper."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Loading the ONNX model once is enough; it's reused across tests.
+        cls.analyzer = SileroVADAnalyzer(sample_rate=16000)
+        cls.analyzer.set_sample_rate(16000)
+        cls.model = cls.analyzer._model
+
+    def test_too_many_dimensions_raises_value_error(self):
+        """A >2-D input must raise a descriptive ValueError, not AttributeError.
+
+        The error message previously called ``x.dim()`` (a PyTorch method) on a
+        NumPy array, which raised ``AttributeError`` and masked the real error.
+        """
+        bad_input = np.zeros((1, 1, 512), dtype=np.float32)
+        with self.assertRaises(ValueError) as ctx:
+            self.model(bad_input, 16000)
+        # The dimension count should be interpolated into the message.
+        self.assertIn("3", str(ctx.exception))
+
+    def test_voice_confidence_silence(self):
+        """voice_confidence converts a raw int16 buffer and returns a valid score."""
+        silence = np.zeros(512, dtype=np.int16).tobytes()
+        confidence = float(np.ravel(self.analyzer.voice_confidence(silence))[0])
+        self.assertGreaterEqual(confidence, 0.0)
+        self.assertLessEqual(confidence, 1.0)
+        # Silence should not be confidently classified as speech.
+        self.assertLess(confidence, 0.5)
+
+    def test_voice_confidence_conversion_matches_expected(self):
+        """The int16->float32 conversion feeds the model the expected values.
+
+        Confirms the simplified single-conversion path (no redundant
+        ``np.frombuffer`` on an already-converted array) produces the same
+        normalized float32 samples the model is expected to receive.
+        """
+        samples = np.array([0, 16384, -32768, 32767], dtype=np.int16)
+        buffer = samples.tobytes()
+
+        captured = {}
+        original_model = self.analyzer._model
+
+        def capturing_model(audio_float32, sample_rate):
+            captured["audio"] = audio_float32
+            # Pad to a valid frame so the underlying model doesn't complain.
+            padded = np.zeros(512, dtype=np.float32)
+            return original_model(padded, sample_rate)
+
+        self.analyzer._model = capturing_model
+        try:
+            self.analyzer.voice_confidence(buffer)
+        finally:
+            self.analyzer._model = original_model
+
+        expected = samples.astype(np.float32) / 32768.0
+        np.testing.assert_array_equal(captured["audio"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**These changes are for correctness; there is no bug that impacts normal usage.**

- Issue 1: The issue would only arise if a >2-d input occurred, but not possible. So it's a fix to unreachable code.
- Issue 2: Is just a simplification. 

## Summary

Two NumPy-correctness fixes in `src/pipecat/audio/vad/silero.py`.

- **`_validate_input` raised the wrong exception on >2-D input.** The "too many dimensions" message interpolated `x.dim()` — a PyTorch-tensor method left over from the upstream silero-vad port. NumPy arrays have no `.dim()`, so the branch raised `AttributeError` and masked the intended `ValueError`. Switched to the `.ndim` property. This path is unreachable from Pipecat's own pipeline (`voice_confidence` always feeds a 1-D buffer); it only matters when `SileroOnnxModel` is used standalone with a malformed shape, where it now surfaces a useful error.
- **`voice_confidence` re-wrapped an already-converted array.** The second `np.frombuffer(audio_int16, ...)` reinterpreted an already-int16 `ndarray` as int16 again — a redundant no-op view that `.astype()` immediately copies over. Output is bit-for-bit identical; the simplified single-conversion form matches the idiom used by the other VAD/turn analyzers (`krisp_viva_vad.py`, `base_smart_turn.py`, etc.).

## Testing

`uv run pytest tests/test_silero_vad.py` — added tests covering:

- A >2-D input raises `ValueError` (with the dim count in the message), not `AttributeError`. Verified to fail on the pre-fix code.
- The int16→float32 conversion feeds the model the expected normalized values.
- End-to-end smoke: silence runs through the real ONNX model and returns a valid confidence in `[0, 1)`.

No runtime behavior change for bots: Fix 1 only changes an error-message path; Fix 2 produces identical output (verified bit-for-bit across the full int16 value space).

## Fixes

- Fixes #4808

🤖 Generated with [Claude Code](https://claude.com/claude-code)