### PR TITLE
Fix WorkerBus dropping all future messages to a subscriber after a hook raises

### DIFF
--- a/changelog/4827.fixed.md
+++ b/changelog/4827.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `WorkerBus` permanently stopping message delivery to a subscriber when that subscriber's `on_bus_message` (or an overridable lifecycle hook such as `on_job_response`/`on_activated`) raised an exception. The router and data dispatch tasks now log the exception and keep running, so subsequent messages — including cancel/cleanup — are still delivered.

--- a/src/pipecat/bus/bus.py
+++ b/src/pipecat/bus/bus.py
@@ -15,6 +15,8 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import cast
 
+from loguru import logger
+
 from pipecat.bus.messages import BusLocalMessage, BusMessage, BusSystemMessage
 from pipecat.bus.queue import BusMessageQueue
 from pipecat.bus.subscriber import BusSubscriber
@@ -170,7 +172,18 @@ class WorkerBus(BaseObject):
             while True:
                 message = await sub.queue.get()
                 if isinstance(message, BusSystemMessage):
-                    await sub.subscriber.on_bus_message(cast(BusMessage, message))
+                    # A subscriber exception must not tear down the dispatch task,
+                    # or the subscriber would silently stop receiving all future
+                    # messages (including cancel/cleanup). Log and keep going.
+                    try:
+                        await sub.subscriber.on_bus_message(cast(BusMessage, message))
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.exception(
+                            f"{self}: subscriber '{sub.subscriber.name}' raised handling "
+                            f"system message {message}; keeping dispatch alive"
+                        )
                 else:
                     sub.data_queue.put_nowait(message)
         except asyncio.CancelledError:
@@ -181,6 +194,17 @@ class WorkerBus(BaseObject):
         try:
             while True:
                 message = await sub.data_queue.get()
-                await sub.subscriber.on_bus_message(message)
+                # A subscriber exception must not tear down the dispatch task,
+                # or the subscriber would silently stop receiving all future
+                # messages (including cancel/cleanup). Log and keep going.
+                try:
+                    await sub.subscriber.on_bus_message(message)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        f"{self}: subscriber '{sub.subscriber.name}' raised handling "
+                        f"data message {message}; keeping dispatch alive"
+                    )
         except asyncio.CancelledError:
             pass

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -270,5 +270,68 @@ class TestBusMessagePriority(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(sub.received[0], BusJobCancelMessage)
 
 
+class _FailingSub(BusSubscriber):
+    """Subscriber that raises on its first message, then records the rest.
+
+    Models a subscriber whose lifecycle hook (e.g. ``on_job_response``) throws:
+    the bus dispatch task must survive so later messages are still delivered.
+    """
+
+    _counter = itertools.count()
+
+    def __init__(self):
+        self._name = f"failing_{next(self._counter)}"
+        self.received = []
+        self._raised = False
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def on_bus_message(self, message):
+        if not self._raised:
+            self._raised = True
+            raise RuntimeError("simulated subscriber failure")
+        self.received.append(message)
+
+
+class TestSubscriberExceptionIsolation(unittest.IsolatedAsyncioTestCase):
+    """A subscriber exception must not stop future delivery to that subscriber."""
+
+    async def test_data_dispatch_survives_subscriber_exception(self):
+        """A raise in on_bus_message must not tear down the data dispatch task."""
+        bus, _ = await create_test_bus()
+        sub = _FailingSub()
+        await bus.subscribe(sub)
+        await bus.start()
+
+        # First data message raises inside _data_dispatch_task.
+        await bus.send(BusDataMessage(source="first"))
+        await asyncio.sleep(0.05)
+        # Second data message must still be delivered (was lost before the fix).
+        await bus.send(BusDataMessage(source="second"))
+        await asyncio.sleep(0.05)
+        await bus.stop()
+
+        self.assertEqual([m.source for m in sub.received], ["second"])
+
+    async def test_router_survives_subscriber_exception_on_system_message(self):
+        """A raise on a system message must not tear down the router task."""
+        bus, _ = await create_test_bus()
+        sub = _FailingSub()
+        await bus.subscribe(sub)
+        await bus.start()
+
+        # First system message raises inline inside _router_task.
+        await bus.send(BusCancelMessage(source="first"))
+        await asyncio.sleep(0.05)
+        # Second system message must still be delivered (was lost before the fix).
+        await bus.send(BusCancelMessage(source="second"))
+        await asyncio.sleep(0.05)
+        await bus.stop()
+
+        self.assertEqual([m.source for m in sub.received], ["second"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Fixes #4827.

A `WorkerBus` delivers messages to each subscriber through two per-subscriber dispatch tasks: `_router_task` (system messages, dispatched inline) and `_data_dispatch_task` (data messages). Both wrapped their `while True` loop in `except asyncio.CancelledError` only.

`BaseWorker.on_bus_message` routes messages into `_handle_*` methods, which call documented, **user-overridable** lifecycle hooks (`on_job_response`, `on_activated`, …) directly — unwrapped. When any of those raises (from user code, or from built-in framework code such as a websocket connect failure), the exception propagates all the way up and out of the dispatch loop. The task coroutine returns, and since these tasks are created once per subscription and never restarted, **the subscriber silently stops receiving all future messages — including cancel/cleanup.**

## Fix

Wrap the `on_bus_message` call inside **both** dispatch tasks so a subscriber exception is logged and the loop continues. `asyncio.CancelledError` is re-raised to preserve graceful shutdown.

This is fixed at the dispatch-task chokepoint rather than per-hook in `BaseWorker`, so it protects every subscriber against any throwing hook and can't be silently regressed when new `_handle_*` methods are added. Both paths are fixed — the data path (per the original report) and the system path in `_router_task`, which had the identical flaw.

## Testing

New `TestSubscriberExceptionIsolation` in `tests/test_bus.py` with a subscriber that raises on its first message, one test per path, asserting the next message is still delivered:

- **Without the fix:** both tests fail (the dispatch task dies; the second message never arrives).
- **With the fix:** both pass.
- Full `tests/test_bus.py` + `tests/test_base_worker.py` suites: 73 passed. Ruff lint/format clean.

## Note for reviewers

For system messages, swallowing an exception could mask a genuine lifecycle failure. Keeping the dispatch task alive (and logging the exception) still seems strictly better than killing all future delivery to the subscriber, but happy to adjust the policy for system vs. data messages if you'd prefer something different.