### PR TITLE
Allow configurable REST base URL for Twilio auto hang-up

### DIFF
--- a/changelog/4845.added.md
+++ b/changelog/4845.added.md
@@ -1,0 +1,1 @@
+- Added a `base_url` parameter to `TwilioFrameSerializer` to configure the REST API host used for auto hang-up. By default the host is still derived from `region`/`edge` (unchanged behavior), but setting `base_url` lets you target a Twilio-API-compatible backend or a self-hosted server instead of `api.twilio.com`.

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -29,6 +29,31 @@ from pipecat.frames.frames import (
 from pipecat.serializers.base_serializer import FrameSerializer
 
 
+def _build_call_resource_url(
+    account_sid: str,
+    call_sid: str,
+    *,
+    base_url: str | None = None,
+    region: str | None = None,
+    edge: str | None = None,
+) -> str:
+    """Build the REST URL for a Call resource (used by auto hang-up).
+
+    When ``base_url`` is provided it is used verbatim as the API root (scheme +
+    host, e.g. ``https://api.twilio.com``), which lets the serializer target a
+    Twilio-API-compatible backend or a self-hosted server. Otherwise the host is
+    derived from Twilio's ``region``/``edge`` FQDN format, preserving the prior
+    default behavior.
+    """
+    if base_url:
+        root = base_url.rstrip("/")
+    else:
+        region_prefix = f"{region}." if region else ""
+        edge_prefix = f"{edge}." if edge else ""
+        root = f"https://api.{edge_prefix}{region_prefix}twilio.com"
+    return f"{root}/2010-04-01/Accounts/{account_sid}/Calls/{call_sid}.json"
+
+
 class TwilioFrameSerializer(FrameSerializer):
     """Serializer for Twilio Media Streams WebSocket protocol.
 
@@ -63,6 +88,7 @@ class TwilioFrameSerializer(FrameSerializer):
         auth_token: str | None = None,
         region: str | None = None,
         edge: str | None = None,
+        base_url: str | None = None,
         params: InputParams | None = None,
     ):
         """Initialize the TwilioFrameSerializer.
@@ -74,6 +100,10 @@ class TwilioFrameSerializer(FrameSerializer):
             auth_token: Twilio auth token (required for auto hang-up).
             region: Twilio region (e.g., "au1", "ie1"). Must be specified with edge.
             edge: Twilio edge location (e.g., "sydney", "dublin"). Must be specified with region.
+            base_url: Optional REST API base URL (scheme + host, e.g.
+                ``https://api.twilio.com``) used for auto hang-up. Defaults to the
+                host derived from region/edge. Set this to target a Twilio-API-
+                compatible backend or a self-hosted server.
             params: Configuration parameters.
         """
         params = params or TwilioFrameSerializer.InputParams()
@@ -110,6 +140,7 @@ class TwilioFrameSerializer(FrameSerializer):
         self._auth_token = auth_token
         self._region = region
         self._edge = edge
+        self._base_url = base_url
 
         self._twilio_sample_rate = self._params.twilio_sample_rate
         self._sample_rate = 0  # Pipeline input rate
@@ -186,14 +217,15 @@ class TwilioFrameSerializer(FrameSerializer):
             account_sid = cast(str, self._account_sid)
             auth_token = cast(str, self._auth_token)
             call_sid = cast(str, self._call_sid)
-            region = self._region
-            edge = self._edge
-
-            region_prefix = f"{region}." if region else ""
-            edge_prefix = f"{edge}." if edge else ""
-
-            # Twilio API endpoint for updating calls
-            endpoint = f"https://api.{edge_prefix}{region_prefix}twilio.com/2010-04-01/Accounts/{account_sid}/Calls/{call_sid}.json"
+            # REST endpoint for updating the call. Derived from base_url when set
+            # (Twilio-API-compatible / self-hosted), else Twilio's region/edge FQDN.
+            endpoint = _build_call_resource_url(
+                account_sid,
+                call_sid,
+                base_url=self._base_url,
+                region=self._region,
+                edge=self._edge,
+            )
 
             # Create basic auth from account_sid and auth_token
             auth = aiohttp.BasicAuth(account_sid, auth_token)

--- a/tests/test_twilio_serializer_base_url.py
+++ b/tests/test_twilio_serializer_base_url.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for TwilioFrameSerializer REST base-URL resolution (auto hang-up)."""
+
+import unittest
+
+from pipecat.serializers.twilio import _build_call_resource_url
+
+
+class TestBuildCallResourceURL(unittest.TestCase):
+    def test_default_host(self):
+        # No base_url, no region/edge -> Twilio's default host (unchanged behavior).
+        self.assertEqual(
+            _build_call_resource_url("ACxxxx", "CAyyyy"),
+            "https://api.twilio.com/2010-04-01/Accounts/ACxxxx/Calls/CAyyyy.json",
+        )
+
+    def test_region_edge_host(self):
+        self.assertEqual(
+            _build_call_resource_url("ACxxxx", "CAyyyy", region="au1", edge="sydney"),
+            "https://api.sydney.au1.twilio.com/2010-04-01/Accounts/ACxxxx/Calls/CAyyyy.json",
+        )
+
+    def test_base_url_override(self):
+        # base_url targets a Twilio-API-compatible backend; region/edge ignored.
+        self.assertEqual(
+            _build_call_resource_url(
+                "ACxxxx", "CAyyyy", base_url="https://api.example.test", region="au1", edge="sydney"
+            ),
+            "https://api.example.test/2010-04-01/Accounts/ACxxxx/Calls/CAyyyy.json",
+        )
+
+    def test_base_url_trailing_slash_normalized(self):
+        self.assertEqual(
+            _build_call_resource_url("ACxxxx", "CAyyyy", base_url="https://api.example.test/"),
+            "https://api.example.test/2010-04-01/Accounts/ACxxxx/Calls/CAyyyy.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`TwilioFrameSerializer`'s auto hang-up builds the REST endpoint from a hardcoded
`api.{edge}.{region}.twilio.com` host, so on `EndFrame` it can only terminate
calls on Twilio itself. Deployments that point Twilio Media Streams at a
Twilio-API-compatible backend (or a self-hosted server) can't use the built-in
auto hang-up — the request goes to Twilio rather than their own platform.

This adds an optional `base_url` parameter that overrides the REST API root used
for the hang-up request.

## Changes

- `TwilioFrameSerializer(..., base_url: str | None = None)`. When provided it is
  used verbatim as the API root (scheme + host, e.g. `https://api.twilio.com`);
  when omitted the behavior is unchanged (host derived from `region`/`edge`).
- Extract the Call-resource URL construction into a pure
  `_build_call_resource_url` helper, with unit tests for the default host, the
  `region`/`edge` host, the `base_url` override, and trailing-slash normalization.

## Backwards compatibility

Fully backwards compatible — callers that don't pass `base_url` get the exact
prior behavior (default `None`).

## Testing

`python -m unittest tests.test_twilio_serializer_base_url` — 4 passing.
