### PR TITLE
fix: clarify segmented stt audio format

### DIFF
--- a/changelog/4836.fixed.md
+++ b/changelog/4836.fixed.md
@@ -1,0 +1,1 @@
+- Fixed segmented STT services so Moonshine and local Whisper/MLX variants keep receiving raw PCM segments while WAV-based providers continue to receive WAV containers.

--- a/src/pipecat/services/moonshine/stt.py
+++ b/src/pipecat/services/moonshine/stt.py
@@ -19,6 +19,7 @@ from enum import StrEnum
 
 import numpy as np
 from loguru import logger
+from typing_extensions import override
 
 from pipecat.frames.frames import Frame, TranscriptionFrame
 from pipecat.services.settings import STTSettings, assert_given
@@ -113,6 +114,11 @@ class MoonshineSTTService(SegmentedSTTService):
             True, as this service supports metric generation.
         """
         return True
+
+    @override
+    def _segment_audio_format(self) -> str:
+        """Moonshine consumes raw 16-bit PCM segments."""
+        return "pcm"
 
     def _load(self) -> Transcriber:
         """Download (first time) and load the Moonshine model.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -722,7 +722,9 @@ class SegmentedSTTService(STTService):
 
     Requires VAD to be enabled in the pipeline to function properly. Maintains a
     small audio buffer to account for the delay between actual speech start and
-    VAD detection.
+    VAD detection. Subclasses can override the protected
+    :meth:`_segment_audio_format` contract to choose whether the buffered segment
+    is delivered to ``run_stt()`` as a WAV container or raw PCM bytes.
     """
 
     def __init__(self, *, sample_rate: int | None = None, **kwargs):
@@ -748,6 +750,35 @@ class SegmentedSTTService(STTService):
         """
         await super().start(frame)
         self._audio_buffer_size_1s = self.sample_rate * 2
+
+    def _segment_audio_format(self) -> str:
+        """Return the audio container format passed to ``run_stt()``.
+
+        Subclasses override this protected contract to opt into a different
+        segment representation. The default remains WAV for backward
+        compatibility with providers that expect a file container.
+
+        Returns:
+            The segment audio format. Supported values are ``"wav"`` and
+            ``"pcm"``.
+        """
+        return "wav"
+
+    def _build_segment_audio(self) -> bytes:
+        """Serialize the buffered segment in the subclass-defined format."""
+        segment_audio_format = self._segment_audio_format()
+        if segment_audio_format == "pcm":
+            return bytes(self._audio_buffer)
+        if segment_audio_format != "wav":
+            raise ValueError(f"Unsupported segment audio format: {segment_audio_format!r}")
+
+        content = io.BytesIO()
+        with wave.open(content, "wb") as wav:
+            wav.setsampwidth(2)
+            wav.setnchannels(1)
+            wav.setframerate(self.sample_rate)
+            wav.writeframes(self._audio_buffer)
+        return content.getvalue()
 
     async def push_frame(self, frame: Frame, direction: FrameDirection = FrameDirection.DOWNSTREAM):
         """Push a frame, marking TranscriptionFrames as finalized.
@@ -778,19 +809,12 @@ class SegmentedSTTService(STTService):
     async def _handle_user_stopped_speaking(self, frame: VADUserStoppedSpeakingFrame):
         self._user_speaking = False
 
-        content = io.BytesIO()
-        wav = wave.open(content, "wb")
-        wav.setsampwidth(2)
-        wav.setnchannels(1)
-        wav.setframerate(self.sample_rate)
-        wav.writeframes(self._audio_buffer)
-        wav.close()
-        content.seek(0)
+        audio = self._build_segment_audio()
 
         # Start clean.
         self._audio_buffer.clear()
 
-        await self.process_generator(self.run_stt(content.read()))
+        await self.process_generator(self.run_stt(audio))
 
     async def process_audio_frame(self, frame: AudioRawFrame, direction: FrameDirection):
         """Process audio frames by buffering them for segmented transcription.

--- a/src/pipecat/services/whisper/stt.py
+++ b/src/pipecat/services/whisper/stt.py
@@ -303,6 +303,11 @@ class WhisperSTTService(SegmentedSTTService):
         """
         return True
 
+    @override
+    def _segment_audio_format(self) -> str:
+        """Whisper local models consume raw 16-bit PCM segments."""
+        return "pcm"
+
     def language_to_service_language(self, language: Language) -> str | None:
         """Convert from pipecat Language to Whisper language code.
 

--- a/tests/test_evals_transcribe.py
+++ b/tests/test_evals_transcribe.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the eval bot-audio transcriber."""
+
+import unittest
+
+from pipecat.evals.transcribe import EvalTranscriber
+from pipecat.frames.frames import TranscriptionFrame
+from pipecat.utils.time import time_now_iso8601
+
+
+class _IdentityResampler:
+    async def resample(self, audio: bytes, source_sample_rate: int, target_sample_rate: int):
+        return audio
+
+
+class _CaptureEvalSTT:
+    def __init__(self):
+        self.last_audio: bytes | None = None
+
+    async def run_stt(self, audio: bytes):
+        self.last_audio = audio
+        yield TranscriptionFrame("hello", "", time_now_iso8601())
+
+
+class TestEvalTranscriber(unittest.IsolatedAsyncioTestCase):
+    async def test_transcribe_passes_raw_pcm_to_service(self):
+        service = _CaptureEvalSTT()
+        transcriber = EvalTranscriber(service, padding_secs=0)
+        transcriber._resampler = _IdentityResampler()
+
+        pcm = b"\x01\x02" * 16
+        text = await transcriber.transcribe(pcm, 16000)
+
+        self.assertEqual(text, "hello")
+        self.assertEqual(service.last_audio, pcm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_segmented_stt_service.py
+++ b/tests/test_segmented_stt_service.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the segmented STT segment-format contract."""
+
+import io
+import unittest
+import wave
+
+from pipecat.frames.frames import VADUserStoppedSpeakingFrame
+from pipecat.services.stt_service import SegmentedSTTService
+
+
+class _CaptureSegmentSTT(SegmentedSTTService):
+    def __init__(self, *, segment_audio_format: str = "wav"):
+        super().__init__(sample_rate=16000)
+        self._segment_audio_format_name = segment_audio_format
+        self.captured_audio: bytes | None = None
+
+    def _segment_audio_format(self) -> str:
+        return self._segment_audio_format_name
+
+    async def run_stt(self, audio: bytes):
+        self.captured_audio = audio
+        if False:
+            yield None
+
+
+class TestSegmentedSTTService(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.pcm = b"\x01\x02" * 8
+
+    async def _run_segment(self, service: _CaptureSegmentSTT):
+        service._sample_rate = 16000
+        service._audio_buffer = bytearray(self.pcm)
+        service._user_speaking = True
+
+        async def _consume(generator):
+            async for _ in generator:
+                pass
+
+        service.process_generator = _consume
+        await service._handle_user_stopped_speaking(VADUserStoppedSpeakingFrame())
+
+    async def test_pcm_mode_passes_raw_buffer(self):
+        service = _CaptureSegmentSTT(segment_audio_format="pcm")
+        await self._run_segment(service)
+        self.assertEqual(service.captured_audio, self.pcm)
+
+    async def test_wav_mode_wraps_buffer(self):
+        service = _CaptureSegmentSTT(segment_audio_format="wav")
+        await self._run_segment(service)
+
+        self.assertIsNotNone(service.captured_audio)
+        with wave.open(io.BytesIO(service.captured_audio), "rb") as wav_file:
+            self.assertEqual(wav_file.getnchannels(), 1)
+            self.assertEqual(wav_file.getsampwidth(), 2)
+            self.assertEqual(wav_file.getframerate(), 16000)
+            self.assertEqual(wav_file.readframes(wav_file.getnframes()), self.pcm)
+
+    async def test_buffer_cleared_after_segment(self):
+        service = _CaptureSegmentSTT(segment_audio_format="pcm")
+        await self._run_segment(service)
+        self.assertEqual(service._audio_buffer, bytearray())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This fixes the segmented STT audio-format mismatch in issue #4836.

Problem

`SegmentedSTTService` always wrapped buffered speech in a WAV container before calling `run_stt()`. That worked for file/container-based providers, but it was incompatible with the local Moonshine and Whisper/MLX implementations, which consume raw 16-bit PCM.

Fix

`SegmentedSTTService` now has a protected `_segment_audio_format()` contract that defaults to `"wav"` for backward compatibility. Moonshine and the local Whisper/MLX service family override that contract to `"pcm"`, so the buffered segment is passed through unchanged for those implementations.

Compatibility

This keeps the existing WAV behavior for the provider families that already expect it, including OpenAI/Groq, Fal, ElevenLabs, and NVIDIA. There is no runtime RIFF sniffing and no new public configuration surface.

Validation

- `git diff --check`
- `python3 -m py_compile src/pipecat/services/stt_service.py src/pipecat/services/moonshine/stt.py src/pipecat/services/whisper/stt.py tests/test_segmented_stt_service.py tests/test_evals_transcribe.py`
- Offline runtime validation of the new segment-format path:
  - PCM mode passed the original buffered bytes through unchanged
  - WAV mode produced a valid WAV container with the expected sample rate and payload
  - `EvalTranscriber` still passed raw PCM through to its STT service

Issue

Closes #4836.
