### PR TITLE
bus: drop redundant CancelledError handling in dispatch tasks

### DIFF
--- a/changelog/4851.changed.md
+++ b/changelog/4851.changed.md
@@ -1,0 +1,1 @@
+- Simplified the `WorkerBus` message-dispatch tasks by removing redundant `CancelledError` handling (the task manager already handles cancellation, and `CancelledError` was never caught by the subscriber-isolation handler). Subscriber-exception isolation and cancellation behavior are unchanged.

--- a/src/pipecat/bus/bus.py
+++ b/src/pipecat/bus/bus.py
@@ -168,43 +168,33 @@ class WorkerBus(BaseObject):
 
     async def _router_task(self, sub: BusSubscription):
         """Route system messages inline, data messages to the data queue."""
-        try:
-            while True:
-                message = await sub.queue.get()
-                if isinstance(message, BusSystemMessage):
-                    # A subscriber exception must not tear down the dispatch task,
-                    # or the subscriber would silently stop receiving all future
-                    # messages (including cancel/cleanup). Log and keep going.
-                    try:
-                        await sub.subscriber.on_bus_message(cast(BusMessage, message))
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        logger.exception(
-                            f"{self}: subscriber '{sub.subscriber.name}' raised handling "
-                            f"system message {message}; keeping dispatch alive"
-                        )
-                else:
-                    sub.data_queue.put_nowait(message)
-        except asyncio.CancelledError:
-            pass
-
-    async def _data_dispatch_task(self, sub: BusSubscription):
-        """Process data messages sequentially from the data queue."""
-        try:
-            while True:
-                message = await sub.data_queue.get()
+        while True:
+            message = await sub.queue.get()
+            if isinstance(message, BusSystemMessage):
                 # A subscriber exception must not tear down the dispatch task,
                 # or the subscriber would silently stop receiving all future
                 # messages (including cancel/cleanup). Log and keep going.
                 try:
-                    await sub.subscriber.on_bus_message(message)
-                except asyncio.CancelledError:
-                    raise
+                    await sub.subscriber.on_bus_message(cast(BusMessage, message))
                 except Exception:
                     logger.exception(
                         f"{self}: subscriber '{sub.subscriber.name}' raised handling "
-                        f"data message {message}; keeping dispatch alive"
+                        f"system message {message}; keeping dispatch alive"
                     )
-        except asyncio.CancelledError:
-            pass
+            else:
+                sub.data_queue.put_nowait(message)
+
+    async def _data_dispatch_task(self, sub: BusSubscription):
+        """Process data messages sequentially from the data queue."""
+        while True:
+            message = await sub.data_queue.get()
+            # A subscriber exception must not tear down the dispatch task,
+            # or the subscriber would silently stop receiving all future
+            # messages (including cancel/cleanup). Log and keep going.
+            try:
+                await sub.subscriber.on_bus_message(message)
+            except Exception:
+                logger.exception(
+                    f"{self}: subscriber '{sub.subscriber.name}' raised handling "
+                    f"data message {message}; keeping dispatch alive"
+                )

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -295,7 +295,7 @@ class _FailingSub(BusSubscriber):
         self.received.append(message)
 
 
-class TestSubscriberExceptionIsolation(unittest.IsolatedAsyncioTestCase):
+class TestSubscriberException(unittest.IsolatedAsyncioTestCase):
     """A subscriber exception must not stop future delivery to that subscriber."""
 
     async def test_data_dispatch_survives_subscriber_exception(self):


### PR DESCRIPTION
## Summary

Simplifies the `WorkerBus` dispatch tasks (`_router_task` / `_data_dispatch_task`) by removing redundant `CancelledError` handling. No behavior change.

Each task previously wrapped its `while True` loop in `try/except asyncio.CancelledError: pass` and re-raised `CancelledError` ahead of the generic `except Exception` subscriber-isolation handler. Both are unnecessary:

- `TaskManager.cancel_task` already cancels the task, awaits it, and swallows the `CancelledError` (these tasks are created with `self.create_task` and torn down with `self.cancel_task`). The task body doesn't need to catch its own cancellation.
- `asyncio.CancelledError` is a `BaseException`, not an `Exception`, so the `except Exception` handler never caught it anyway. The explicit `except CancelledError: raise` ahead of it was a no-op.

What's preserved: a subscriber raising while handling a message is still logged and dispatch keeps running (the isolation added in #4840); cancellation still tears the tasks down cleanly via the TaskManager.

