### PR TITLE
fix(serializers): skip Twilio region/edge validation when base_url is set

### DIFF
--- a/changelog/4885.fixed.md
+++ b/changelog/4885.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TwilioFrameSerializer` rejecting a valid `base_url` configuration when only one of `region`/`edge` was also set. The `region`/`edge` pairing is only required when deriving Twilio's FQDN host; since `base_url` is used verbatim and ignores `region`/`edge`, the validation now skips that check when `base_url` is provided.

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -126,8 +126,10 @@ class TwilioFrameSerializer(FrameSerializer):
                     f"auto_hang_up is enabled but missing required parameters: {', '.join(missing_credentials)}"
                 )
 
-            # Validate region and edge are both provided if either is specified
-            if (region and not edge) or (edge and not region):
+            # Validate region and edge are both provided if either is specified.
+            # Only applies when deriving Twilio's FQDN host; base_url is used
+            # verbatim and ignores region/edge, so the pairing requirement is moot.
+            if not base_url and ((region and not edge) or (edge and not region)):
                 raise ValueError(
                     "Both edge and region parameters are required if one is set. "
                     f"Twilio's FQDN format requires both: api.{{edge}}.{{region}}.twilio.com. "

--- a/tests/test_twilio_serializer_base_url.py
+++ b/tests/test_twilio_serializer_base_url.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-from pipecat.serializers.twilio import _build_call_resource_url
+from pipecat.serializers.twilio import TwilioFrameSerializer, _build_call_resource_url
 
 
 class TestBuildCallResourceURL(unittest.TestCase):
@@ -39,6 +39,23 @@ class TestBuildCallResourceURL(unittest.TestCase):
             _build_call_resource_url("ACxxxx", "CAyyyy", base_url="https://api.example.test/"),
             "https://api.example.test/2010-04-01/Accounts/ACxxxx/Calls/CAyyyy.json",
         )
+
+
+class TestConstructorRegionEdgeValidation(unittest.TestCase):
+    CREDS = dict(call_sid="CAyyyy", account_sid="ACxxxx", auth_token="token")
+
+    def test_partial_region_edge_rejected_without_base_url(self):
+        # FQDN host is derived from region/edge, so a lone region is rejected.
+        with self.assertRaises(ValueError):
+            TwilioFrameSerializer("MZstream", region="au1", **self.CREDS)
+
+    def test_partial_region_edge_allowed_with_base_url(self):
+        # base_url is used verbatim and ignores region/edge, so the pairing
+        # requirement does not apply.
+        serializer = TwilioFrameSerializer(
+            "MZstream", base_url="https://api.example.test", region="au1", **self.CREDS
+        )
+        self.assertEqual(serializer._base_url, "https://api.example.test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`TwilioFrameSerializer` enforced the `region`/`edge` pairing requirement unconditionally whenever `auto_hang_up` was enabled. This rejected valid configurations that set `base_url` together with only one of `region`/`edge`, and surfaced a misleading error citing *"Twilio's FQDN format requires both: api.{edge}.{region}.twilio.com"* — a constraint that does not apply when `base_url` is set.

When `base_url` is provided it is used verbatim as the REST API root and `region`/`edge` are ignored (see `_build_call_resource_url`). The pairing requirement only exists to derive Twilio's FQDN host, so this PR skips that validation when `base_url` is set.

This is a follow-up to #4845, which introduced `base_url` but did not update the pre-existing constructor validation.

Fixes #4872.

## Changes

- `src/pipecat/serializers/twilio.py`: gate the `region`/`edge` pairing check behind `not base_url`.
- `tests/test_twilio_serializer_base_url.py`: add constructor-level regression tests. The existing tests only exercised `_build_call_resource_url`, which has no validation, so the inconsistency went uncaught.

## Test plan

- [x] `uv run pytest tests/test_twilio_serializer_base_url.py` — 6 passed
- New test `test_partial_region_edge_allowed_with_base_url` fails on the old code and passes now; `test_partial_region_edge_rejected_without_base_url` confirms the original behavior is preserved.