### PR TITLE
fix(user_mute): tolerate double / orphan function-call result frames

### DIFF
--- a/changelog/4824.fixed.md
+++ b/changelog/4824.fixed.md
@@ -1,0 +1,7 @@
+- Fixed `FunctionCallUserMuteStrategy.process_frame` raising `KeyError` when the
+  same `FunctionCallResultFrame` / `FunctionCallCancelFrame` is delivered twice
+  (or once with no preceding `FunctionCallsStartedFrame`). In multi-worker bus
+  topologies a child worker can see the same result frame the parent already
+  handled, and the second delivery would tear down the frame loop. Switched the
+  removal to `set.discard`, which is identical in single-worker (id always
+  present → removed) and a silent no-op on absent ids.

--- a/changelog/4824.fixed.md
+++ b/changelog/4824.fixed.md
@@ -1,7 +1,1 @@
-- Fixed `FunctionCallUserMuteStrategy.process_frame` raising `KeyError` when the
-  same `FunctionCallResultFrame` / `FunctionCallCancelFrame` is delivered twice
-  (or once with no preceding `FunctionCallsStartedFrame`). In multi-worker bus
-  topologies a child worker can see the same result frame the parent already
-  handled, and the second delivery would tear down the frame loop. Switched the
-  removal to `set.discard`, which is identical in single-worker (id always
-  present → removed) and a silent no-op on absent ids.
+- Fixed `FunctionCallUserMuteStrategy` raising `KeyError` on a `FunctionCallResultFrame` / `FunctionCallCancelFrame` whose tool call id it was not tracking, which aborted the user aggregator's handling of that frame and surfaced an `ErrorFrame` to the application. Such frames arrive when the LLM invokes the built-in `cancel_async_tool_call` (excluded from `FunctionCallsStartedFrame`, but it still emits a result), when an async tool reports intermediate updates (a result frame per update, plus the final one), and when a bus bridge re-delivers a result another worker already handled. Untracked tool call ids are now ignored.

--- a/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
@@ -44,7 +44,14 @@ class FunctionCallUserMuteStrategy(BaseUserMuteStrategy):
         if isinstance(frame, FunctionCallsStartedFrame):
             await self._handle_function_calls_started(frame)
         elif isinstance(frame, (FunctionCallCancelFrame, FunctionCallResultFrame)):
-            self._function_call_in_progress.remove(frame.tool_call_id)
+            # ``discard`` (silent no-op on absent id) over ``remove`` (KeyError):
+            # in multi-worker bus topologies a child worker can see the same
+            # result frame twice (the bus bridge re-delivers a frame the
+            # downstream worker has already handled). ``remove`` would raise on
+            # the second delivery and tear down the frame loop. ``discard`` is
+            # identical in single-worker (id always present → removed) and
+            # robust everywhere else.
+            self._function_call_in_progress.discard(frame.tool_call_id)
 
         return bool(self._function_call_in_progress)
 

--- a/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/function_call_user_mute_strategy.py
@@ -44,13 +44,10 @@ class FunctionCallUserMuteStrategy(BaseUserMuteStrategy):
         if isinstance(frame, FunctionCallsStartedFrame):
             await self._handle_function_calls_started(frame)
         elif isinstance(frame, (FunctionCallCancelFrame, FunctionCallResultFrame)):
-            # ``discard`` (silent no-op on absent id) over ``remove`` (KeyError):
-            # in multi-worker bus topologies a child worker can see the same
-            # result frame twice (the bus bridge re-delivers a frame the
-            # downstream worker has already handled). ``remove`` would raise on
-            # the second delivery and tear down the frame loop. ``discard`` is
-            # identical in single-worker (id always present → removed) and
-            # robust everywhere else.
+            # Untracked ids reach here: cancel_async_tool_call is excluded from
+            # FunctionCallsStartedFrame yet still emits a result, async tools
+            # emit a result frame per intermediate update, and a bus bridge can
+            # re-deliver a result another worker already handled.
             self._function_call_in_progress.discard(frame.tool_call_id)
 
         return bool(self._function_call_in_progress)

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -17,6 +17,7 @@ from pipecat.frames.frames import (
     FunctionCallFromLLM,
     FunctionCallInProgressFrame,
     FunctionCallResultFrame,
+    FunctionCallResultProperties,
     FunctionCallsStartedFrame,
     LLMContextFrame,
     LLMSetToolsFrame,
@@ -24,10 +25,11 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.aggregators.llm_context import NOT_GIVEN, LLMContext
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.llm_service import LLMService
+from pipecat.services.llm_service import FunctionCallParams, LLMService
 from pipecat.services.settings import LLMSettings
 from pipecat.turns.user_mute.function_call_user_mute_strategy import FunctionCallUserMuteStrategy
 from pipecat.turns.user_turn_completion_mixin import UserTurnCompletionConfig
+from pipecat.utils.async_tool_cancellation import CANCEL_ASYNC_TOOL_NAME
 
 
 def _expected_missing_tool_message(name: str) -> str:
@@ -315,6 +317,92 @@ class TestLLMService(unittest.IsolatedAsyncioTestCase):
                     context=LLMContext(),
                 )
             ]
+        )
+
+        strategy = FunctionCallUserMuteStrategy()
+        muted = False
+        for frame in recorded_frames:
+            muted = await strategy.process_frame(frame)
+
+        self.assertFalse(muted)
+
+    async def test_builtin_cancel_tool_allows_user_mute_cleanup(self):
+        """The built-in cancel tool is excluded from FunctionCallsStartedFrame,
+        so the mute strategy sees a result frame for a tool call id it is not
+        tracking.
+        """
+        service = MockLLMService()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        async def async_tool(params: FunctionCallParams):
+            await params.result_callback("done")
+
+        service.register_function("async_tool", async_tool, cancel_on_interruption=False)
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls(**kwargs))
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name=CANCEL_ASYNC_TOOL_NAME,
+                    tool_call_id="cancel_1",
+                    arguments={"tool_call_id": "call_1"},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        self.assertNotIn(FunctionCallsStartedFrame, [type(frame) for frame in recorded_frames])
+
+        strategy = FunctionCallUserMuteStrategy()
+        muted = False
+        for frame in recorded_frames:
+            muted = await strategy.process_frame(frame)
+
+        self.assertFalse(muted)
+
+    async def test_intermediate_results_allow_user_mute_cleanup(self):
+        """An async tool reporting intermediate updates emits a result frame per
+        update, so the mute strategy sees the same tool call id finish twice.
+        """
+        service = MockLLMService()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        async def async_tool(params: FunctionCallParams):
+            await params.result_callback(
+                "working", properties=FunctionCallResultProperties(is_final=False)
+            )
+            await params.result_callback("done")
+
+        service.register_function("async_tool", async_tool, cancel_on_interruption=False)
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls(**kwargs))
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="async_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        self.assertEqual(
+            len([f for f in recorded_frames if isinstance(f, FunctionCallResultFrame)]), 2
         )
 
         strategy = FunctionCallUserMuteStrategy()

--- a/tests/test_user_mute_strategy.py
+++ b/tests/test_user_mute_strategy.py
@@ -138,6 +138,38 @@ class TestFunctionCallUserMuteStrategy(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(await strategy.process_frame(InterruptionFrame()))
 
+    async def test_tolerates_double_delivery_of_result_frame(self):
+        """Multi-worker bus topologies can redeliver the same result frame
+        to a child worker (it has already been handled by the parent). The
+        strategy must tolerate the second delivery — ``set.discard`` over
+        ``set.remove``. Pre-fix ``remove`` would ``KeyError`` and tear down
+        the frame loop."""
+        strategy = FunctionCallUserMuteStrategy()
+        started = FunctionCallsStartedFrame(
+            function_calls=[
+                FunctionCallFromLLM(
+                    function_name="fn", tool_call_id="abc-123", arguments={}, context=None
+                )
+            ]
+        )
+        result = FunctionCallResultFrame(
+            function_name="fn", tool_call_id="abc-123", arguments={}, result={}
+        )
+        await strategy.process_frame(started)
+        await strategy.process_frame(result)
+        # Second delivery must NOT raise — multi-worker reality.
+        await strategy.process_frame(result)
+        self.assertFalse(bool(strategy._function_call_in_progress))
+
+    async def test_tolerates_orphan_cancel_frame(self):
+        """An orphan ``FunctionCallCancelFrame`` (tool_call_id never seen
+        in a started frame) must be a silent no-op, not a ``KeyError``."""
+        strategy = FunctionCallUserMuteStrategy()
+        orphan = FunctionCallCancelFrame(function_name="fn", tool_call_id="never-started")
+        # Must not raise.
+        await strategy.process_frame(orphan)
+        self.assertFalse(bool(strategy._function_call_in_progress))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_user_mute_strategy.py
+++ b/tests/test_user_mute_strategy.py
@@ -138,37 +138,77 @@ class TestFunctionCallUserMuteStrategy(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(await strategy.process_frame(InterruptionFrame()))
 
-    async def test_tolerates_double_delivery_of_result_frame(self):
-        """Multi-worker bus topologies can redeliver the same result frame
-        to a child worker (it has already been handled by the parent). The
-        strategy must tolerate the second delivery — ``set.discard`` over
-        ``set.remove``. Pre-fix ``remove`` would ``KeyError`` and tear down
-        the frame loop."""
+    async def test_repeated_result_frame_stays_unmuted(self):
+        """A tool call id can be reported as finished more than once, e.g. an
+        async tool emitting an intermediate update and then its final result.
+        """
         strategy = FunctionCallUserMuteStrategy()
-        started = FunctionCallsStartedFrame(
-            function_calls=[
-                FunctionCallFromLLM(
-                    function_name="fn", tool_call_id="abc-123", arguments={}, context=None
+
+        self.assertTrue(
+            await strategy.process_frame(
+                FunctionCallsStartedFrame(
+                    function_calls=[
+                        FunctionCallFromLLM(
+                            function_name="fn", tool_call_id="1", arguments={}, context=None
+                        )
+                    ]
                 )
-            ]
+            )
         )
         result = FunctionCallResultFrame(
-            function_name="fn", tool_call_id="abc-123", arguments={}, result={}
+            function_name="fn", tool_call_id="1", arguments={}, result={}
         )
-        await strategy.process_frame(started)
-        await strategy.process_frame(result)
-        # Second delivery must NOT raise — multi-worker reality.
-        await strategy.process_frame(result)
-        self.assertFalse(bool(strategy._function_call_in_progress))
+        self.assertFalse(await strategy.process_frame(result))
+        self.assertFalse(await strategy.process_frame(result))
 
-    async def test_tolerates_orphan_cancel_frame(self):
-        """An orphan ``FunctionCallCancelFrame`` (tool_call_id never seen
-        in a started frame) must be a silent no-op, not a ``KeyError``."""
+    async def test_unknown_tool_call_id_stays_unmuted(self):
+        """Result and cancel frames can arrive for a tool call id that never
+        appeared in a started frame, e.g. the built-in cancel tool.
+        """
         strategy = FunctionCallUserMuteStrategy()
-        orphan = FunctionCallCancelFrame(function_name="fn", tool_call_id="never-started")
-        # Must not raise.
-        await strategy.process_frame(orphan)
-        self.assertFalse(bool(strategy._function_call_in_progress))
+
+        self.assertFalse(
+            await strategy.process_frame(
+                FunctionCallCancelFrame(function_name="fn", tool_call_id="unknown")
+            )
+        )
+        self.assertFalse(
+            await strategy.process_frame(
+                FunctionCallResultFrame(
+                    function_name="fn", tool_call_id="unknown", arguments={}, result={}
+                )
+            )
+        )
+
+    async def test_unknown_tool_call_id_leaves_other_calls_muted(self):
+        """An unknown id must not disturb the calls that are still running."""
+        strategy = FunctionCallUserMuteStrategy()
+
+        self.assertTrue(
+            await strategy.process_frame(
+                FunctionCallsStartedFrame(
+                    function_calls=[
+                        FunctionCallFromLLM(
+                            function_name="fn", tool_call_id="1", arguments={}, context=None
+                        )
+                    ]
+                )
+            )
+        )
+        self.assertTrue(
+            await strategy.process_frame(
+                FunctionCallResultFrame(
+                    function_name="other", tool_call_id="unknown", arguments={}, result={}
+                )
+            )
+        )
+        self.assertFalse(
+            await strategy.process_frame(
+                FunctionCallResultFrame(
+                    function_name="fn", tool_call_id="1", arguments={}, result={}
+                )
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`FunctionCallUserMuteStrategy` drops a tool call id from its in-progress set with `set.remove` on every `FunctionCallResultFrame` / `FunctionCallCancelFrame`. Those frames can carry an id the strategy is not tracking, and `remove` raises `KeyError`.

`FrameProcessor.__process_frame` catches it and calls `push_error(fatal=False)`, so the pipeline stays up, but the user aggregator abandons the rest of its handling for that frame and an `ErrorFrame` goes upstream to the application.

### Where untracked ids come from

- **The built-in `cancel_async_tool_call`.** `run_function_calls` excludes it from `FunctionCallsStartedFrame` (`llm_service.py:1258-1263`) but still broadcasts its result, so the strategy sees a result for an id it never added. Any bot with an async tool and `enable_async_tool_cancellation=True` hits this the first time the LLM cancels a call.
- **Async tools reporting progress.** `result_callback(..., properties=FunctionCallResultProperties(is_final=False))` broadcasts a result frame per update plus the final one, so the same id is reported finished more than once — the pattern in `examples/function-calling/function-calling-*-async-stream.py`.
- **Bus re-delivery.** In multi-worker topologies a bridge can re-deliver a result frame a downstream worker already handled.

### Fix

`set.discard` — identical to `remove` when the id is present, a no-op when it isn't. Ids the strategy is not tracking are ignored.

### Tests

`tests/test_user_mute_strategy.py` covers the strategy directly:

- `test_repeated_result_frame_stays_unmuted`
- `test_unknown_tool_call_id_stays_unmuted`
- `test_unknown_tool_call_id_leaves_other_calls_muted` — an untracked id must not unmute while another call is still in progress

`tests/test_llm_service.py` drives a real `LLMService` and feeds its broadcast frames to the strategy, pinning the two single-worker paths at their source:

- `test_builtin_cancel_tool_allows_user_mute_cleanup`
- `test_intermediate_results_allow_user_mute_cleanup`

### Follow-up, not in this PR

The strategy mutes on `FunctionCallsStartedFrame` for every user-visible call, async ones included, so the user is muted for as long as a background tool runs. The unmute on an intermediate update is incidental rather than a designed escape hatch — an async tool that reports no progress keeps the user muted until it finishes. Now that `@tool_options(cancel_on_interruption=False)` keeps a tool call alive without suppressing user speech, the strategy is a candidate for deprecation. Tracked separately.
