### PR TITLE
Update paths in docs-update skill

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -14,6 +14,7 @@ Update documentation pages to reflect source code changes on the current branch.
 - `DOCS_PATH` (optional): Path to the docs repository root. If not provided, ask the user.
 
 Examples:
+
 - `/update-docs /Users/me/src/docs`
 - `/update-docs`
 
@@ -23,16 +24,18 @@ Examples:
 
 If `DOCS_PATH` was provided as an argument, use it. Otherwise, ask the user for the path to their docs repository.
 
-Verify the path exists and contains `server/services/` subdirectory.
+Verify the path exists and contains `api-reference/server/services/` subdirectory.
 
 ### Step 2: Create docs branch
 
 Get the current pipecat branch name:
+
 ```bash
 git rev-parse --abbrev-ref HEAD
 ```
 
 In the docs repo, create a new branch off main with a matching name:
+
 ```bash
 cd DOCS_PATH && git checkout main && git pull && git checkout -b {branch-name}-docs
 ```
@@ -44,11 +47,13 @@ All doc edits in subsequent steps are made on this branch.
 ### Step 3: Detect changed source files
 
 Run:
+
 ```bash
 git diff main..HEAD --name-only
 ```
 
 Filter to files that could affect documentation:
+
 - `src/pipecat/services/**/*.py` (service implementations)
 - `src/pipecat/transports/**/*.py` (transport implementations)
 - `src/pipecat/serializers/**/*.py` (serializer implementations)
@@ -96,61 +101,71 @@ For each doc page that needs updates, edit **only the sections that need changes
 #### Section-specific guidance
 
 **Configuration** (constructor params):
+
 - Use `<ParamField path="name" type="type" default="value">` format if the page already uses it
 - Add new params in logical order (required first, then optional)
 - Remove params that no longer exist in source
 - Update types/defaults that changed
 
 **InputParams** (runtime settings):
+
 - Use markdown table format: `| Parameter | Type | Default | Description |`
 - Match the field names and types from the `InputParams(BaseModel)` class
 - Include the default values from the source
 
 **Usage** (code examples):
+
 - Update import paths, class names, and parameter names
 - Only modify examples if they would break or be misleading with the new API
 - Don't rewrite working examples just to add new optional params
 
 **Notes**:
+
 - Add notes for new behavioral gotchas or breaking changes
 - Remove notes about limitations that were fixed
 - Keep existing notes that are still accurate
 
 **Event Handlers**:
+
 - Update the event table and example code
 - Add new events, remove deleted ones
 - Update handler signatures if they changed
 
 **Overview / Key Features / Prerequisites**:
+
 - Only update if the PR fundamentally changes what the service does (new capability, removed capability, renamed class)
 - Most PRs will NOT need changes to these sections
 
 ### Step 7: Update guides
 
-Guides at `DOCS_PATH/guides/` reference specific class names, parameters, imports, and code patterns. After completing reference doc edits, check if any guides need updates too.
+Guides at `DOCS_PATH/pipecat/` reference specific class names, parameters, imports, and code patterns. After completing reference doc edits, check if any guides need updates too.
 
 For each changed source file, collect the class names, renamed parameters, and changed imports from the diff. Search the guides directory:
+
 ```bash
-grep -rl "ClassName\|old_param_name" DOCS_PATH/guides/
+grep -rl "ClassName\|old_param_name" DOCS_PATH/pipecat/
 ```
 
 For each guide that references changed code:
+
 1. Read the full guide
 2. Update class names, parameter names, import paths, and code examples that are now incorrect
 3. **Don't rewrite prose** — only fix the specific references that changed
 4. Leave guides alone if they reference the service generally but don't use any changed APIs
 
 Guide directories:
-- `guides/learn/` — conceptual tutorials (pipeline, LLM, STT, TTS, etc.)
-- `guides/fundamentals/` — practical how-tos (metrics, recording, transcripts, etc.)
-- `guides/features/` — feature-specific guides (Gemini Live, OpenAI audio, WhatsApp, etc.)
-- `guides/telephony/` — telephony integration guides (Twilio, Plivo, Telnyx, etc.)
+
+- `pipecat/learn/` — conceptual tutorials (pipeline, LLM, STT, TTS, etc.)
+- `pipecat/fundamentals/` — practical how-tos (metrics, recording, transcripts, etc.)
+- `pipecat/features/` — feature-specific guides (Gemini Live, OpenAI audio, WhatsApp, etc.)
+- `pipecat/telephony/` — telephony integration guides (Twilio, Plivo, Telnyx, etc.)
 
 ### Step 8: Identify doc gaps
 
 After processing all mapped pairs, check for two kinds of gaps:
 
 **Missing pages**: Source files that had no doc page mapping (neither tier 1, 2, nor 3) and are not marked as "(skip)". For each, tell the user:
+
 - The source file path
 - The main class(es) it defines
 - Whether a new doc page should be created
@@ -161,8 +176,9 @@ If the user wants a new page, do all three of the following:
 
 #### 8a: Create the doc page
 
-Create the new `.mdx` file using this template structure:
-```
+Create the new `.mdx` file under `DOCS_PATH/api-reference/server/services/{category}/{provider}.mdx` using this template structure:
+
+````
 ---
 title: "Service Name"
 description: "Brief description"
@@ -180,7 +196,7 @@ description: "Brief description"
 
 ```bash
 uv add "pipecat-ai[package-name]"
-```
+````
 
 ## Prerequisites
 
@@ -209,11 +225,12 @@ uv add "pipecat-ai[package-name]"
 ## Event Handlers
 
 [Event table and example code]
-```
+
+````
 
 #### 8b: Add to docs.json
 
-Add the new page path to `DOCS_PATH/docs.json` in the correct navigation group. The path format is `server/services/{category}/{provider}` (without the `.mdx` extension).
+Add the new page path to `DOCS_PATH/docs.json` in the correct navigation group. The path format is `api-reference/server/services/{category}/{provider}` (without the `.mdx` extension).
 
 Find the matching group in the navigation structure:
 - **STT** → `"group": "Speech-to-Text"` under Services
@@ -233,25 +250,27 @@ Insert the new entry **alphabetically** within the group's `pages` array. For ex
 {
   "group": "Speech-to-Text",
   "pages": [
-    "server/services/stt/assemblyai",
-    "server/services/stt/aws",
+    "api-reference/server/services/stt/assemblyai",
+    "api-reference/server/services/stt/aws",
     ...
-    "server/services/stt/foo",
+    "api-reference/server/services/stt/foo",
     ...
   ]
 }
-```
+````
 
 #### 8c: Add to supported-services.mdx
 
-Add a new row to the correct category table in `DOCS_PATH/server/services/supported-services.mdx`.
+Add a new row to the correct category table in `DOCS_PATH/api-reference/server/services/supported-services.mdx`.
 
 Use this format:
+
 ```
-| [DisplayName](/server/services/{category}/{provider}) | `uv add "pipecat-ai[package]"` |
+| [DisplayName](/api-reference/server/services/{category}/{provider}) | `uv add "pipecat-ai[package]"` |
 ```
 
 To determine the correct values:
+
 - **DisplayName**: Use the service's human-readable name (e.g., "ElevenLabs", "AWS Polly", "Google Gemini")
 - **package**: Look at the service's `pyproject.toml` extras or the import pattern in the source code. For example, if the service is in `src/pipecat/services/foo/`, the package is typically `foo`.
 - If no pip dependencies are required, use `No dependencies required` instead.
@@ -266,14 +285,14 @@ After all edits are complete, print a summary:
 ## Documentation Updates
 
 ### Updated reference pages
-- `server/services/stt/deepgram.mdx` — Updated Configuration (added `new_param`), InputParams (updated `language` default)
-- `server/services/tts/elevenlabs.mdx` — Updated Event Handlers (added `on_connected`)
+- `api-reference/server/services/stt/deepgram.mdx` — Updated Configuration (added `new_param`), InputParams (updated `language` default)
+- `api-reference/server/services/tts/elevenlabs.mdx` — Updated Event Handlers (added `on_connected`)
 
 ### Updated guides
-- `guides/learn/speech-to-text.mdx` — Updated code example (renamed `old_param` → `new_param`)
+- `pipecat/learn/speech-to-text.mdx` — Updated code example (renamed `old_param` → `new_param`)
 
 ### New service pages
-- `server/services/tts/newprovider.mdx` — Created page, added to docs.json (Text-to-Speech), added to supported-services.mdx
+- `api-reference/server/services/tts/newprovider.mdx` — Created page, added to docs.json (Text-to-Speech), added to supported-services.mdx
 
 ### Unmapped source files
 - `src/pipecat/services/newprovider/tts.py` — NewProviderTTSService (no doc page exists)

--- a/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
+++ b/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
@@ -4,76 +4,74 @@ Maps pipecat source files to their documentation pages. Source paths are relativ
 
 ## Name mismatches
 
-These source paths don't follow the standard `services/{provider}/{type}.py` → `server/services/{type}/{provider}.mdx` pattern.
+These source paths don't follow the standard `services/{provider}/{type}.py` → `api-reference/server/services/{type}/{provider}.mdx` pattern.
 
-| Source path | Doc page |
-|---|---|
-| `services/google/llm.py` | `server/services/llm/gemini.mdx` |
-| `services/google/llm_vertex.py` | `server/services/llm/google-vertex.mdx` |
-| `services/google/google.py` | (shared base — check which services use it) |
-| `services/google/gemini_live/**` | `server/services/s2s/gemini-live.mdx` |
-| `services/google/gemini_live/llm_vertex.py` | `server/services/s2s/gemini-live-vertex.mdx` |
-| `services/aws_nova_sonic/**` | `server/services/s2s/aws.mdx` |
-| `services/ultravox/**` | `server/services/s2s/ultravox.mdx` |
-| `services/grok/realtime/**` | `server/services/s2s/grok.mdx` |
-| `services/openai/realtime/**` | `server/services/s2s/openai.mdx` |
-| `processors/frameworks/rtvi.py` | `server/frameworks/rtvi/rtvi-processor.mdx` and `server/frameworks/rtvi/rtvi-observer.mdx` |
-| `processors/transcript_processor.py` | `server/utilities/transcript-processor.mdx` |
-| `processors/user_idle_processor.py` | `server/utilities/user-idle-processor.mdx` |
-| `processors/idle_frame_processor.py` | `server/pipeline/pipeline-idle-detection.mdx` |
-| `pipeline/task.py` | `server/pipeline/pipeline-task.mdx` |
-| `pipeline/runner.py` | `server/utilities/runner/guide.mdx` |
-| `transports/base_transport.py` | `server/services/transport/transport-params.mdx` |
+| Source path                                 | Doc page                                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `services/google/llm_vertex.py`             | `api-reference/server/services/llm/google-vertex.mdx`                                            |
+| `services/google/google.py`                 | (shared base — check which services use it)                                                      |
+| `services/google/gemini_live/**`            | `api-reference/server/services/s2s/gemini-live.mdx`                                              |
+| `services/google/gemini_live/llm_vertex.py` | `api-reference/server/services/s2s/gemini-live-vertex.mdx`                                       |
+| `services/aws_nova_sonic/**`                | `api-reference/server/services/s2s/aws.mdx`                                                      |
+| `services/ultravox/**`                      | `api-reference/server/services/s2s/ultravox.mdx`                                                 |
+| `services/grok/realtime/**`                 | `api-reference/server/services/s2s/grok.mdx`                                                     |
+| `services/openai/realtime/**`               | `api-reference/server/services/s2s/openai.mdx`                                                   |
+| `processors/frameworks/rtvi.py`             | `api-reference/server/rtvi/rtvi-processor.mdx` and `api-reference/server/rtvi/rtvi-observer.mdx` |
+| `processors/idle_frame_processor.py`        | `api-reference/server/pipeline/pipeline-idle-detection.mdx`                                      |
+| `pipeline/worker.py`                        | `api-reference/server/pipeline/pipeline-worker.mdx`                                              |
+| `pipeline/runner.py`                        | `api-reference/server/utilities/runner/guide.mdx`                                                |
+| `transports/base_transport.py`              | `api-reference/server/services/transport/transport-params.mdx`                                   |
 
 ## Skip list
 
 These files should never trigger doc updates.
 
-| Pattern | Reason |
-|---|---|
-| `services/ai_service.py` | Internal base class |
-| `services/stt_service.py` | Internal base class |
-| `services/tts_service.py` | Internal base class |
-| `services/llm_service.py` | Internal base class |
-| `services/websocket_service.py` | Internal base class |
-| `services/openai_realtime_beta/**` | Deprecated |
-| `services/openai_realtime/**` | Deprecated |
-| `services/gemini_multimodal_live/**` | Deprecated |
-| `services/aws/agent_core.py` | Internal |
-| `services/aws/sagemaker/**` | No doc page |
-| `transports/base_input.py` | Internal base class |
-| `transports/base_output.py` | Internal base class |
-| `transports/websocket/client.py` | No doc page |
-| `serializers/base_serializer.py` | Internal base class |
-| `serializers/protobuf.py` | Internal |
-| `processors/audio/**` | Internal |
-| `pipeline/pipeline.py` | Core architecture, not a service doc |
+| Pattern                              | Reason                               |
+| ------------------------------------ | ------------------------------------ |
+| `services/ai_service.py`             | Internal base class                  |
+| `services/stt_service.py`            | Internal base class                  |
+| `services/tts_service.py`            | Internal base class                  |
+| `services/llm_service.py`            | Internal base class                  |
+| `services/websocket_service.py`      | Internal base class                  |
+| `services/openai_realtime_beta/**`   | Deprecated                           |
+| `services/openai_realtime/**`        | Deprecated                           |
+| `services/gemini_multimodal_live/**` | Deprecated                           |
+| `services/aws/agent_core.py`         | Internal                             |
+| `services/aws/sagemaker/**`          | No doc page                          |
+| `transports/base_input.py`           | Internal base class                  |
+| `transports/base_output.py`          | Internal base class                  |
+| `transports/websocket/client.py`     | No doc page                          |
+| `serializers/base_serializer.py`     | Internal base class                  |
+| `serializers/protobuf.py`            | Internal                             |
+| `processors/audio/**`                | Internal                             |
+| `pipeline/pipeline.py`               | Core architecture, not a service doc |
 
 ## Pattern matching
 
 For files not in the tables above, apply these patterns. Convert underscores to hyphens in provider names for doc filenames.
 
-| Source pattern | Doc pattern |
-|---|---|
-| `services/{provider}/stt*.py` | `server/services/stt/{provider}.mdx` |
-| `services/{provider}/tts*.py` | `server/services/tts/{provider}.mdx` |
-| `services/{provider}/llm*.py` | `server/services/llm/{provider}.mdx` |
-| `services/{provider}/image*.py` | `server/services/image-generation/{provider}.mdx` |
-| `services/{provider}/video*.py` | `server/services/video/{provider}.mdx` |
-| `services/{provider}/realtime/**` | `server/services/s2s/{provider}.mdx` |
-| `transports/{name}/**` | `server/services/transport/{name}.mdx` |
-| `serializers/{name}.py` | `server/services/serializers/{name}.mdx` |
-| `observers/**` | `server/utilities/observers/` (match by class name) |
-| `audio/vad/**` | `server/utilities/audio/` (match by class name) |
-| `audio/filters/**` | `server/utilities/audio/` (match by class name) |
-| `audio/mixers/**` | `server/utilities/audio/` (match by class name) |
-| `processors/filters/**` | `server/utilities/filters/` (match by class name) |
+| Source pattern                    | Doc pattern                                                       |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `services/{provider}/stt*.py`     | `api-reference/server/services/stt/{provider}.mdx`                |
+| `services/{provider}/tts*.py`     | `api-reference/server/services/tts/{provider}.mdx`                |
+| `services/{provider}/llm*.py`     | `api-reference/server/services/llm/{provider}.mdx`                |
+| `services/{provider}/image*.py`   | `api-reference/server/services/image-generation/{provider}.mdx`   |
+| `services/{provider}/video*.py`   | `api-reference/server/services/video/{provider}.mdx`              |
+| `services/{provider}/realtime/**` | `api-reference/server/services/s2s/{provider}.mdx`                |
+| `transports/{name}/**`            | `api-reference/server/services/transport/{name}.mdx`              |
+| `serializers/{name}.py`           | `api-reference/server/services/serializers/{name}.mdx`            |
+| `observers/**`                    | `api-reference/server/utilities/observers/` (match by class name) |
+| `audio/vad/**`                    | `api-reference/server/utilities/audio/` (match by class name)     |
+| `audio/filters/**`                | `api-reference/server/utilities/audio/` (match by class name)     |
+| `audio/mixers/**`                 | `api-reference/server/utilities/audio/` (match by class name)     |
+| `processors/filters/**`           | `api-reference/server/utilities/filters/` (match by class name)   |
 
 If the doc file doesn't exist at the resolved path, the file is **unmapped**.
 
 ## Search fallback
 
 For files that don't match any table or pattern above:
+
 1. Extract the main class name(s) from the source file
-2. Search the docs directory for that class name: `grep -r "ClassName" DOCS_PATH/server/`
+2. Search the docs directory for that class name: `grep -r "ClassName" DOCS_PATH/api-reference/ DOCS_PATH/pipecat/`
 3. If found in a doc page, use that as the mapping


### PR DESCRIPTION
- Update reference paths from `server/` to `api-reference/server/`
- Update guide paths from `guides/` to `pipecat/`
- Replace deprecated `pipeline/task.py` with `pipeline/worker.py`
- Remove obsolete processor mappings (transcript, user-idle)
- Update rtvi doc paths from `frameworks/rtvi/` to `rtvi/`
- Standardize table formatting in mappings file
- Update search fallback to include both `api-reference/` and `pipecat/` directories