### PR TITLE
Fix bus adapters dropping ToolsSchema.custom_tools during serialization

### DIFF
--- a/changelog/4833.fixed.md
+++ b/changelog/4833.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the bus type adapters (`ToolsSchemaAdapter` and `LLMContextAdapter`) silently dropping `ToolsSchema.custom_tools` during serialization. Provider-specific tools (e.g. Gemini's `google_search`) are now preserved when an `LLMContext`/`ToolsSchema` crosses a network bus (`RedisBus`/`PgmqBus`), so remote workers no longer lose them.

--- a/src/pipecat/bus/adapters/llm_context_adapter.py
+++ b/src/pipecat/bus/adapters/llm_context_adapter.py
@@ -11,7 +11,7 @@ from typing import Any
 from openai import NOT_GIVEN as OPENAI_NOT_GIVEN
 
 from pipecat.adapters.schemas.function_schema import FunctionSchema
-from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.bus.adapters.base import DeserializeFunc, SerializeFunc, TypeAdapter
 from pipecat.processors.aggregators.llm_context import (
     LLMContext,
@@ -90,12 +90,21 @@ class LLMContextAdapter(TypeAdapter):
             )
         return deserialize_value(data)
 
-    def _serialize_tools(self, tools: Any) -> list[dict[str, Any]]:
-        return [tool.to_default_dict() for tool in tools.standard_tools]
+    def _serialize_tools(self, tools: Any) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "standard_tools": [tool.to_default_dict() for tool in tools.standard_tools]
+        }
+        if tools.custom_tools:
+            # custom_tools is dict[AdapterType, list[dict]] of pure JSON; serialize
+            # the enum keys to their string values so it survives network transport.
+            result["custom_tools"] = {
+                adapter_type.value: t for adapter_type, t in tools.custom_tools.items()
+            }
+        return result
 
-    def _deserialize_tools(self, data: list[dict[str, Any]]) -> Any:
+    def _deserialize_tools(self, data: dict[str, Any]) -> Any:
         tools = []
-        for item in data:
+        for item in data["standard_tools"]:
             params = item.get("parameters", {})
             tools.append(
                 FunctionSchema(
@@ -105,4 +114,7 @@ class LLMContextAdapter(TypeAdapter):
                     required=params.get("required", []),
                 )
             )
-        return ToolsSchema(standard_tools=tools)
+        custom_tools = None
+        if data.get("custom_tools"):
+            custom_tools = {AdapterType(key): value for key, value in data["custom_tools"].items()}
+        return ToolsSchema(standard_tools=tools, custom_tools=custom_tools)

--- a/src/pipecat/bus/adapters/tools_schema_adapter.py
+++ b/src/pipecat/bus/adapters/tools_schema_adapter.py
@@ -9,7 +9,7 @@
 from typing import Any
 
 from pipecat.adapters.schemas.function_schema import FunctionSchema
-from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.bus.adapters.base import DeserializeFunc, SerializeFunc, TypeAdapter
 
 
@@ -24,9 +24,19 @@ class ToolsSchemaAdapter(TypeAdapter):
             serialize_value: Callback to recursively serialize nested values.
 
         Returns:
-            A dict with a ``standard_tools`` list.
+            A dict with a ``standard_tools`` list and, when present, a
+            ``custom_tools`` map of provider-specific tool definitions.
         """
-        return {"standard_tools": [tool.to_default_dict() for tool in obj.standard_tools]}
+        result: dict[str, Any] = {
+            "standard_tools": [tool.to_default_dict() for tool in obj.standard_tools]
+        }
+        if obj.custom_tools:
+            # custom_tools is dict[AdapterType, list[dict]] of pure JSON; serialize
+            # the enum keys to their string values so it survives network transport.
+            result["custom_tools"] = {
+                adapter_type.value: tools for adapter_type, tools in obj.custom_tools.items()
+            }
+        return result
 
     def deserialize(
         self,
@@ -55,4 +65,7 @@ class ToolsSchemaAdapter(TypeAdapter):
                     required=params.get("required", []),
                 )
             )
-        return ToolsSchema(standard_tools=tools)
+        custom_tools = None
+        if data.get("custom_tools"):
+            custom_tools = {AdapterType(key): value for key, value in data["custom_tools"].items()}
+        return ToolsSchema(standard_tools=tools, custom_tools=custom_tools)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass, field
 
 from pydantic import BaseModel
 
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
+from pipecat.bus.adapters import ToolsSchemaAdapter
 from pipecat.bus.messages import (
     BusActivateWorkerMessage,
     BusCancelMessage,
@@ -20,8 +23,9 @@ from pipecat.bus.messages import (
     BusMessage,
 )
 from pipecat.bus.serializers import JSONMessageSerializer
-from pipecat.frames.frames import TextFrame
+from pipecat.frames.frames import LLMContextFrame, TextFrame
 from pipecat.pipeline.job_context import JobStatus
+from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 
 
@@ -245,6 +249,49 @@ class TestJSONMessageSerializer(unittest.TestCase):
         restored = self.serializer.deserialize(data)
 
         self.assertEqual(restored.tag, "custom_tag")
+
+
+def _tools_with_custom():
+    """A ToolsSchema with both a standard tool and provider-specific custom tools."""
+    standard = FunctionSchema(
+        name="get_weather",
+        description="Get the weather",
+        properties={"city": {"type": "string"}},
+        required=["city"],
+    )
+    custom = {AdapterType.GEMINI: [{"google_search": {}}]}
+    return ToolsSchema(standard_tools=[standard], custom_tools=custom)
+
+
+class TestCustomToolsRoundTrip(unittest.TestCase):
+    """Provider-specific custom_tools must survive bus serialization (see #4833)."""
+
+    def test_tools_schema_adapter_preserves_custom_tools(self):
+        """ToolsSchemaAdapter round-trips custom_tools, not just standard_tools."""
+        adapter = ToolsSchemaAdapter()
+        ident = lambda x: x  # noqa: E731  (callback unused for tools)
+
+        restored = adapter.deserialize(adapter.serialize(_tools_with_custom(), ident), ident)
+
+        self.assertEqual([t.name for t in restored.standard_tools], ["get_weather"])
+        self.assertEqual(restored.custom_tools, {AdapterType.GEMINI: [{"google_search": {}}]})
+
+    def test_llm_context_frame_preserves_custom_tools_over_bus(self):
+        """An LLMContextFrame crossing the bus keeps the context's custom_tools."""
+        serializer = JSONMessageSerializer()
+        ctx = LLMContext(messages=[{"role": "user", "content": "hi"}], tools=_tools_with_custom())
+        msg = BusFrameMessage(
+            source="task_a",
+            frame=LLMContextFrame(context=ctx),
+            direction=FrameDirection.DOWNSTREAM,
+        )
+
+        restored = serializer.deserialize(serializer.serialize(msg))
+
+        self.assertIsInstance(restored.frame, LLMContextFrame)
+        tools = restored.frame.context.tools
+        self.assertEqual([t.name for t in tools.standard_tools], ["get_weather"])
+        self.assertEqual(tools.custom_tools, {AdapterType.GEMINI: [{"google_search": {}}]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Fixes #4833.

`ToolsSchemaAdapter` and `LLMContextAdapter` (the bus type adapters used for network transport) only serialized `standard_tools`. `ToolsSchema.custom_tools` — provider-specific tool definitions such as Gemini's `google_search` — was dropped on serialize and reconstructed as `None`, so it did not survive a serialize/deserialize round-trip.

In distributed setups (`RedisBus`/`PgmqBus`), an `LLMContext` crossing the bus to a remote worker silently lost these tools. Remote LLM adapters gate on `tools_schema.custom_tools` (`gemini_adapter`, `open_ai_adapter`, `open_ai_realtime_adapter`, `open_ai_responses_adapter`), so the provider request was built without them. In-process (`AsyncQueueBus`) was unaffected because it skips serialization — so the same config worked locally and broke only in distributed mode.

## Fix

`custom_tools` is `dict[AdapterType, list[dict]]` of pure JSON, so it is trivially serializable: emit the enum keys as their string values on serialize, restore them via `AdapterType(key)` on deserialize. Applied symmetrically to both adapters, only when `custom_tools` is present.

## Testing

New `TestCustomToolsRoundTrip` in `tests/test_serializers.py`:
- `test_tools_schema_adapter_preserves_custom_tools` — direct `ToolsSchemaAdapter` round-trip.
- `test_llm_context_frame_preserves_custom_tools_over_bus` — the realistic end-to-end path: a `BusFrameMessage` carrying an `LLMContextFrame` round-tripped through the full `JSONMessageSerializer`.

Both assert `standard_tools` **and** `custom_tools` survive.

- **Without the fix:** both fail (`None != {AdapterType.GEMINI: [...]}`).
- **With the fix:** both pass.
- No regressions: `test_serializers.py` + `test_redis_bus.py` + `test_pgmq_bus.py` + `test_frame_adapters.py` = 53 passed. Ruff lint/format clean.

## Note for reviewers

This is a deliberately minimal in-place fix. The two adapters' tool (de)serialization is near-identical duplication — which is why this bug existed in both places — so a reasonable follow-up would be to have `LLMContextAdapter` reuse `ToolsSchemaAdapter` for tools. Happy to fold that in here if you'd prefer.