### PR TITLE
chore: bump @pipecat-ai JS client dependencies

### DIFF
--- a/changelog/4866.changed.md
+++ b/changelog/4866.changed.md
@@ -1,0 +1,1 @@
+- Bumped the `@pipecat-ai/*` JS client dependencies used by the `pipecat init` client templates (and the UI-worker examples): `client-js` to `1.12.0`, `client-react` to `1.7.1`, `daily-transport` to `1.6.7`, `small-webrtc-transport` to `1.10.5`, and `websocket-transport` to `1.7.0`.

--- a/examples/multi-worker/ui-worker/async-tasks/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/async-tasks/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "async-tasks-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/async-tasks/client/package.json
+++ b/examples/multi-worker/ui-worker/async-tasks/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/examples/multi-worker/ui-worker/deixis/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/deixis/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "deixis-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/deixis/client/package.json
+++ b/examples/multi-worker/ui-worker/deixis/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/examples/multi-worker/ui-worker/document-review/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/document-review/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "document-review-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/document-review/client/package.json
+++ b/examples/multi-worker/ui-worker/document-review/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/examples/multi-worker/ui-worker/form-fill/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/form-fill/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "form-fill-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/form-fill/client/package.json
+++ b/examples/multi-worker/ui-worker/form-fill/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/examples/multi-worker/ui-worker/hello-snapshot/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/hello-snapshot/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "hello-snapshot-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/hello-snapshot/client/package.json
+++ b/examples/multi-worker/ui-worker/hello-snapshot/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/examples/multi-worker/ui-worker/shopping-list/client/package-lock.json
+++ b/examples/multi-worker/ui-worker/shopping-list/client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "shopping-list-client",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "1.10.0",
-        "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+        "@pipecat-ai/client-js": "1.12.0",
+        "@pipecat-ai/small-webrtc-transport": "^1.10.5"
       },
       "devDependencies": {
         "vite": "^8.0.16"
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
+      "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.3.tgz",
-      "integrity": "sha512-C1ApWYIv0AmfUfVWYf2QUSKzjQfh7YuOBIoP7fX7hQbbzi2GIdDXdlUKWTDi5atbzbe+8/Skc/By9Ynol9JPeQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.10.5.tgz",
+      "integrity": "sha512-TF2TV/GQUVuC8Pr69fG/MSvUtuwEGcPcUg/H5d8O0RmSthVief0APgC5cKuyrjh/Rtl7+AjhxxWbrkuACdxulQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -128,7 +128,7 @@
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/examples/multi-worker/ui-worker/shopping-list/client/package.json
+++ b/examples/multi-worker/ui-worker/shopping-list/client/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "1.10.0",
-    "@pipecat-ai/small-webrtc-transport": "^1.10.3"
+    "@pipecat-ai/client-js": "1.12.0",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/src/pipecat/cli/templates/client/react-nextjs/package.json.jinja2
+++ b/src/pipecat/cli/templates/client/react-nextjs/package.json.jinja2
@@ -9,15 +9,15 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.11.0",
-    "@pipecat-ai/client-react": "^1.6.0",
+    "@pipecat-ai/client-js": "^1.12.0",
+    "@pipecat-ai/client-react": "^1.7.1",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
-    "@pipecat-ai/daily-transport": "^1.6.6",
+    "@pipecat-ai/daily-transport": "^1.6.7",
 {%- elif transport.value == 'smallwebrtc' %}
-    "@pipecat-ai/small-webrtc-transport": "^1.10.4",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5",
 {%- elif transport.value == 'websocket' %}
-    "@pipecat-ai/websocket-transport": "^1.6.7",
+    "@pipecat-ai/websocket-transport": "^1.7.0",
 {%- endif %}
 {%- endfor %}
     "@pipecat-ai/voice-ui-kit": "^0.11.0",

--- a/src/pipecat/cli/templates/client/react-vite/package.json.jinja2
+++ b/src/pipecat/cli/templates/client/react-vite/package.json.jinja2
@@ -10,15 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.11.0",
-    "@pipecat-ai/client-react": "^1.6.0",
+    "@pipecat-ai/client-js": "^1.12.0",
+    "@pipecat-ai/client-react": "^1.7.1",
 {%- for transport in transports %}
 {%- if transport.value == 'daily' %}
-    "@pipecat-ai/daily-transport": "^1.6.6",
+    "@pipecat-ai/daily-transport": "^1.6.7",
 {%- elif transport.value == 'smallwebrtc' %}
-    "@pipecat-ai/small-webrtc-transport": "^1.10.4",
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5",
 {%- elif transport.value == 'websocket' %}
-    "@pipecat-ai/websocket-transport": "^1.6.7",
+    "@pipecat-ai/websocket-transport": "^1.7.0",
 {%- endif %}
 {%- endfor %}
     "@pipecat-ai/voice-ui-kit": "^0.11.0",

--- a/src/pipecat/cli/templates/client/vanilla-js-vite/package.json.jinja2
+++ b/src/pipecat/cli/templates/client/vanilla-js-vite/package.json.jinja2
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.11.0"
+    "@pipecat-ai/client-js": "^1.12.0"
 {%- for transport in transports -%}
 {%- if transport.value == 'daily' %},
-    "@pipecat-ai/daily-transport": "^1.6.6"
+    "@pipecat-ai/daily-transport": "^1.6.7"
 {%- elif transport.value == 'smallwebrtc' %},
-    "@pipecat-ai/small-webrtc-transport": "^1.10.4"
+    "@pipecat-ai/small-webrtc-transport": "^1.10.5"
 {%- elif transport.value == 'websocket' %},
-    "@pipecat-ai/websocket-transport": "^1.6.7",
+    "@pipecat-ai/websocket-transport": "^1.7.0",
     "protobufjs": "^7.5.7"
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
## Summary

Bump the `@pipecat-ai/*` JS client libraries across the CLI client templates and the UI-worker examples so newly generated and example clients pull in the latest releases.

Version bumps:

- `@pipecat-ai/client-js` → `1.12.0`
- `@pipecat-ai/client-react` → `1.7.1`
- `@pipecat-ai/daily-transport` → `1.6.7`
- `@pipecat-ai/small-webrtc-transport` → `1.10.5`
- `@pipecat-ai/websocket-transport` → `1.7.0`

Touched files:

- `src/pipecat/cli/templates/client/{react-nextjs,react-vite,vanilla-js-vite}/package.json.jinja2`
- `examples/multi-worker/ui-worker/*/client/{package.json,package-lock.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)