### PR TITLE
fix: add pipecat/workers/__init__.py so py.typed covers the package

### DIFF
--- a/changelog/4846.fixed.md
+++ b/changelog/4846.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a missing `pipecat/workers/__init__.py` so the `py.typed` marker covers `pipecat.workers.*` and type checkers (e.g. pyright in strict mode) resolve `from pipecat.workers.runner import WorkerRunner` without reporting `reportMissingTypeStubs`.


### PR DESCRIPTION
## Summary

`src/pipecat/workers/__init__.py` is missing, so `pipecat.workers` is resolved as a [PEP 420](https://peps.python.org/pep-0420/) implicit namespace package and the root `py.typed` marker ([PEP 561](https://peps.python.org/pep-0561/)) does not propagate to it. Type checkers that honor `py.typed` (e.g. pyright in strict mode) therefore cannot resolve types under `pipecat.workers.*` and report `reportMissingTypeStubs` for the documented public import:

```python
from pipecat.workers.runner import WorkerRunner
# error: Stub file not found for "pipecat.workers.runner" (reportMissingTypeStubs)
```

This is the import path the project itself recommends for new code — `pipecat/pipeline/runner.py`'s docstring says *"New code should import `WorkerRunner` from `pipecat.workers.runner`"*, and the CLI scaffolding template (`pipecat/cli/registry/_imports.py`) and test utils both emit exactly this import.

`workers/` is the only top-level subpackage under `pipecat/` without an `__init__.py`: every sibling (`pipeline/`, `services/`, `transports/`, `processors/`, …) has an empty one, and even `workers/`'s own children (`llm/`, `proxy/`, `ui/`) ship one. This looks like it was introduced by #4589 ("Consolidate the worker framework into pipecat.workers"), which added the `pipecat/workers/` package without an `__init__.py` at its root.

Runtime is unaffected (the namespace-package import works); this is type-checking only.

## Fix

Add an empty `src/pipecat/workers/__init__.py`, matching the empty top-level sibling packages, so `py.typed` covers `pipecat.workers.*`.

## Verification

pyright in strict mode on `from pipecat.workers.runner import WorkerRunner`:

- before: `error: Stub file not found for "pipecat.workers.runner" (reportMissingTypeStubs)` (1 error)
- after adding this file: `0 errors, 0 warnings, 0 informations`

No GitHub issue exists for this; happy to adjust the approach (e.g. leave it empty vs add a docstring) to match your preference.
