### PR TITLE
Verify doc paths before editing in update-docs and fix mapping drift

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -68,7 +68,15 @@ Ignore `__init__.py`, `__pycache__`, test files, and files that only contain typ
 
 ### Step 4: Map source files to doc pages
 
-For each changed source file, find the corresponding doc page. Read the mapping file at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` and apply its tiered lookup: tier 1 (known exceptions) → tier 2 (pattern matching) → tier 3 (search fallback). **First match wins.**
+For each changed source file, resolve the doc page to edit. Read the mapping file at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` and apply this resolution order. **Confirm every candidate path exists in `DOCS_PATH` before using it.**
+
+1. **Skip list** — if the file matches the skip list, stop. It triggers no doc update.
+2. **Pattern match** — apply the pattern table to get a candidate path, then confirm the `.mdx` file exists (glob/`ls` it under `DOCS_PATH`). If it exists, use it.
+3. **Non-standard locations** — if the file is in the non-standard table, use that entry as the candidate path and confirm it exists.
+4. **Search** — if no candidate from steps 2–3 exists on disk, grep `DOCS_PATH` for the file's main class name (see the mapping file's Search section).
+5. **Unmapped** — if nothing resolves, treat the file as unmapped and report it in Step 8.
+
+Never edit a path you haven't confirmed exists. If a candidate path doesn't resolve, fall through to the search step.
 
 ### Step 5: Analyze each source-doc pair
 
@@ -166,7 +174,7 @@ Guide directories:
 
 After processing all mapped pairs, check for two kinds of gaps:
 
-**Missing pages**: Source files that had no doc page mapping (neither tier 1, 2, nor 3) and are not marked as "(skip)". For each, tell the user:
+**Missing pages**: Source files that resolved to no doc page (pattern, non-standard table, and search all came up empty) and are not on the skip list. For each, tell the user:
 
 - The source file path
 - The main class(es) it defines
@@ -316,7 +324,7 @@ After all edits are complete, print a summary:
 - **Preserve voice** — match the writing style of the existing doc page, don't impose a different tone.
 - **One PR at a time** — this skill operates on the current branch's diff against main. Don't look at other branches.
 - **Parallel analysis** — when multiple source files map to different doc pages, analyze and edit them in parallel for efficiency.
-- **Shared source files** — files like `services/google/google.py` are shared bases. Check which services import from them and update all affected doc pages.
+- **Shared source files** — files like `services/google/llm.py` are shared bases. Check which services import from them and update all affected doc pages.
 
 ## Checklist
 

--- a/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
+++ b/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
@@ -2,25 +2,28 @@
 
 Maps pipecat source files to their documentation pages. Source paths are relative to `src/pipecat/`. Doc paths are relative to `DOCS_PATH`.
 
-## Name mismatches
+Doc paths in this file are candidates. Confirm each exists in `DOCS_PATH` before editing it; if it doesn't exist, fall through to the Search section.
 
-These source paths don't follow the standard `services/{provider}/{type}.py` → `api-reference/server/services/{type}/{provider}.mdx` pattern.
+## Non-standard locations
 
-| Source path                                 | Doc page                                                                                         |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `services/google/llm_vertex.py`             | `api-reference/server/services/llm/google-vertex.mdx`                                            |
-| `services/google/google.py`                 | (shared base — check which services use it)                                                      |
-| `services/google/gemini_live/**`            | `api-reference/server/services/s2s/gemini-live.mdx`                                              |
-| `services/google/gemini_live/llm_vertex.py` | `api-reference/server/services/s2s/gemini-live-vertex.mdx`                                       |
-| `services/aws_nova_sonic/**`                | `api-reference/server/services/s2s/aws.mdx`                                                      |
-| `services/ultravox/**`                      | `api-reference/server/services/s2s/ultravox.mdx`                                                 |
-| `services/grok/realtime/**`                 | `api-reference/server/services/s2s/grok.mdx`                                                     |
-| `services/openai/realtime/**`               | `api-reference/server/services/s2s/openai.mdx`                                                   |
-| `processors/frameworks/rtvi.py`             | `api-reference/server/rtvi/rtvi-processor.mdx` and `api-reference/server/rtvi/rtvi-observer.mdx` |
-| `processors/idle_frame_processor.py`        | `api-reference/server/pipeline/pipeline-idle-detection.mdx`                                      |
-| `pipeline/worker.py`                        | `api-reference/server/pipeline/pipeline-worker.mdx`                                              |
-| `pipeline/runner.py`                        | `api-reference/server/utilities/runner/guide.mdx`                                                |
-| `transports/base_transport.py`              | `api-reference/server/services/transport/transport-params.mdx`                                   |
+These source paths don't follow the standard `services/{provider}/{type}.py` → `api-reference/server/services/{type}/{provider}.mdx` pattern. Use the doc page below as the candidate path.
+
+| Source path                                 | Doc page                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `services/google/vertex/llm.py`             | `api-reference/server/services/llm/google-vertex.mdx`                                              |
+| `services/google/llm.py`                    | `api-reference/server/services/llm/google.mdx` (shared base; also affects `llm/google-vertex.mdx`) |
+| `services/google/gemini_live/**`            | `api-reference/server/services/s2s/gemini-live.mdx`                                                |
+| `services/google/gemini_live/vertex/llm.py` | `api-reference/server/services/s2s/gemini-live-vertex.mdx`                                         |
+| `services/aws/nova_sonic/**`                | `api-reference/server/services/s2s/aws.mdx`                                                        |
+| `services/ultravox/**`                      | `api-reference/server/services/s2s/ultravox.mdx`                                                   |
+| `services/grok/realtime/**`                 | `api-reference/server/services/s2s/grok.mdx`                                                       |
+| `services/openai/realtime/**`               | `api-reference/server/services/s2s/openai.mdx`                                                     |
+| `services/openai/responses/llm.py`          | `api-reference/server/services/llm/openai-responses.mdx`                                           |
+| `processors/frameworks/rtvi.py`             | `api-reference/server/rtvi/rtvi-processor.mdx` and `api-reference/server/rtvi/rtvi-observer.mdx`   |
+| `processors/idle_frame_processor.py`        | `api-reference/server/pipeline/pipeline-idle-detection.mdx`                                        |
+| `pipeline/worker.py`                        | `api-reference/server/pipeline/pipeline-worker.mdx`                                                |
+| `pipeline/runner.py`                        | `api-reference/server/utilities/runner/guide.mdx`                                                  |
+| `transports/base_transport.py`              | `api-reference/server/services/transport/transport-params.mdx`                                     |
 | `flows/types.py`                            | `api-reference/pipecat-flows/types.mdx`                                                          |
 | `flows/manager.py`                          | `api-reference/pipecat-flows/flow-manager.mdx`                                                   |
 | `flows/actions.py`                          | `api-reference/pipecat-flows/flow-manager.mdx` and `api-reference/pipecat-flows/types.mdx`       |
@@ -38,9 +41,9 @@ These files should never trigger doc updates.
 | `services/tts_service.py`            | Internal base class                  |
 | `services/llm_service.py`            | Internal base class                  |
 | `services/websocket_service.py`      | Internal base class                  |
-| `services/openai_realtime_beta/**`   | Deprecated                           |
-| `services/openai_realtime/**`        | Deprecated                           |
-| `services/gemini_multimodal_live/**` | Deprecated                           |
+| `services/image_service.py`          | Internal base class                  |
+| `services/vision_service.py`         | Internal base class                  |
+| `services/settings.py`               | Internal                             |
 | `services/aws/agent_core.py`         | Internal                             |
 | `services/aws/sagemaker/**`          | No doc page                          |
 | `transports/base_input.py`           | Internal base class                  |
@@ -48,7 +51,7 @@ These files should never trigger doc updates.
 | `transports/websocket/client.py`     | No doc page                          |
 | `serializers/base_serializer.py`     | Internal base class                  |
 | `serializers/protobuf.py`            | Internal                             |
-| `processors/audio/**`                | Internal                             |
+| `processors/audio/vad_processor.py`  | No doc page                          |
 | `pipeline/pipeline.py`               | Core architecture, not a service doc |
 
 ## Pattern matching
@@ -69,14 +72,15 @@ For files not in the tables above, apply these patterns. Convert underscores to 
 | `audio/vad/**`                    | `api-reference/server/utilities/audio/` (match by class name)     |
 | `audio/filters/**`                | `api-reference/server/utilities/audio/` (match by class name)     |
 | `audio/mixers/**`                 | `api-reference/server/utilities/audio/` (match by class name)     |
+| `processors/audio/**`             | `api-reference/server/utilities/audio/` (match by class name)     |
 | `processors/filters/**`           | `api-reference/server/utilities/filters/` (match by class name)   |
 
-If the doc file doesn't exist at the resolved path, the file is **unmapped**.
+A pattern result is only valid if the file exists in `DOCS_PATH`. If it doesn't exist, fall through to the Search section before treating the file as unmapped.
 
-## Search fallback
+## Search
 
-For files that don't match any table or pattern above:
+For files that match no pattern above, or whose candidate doesn't exist in `DOCS_PATH`:
 
-1. Extract the main class name(s) from the source file
-2. Search the docs directory for that class name: `grep -r "ClassName" DOCS_PATH/api-reference/ DOCS_PATH/pipecat/`
-3. If found in a doc page, use that as the mapping
+1. Extract the main class name(s) from the source file.
+2. Grep `DOCS_PATH` for that class name: `grep -rl "ClassName" DOCS_PATH/api-reference/ DOCS_PATH/pipecat/`.
+3. If a page is found, use it. If nothing is found, the file is **unmapped** — report it in SKILL.md Step 8.


### PR DESCRIPTION
## Summary

The `update-docs` skill maps changed pipecat source files to their documentation pages. This reworks how a doc page is resolved and corrects the mapping tables against the current `pipecat-ai/pipecat` source and `pipecat-ai/docs` trees.

### Resolution

`SKILL.md` Step 4 resolves each changed source file in a fixed order — skip list → pattern match → non-standard table → class-name search → unmapped — and confirms each candidate path exists in the checked-out docs tree before editing it. A candidate that doesn't exist falls through to a class-name search rather than editing a missing path.

### Mapping tables

`SOURCE_DOC_MAPPING.md` carries the routing knowledge that can't be derived from the docs tree: the skip-list policy and non-standard source locations.

**Non-standard locations**
- Correct source paths: `google/vertex/llm.py`, `google/gemini_live/vertex/llm.py`, `aws/nova_sonic/**`
- Map the shared base `google/llm.py` to `llm/google.mdx` (also affects `llm/google-vertex.mdx`)
- Add `openai/responses/llm.py` → `llm/openai-responses.mdx`

**Skip list**
- Scope `processors/audio/` to `vad_processor.py` (`audio_buffer_processor.py` has a doc page)
- Add `image_service.py`, `vision_service.py`, `settings.py` (internal, no doc page)

**Pattern matching**
- Add `processors/audio/**` → `utilities/audio/` so `AudioBufferProcessor` resolves by pattern; the skip list is checked first, so `vad_processor.py` is still excluded

## Test plan

- Verified every non-standard, skip-list, and pattern entry against `pipecat-ai/pipecat` source and the `pipecat-ai/docs` tree
- Skill/markdown only; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
