### PR TITLE
evals: add DTMF keypress support to behavioral evals

### DIFF
--- a/changelog/4849.added.2.md
+++ b/changelog/4849.added.2.md
@@ -1,0 +1,1 @@
+- Added DTMF keypress support to the behavioral evals. A scenario turn can now press keys with a `dtmf:` field (e.g. `dtmf: "123#"`) instead of `user:`, sent as one RTVI `dtmf` message per key. A bot running a `DTMFAggregator` reacts to them as a transcription, so a `dtmf` turn can assert on `user_transcription` and `response` like a spoken turn.

--- a/changelog/4849.added.md
+++ b/changelog/4849.added.md
@@ -1,0 +1,1 @@
+- Added a first-class RTVI `dtmf` client message. Sending `{type: "dtmf", data: {button: "1"}}` makes the `RTVIProcessor` push an `InputDTMFFrame` downstream, the same path a telephony transport's keypress takes, so any bot with DTMF handling (e.g. a `DTMFAggregator`) reacts to it. One keypress per message.

--- a/changelog/4849.changed.md
+++ b/changelog/4849.changed.md
@@ -1,0 +1,1 @@
+- Eval scenarios now accept a `send_after:` with only `delay_ms` (no `event`), a pure time delay relative to the previous send, and `expect:` is now optional so a turn can just send input or wait.

--- a/examples/features/features-dtmf-menu.py
+++ b/examples/features/features-dtmf-menu.py
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A keypad-driven phone menu (IVR) bot.
+
+The caller interacts entirely with DTMF keypresses, no speech. A
+``DTMFAggregator`` turns each key sequence into a ``DTMF: ...`` transcription
+that the LLM reacts to:
+
+- press 1 for business hours
+- press 2 for the office location
+
+DTMF arrives as ``InputDTMFFrame`` from the transport (e.g. a telephony provider,
+or the eval harness), so there's no STT in the pipeline. The bot speaks its
+responses with TTS, like a real phone menu would.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.dtmf_aggregator import DTMFAggregator
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+SYSTEM_INSTRUCTION = """You are an automated phone menu for Acme Corp.
+
+The caller interacts only with their phone keypad. Each keypress arrives as a \
+message like "DTMF: 1" (the digits they pressed, possibly ending in #).
+
+When the call starts, greet the caller and read this menu: press 1 for our \
+business hours, press 2 for our location.
+
+When the caller presses 1, tell them Acme Corp is open from 9 AM to 5 PM, Monday \
+through Friday. When they press 2, tell them Acme Corp is located at 123 Main \
+Street. For any other key, say that's not a valid option and read the menu again.
+
+Keep every response short. Your responses may be read aloud, so don't use emojis \
+or formatting."""
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info("Starting bot")
+
+    llm = OpenAILLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAILLMService.Settings(system_instruction=SYSTEM_INSTRUCTION),
+    )
+
+    tts = CartesiaTTSService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaTTSService.Settings(
+            voice="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+        ),
+    )
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(context)
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input (incl. DTMF keypresses)
+            DTMFAggregator(),  # InputDTMFFrame -> "DTMF: ..." TranscriptionFrame
+            user_aggregator,  # User (keypad) turns
+            llm,  # LLM
+            tts,  # TTS
+            transport.output(),  # Transport bot output
+            assistant_aggregator,  # Assistant responses
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info("Client connected")
+        # Kick off the call with the menu greeting.
+        context.add_message({"role": "developer", "content": "Greet the caller and read the menu."})
+        await worker.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info("Client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -255,3 +255,12 @@ suite:
     scenarios: [filter_incomplete_turns_function_calling]
   - bot: turn-management/turn-management-filter-incomplete-turns-function-calling.py
     scenarios: [filter_incomplete_turns]
+
+  #
+  # DTMF: the caller drives a keypad phone menu (IVR) with DTMF tones instead of
+  # speech. The bot's DTMFAggregator turns each keypress into a transcription the
+  # LLM responds to, so the harness can assert on the resulting transcription and
+  # reply just like a spoken turn.
+  #
+  - bot: features/features-dtmf-menu.py
+    scenarios: [dtmf_menu]

--- a/scripts/release-evals/scenarios/dtmf_menu.yaml
+++ b/scripts/release-evals/scenarios/dtmf_menu.yaml
@@ -1,0 +1,31 @@
+name: dtmf_menu
+
+# DTMF: the caller drives a keypad phone menu (IVR) entirely with DTMF tones, no
+# speech. Each `dtmf:` turn presses keys that the bot's DTMFAggregator turns into
+# a "DTMF: ..." transcription, which (via the default transcription-based
+# turn-start strategy) drives a full user turn the LLM responds to.
+
+judge: !include judge_text.yaml
+
+turns:
+  # The bot greets the caller and reads the menu on connect.
+  - expect:
+      - event: response
+        eval: "presents a keypad menu, mentioning pressing 1 and pressing 2"
+
+  # Press 1: business hours.
+  - dtmf: "1#"
+    expect:
+      - event: user_transcription
+        text_contains: "DTMF: 1#"
+      - event: response
+        eval: "states the business hours (open 9 AM to 5 PM, Monday through Friday)"
+
+  # Press 2: office location. No '#' terminator here, so the aggregator flushes
+  # on its idle timeout instead (turn 1 covers the '#' immediate flush).
+  - dtmf: "2"
+    expect:
+      - event: user_transcription
+        text_contains: "DTMF: 2"
+      - event: response
+        eval: "gives the office location (123 Main Street)"

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -930,8 +930,15 @@ class EvalSession:
             # judged in context (e.g. a terse "That's four" answering this question).
             if self._judge is not None:
                 self._judge.add_user_message(turn.user)
+        elif turn.dtmf is not None:
+            self._debug(f"send: dtmf {turn.dtmf!r}")
+            await self._send_user_dtmf(turn.dtmf)
+            # Record the keypresses for judge context, so the bot's reply is judged
+            # knowing what was pressed.
+            if self._judge is not None:
+                self._judge.add_user_message(f"(DTMF keypad input: {turn.dtmf})")
 
-        self._progress(EvalTurnProgress(turn_idx, -1, turn.user or "", "turn"))
+        self._progress(EvalTurnProgress(turn_idx, -1, turn.user or turn.dtmf or "", "turn"))
 
         # All of a turn's expectations share one deadline anchored at the send, so a
         # stalled turn fails within a single ``within_ms`` budget instead of spending
@@ -991,6 +998,23 @@ class EvalSession:
             ).model_dump(),
         )
         await self._send(message)
+
+    async def _send_user_dtmf(self, keys: str) -> None:
+        """Send a DTMF keypress turn: one RTVI ``dtmf`` message per key.
+
+        The bot's ``RTVIProcessor`` turns each into an ``InputDTMFFrame`` pushed
+        downstream, the same path a telephony transport's keypress takes. The
+        bot's ``DTMFAggregator`` (if any) accumulates them and flushes — on the
+        ``#`` terminator or its idle timeout — into a transcription the bot reacts
+        to. Keys go out back-to-back; use ``send_after`` across turns to pace them.
+        """
+        for key in keys:
+            message = RTVI.Message(
+                type="dtmf",
+                id=self._message_id(),
+                data={"button": key},
+            )
+            await self._send(message)
 
     async def _send_image(self, image_path: str) -> None:
         """Register an image (base64, with its MIME type) for the current turn.

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -898,19 +898,20 @@ class EvalSession:
             try:
                 await self._wait_send_after(turn.send_after)
             except TimeoutError as e:
+                # Only the event-anchored wait can time out; the pure-delay form
+                # just sleeps. So event is never None here, but fall back for typing.
+                event_name = turn.send_after.event or "send_after"
                 failures.append(
                     EvalAssertionFailure(
                         turn_index=turn_idx,
                         expectation_index=-1,
-                        event_name=turn.send_after.event,
+                        event_name=event_name,
                         reason=f"send_after never fired: {e}",
                     )
                 )
-                self._debug(f"FAIL: {turn.send_after.event}: {failures[-1].reason}")
+                self._debug(f"FAIL: {event_name}: {failures[-1].reason}")
                 self._progress(
-                    EvalTurnProgress(
-                        turn_idx, -1, turn.send_after.event, "timeout", failures[-1].reason
-                    )
+                    EvalTurnProgress(turn_idx, -1, event_name, "timeout", failures[-1].reason)
                 )
                 return failures
 
@@ -1048,8 +1049,17 @@ class EvalSession:
         If the event was seen earlier in the run, anchor on that time (potentially
         fire immediately). Otherwise, poll the latest_event_times map until the
         event arrives, then anchor on that.
+
+        With no event (``send_after.event is None``), it's a pure time delay:
+        sleep ``delay_ms`` from now (i.e. from the previous turn's send).
         """
         target_delay_s = send_after.delay_ms / 1000.0
+
+        if send_after.event is None:
+            self._debug(f"send_after: waiting {send_after.delay_ms}ms")
+            await asyncio.sleep(target_delay_s)
+            return
+
         deadline = time.monotonic() + SEND_AFTER_MAX_WAIT_S
         self._debug(f"send_after: waiting for {send_after.event!r} + {send_after.delay_ms}ms")
 

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -731,20 +731,30 @@ class EvalSession:
     def _discard_interrupted_output(self) -> None:
         """Drop the bot's interrupted, un-matched output (on user interruption).
 
-        Clears the response buffers and drains the unmatched event queue, so a
-        greeting (or any prior bot output) the user just interrupted can't be
-        matched against this turn. Diagnostics (``events_seen``,
-        ``latest_event_times``) are left intact for send_after lookups.
+        Clears the response buffers and drains the bot's pending output from the
+        event queue, so a greeting (or any prior bot output) the user just
+        interrupted can't be matched against this turn. ``user_transcription`` is
+        preserved: a DTMF keypress emits its transcription immediately before the
+        turn-start interruption, and that transcription is the turn's *input*, not
+        the stale bot output this discard is meant to clear — dropping it would
+        race the matcher. Diagnostics (``events_seen``, ``latest_event_times``)
+        are left intact for send_after lookups.
         """
         self._text_buffer = []
         self._tts_audio = bytearray()
+        preserved: list[dict] = []
         dropped = 0
         while not self._queue.empty():
             try:
-                self._queue.get_nowait()
-                dropped += 1
+                event = self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
+            if event.get("type") == "user_transcription":
+                preserved.append(event)
+            else:
+                dropped += 1
+        for event in preserved:
+            self._queue.put_nowait(event)
         if dropped:
             self._debug(f"discard: dropped {dropped} queued event(s) on interruption")
 

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -61,6 +61,8 @@ A turn may also include ``send_after:`` to schedule its user send relative to a
 prior event (used for interruption / barge-in tests), or ``image:`` (a path,
 relative to the scenario file) to register an image for the turn — when a
 function-calling-video bot requests a user image, the eval transport serves it.
+``send_after`` with only ``delay_ms`` (no ``event``) is a pure time delay
+relative to the previous send, rather than an event anchor.
 
 Top-level optional fields:
     context: LLM messages the bot's context should start from. When given, the
@@ -167,7 +169,7 @@ class EvalExpectation:
 
 @dataclass
 class EvalSendAfter:
-    """Event-driven scheduling for a turn's user send.
+    """Scheduling for when a turn's user send fires.
 
     When set on a :class:`EvalTurn`, the harness waits for ``event`` to have been
     seen (either earlier in the run or arriving now), then waits an additional
@@ -175,12 +177,17 @@ class EvalSendAfter:
     tests: ``send_after: {event: llm_started, delay_ms: 500}`` means
     "interrupt 500ms after the bot started responding."
 
+    ``event`` is optional: a bare ``send_after: {delay_ms: 500}`` is a pure time
+    delay with no event anchor (500ms after the previous turn's send).
+
     Parameters:
-        event: Name of the event to schedule from.
-        delay_ms: Additional delay in milliseconds after the event was received.
+        event: Name of the event to schedule from, or ``None`` for a pure
+            ``delay_ms`` time delay with no event anchor.
+        delay_ms: Additional delay in milliseconds after the event was received
+            (or, when ``event`` is ``None``, after the previous turn's send).
     """
 
-    event: str
+    event: str | None
     delay_ms: int
 
 
@@ -507,13 +514,19 @@ def _parse_send_after(s: Any, path: Path, turn_idx: int) -> EvalSendAfter:
         raise ValueError(f"{path}: turn #{turn_idx} 'send_after:' must be a mapping")
 
     event = s.get("event")
-    if not event or not isinstance(event, str):
-        raise ValueError(f"{path}: turn #{turn_idx} 'send_after:' missing or invalid 'event:'")
+    if event is not None and not isinstance(event, str):
+        raise ValueError(f"{path}: turn #{turn_idx} 'send_after.event' must be a string if present")
 
     delay_ms = s.get("delay_ms", 0)
     if not isinstance(delay_ms, int) or delay_ms < 0:
         raise ValueError(
             f"{path}: turn #{turn_idx} 'send_after.delay_ms' must be a non-negative int"
+        )
+
+    # With no event to anchor on, a zero delay would be a no-op send_after.
+    if event is None and delay_ms == 0:
+        raise ValueError(
+            f"{path}: turn #{turn_idx} 'send_after:' needs an 'event:' or a positive 'delay_ms:'"
         )
 
     return EvalSendAfter(event=event, delay_ms=delay_ms)

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -57,12 +57,31 @@ Supported expectation fields (per event):
                                must satisfy, evaluated by a judge LLM (see
                                :mod:`pipecat.evals.judge`).
 
-A turn may also include ``send_after:`` to schedule its user send relative to a
-prior event (used for interruption / barge-in tests), or ``image:`` (a path,
-relative to the scenario file) to register an image for the turn — when a
-function-calling-video bot requests a user image, the eval transport serves it.
-``send_after`` with only ``delay_ms`` (no ``event``) is a pure time delay
-relative to the previous send, rather than an event anchor.
+Instead of ``user:``, a turn may press DTMF keys with ``dtmf:`` (the two are
+mutually exclusive — you press keys or you talk)::
+
+    turns:
+      - dtmf: "123#"            # quote it: an unquoted # starts a YAML comment
+        expect:
+          - event: user_transcription
+            text_contains: "DTMF: 123#"
+          - event: response
+            eval: "confirms the entered digits"
+
+Each character is sent as one ``InputDTMFFrame`` (``0``-``9``, ``*``, ``#``),
+regardless of the scenario's user/judge modality. A bot running a
+``DTMFAggregator`` accumulates them and flushes — on the ``#`` terminator or its
+idle timeout — into a ``DTMF: ...`` transcription it reacts to.
+
+A turn may also include ``send_after:`` to schedule its ``user``/``dtmf`` send
+relative to a prior event (used for interruption / barge-in tests), or
+``image:`` (a path, relative to the scenario file) to register an image for the
+turn — when a function-calling-video bot requests a user image, the eval
+transport serves it. ``send_after`` with only ``delay_ms`` (no ``event``) is a
+pure time delay relative to the previous send — handy for pacing keypresses
+across ``dtmf`` turns to exercise the aggregator's idle-timeout flush.
+
+``expect:`` is optional; omit it for a turn that only sends input or only waits.
 
 Top-level optional fields:
     context: LLM messages the bot's context should start from. When given, the
@@ -111,6 +130,8 @@ from typing import Any
 import yaml
 from loguru import logger
 from yamlinclude import YamlIncludeConstructor
+
+from pipecat.audio.dtmf.types import KeypadEntry
 
 # Events whose payloads carry bot-generated text the judge can sensibly
 # evaluate. Asserting ``eval:`` on anything else (user transcripts, tool
@@ -169,16 +190,18 @@ class EvalExpectation:
 
 @dataclass
 class EvalSendAfter:
-    """Scheduling for when a turn's user send fires.
+    """Scheduling for when a turn's input (``user`` or ``dtmf``) is sent.
 
     When set on a :class:`EvalTurn`, the harness waits for ``event`` to have been
     seen (either earlier in the run or arriving now), then waits an additional
-    ``delay_ms`` before sending the turn's ``user`` text. Used for barge-in
-    tests: ``send_after: {event: llm_started, delay_ms: 500}`` means
-    "interrupt 500ms after the bot started responding."
+    ``delay_ms`` before sending the turn's input. Used for barge-in tests:
+    ``send_after: {event: llm_started, delay_ms: 500}`` means "interrupt 500ms
+    after the bot started responding."
 
     ``event`` is optional: a bare ``send_after: {delay_ms: 500}`` is a pure time
-    delay with no event anchor (500ms after the previous turn's send).
+    delay with no event anchor (500ms after the previous turn's send). Handy for
+    pacing keypresses across ``dtmf`` turns, where there is no per-key event to
+    anchor on.
 
     Parameters:
         event: Name of the event to schedule from, or ``None`` for a pure
@@ -195,18 +218,31 @@ class EvalSendAfter:
 class EvalTurn:
     """One turn in a scenario.
 
-    A turn is either driven by the harness sending a ``user`` utterance, or it
-    is observation-only (no ``user`` field — useful for bot-first scenarios
-    like opening greetings).
+    A turn drives the bot one of three ways: the harness sends a ``user``
+    utterance (the person speaks), it sends a ``dtmf`` keypress sequence (the
+    person presses keys), or it is observation-only (neither field — useful for
+    bot-first scenarios like opening greetings). ``user`` and ``dtmf`` are
+    mutually exclusive: a turn is one or the other.
 
     Parameters:
         user: Optional text the harness sends as the user's turn — an RTVI
             ``send-text`` in text modality, or synthesized speech (``raw-audio``)
             in audio modality. If absent, the turn just waits for and asserts on
             expected events.
-        expect: Expected events, in the order they should arrive.
-        send_after: Optional event-driven schedule for when the ``user`` send
-            should fire. Only meaningful when ``user`` is set.
+        dtmf: Optional DTMF keypad sequence the harness sends, one
+            :class:`~pipecat.frames.frames.InputDTMFFrame` per character (e.g.
+            ``"123#"``). Each character must be a valid
+            :class:`~pipecat.audio.dtmf.types.KeypadEntry` (``0``-``9``, ``*``,
+            ``#``). Mutually exclusive with ``user``. The keys are injected the
+            same way regardless of the scenario's user/judge modality; a bot with
+            a ``DTMFAggregator`` turns them into a transcription it reacts to.
+            Quote the value in YAML (``dtmf: "123#"``) — an unquoted ``#`` starts
+            a comment.
+        expect: Expected events, in the order they should arrive. Optional —
+            omit it for a pure pacing/observation turn (e.g. a ``dtmf`` turn that
+            only presses keys, with the assertion on a later turn).
+        send_after: Optional schedule for when the turn's input should fire. Only
+            meaningful when ``user`` or ``dtmf`` is set.
         image: Optional path to an image to register for this turn (resolved
             relative to the scenario file). When a function-calling-video bot
             requests a user image during the turn, the eval transport serves this
@@ -214,7 +250,8 @@ class EvalTurn:
     """
 
     user: str | None
-    expect: list[EvalExpectation]
+    expect: list[EvalExpectation] = field(default_factory=list)
+    dtmf: str | None = None
     send_after: EvalSendAfter | None = None
     image: str | None = None
 
@@ -485,17 +522,25 @@ def _parse_turn(t: Any, path: Path, idx: int) -> EvalTurn:
     if user is not None and not isinstance(user, str):
         raise ValueError(f"{path}: turn #{idx} 'user:' must be a string if present")
 
-    raw_expect = t.get("expect")
+    dtmf = _parse_dtmf(t.get("dtmf"), path, idx)
+    if user is not None and dtmf is not None:
+        raise ValueError(
+            f"{path}: turn #{idx} has both 'user:' and 'dtmf:' — a turn is one or the other"
+        )
+
+    # `expect:` is optional: a turn may just send input (e.g. paced keypresses)
+    # or just wait, with the assertion living on another turn.
+    raw_expect = t.get("expect", [])
     if not isinstance(raw_expect, list):
-        raise ValueError(f"{path}: turn #{idx} missing or invalid 'expect:' list")
+        raise ValueError(f"{path}: turn #{idx} 'expect:' must be a list if present")
 
     expect = [_parse_expectation(e, path, idx, ei) for ei, e in enumerate(raw_expect)]
 
     send_after = _parse_send_after(t.get("send_after"), path, idx) if "send_after" in t else None
-    if send_after is not None and user is None:
+    if send_after is not None and user is None and dtmf is None:
         raise ValueError(
-            f"{path}: turn #{idx} has 'send_after:' but no 'user:' — "
-            "send_after only schedules when the user message gets sent"
+            f"{path}: turn #{idx} has 'send_after:' but no 'user:' or 'dtmf:' — "
+            "send_after only schedules when the turn's input gets sent"
         )
 
     # Image paths resolve relative to the scenario file, so a scenario is portable.
@@ -505,7 +550,31 @@ def _parse_turn(t: Any, path: Path, idx: int) -> EvalTurn:
             raise ValueError(f"{path}: turn #{idx} 'image:' must be a path string")
         image = str((path.parent / image).resolve())
 
-    return EvalTurn(user=user, expect=expect, send_after=send_after, image=image)
+    return EvalTurn(user=user, dtmf=dtmf, expect=expect, send_after=send_after, image=image)
+
+
+def _parse_dtmf(dtmf: Any, path: Path, turn_idx: int) -> str | None:
+    """Parse and validate a turn's ``dtmf:`` keypad sequence."""
+    if dtmf is None:
+        return None
+    # YAML parses an unquoted digit sequence as an int (`dtmf: 123`); normalize so
+    # both `dtmf: 123` and `dtmf: "123#"` work the same.
+    if isinstance(dtmf, int):
+        dtmf = str(dtmf)
+    if not isinstance(dtmf, str) or not dtmf:
+        raise ValueError(
+            f"{path}: turn #{turn_idx} 'dtmf:' must be a non-empty string of keypad entries"
+        )
+    for ch in dtmf:
+        try:
+            KeypadEntry(ch)
+        except ValueError:
+            valid = ", ".join(e.value for e in KeypadEntry)
+            raise ValueError(
+                f"{path}: turn #{turn_idx} 'dtmf:' has invalid keypad entry {ch!r} "
+                f"(valid entries: {valid})"
+            )
+    return dtmf
 
 
 def _parse_send_after(s: Any, path: Path, turn_idx: int) -> EvalSendAfter:

--- a/src/pipecat/processors/frameworks/rtvi/models.py
+++ b/src/pipecat/processors/frameworks/rtvi/models.py
@@ -22,6 +22,7 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict
 
+from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.frames.frames import (
     AggregationType,
 )
@@ -238,6 +239,17 @@ class SendTextData(BaseModel):
 
     content: str
     options: SendTextOptions | None = None
+
+
+class DTMFInputData(BaseModel):
+    """Data format for a DTMF keypress sent from the client.
+
+    Carries a single keypad entry. Clients send one ``dtmf`` message per key, the
+    way a telephony transport delivers them; the bot's DTMF handling (e.g. a
+    ``DTMFAggregator``) sequences them.
+    """
+
+    button: KeypadEntry
 
 
 class LLMFunctionCallStartMessageData(BaseModel):

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -24,6 +24,7 @@ from pipecat.frames.frames import (
     Frame,
     FunctionCallResultFrame,
     InputAudioRawFrame,
+    InputDTMFFrame,
     InputTransportMessageFrame,
     InputTransportStartAudioStreamingFrame,
     LLMConfigureOutputFrame,
@@ -359,6 +360,9 @@ class RTVIProcessor(FrameProcessor):
                     await self._handle_send_text(data)
                 case "raw-audio" | "raw-audio-batch":
                     await self._handle_audio_buffer(message.data)
+                case "dtmf":
+                    data = RTVI.DTMFInputData.model_validate(message.data)
+                    await self._handle_dtmf(data)
 
                 case _:
                     await self._send_error_response(message.id, f"Unsupported type {message.type}")
@@ -442,6 +446,16 @@ class RTVIProcessor(FrameProcessor):
         except (KeyError, TypeError, ValueError) as e:
             # Handle missing keys, decoding errors, and invalid types
             logger.error(f"Error processing audio buffer: {e}")
+
+    async def _handle_dtmf(self, data: RTVI.DTMFInputData):
+        """Handle a DTMF keypress from the client.
+
+        Like ``_handle_audio_buffer``, the RTVIProcessor sits at the top of the
+        pipeline, so pushing ``InputDTMFFrame`` downstream reaches the input
+        transport and the bot's DTMF handling exactly as a telephony transport's
+        keypress would.
+        """
+        await self.push_frame(InputDTMFFrame(button=data.button))
 
     async def _handle_send_text(self, data: RTVI.SendTextData):
         """Handle a send-text message from the client."""

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -398,6 +398,24 @@ class TestAudioSender(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(all(rate == 16000 for _, rate in sent))
 
 
+class TestDTMFSender(unittest.IsolatedAsyncioTestCase):
+    """A dtmf turn sends one RTVI ``dtmf`` message per key."""
+
+    async def test_send_user_dtmf_one_message_per_key(self):
+        s = _session()
+        sent: list[RTVI.Message] = []
+
+        async def fake_send(message):
+            sent.append(message)
+
+        s._send = fake_send
+        await s._send_user_dtmf("12#")
+
+        self.assertEqual(len(sent), 3)
+        self.assertTrue(all(m.type == "dtmf" for m in sent))
+        self.assertEqual([m.data["button"] for m in sent], ["1", "2", "#"])
+
+
 def _free_port() -> int:
     with socket.socket() as s:
         s.bind(("localhost", 0))

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -68,6 +68,23 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(len(s._tts_audio), 0)
         self.assertTrue(s._queue.empty())
 
+    def test_discard_preserves_user_transcription(self):
+        # A DTMF keypress emits its user_transcription right before the turn-start
+        # interruption. The discard must keep it (it's the turn's input) while
+        # still dropping the bot's interrupted output.
+        s = _session(bot_audio=True)
+        s._queue.put_nowait({"type": "llm_response", "text": "greeting"})
+        s._queue.put_nowait({"type": "user_transcription", "transcript": "DTMF: 1#"})
+        self.assertEqual(
+            s._translate({"type": "user-started-speaking"}),
+            [{"type": "user_started_speaking"}],
+        )
+        # The bot output is gone; the user transcription survives, still queued.
+        self.assertEqual(
+            s._queue.get_nowait(), {"type": "user_transcription", "transcript": "DTMF: 1#"}
+        )
+        self.assertTrue(s._queue.empty())
+
     def test_user_transcription_final_only(self):
         s = _session()
         interim = {"type": "user-transcription", "data": {"text": "he", "final": False}}

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -231,6 +231,51 @@ class TestEvalsScenarioParser(unittest.TestCase):
         self.assertIsNone(s.turns[0].user)
         self.assertEqual(s.turns[0].expect[0].event, "llm_response")
 
+    def test_dtmf_turn_parsed(self):
+        s = EvalScenario.load(
+            _write(
+                """
+                name: dtmf
+                turns:
+                  - dtmf: "123#"
+                    expect:
+                      - event: user_transcription
+                        text_contains: "DTMF: 123#"
+                """
+            )
+        )
+        self.assertEqual(s.turns[0].dtmf, "123#")
+        self.assertIsNone(s.turns[0].user)
+
+    def test_dtmf_unquoted_int_normalized(self):
+        """An unquoted digit sequence parses as int; it's coerced to a string."""
+        s = EvalScenario.load(_write("name: dtmf\nturns: [{dtmf: 123}]\n"))
+        self.assertEqual(s.turns[0].dtmf, "123")
+
+    def test_dtmf_invalid_entry_rejected(self):
+        with self.assertRaises(ValueError) as cm:
+            EvalScenario.load(_write('name: bad\nturns: [{dtmf: "1A"}]\n'))
+        self.assertIn("invalid keypad entry", str(cm.exception))
+
+    def test_dtmf_and_user_mutually_exclusive(self):
+        with self.assertRaises(ValueError) as cm:
+            EvalScenario.load(_write('name: bad\nturns: [{user: hi, dtmf: "1"}]\n'))
+        self.assertIn("one or the other", str(cm.exception))
+
+    def test_send_after_allowed_on_dtmf_turn(self):
+        s = EvalScenario.load(
+            _write(
+                """
+                name: bargein
+                turns:
+                  - dtmf: "0"
+                    send_after: {event: llm_started, delay_ms: 300}
+                """
+            )
+        )
+        assert s.turns[0].send_after is not None
+        self.assertEqual(s.turns[0].send_after.event, "llm_started")
+
     def test_judge_eval_preserved(self):
         s = EvalScenario.load(
             _write(
@@ -330,9 +375,14 @@ class TestEvalsScenarioParser(unittest.TestCase):
             )
         self.assertIn("positive 'delay_ms:'", str(cm.exception))
 
-    def test_missing_expect_rejected(self):
+    def test_missing_expect_defaults_to_empty(self):
+        """A turn without `expect:` just sends/waits (e.g. paced keypresses)."""
+        s = EvalScenario.load(_write("name: ok\nturns: [{user: hi}]\n"))
+        self.assertEqual(s.turns[0].expect, [])
+
+    def test_expect_non_list_rejected(self):
         with self.assertRaises(ValueError) as cm:
-            EvalScenario.load(_write("name: bad\nturns: [{user: hi}]\n"))
+            EvalScenario.load(_write("name: bad\nturns: [{user: hi, expect: nope}]\n"))
         self.assertIn("expect", str(cm.exception))
 
     def test_expectation_missing_event_rejected(self):

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -302,6 +302,34 @@ class TestEvalsScenarioParser(unittest.TestCase):
             )
         self.assertIn("non-negative", str(cm.exception))
 
+    def test_send_after_without_event_is_pure_delay(self):
+        s = EvalScenario.load(
+            _write(
+                """
+                name: paced
+                turns:
+                  - user: "first"
+                    expect: [{event: llm_started}]
+                  - user: "second"
+                    send_after: {delay_ms: 500}
+                    expect: [{event: llm_started}]
+                """
+            )
+        )
+        assert s.turns[1].send_after is not None
+        self.assertIsNone(s.turns[1].send_after.event)
+        self.assertEqual(s.turns[1].send_after.delay_ms, 500)
+
+    def test_send_after_without_event_or_delay_rejected(self):
+        with self.assertRaises(ValueError) as cm:
+            EvalScenario.load(
+                _write(
+                    "name: bad\n"
+                    "turns: [{user: hi, send_after: {delay_ms: 0}, expect: [{event: x}]}]\n"
+                )
+            )
+        self.assertIn("positive 'delay_ms:'", str(cm.exception))
+
     def test_missing_expect_rejected(self):
         with self.assertRaises(ValueError) as cm:
             EvalScenario.load(_write("name: bad\nturns: [{user: hi}]\n"))

--- a/tests/test_evals_serializer.py
+++ b/tests/test_evals_serializer.py
@@ -120,6 +120,19 @@ class TestRTVIEvalSerializerDeserialize(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(await self.serializer.deserialize(json.dumps(msg)))
         self.assertEqual(self.serializer.get_user_image(), (img, "image/png"))
 
+    async def test_dtmf_message_forwarded_to_processor(self):
+        # DTMF is now a first-class RTVI message handled by the RTVIProcessor, so
+        # the serializer just forwards it like any other RTVI message.
+        msg = {
+            "label": RTVI.MESSAGE_LABEL,
+            "type": "dtmf",
+            "id": "9",
+            "data": {"button": "#"},
+        }
+        frame = await self.serializer.deserialize(json.dumps(msg))
+        self.assertIsInstance(frame, InputTransportMessageFrame)
+        self.assertEqual(frame.message["type"], "dtmf")
+
     async def test_non_context_client_message_is_forwarded(self):
         msg = {
             "label": RTVI.MESSAGE_LABEL,

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -8,9 +8,13 @@ import unittest
 import warnings
 from unittest.mock import AsyncMock, Mock
 
+from pydantic import ValidationError
+
 import pipecat.processors.frameworks.rtvi.models as RTVI
+from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.frames.frames import (
     InputAudioRawFrame,
+    InputDTMFFrame,
     InputTransportStartAudioStreamingFrame,
 )
 from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
@@ -180,6 +184,25 @@ class TestRTVIFrameBasedAudio(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(pushed), 1)
         self.assertIsInstance(pushed[0], InputAudioRawFrame)
         self.assertEqual(pushed[0].sample_rate, 16000)
+
+
+class TestRTVIDTMF(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self):
+        if hasattr(self, "processor"):
+            await self.processor.cleanup()
+
+    async def test_dtmf_pushes_input_dtmf_frame_downstream(self):
+        self.processor = RTVIProcessor()
+        self.processor.push_frame = AsyncMock()
+        await self.processor._handle_dtmf(RTVI.DTMFInputData(button=KeypadEntry.ONE))
+        pushed = [c.args[0] for c in self.processor.push_frame.call_args_list]
+        self.assertEqual(len(pushed), 1)
+        self.assertIsInstance(pushed[0], InputDTMFFrame)
+        self.assertEqual(pushed[0].button, KeypadEntry.ONE)
+
+    def test_dtmf_input_data_rejects_invalid_button(self):
+        with self.assertRaises(ValidationError):
+            RTVI.DTMFInputData.model_validate({"button": "Z"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds DTMF keypress support, built on a new first-class RTVI `dtmf` client message, exercised by the behavioral evals and a worked example bot.

### A first-class RTVI `dtmf` message

A client sends `{type: "dtmf", data: {button: "1"}}` and the `RTVIProcessor` validates the keypad entry and pushes an `InputDTMFFrame` downstream, mirroring how `raw-audio` becomes an `InputAudioRawFrame`. Since the processor sits at the top of the pipeline, the frame reaches the input transport and the bot's DTMF handling (e.g. a `DTMFAggregator`) exactly as a telephony transport's keypress would. One keypress per message.

This is the server-side half. Client SDKs and a playground keypad UI are a later phase; for now the eval harness is the first caller. There's a single DTMF path everywhere: telephony, web clients (later), and evals all go through the same `RTVIProcessor` → `InputDTMFFrame` flow.

### DTMF in the evals

A scenario turn can press keys with a `dtmf:` field, a sibling to `user:` and mutually exclusive with it:

```yaml
turns:
  - dtmf: "123#"
    expect:
      - event: user_transcription
        text_contains: "DTMF: 123#"
      - event: response
        eval: "confirms the entered digits"
```

The harness sends one RTVI `dtmf` message per key. A bot with a `DTMFAggregator` turns the keys into a `DTMF: ...` transcription; with the default transcription-based turn-start strategy that drives a full user turn, so a `dtmf` turn fires `user_started_speaking`, `user_transcription`, `user_stopped_speaking`, and the bot `response`, and can be asserted on like a spoken turn.

### Example bot

`examples/features/features-dtmf-menu.py` is a keypad-driven phone menu (IVR): press 1 for business hours, press 2 for the office location. It speaks its replies via TTS, has no STT (DTMF comes from the transport), and is wired into the release-evals manifest via the `dtmf_menu` scenario. Verified end to end in both text and audio judge modes (the audio run transcribes the bot's actual TTS audio).

## Supporting changes

- `send_after.event` is now optional: a bare `send_after: { delay_ms: N }` is a pure time delay relative to the previous send. A zero-delay no-event `send_after` is rejected.
- `expect:` is optional (defaults to empty), so a turn can just send input or wait.
- The harness `_discard_interrupted_output` now preserves a queued `user_transcription` (the turn's input) when an interruption clears the bot's output. A DTMF keypress emits its transcription right before the turn-start interruption; without this it was raced away. Existing barge-in scenarios are unaffected (a spoken turn's transcription arrives after user-started-speaking).
