### PR TITLE
fix(nvidia): keep idle STT streams alive with keepalive silence

### DIFF
--- a/changelog/4877.added.md
+++ b/changelog/4877.added.md
@@ -1,0 +1,1 @@
+- Added silence-based keepalive to `NvidiaSTTService` to keep idle NVIDIA streaming ASR sessions from going stale. When no audio arrives for a while, the service sends silence over the existing stream instead of letting it sit idle and degrade.

--- a/examples/transcription/transcription-nvidia.py
+++ b/examples/transcription/transcription-nvidia.py
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import Frame, InterimTranscriptionFrame, TranscriptionFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineWorker
+from pipecat.processors.audio.vad_processor import VADProcessor
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.nvidia.stt import NvidiaSTTService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+
+class TranscriptionLogger(FrameProcessor):
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, TranscriptionFrame):
+            print(f"Transcription: {frame.text}")
+        elif isinstance(frame, InterimTranscriptionFrame):
+            print(f"Interim transcription: {frame.text}")
+
+        # Push all frames through
+        await self.push_frame(frame, direction)
+
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "daily": lambda: DailyParams(audio_in_enabled=True),
+    "twilio": lambda: FastAPIWebsocketParams(audio_in_enabled=True),
+    "webrtc": lambda: TransportParams(audio_in_enabled=True),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = NvidiaSTTService(api_key=os.environ["NVIDIA_API_KEY"])
+
+    tl = TranscriptionLogger()
+
+    vad_processor = VADProcessor(vad_analyzer=SileroVADAnalyzer())
+
+    pipeline = Pipeline([transport.input(), vad_processor, stt, tl, transport.output()])
+
+    worker = PipelineWorker(
+        pipeline,
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -270,6 +270,8 @@ class NvidiaSTTService(STTService):
         stop_history_eou: int = -1,
         stop_threshold_eou: float = -1.0,
         custom_configuration: str = "",
+        keepalive_timeout: float | None = 30.0,
+        keepalive_interval: float = 5.0,
         settings: Settings | None = None,
         ttfs_p99_latency: float | None = NVIDIA_TTFS_P99,
         **kwargs,
@@ -300,6 +302,9 @@ class NvidiaSTTService(STTService):
             stop_threshold_eou: End-of-utterance stop threshold. Use -1.0 for Nemotron Speech default.
             custom_configuration: Custom Nemotron Speech configuration string
                 (e.g. ``"enable_vad_endpointing:true,neural_vad.onset:0.65"``).
+            keepalive_timeout: Seconds of no audio before sending silence to keep the
+                NVIDIA ASR stream active. None disables keepalive.
+            keepalive_interval: Seconds between idle checks when keepalive is enabled.
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.
             ttfs_p99_latency: P99 latency from speech end to final transcript in seconds.
@@ -337,6 +342,8 @@ class NvidiaSTTService(STTService):
         super().__init__(
             sample_rate=sample_rate,
             ttfs_p99_latency=ttfs_p99_latency,
+            keepalive_timeout=keepalive_timeout,
+            keepalive_interval=keepalive_interval,
             settings=default_settings,
             **kwargs,
         )
@@ -477,6 +484,8 @@ class NvidiaSTTService(STTService):
         if not self._thread_task:
             self._thread_task = self.create_task(self._thread_task_handler())
 
+        self._create_keepalive_task()
+
         logger.debug(f"Initialized NvidiaSTTService with model: {self._settings.model}")
 
     async def stop(self, frame: EndFrame):
@@ -504,6 +513,9 @@ class NvidiaSTTService(STTService):
         current gRPC stream but keep buffering audio on the same iterator until
         the replacement stream starts consuming it.
         """
+        if close_iterator:
+            await self._cancel_keepalive_task()
+
         iterator = self._audio_iterator
         if close_iterator:
             self._audio_iterator = None
@@ -568,6 +580,17 @@ class NvidiaSTTService(STTService):
             await asyncio.to_thread(self._response_handler, iterator)
         except asyncio.CancelledError:
             raise
+
+    def _is_keepalive_ready(self) -> bool:
+        """Check if there is an active NVIDIA audio stream for keepalive."""
+        iterator = self._audio_iterator
+        return iterator is not None and not iterator.closed
+
+    async def _send_keepalive(self, silence: bytes):
+        """Send silent audio through the active NVIDIA stream iterator."""
+        iterator = self._audio_iterator
+        if iterator is not None and not iterator.closed:
+            await iterator.put(silence)
 
     @traced_stt
     async def _handle_transcription(

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -270,8 +270,6 @@ class NvidiaSTTService(STTService):
         stop_history_eou: int = -1,
         stop_threshold_eou: float = -1.0,
         custom_configuration: str = "",
-        keepalive_timeout: float | None = 30.0,
-        keepalive_interval: float = 5.0,
         settings: Settings | None = None,
         ttfs_p99_latency: float | None = NVIDIA_TTFS_P99,
         **kwargs,
@@ -302,9 +300,6 @@ class NvidiaSTTService(STTService):
             stop_threshold_eou: End-of-utterance stop threshold. Use -1.0 for Nemotron Speech default.
             custom_configuration: Custom Nemotron Speech configuration string
                 (e.g. ``"enable_vad_endpointing:true,neural_vad.onset:0.65"``).
-            keepalive_timeout: Seconds of no audio before sending silence to keep the
-                NVIDIA ASR stream active. None disables keepalive.
-            keepalive_interval: Seconds between idle checks when keepalive is enabled.
             settings: Runtime-updatable settings. When provided alongside deprecated
                 parameters, ``settings`` values take precedence.
             ttfs_p99_latency: P99 latency from speech end to final transcript in seconds.
@@ -342,8 +337,8 @@ class NvidiaSTTService(STTService):
         super().__init__(
             sample_rate=sample_rate,
             ttfs_p99_latency=ttfs_p99_latency,
-            keepalive_timeout=keepalive_timeout,
-            keepalive_interval=keepalive_interval,
+            keepalive_timeout=30.0,
+            keepalive_interval=5.0,
             settings=default_settings,
             **kwargs,
         )

--- a/tests/test_nvidia_stt.py
+++ b/tests/test_nvidia_stt.py
@@ -8,6 +8,8 @@ import asyncio
 
 import pytest
 
+pytest.importorskip("riva.client")
+
 from pipecat.services.nvidia.stt import AudioChunkIterator, NvidiaSTTService
 
 

--- a/tests/test_nvidia_stt.py
+++ b/tests/test_nvidia_stt.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import asyncio
+
+import pytest
+
+from pipecat.services.nvidia.stt import AudioChunkIterator, NvidiaSTTService
+
+
+def _make_service(**kwargs) -> NvidiaSTTService:
+    return NvidiaSTTService(api_key="test-key", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_keepalive_enabled():
+    """NVIDIA STT enables silence keepalive (the base default is off)."""
+    service = _make_service()
+    assert service._keepalive_timeout == 30.0
+    assert service._keepalive_interval == 5.0
+
+
+@pytest.mark.asyncio
+async def test_keepalive_not_ready_without_iterator():
+    """No active stream means keepalive should not fire."""
+    service = _make_service()
+    assert service._audio_iterator is None
+    assert service._is_keepalive_ready() is False
+
+
+@pytest.mark.asyncio
+async def test_keepalive_ready_with_open_iterator():
+    """An open iterator is a valid keepalive target."""
+    service = _make_service()
+    service._audio_iterator = AudioChunkIterator(asyncio.get_running_loop())
+    assert service._is_keepalive_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_keepalive_not_ready_with_closed_iterator():
+    """A closed iterator must not be fed silence."""
+    service = _make_service()
+    iterator = AudioChunkIterator(asyncio.get_running_loop())
+    await iterator.close()
+    service._audio_iterator = iterator
+    assert service._is_keepalive_ready() is False
+
+
+@pytest.mark.asyncio
+async def test_send_keepalive_enqueues_silence():
+    """Silence is pushed into the active stream iterator."""
+    service = _make_service()
+    iterator = AudioChunkIterator(asyncio.get_running_loop())
+    service._audio_iterator = iterator
+
+    silence = b"\x00\x00\x00\x00"
+    await service._send_keepalive(silence)
+
+    assert iterator._queue.get_nowait() == silence
+
+
+@pytest.mark.asyncio
+async def test_send_keepalive_noop_when_closed():
+    """Sending keepalive to a closed iterator is a no-op."""
+    service = _make_service()
+    iterator = AudioChunkIterator(asyncio.get_running_loop())
+    await iterator.close()
+    # close() enqueues a sentinel; drain it so the queue reflects keepalive only.
+    iterator._queue.get_nowait()
+    service._audio_iterator = iterator
+
+    await service._send_keepalive(b"\x00\x00")
+
+    assert iterator._queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_send_keepalive_noop_without_iterator():
+    """Sending keepalive with no active stream does not raise."""
+    service = _make_service()
+    await service._send_keepalive(b"\x00\x00")


### PR DESCRIPTION
## Summary

Keeps idle NVIDIA streaming ASR sessions alive by sending periodic silence, instead of letting the stream sit idle and go stale.

## What changed

Wires `NvidiaSTTService` into the generic keepalive mechanism already provided by the base `STTService`:

- Adds `keepalive_timeout` (default `30.0`) and `keepalive_interval` (default `5.0`) params and forwards them to `super().__init__`. Note this enables keepalive **by default** for NVIDIA STT (the base-class default is `None`/off).
- Starts the keepalive task in `start()` and cancels it in `_stop_tasks()` when the iterator is being closed.
- Overrides `_is_keepalive_ready()` to report whether there's an active, open `AudioChunkIterator`, and `_send_keepalive()` to push silence into it (mirroring how `run_stt` feeds real audio).

The keepalive task is left running across reconnects (`_stop_tasks(close_iterator=False)`), so the same iterator keeps being fed silence while the gRPC stream is re-established.

## Why

NVIDIA streaming ASR sessions can go stale after idle periods. Periodically feeding silence keeps the stream active so it stays usable rather than degrading or being dropped during silence.

## Validation

- `uv run ruff format --diff`
- `uv run ruff check`

CC: @markbackman @filipi87
