### PR TITLE
Forward TTFA metrics to RTVI clients

### DIFF
--- a/changelog/4880.fixed.md
+++ b/changelog/4880.fixed.md
@@ -1,0 +1,3 @@
+Fixed `RTVIObserver` silently dropping TTFA (Time To First Audio) metrics.
+TTFA metrics are now forwarded to RTVI clients under a `ttfa` key, alongside
+TTFB, processing, token, and character metrics.

--- a/src/pipecat/processors/frameworks/rtvi/observer.py
+++ b/src/pipecat/processors/frameworks/rtvi/observer.py
@@ -56,6 +56,7 @@ from pipecat.frames.frames import (
 from pipecat.metrics.metrics import (
     LLMUsageMetricsData,
     ProcessingMetricsData,
+    TTFAMetricsData,
     TTFBMetricsData,
     TTSUsageMetricsData,
 )
@@ -827,6 +828,10 @@ class RTVIObserver(BaseObserver):
                 if "ttfb" not in metrics:
                     metrics["ttfb"] = []
                 metrics["ttfb"].append(d.model_dump(exclude_none=True))
+            elif isinstance(d, TTFAMetricsData):
+                if "ttfa" not in metrics:
+                    metrics["ttfa"] = []
+                metrics["ttfa"].append(d.model_dump(exclude_none=True))
             elif isinstance(d, ProcessingMetricsData):
                 if "processing" not in metrics:
                     metrics["processing"] = []

--- a/tests/test_rtvi_observer_metrics.py
+++ b/tests/test_rtvi_observer_metrics.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for RTVIObserver metrics handling."""
+
+import unittest
+from unittest.mock import AsyncMock
+
+from pipecat.frames.frames import MetricsFrame
+from pipecat.metrics.metrics import (
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    ProcessingMetricsData,
+    TTFAMetricsData,
+    TTFBMetricsData,
+    TTSUsageMetricsData,
+)
+from pipecat.processors.frameworks.rtvi.observer import RTVIObserver, RTVIObserverParams
+
+
+class TestRTVIObserverMetrics(unittest.IsolatedAsyncioTestCase):
+    async def test_ttfb_and_ttfa_forwarded_to_clients(self):
+        # TTFB and TTFA are emitted in separate frames during a real TTS turn;
+        # both must reach RTVI clients.
+        observer = RTVIObserver(params=RTVIObserverParams(metrics_enabled=True))
+        sent = []
+        observer.send_rtvi_message = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        await observer._handle_metrics(
+            MetricsFrame(
+                data=[TTFBMetricsData(processor="cartesia_tts", value=0.2, model="sonic-english")]
+            )
+        )
+        await observer._handle_metrics(
+            MetricsFrame(
+                data=[
+                    TTFAMetricsData(
+                        processor="cartesia_tts",
+                        ttfa=0.6,
+                        ttfb=0.2,
+                        leading_silence=0.4,
+                        model="sonic-english",
+                    )
+                ]
+            )
+        )
+
+        self.assertEqual(len(sent), 2)
+        self.assertIn("ttfb", sent[0].data)
+        self.assertEqual(sent[0].data["ttfb"][0]["value"], 0.2)
+        self.assertIn("ttfa", sent[1].data)
+        self.assertEqual(sent[1].data["ttfa"][0]["leading_silence"], 0.4)
+
+    async def test_all_metric_types_accumulate_into_one_message(self):
+        # A single frame can carry several metric types; each must land under its
+        # own key in one outgoing message. LLM usage is special-cased: the message
+        # carries the nested token-usage value, not the wrapper.
+        observer = RTVIObserver(params=RTVIObserverParams(metrics_enabled=True))
+        sent = []
+        observer.send_rtvi_message = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        await observer._handle_metrics(
+            MetricsFrame(
+                data=[
+                    TTFBMetricsData(processor="cartesia_tts", value=0.2),
+                    TTFAMetricsData(
+                        processor="cartesia_tts", ttfa=0.6, ttfb=0.2, leading_silence=0.4
+                    ),
+                    ProcessingMetricsData(processor="llm", value=0.05),
+                    LLMUsageMetricsData(
+                        processor="llm",
+                        value=LLMTokenUsage(
+                            prompt_tokens=10, completion_tokens=20, total_tokens=30
+                        ),
+                    ),
+                    TTSUsageMetricsData(processor="cartesia_tts", value=42),
+                ]
+            )
+        )
+
+        self.assertEqual(len(sent), 1)
+        data = sent[0].data
+        self.assertEqual(data["ttfb"][0]["value"], 0.2)
+        self.assertEqual(data["ttfa"][0]["leading_silence"], 0.4)
+        self.assertEqual(data["processing"][0]["value"], 0.05)
+        # LLM usage unwraps to the token-usage payload.
+        self.assertEqual(data["tokens"][0]["total_tokens"], 30)
+        self.assertEqual(data["characters"][0]["value"], 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`RTVIObserver._handle_metrics` matched each `MetricsFrame.data` element against TTFB, Processing, LLMUsage, and TTSUsage — but not `TTFAMetricsData`. TTFA (Time To First Audio) frames fell through and produced an empty `{}` payload, so RTVI clients never saw TTFA or its leading-silence breakdown.

This was a gap left when `TTFAMetricsData` was added in #4782: `MetricsLogObserver` was updated but the client-facing `RTVIObserver` was overlooked.

## Changes

- Import `TTFAMetricsData` in the observer and add an `elif isinstance(d, TTFAMetricsData)` branch that appends `d.model_dump(exclude_none=True)` under a `"ttfa"` key, mirroring how `"ttfb"` is handled. No model change is needed since `MetricsMessage.data` is already `Mapping[str, Any]`.
- Add `tests/test_rtvi_observer_metrics.py` covering the realistic separate-frame TTFB→TTFA flow and accumulation of all five metric types into a single outgoing message (including the `LLMUsageMetricsData` `d.value` unwrap quirk). The method previously had no test coverage.

## Test plan

- `uv run pytest tests/test_rtvi_observer_metrics.py tests/test_rtvi_observer_config.py tests/test_rtvi_processor.py` — all pass.

Fixes #4873

🤖 Generated with [Claude Code](https://claude.com/claude-code)