### PR TITLE
feat(xai): align TTS services with xAI API and add word-level timestamps

### DIFF
--- a/changelog/4821.added.2.md
+++ b/changelog/4821.added.2.md
@@ -1,0 +1,1 @@
+- Added tunable parameters to the xAI TTS services: `speed`, `optimize_streaming_latency`, and `text_normalization` (plus `with_timestamps` on the WebSocket service). Set them via the service's `Settings`, e.g. `XAITTSService.Settings(speed=1.1)`.

--- a/changelog/4821.added.md
+++ b/changelog/4821.added.md
@@ -1,0 +1,1 @@
+- Added word-level timestamps to `XAITTSService`. When `with_timestamps` is enabled (now the default), xAI's per-character timing is converted into per-word `TTSTextFrame` objects, each carrying an accurate `pts`. Note that xAI delivers timestamps in coarse batches, so word frames are emitted in bursts; consumers should schedule off `pts` rather than arrival time.

--- a/changelog/4821.changed.md
+++ b/changelog/4821.changed.md
@@ -1,0 +1,1 @@
+- `XAITTSService` now cancels the current utterance on interruption by sending a `text.clear` message over the existing WebSocket, instead of disconnecting and reconnecting. This makes barge-in faster by avoiding a reconnect on every interruption.

--- a/changelog/4821.fixed.md
+++ b/changelog/4821.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `XAIHttpTTSService` omitting the `language` field when it was unset. xAI marks `language` as required, so it is now always sent, falling back to `"auto"` for language auto-detection.

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -19,7 +19,7 @@ See https://docs.x.ai/developers/rest-api-reference/inference/voice.
 import base64
 import json
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlencode
 
@@ -37,7 +37,7 @@ from pipecat.frames.frames import (
     TTSAudioRawFrame,
     TTSStoppedFrame,
 )
-from pipecat.services.settings import TTSSettings
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, assert_given
 from pipecat.services.tts_service import InterruptibleTTSService, TTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
@@ -86,9 +86,19 @@ def language_to_xai_language(language: Language) -> str:
 
 @dataclass
 class XAITTSSettings(TTSSettings):
-    """Settings for XAIHttpTTSService."""
+    """Settings for XAIHttpTTSService.
 
-    pass
+    Parameters:
+        speed: Speech speed multiplier from 0.7 to 1.5 (1.0 is normal).
+        optimize_streaming_latency: Latency optimization level (0, 1, or 2).
+        text_normalization: Whether to normalize text before synthesis.
+        with_timestamps: Whether to request character-level timing metadata.
+    """
+
+    speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    optimize_streaming_latency: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    text_normalization: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    with_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class XAIHttpTTSService(TTSService):
@@ -127,6 +137,10 @@ class XAIHttpTTSService(TTSService):
             model=None,
             voice="eve",
             language=Language.EN,
+            speed=None,
+            optimize_streaming_latency=None,
+            text_normalization=None,
+            with_timestamps=None,
         )
 
         if settings is not None:
@@ -193,7 +207,7 @@ class XAIHttpTTSService(TTSService):
             self._session = aiohttp.ClientSession()
             self._session_owner = True
 
-        payload = {
+        payload: dict[str, Any] = {
             "text": text,
             "voice_id": self._settings.voice,
             "output_format": {
@@ -202,6 +216,15 @@ class XAIHttpTTSService(TTSService):
             },
         }
         payload["language"] = str(self._settings.language) if self._settings.language else "auto"
+
+        if assert_given(self._settings.speed) is not None:
+            payload["speed"] = self._settings.speed
+        if assert_given(self._settings.optimize_streaming_latency) is not None:
+            payload["optimize_streaming_latency"] = self._settings.optimize_streaming_latency
+        if assert_given(self._settings.text_normalization) is not None:
+            payload["text_normalization"] = self._settings.text_normalization
+        if assert_given(self._settings.with_timestamps) is not None:
+            payload["with_timestamps"] = self._settings.with_timestamps
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",
@@ -240,9 +263,19 @@ class XAIHttpTTSService(TTSService):
 
 @dataclass
 class XAIWebsocketTTSSettings(TTSSettings):
-    """Settings for XAITTSService (WebSocket streaming)."""
+    """Settings for XAITTSService (WebSocket streaming).
 
-    pass
+    Parameters:
+        speed: Speech speed multiplier from 0.7 to 1.5 (1.0 is normal).
+        optimize_streaming_latency: Latency optimization level (0, 1, or 2).
+        text_normalization: Whether to normalize text before synthesis.
+        with_timestamps: Whether to request character-level timing metadata.
+    """
+
+    speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    optimize_streaming_latency: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    text_normalization: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    with_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class XAITTSService(InterruptibleTTSService):
@@ -290,6 +323,10 @@ class XAITTSService(InterruptibleTTSService):
             model=None,
             voice="eve",
             language=Language.EN,
+            speed=None,
+            optimize_streaming_latency=None,
+            text_normalization=None,
+            with_timestamps=None,
         )
 
         if settings is not None:
@@ -371,6 +408,15 @@ class XAITTSService(InterruptibleTTSService):
             "codec": self._codec,
             "sample_rate": self.sample_rate,
         }
+        if assert_given(self._settings.speed) is not None:
+            params["speed"] = self._settings.speed
+        if assert_given(self._settings.optimize_streaming_latency) is not None:
+            params["optimize_streaming_latency"] = self._settings.optimize_streaming_latency
+        # urlencode stringifies bools as "True"/"False"; xAI expects "true"/"false".
+        if assert_given(self._settings.text_normalization) is not None:
+            params["text_normalization"] = str(self._settings.text_normalization).lower()
+        if assert_given(self._settings.with_timestamps) is not None:
+            params["with_timestamps"] = str(self._settings.with_timestamps).lower()
         return f"{self._base_url}?{urlencode(params)}"
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -84,6 +84,56 @@ def language_to_xai_language(language: Language) -> str:
     return resolve_language(language, LANGUAGE_MAP, use_base_code=True)
 
 
+def _xai_word_times(
+    graph_chars: list[str],
+    graph_times: list[list[float]],
+    partial_word: str = "",
+    partial_word_start_time: float = 0.0,
+) -> tuple[list[tuple[str, float]], str, float]:
+    """Convert xAI character timings into ``(word, start_time)`` pairs.
+
+    When ``with_timestamps`` is enabled, each xAI ``audio.delta`` carries
+    per-character ``graph_chars`` (including spaces and punctuation) and
+    ``graph_times`` as ``[start, end]`` second pairs. The times are absolute
+    from the start of the utterance and continue across chunks, so they are
+    used as-is. Words are split on spaces, each assigned the start time of its
+    first character, and a word that straddles a chunk boundary is carried over
+    via ``partial_word``.
+
+    Returns:
+        ``(word_times, partial_word, partial_word_start_time)`` where the latter
+        two describe an unterminated trailing word for the next chunk to finish.
+    """
+    if len(graph_chars) != len(graph_times):
+        logger.error(
+            f"xAI timestamp length mismatch: chars={len(graph_chars)}, times={len(graph_times)}"
+        )
+        return ([], partial_word, partial_word_start_time)
+
+    words: list[str] = []
+    word_start_times: list[float] = []
+    current_word = partial_word
+    word_start_time: float | None = partial_word_start_time if partial_word else None
+
+    for char, times in zip(graph_chars, graph_times):
+        if char == " ":
+            if current_word:
+                words.append(current_word)
+                word_start_times.append(word_start_time or 0.0)
+                current_word = ""
+                word_start_time = None
+        else:
+            if word_start_time is None:
+                word_start_time = times[0]
+            current_word += char
+
+    return (
+        list(zip(words, word_start_times)),
+        current_word,
+        word_start_time if word_start_time is not None else 0.0,
+    )
+
+
 @dataclass
 class XAITTSSettings(TTSSettings):
     """Settings for XAIHttpTTSService.
@@ -92,13 +142,11 @@ class XAITTSSettings(TTSSettings):
         speed: Speech speed multiplier from 0.7 to 1.5 (1.0 is normal).
         optimize_streaming_latency: Latency optimization level (0, 1, or 2).
         text_normalization: Whether to normalize text before synthesis.
-        with_timestamps: Whether to request character-level timing metadata.
     """
 
     speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     optimize_streaming_latency: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     text_normalization: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
-    with_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class XAIHttpTTSService(TTSService):
@@ -140,7 +188,6 @@ class XAIHttpTTSService(TTSService):
             speed=None,
             optimize_streaming_latency=None,
             text_normalization=None,
-            with_timestamps=None,
         )
 
         if settings is not None:
@@ -223,8 +270,6 @@ class XAIHttpTTSService(TTSService):
             payload["optimize_streaming_latency"] = self._settings.optimize_streaming_latency
         if assert_given(self._settings.text_normalization) is not None:
             payload["text_normalization"] = self._settings.text_normalization
-        if assert_given(self._settings.with_timestamps) is not None:
-            payload["with_timestamps"] = self._settings.with_timestamps
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",
@@ -269,7 +314,8 @@ class XAIWebsocketTTSSettings(TTSSettings):
         speed: Speech speed multiplier from 0.7 to 1.5 (1.0 is normal).
         optimize_streaming_latency: Latency optimization level (0, 1, or 2).
         text_normalization: Whether to normalize text before synthesis.
-        with_timestamps: Whether to request character-level timing metadata.
+        with_timestamps: Whether to request character timings. When enabled, the
+            service converts them into per-word ``TTSTextFrame`` objects.
     """
 
     speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -288,7 +334,14 @@ class XAITTSService(WebsocketTTSService):
 
     Audio parameters (voice, language, codec, sample rate) are passed as query
     string parameters on the WebSocket URL; changing any of them at runtime
-    reconnects the WebSocket.
+    reconnects the WebSocket. With ``with_timestamps`` enabled, xAI's
+    per-character timings are converted into per-word ``TTSTextFrame`` objects.
+
+    Note that xAI delivers timestamps in batches that are decoupled from the
+    audio stream (a batch can cover several seconds of speech and arrive in one
+    message), so the word ``TTSTextFrame`` objects are pushed in bursts rather
+    than evenly spread across playback. Each frame still carries an accurate
+    ``pts``, so consumers should schedule off ``pts`` rather than arrival time.
     """
 
     Settings = XAIWebsocketTTSSettings
@@ -326,15 +379,22 @@ class XAITTSService(WebsocketTTSService):
             speed=None,
             optimize_streaming_latency=None,
             text_normalization=None,
-            with_timestamps=None,
+            with_timestamps=True,
         )
 
         if settings is not None:
             default_settings.apply_update(settings)
 
+        # With word timestamps enabled, per-word TTSTextFrames drive the text
+        # output, so suppress the base class's aggregated text frame. Without
+        # them, fall back to the normal aggregated-text behavior.
+        with_timestamps = bool(assert_given(default_settings.with_timestamps))
+
         super().__init__(
             push_start_frame=True,
             push_stop_frames=True,
+            push_text_frames=not with_timestamps,
+            append_trailing_space=True,
             sample_rate=sample_rate,
             settings=default_settings,
             **kwargs,
@@ -344,6 +404,15 @@ class XAITTSService(WebsocketTTSService):
         self._base_url = base_url
         self._codec = codec
         self._receive_task = None
+
+        self._timestamp_context_id: str | None = None
+        self._partial_word: str = ""
+        self._partial_word_start_time: float = 0.0
+
+    def _reset_timestamp_state(self):
+        self._timestamp_context_id = None
+        self._partial_word = ""
+        self._partial_word_start_time = 0.0
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics."""
@@ -465,7 +534,38 @@ class XAITTSService(WebsocketTTSService):
         await self.stop_all_metrics()
         if self._websocket and self._websocket.state is State.OPEN:
             await self._get_websocket().send(json.dumps({"type": "text.clear"}))
+        self._reset_timestamp_state()
         await super().on_audio_context_interrupted(context_id)
+
+    async def _close_audio_context(self, context_id: str):
+        """Mark a context finished: emit its stop frame and drop it."""
+        await self.append_to_audio_context(context_id, TTSStoppedFrame(context_id=context_id))
+        await self.remove_audio_context(context_id)
+
+    async def _handle_word_timestamps(self, msg: dict, context_id: str):
+        """Emit word-timestamp frames from an ``audio.delta`` timing payload."""
+        timestamps = msg.get("audio_timestamps")
+        if not timestamps:
+            return
+        graph_chars = timestamps.get("graph_chars")
+        graph_times = timestamps.get("graph_times")
+        if not graph_chars or not graph_times:
+            return
+
+        # A new utterance clears any word carried over from the previous one.
+        if context_id != self._timestamp_context_id:
+            self._reset_timestamp_state()
+            self._timestamp_context_id = context_id
+
+        word_times, self._partial_word, self._partial_word_start_time = _xai_word_times(
+            graph_chars,
+            graph_times,
+            self._partial_word,
+            self._partial_word_start_time,
+        )
+
+        if word_times:
+            await self.add_word_timestamps(word_times, context_id)
 
     async def _receive_messages(self):
         async for message in self._get_websocket():
@@ -483,33 +583,35 @@ class XAITTSService(WebsocketTTSService):
 
             if msg_type == "audio.delta":
                 audio_b64 = msg.get("delta")
-                if not audio_b64:
-                    continue
-                audio = base64.b64decode(audio_b64)
-                await self.stop_ttfb_metrics()
+                if audio_b64:
+                    await self.stop_ttfb_metrics()
                 if context_id:
-                    frame = TTSAudioRawFrame(
-                        audio=audio,
-                        sample_rate=self.sample_rate,
-                        num_channels=1,
-                        context_id=context_id,
-                    )
-                    await self.append_to_audio_context(context_id, frame)
+                    if audio_b64:
+                        frame = TTSAudioRawFrame(
+                            audio=base64.b64decode(audio_b64),
+                            sample_rate=self.sample_rate,
+                            num_channels=1,
+                            context_id=context_id,
+                        )
+                        await self.append_to_audio_context(context_id, frame)
+                    # Timestamps arrive in their own (sometimes audio-less) deltas.
+                    await self._handle_word_timestamps(msg, context_id)
             elif msg_type == "audio.done":
                 await self.stop_all_metrics()
                 if context_id:
-                    await self.append_to_audio_context(
-                        context_id, TTSStoppedFrame(context_id=context_id)
-                    )
-                    await self.remove_audio_context(context_id)
+                    # Flush a trailing word that had no terminating space.
+                    if self._timestamp_context_id == context_id and self._partial_word:
+                        await self.add_word_timestamps(
+                            [(self._partial_word, self._partial_word_start_time)], context_id
+                        )
+                    self._reset_timestamp_state()
+                    await self._close_audio_context(context_id)
             elif msg_type == "error":
                 await self.stop_all_metrics()
+                self._reset_timestamp_state()
                 error_detail = msg.get("message") or msg.get("error") or str(msg)
                 if context_id:
-                    await self.append_to_audio_context(
-                        context_id, TTSStoppedFrame(context_id=context_id)
-                    )
-                    await self.remove_audio_context(context_id)
+                    await self._close_audio_context(context_id)
                 await self.push_error(error_msg=f"xAI TTS error: {error_detail}")
             elif msg_type == "audio.clear":
                 logger.trace(f"{self}: xAI acknowledged audio clear")

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -38,7 +38,7 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
 )
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven, assert_given
-from pipecat.services.tts_service import InterruptibleTTSService, TTSService
+from pipecat.services.tts_service import TTSService, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
 
@@ -278,7 +278,7 @@ class XAIWebsocketTTSSettings(TTSSettings):
     with_timestamps: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
-class XAITTSService(InterruptibleTTSService):
+class XAITTSService(WebsocketTTSService):
     """xAI streaming text-to-speech service.
 
     Connects to xAI's WebSocket TTS endpoint and streams audio chunks back as
@@ -317,7 +317,7 @@ class XAITTSService(InterruptibleTTSService):
                 objects need no decoding downstream.
             settings: Runtime-updatable settings.
             **kwargs: Additional arguments passed to parent
-                ``InterruptibleTTSService``.
+                ``WebsocketTTSService``.
         """
         default_settings = self.Settings(
             model=None,
@@ -460,6 +460,13 @@ class XAITTSService(InterruptibleTTSService):
             return
         await self._get_websocket().send(json.dumps({"type": "text.done"}))
 
+    async def on_audio_context_interrupted(self, context_id: str):
+        """Cancel the current xAI utterance on barge-in without reconnecting."""
+        await self.stop_all_metrics()
+        if self._websocket and self._websocket.state is State.OPEN:
+            await self._get_websocket().send(json.dumps({"type": "text.clear"}))
+        await super().on_audio_context_interrupted(context_id)
+
     async def _receive_messages(self):
         async for message in self._get_websocket():
             if isinstance(message, bytes):
@@ -504,6 +511,8 @@ class XAITTSService(InterruptibleTTSService):
                     )
                     await self.remove_audio_context(context_id)
                 await self.push_error(error_msg=f"xAI TTS error: {error_detail}")
+            elif msg_type == "audio.clear":
+                logger.trace(f"{self}: xAI acknowledged audio clear")
             else:
                 logger.debug(f"{self}: unhandled xAI message type: {msg_type}")
 

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -201,8 +201,7 @@ class XAIHttpTTSService(TTSService):
                 "sample_rate": self.sample_rate,
             },
         }
-        if self._settings.language:
-            payload["language"] = str(self._settings.language)
+        payload["language"] = str(self._settings.language) if self._settings.language else "auto"
 
         headers = {
             "Authorization": f"Bearer {self._api_key}",
@@ -254,9 +253,9 @@ class XAITTSService(InterruptibleTTSService):
     messages and each utterance is terminated with ``text.done``. The server
     responds with ``audio.delta`` chunks followed by an ``audio.done`` message.
 
-    Audio parameters (voice, language, codec, sample rate, bit rate) are passed
-    as query string parameters on the WebSocket URL; changing any of them at
-    runtime reconnects the WebSocket.
+    Audio parameters (voice, language, codec, sample rate) are passed as query
+    string parameters on the WebSocket URL; changing any of them at runtime
+    reconnects the WebSocket.
     """
 
     Settings = XAIWebsocketTTSSettings

--- a/tests/test_xai_tts.py
+++ b/tests/test_xai_tts.py
@@ -34,6 +34,7 @@ from pipecat.services.xai.tts import (
     XAITTSService,
     XAITTSSettings,
     XAIWebsocketTTSSettings,
+    _xai_word_times,
 )
 from pipecat.tests.utils import run_test
 
@@ -172,7 +173,8 @@ async def test_run_xai_websocket_tts_success():
     assert "text.delta" in types_sent
     assert "text.done" in types_sent
     delta_msg = next(m for m in captured["messages"] if m.get("type") == "text.delta")
-    assert delta_msg["delta"] == "Hello from xAI."
+    # A trailing space is appended so consecutive sentence segments don't glue.
+    assert delta_msg["delta"] == "Hello from xAI. "
 
 
 @pytest.mark.asyncio
@@ -273,7 +275,6 @@ async def test_xai_http_settings_in_body(aiohttp_client):
                 speed=1.2,
                 optimize_streaming_latency=2,
                 text_normalization=True,
-                with_timestamps=True,
             ),
         )
 
@@ -285,7 +286,7 @@ async def test_xai_http_settings_in_body(aiohttp_client):
     assert body["speed"] == 1.2
     assert body["optimize_streaming_latency"] == 2
     assert body["text_normalization"] is True
-    assert body["with_timestamps"] is True
+    assert "with_timestamps" not in body
 
 
 @pytest.mark.asyncio
@@ -323,6 +324,137 @@ async def test_xai_websocket_audio_clear_handled():
         )
 
     assert not any(isinstance(frame, ErrorFrame) for frame in down_frames + up_frames)
+
+
+def test_xai_word_times_splits_and_carries_partials():
+    """Character timings convert to absolute word starts, carrying partials across chunks."""
+    # Chunk 1: "Hi there" — "there" has no terminating space, so it is partial.
+    chars = ["H", "i", " ", "t", "h", "e", "r", "e"]
+    times = [[i * 0.1, (i + 1) * 0.1] for i in range(len(chars))]
+    word_times, partial, partial_start = _xai_word_times(chars, times)
+    assert word_times == [("Hi", 0.0)]
+    assert partial == "there"
+    assert partial_start == pytest.approx(0.3)
+
+    # Chunk 2: "! ok" — finishes "there!" then starts a new partial "ok". xAI times
+    # are absolute across the utterance, so they are used as-is (no offset).
+    chars2 = ["!", " ", "o", "k"]
+    times2 = [[2.0, 2.05], [2.05, 2.1], [2.1, 2.15], [2.15, 2.2]]
+    word_times2, partial2, partial2_start = _xai_word_times(
+        chars2, times2, partial_word=partial, partial_word_start_time=partial_start
+    )
+    assert word_times2 == [("there!", pytest.approx(0.3))]
+    assert partial2 == "ok"
+    assert partial2_start == pytest.approx(2.1)
+
+
+def test_xai_word_times_length_mismatch_is_safe():
+    """A chars/times length mismatch yields no words and preserves the partial."""
+    word_times, partial, partial_start = _xai_word_times(
+        ["a", "b"], [[0.0, 0.1]], partial_word="x", partial_word_start_time=1.0
+    )
+    assert word_times == []
+    assert partial == "x"
+    assert partial_start == 1.0
+
+
+@pytest.mark.asyncio
+async def test_xai_websocket_emits_word_timestamps():
+    """With with_timestamps enabled, the WS service emits TTSTextFrames per word."""
+    audio_bytes = b"\x00\x01\x02\x03" * 1024
+    chars = list("Hello world")
+    times = [[i * 0.1, (i + 1) * 0.1] for i in range(len(chars))]
+
+    async def handler(ws):
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("type") == "text.done":
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "audio.delta",
+                                "delta": base64.b64encode(audio_bytes).decode("ascii"),
+                                "audio_timestamps": {"graph_chars": chars, "graph_times": times},
+                                "audio_duration": 1.1,
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "audio.done", "trace_id": "t"}))
+        except websockets.ConnectionClosed:
+            pass
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        host, port = next(iter(server.sockets)).getsockname()[:2]
+        base_url = f"ws://{host}:{port}/v1/tts"
+
+        tts_service = XAITTSService(
+            api_key="test-key",
+            base_url=base_url,
+            sample_rate=24000,
+            settings=XAIWebsocketTTSSettings(with_timestamps=True),
+        )
+
+        down_frames, _ = await run_test(
+            tts_service,
+            frames_to_send=[TTSSpeakFrame(text="Hello world"), _SleepAfterSpeak(0.3)],
+        )
+
+    words = [frame.text for frame in down_frames if isinstance(frame, TTSTextFrame)]
+    joined = "".join(words)
+    assert "Hello" in joined
+    assert "world" in joined
+
+
+@pytest.mark.asyncio
+async def test_xai_websocket_word_timestamps_from_audioless_delta():
+    """xAI sends timestamps in their own (audio-less) deltas; they must still emit words."""
+    audio_bytes = b"\x00\x01\x02\x03" * 1024
+    chars = list("Hi there")
+    times = [[i * 0.1, (i + 1) * 0.1] for i in range(len(chars))]
+
+    async def handler(ws):
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("type") == "text.done":
+                    # Audio arrives first with no timestamps...
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "audio.delta",
+                                "delta": base64.b64encode(audio_bytes).decode("ascii"),
+                            }
+                        )
+                    )
+                    # ...then timestamps arrive in a delta carrying no audio.
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "audio.delta",
+                                "delta": "",
+                                "audio_timestamps": {"graph_chars": chars, "graph_times": times},
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "audio.done", "trace_id": "t"}))
+        except websockets.ConnectionClosed:
+            pass
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        host, port = next(iter(server.sockets)).getsockname()[:2]
+        base_url = f"ws://{host}:{port}/v1/tts"
+
+        tts_service = XAITTSService(api_key="test-key", base_url=base_url, sample_rate=24000)
+
+        down_frames, _ = await run_test(
+            tts_service,
+            frames_to_send=[TTSSpeakFrame(text="Hi there"), _SleepAfterSpeak(0.3)],
+        )
+
+    joined = "".join(frame.text for frame in down_frames if isinstance(frame, TTSTextFrame))
+    assert "Hi" in joined
+    assert "there" in joined
 
 
 # Small helper imported lazily to avoid circular import in fixture-lite tests.

--- a/tests/test_xai_tts.py
+++ b/tests/test_xai_tts.py
@@ -10,6 +10,7 @@ import asyncio
 import base64
 import json
 import unittest
+from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import aiohttp
@@ -17,16 +18,23 @@ import pytest
 import websockets
 from aiohttp import web
 from websockets.asyncio.server import serve
+from websockets.protocol import State
 
 from pipecat.frames.frames import (
     AggregatedTextFrame,
+    ErrorFrame,
     TTSAudioRawFrame,
     TTSSpeakFrame,
     TTSStartedFrame,
     TTSStoppedFrame,
     TTSTextFrame,
 )
-from pipecat.services.xai.tts import XAIHttpTTSService, XAITTSService
+from pipecat.services.xai.tts import (
+    XAIHttpTTSService,
+    XAITTSService,
+    XAITTSSettings,
+    XAIWebsocketTTSSettings,
+)
 from pipecat.tests.utils import run_test
 
 
@@ -165,6 +173,156 @@ async def test_run_xai_websocket_tts_success():
     assert "text.done" in types_sent
     delta_msg = next(m for m in captured["messages"] if m.get("type") == "text.delta")
     assert delta_msg["delta"] == "Hello from xAI."
+
+
+@pytest.mark.asyncio
+async def test_xai_websocket_interruption_sends_text_clear():
+    """On barge-in the WS service cancels via text.clear and keeps the socket open."""
+    tts_service = XAITTSService(api_key="test-key", sample_rate=24000)
+
+    websocket = AsyncMock()
+    websocket.state = State.OPEN
+    tts_service._websocket = websocket
+
+    with (
+        patch.object(tts_service, "_connect", new=AsyncMock()) as connect_spy,
+        patch.object(tts_service, "_disconnect", new=AsyncMock()) as disconnect_spy,
+    ):
+        await tts_service.on_audio_context_interrupted("ctx-1")
+
+    sent = [json.loads(call.args[0]) for call in websocket.send.call_args_list]
+    assert {"type": "text.clear"} in sent
+    assert not connect_spy.called
+    assert not disconnect_spy.called
+
+
+@pytest.mark.asyncio
+async def test_xai_websocket_settings_in_url():
+    """Tunable settings appear as query params; booleans are lowercased for the URL."""
+    captured: dict = {"request_path": None}
+
+    async def handler(ws):
+        captured["request_path"] = ws.request.path
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("type") == "text.done":
+                    await ws.send(json.dumps({"type": "audio.done", "trace_id": "t"}))
+        except websockets.ConnectionClosed:
+            pass
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        host, port = next(iter(server.sockets)).getsockname()[:2]
+        base_url = f"ws://{host}:{port}/v1/tts"
+
+        tts_service = XAITTSService(
+            api_key="test-key",
+            base_url=base_url,
+            sample_rate=24000,
+            settings=XAIWebsocketTTSSettings(
+                speed=1.2,
+                optimize_streaming_latency=2,
+                text_normalization=True,
+                with_timestamps=False,
+            ),
+        )
+
+        await run_test(
+            tts_service,
+            frames_to_send=[TTSSpeakFrame(text="Hello from xAI."), _SleepAfterSpeak(0.3)],
+        )
+
+    query = parse_qs(urlparse(captured["request_path"]).query)
+    assert query["speed"] == ["1.2"]
+    assert query["optimize_streaming_latency"] == ["2"]
+    assert query["text_normalization"] == ["true"]
+    assert query["with_timestamps"] == ["false"]
+
+
+@pytest.mark.asyncio
+async def test_xai_http_settings_in_body(aiohttp_client):
+    """Tunable settings and language=auto appear in the HTTP request body."""
+    request_bodies = []
+
+    async def handler(request):
+        request_bodies.append(await request.json())
+
+        response = web.StreamResponse(
+            status=200,
+            reason="OK",
+            headers={"Content-Type": "audio/pcm"},
+        )
+        await response.prepare(request)
+        await response.write(b"\x00\x01\x02\x03" * 1024)
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/v1/tts", handler)
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/v1/tts"))
+
+    async with aiohttp.ClientSession() as session:
+        tts_service = XAIHttpTTSService(
+            api_key="test-key",
+            base_url=base_url,
+            aiohttp_session=session,
+            sample_rate=24000,
+            settings=XAITTSSettings(
+                language="auto",
+                speed=1.2,
+                optimize_streaming_latency=2,
+                text_normalization=True,
+                with_timestamps=True,
+            ),
+        )
+
+        await run_test(tts_service, frames_to_send=[TTSSpeakFrame(text="Hello from xAI.")])
+
+    assert len(request_bodies) == 1
+    body = request_bodies[0]
+    assert body["language"] == "auto"
+    assert body["speed"] == 1.2
+    assert body["optimize_streaming_latency"] == 2
+    assert body["text_normalization"] is True
+    assert body["with_timestamps"] is True
+
+
+@pytest.mark.asyncio
+async def test_xai_websocket_audio_clear_handled():
+    """A server audio.clear ack is handled without producing an error."""
+    audio_bytes = b"\x00\x01\x02\x03" * 1024
+
+    async def handler(ws):
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("type") == "text.done":
+                    await ws.send(json.dumps({"type": "audio.clear"}))
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "audio.delta",
+                                "delta": base64.b64encode(audio_bytes).decode("ascii"),
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "audio.done", "trace_id": "t"}))
+        except websockets.ConnectionClosed:
+            pass
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        host, port = next(iter(server.sockets)).getsockname()[:2]
+        base_url = f"ws://{host}:{port}/v1/tts"
+
+        tts_service = XAITTSService(api_key="test-key", base_url=base_url, sample_rate=24000)
+
+        down_frames, up_frames = await run_test(
+            tts_service,
+            frames_to_send=[TTSSpeakFrame(text="Hello from xAI."), _SleepAfterSpeak(0.3)],
+        )
+
+    assert not any(isinstance(frame, ErrorFrame) for frame in down_frames + up_frames)
 
 
 # Small helper imported lazily to avoid circular import in fixture-lite tests.


### PR DESCRIPTION
## Summary

Aligns the xAI TTS services (`src/pipecat/services/xai/tts.py`) with xAI's current TTS API, and adds word-level timestamp support to the streaming WebSocket service. Done as four reviewable commits.

## Changes

**Correctness fixes**
- HTTP `language` is now always sent (it's required by the API), falling back to xAI's documented `"auto"` when unset.
- Corrected the WS class docstring (it claimed `bit_rate` was a query param when it wasn't).

**Tunable params**
- Added `speed`, `optimize_streaming_latency`, `text_normalization`, and `with_timestamps` to the settings classes, wired into the HTTP payload and the WS URL (booleans lowercased for the query string).

**Interruption via `text.clear`**
- `XAITTSService` now extends `WebsocketTTSService` (matching Cartesia/Rime/ElevenLabs) instead of `InterruptibleTTSService`. On barge-in it sends `{"type": "text.clear"}` on the persistent socket instead of tearing down and reconnecting the WebSocket. Also acknowledges the server's `audio.clear` message.

**Word-level timestamps** (WS, on by default via `with_timestamps`)
- Converts xAI's per-character `graph_chars`/`graph_times` into per-word `TTSTextFrame`s.
- Handles xAI's actual delivery model: timestamps arrive in their own (sometimes audio-less) deltas, decoupled from the audio stream; character times are absolute across the utterance; partial words are carried across chunk boundaries.
- `push_text_frames` is derived from `with_timestamps` so per-word frames drive the text output (normal aggregated path when disabled).
- `append_trailing_space=True` keeps the sentence aggregator's separate segments from gluing (e.g. `"xAI."` + `"What"`), since xAI concatenates consecutive text deltas verbatim but preserves spaces it is given.
- `with_timestamps` is intentionally **not** exposed on the HTTP service: it switches that endpoint to a JSON envelope the streaming reader can't parse.

> Note: xAI delivers timestamps in coarse batches, so word frames are emitted in bursts; each frame still carries an accurate `pts` (documented on the class), so consumers should schedule off `pts` rather than arrival time.

## Behavior Changes

- `XAITTSService` now defaults to `with_timestamps=True`, so it emits per-word `TTSTextFrame`s (with `push_text_frames=False`) by default instead of the previous single aggregated text frame per utterance. Pass `settings=XAITTSService.Settings(with_timestamps=False)` to restore the old behavior.
- On interruption the WebSocket is no longer torn down and reconnected; the utterance is cancelled in place via `text.clear`.

## Testing

- `uv run pytest tests/test_xai_tts.py` — 10 tests passing (HTTP/WS happy paths, settings propagation, `text.clear` interruption, `audio.clear` handling, word-timestamp emission incl. audio-less delta).
- Verified the timestamp behavior against the live xAI API (absolute times, audio-less timestamp deltas, and that xAI preserves spaces in the text we send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
