### PR TITLE
Default AssemblyAI STT to universal-3-5-pro

### DIFF
--- a/changelog/4863.changed.md
+++ b/changelog/4863.changed.md
@@ -1,0 +1,1 @@
+- `AssemblyAISTTService` now defaults to the `universal-3-5-pro` model (AssemblyAI's launched flagship streaming model), replacing the pre-GA alias `u3-rt-pro`. Both resolve to the same U3 Pro family and feature set, so the only change is the model id sent on the wire. `u3-rt-pro` and `u3-rt-pro-beta-1` remain accepted for backward compatibility.

--- a/src/pipecat/services/assemblyai/models.py
+++ b/src/pipecat/services/assemblyai/models.py
@@ -141,8 +141,8 @@ class AssemblyAIConnectionParams(BaseModel):
         min_end_of_turn_silence_when_confident: DEPRECATED. Use min_turn_silence instead.
         max_turn_silence: Maximum silence duration before forcing end-of-turn.
         keyterms_prompt: List of key terms to guide transcription. Will be JSON serialized before sending.
-        prompt: Optional text prompt to guide the transcription. Only used when speech_model is "u3-rt-pro".
-        speech_model: Select between English, multilingual, and u3-rt-pro models. Defaults to "u3-rt-pro".
+        prompt: Optional text prompt to guide the transcription. Only used when speech_model is "universal-3-5-pro".
+        speech_model: Select between English, multilingual, and Universal-3.5 Pro models. Defaults to "universal-3-5-pro".
         language_detection: Enable automatic language detection. Only applicable to
             universal-streaming-multilingual. When enabled, Turn messages include
             language_code and language_confidence fields. Defaults to None (not sent).
@@ -176,7 +176,7 @@ class AssemblyAIConnectionParams(BaseModel):
         "u3-rt-pro",
         "u3-rt-pro-beta-1",
         "universal-3-5-pro",
-    ] = "u3-rt-pro"
+    ] = "universal-3-5-pro"
     language_detection: bool | None = None
     format_turns: bool = True
     speaker_labels: bool | None = None

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -278,7 +278,7 @@ class AssemblyAISTTService(WebsocketSTTService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="u3-rt-pro",
+            model="universal-3-5-pro",
             language=Language.EN,
             formatted_finals=True,
             word_finalization_max_wait_time=None,

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -19,8 +19,14 @@ def _query(service: AssemblyAISTTService) -> dict[str, list[str]]:
     return parse_qs(urlparse(service._build_ws_url()).query)
 
 
-def test_continuous_partials_defaults_to_true_for_u3_rt_pro():
-    # u3-rt-pro is the default model; continuous_partials should be on by default.
+def test_default_model_is_universal_3_5_pro():
+    # universal-3-5-pro is the default model sent to AssemblyAI.
+    service = AssemblyAISTTService(api_key="test-key")
+    assert _query(service)["speech_model"] == ["universal-3-5-pro"]
+
+
+def test_continuous_partials_defaults_to_true_for_u3_pro():
+    # universal-3-5-pro is the default U3 Pro model; continuous_partials should be on by default.
     service = AssemblyAISTTService(api_key="test-key")
     assert _query(service)["continuous_partials"] == ["true"]
 


### PR DESCRIPTION
## Summary

Makes `universal-3-5-pro` the default AssemblyAI streaming STT model, replacing the pre-GA alias `u3-rt-pro`.

`universal-3-5-pro` is AssemblyAI's launched flagship streaming model. The plugin previously defaulted to `u3-rt-pro`, the pre-GA alias for the same model. Both match `U3_PRO_MODEL_PREFIXES` and expose the identical U3 Pro feature set (built-in turn detection, prompting, continuous partials, context carryover, voice focus), so this changes only the model id sent on the wire — behavior is unchanged.

## Changes

- `AssemblyAISTTService` default `model` → `universal-3-5-pro` (`stt.py`).
- Deprecated `AssemblyAIConnectionParams.speech_model` default → `universal-3-5-pro` (+ docstring) for consistency.
- Tests: added an explicit assertion that the default model sent is `universal-3-5-pro`; refreshed the stale `u3-rt-pro` default comment.

`u3-rt-pro` / `u3-rt-pro-beta-1` remain accepted (still in the `speech_model` Literal and matched by `is_u3_pro_model`) for backward compatibility.

## Test plan

- `uv run pytest tests/test_assemblyai_stt.py` — 59 passed.
- `uv run ruff check` / `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
