### PR TITLE
Allow configuring SOXRStreamAudioResampler.clear_after_secs

### DIFF
--- a/changelog/4886.added.2.md
+++ b/changelog/4886.added.2.md
@@ -1,0 +1,1 @@
+- Added `resampler_clear_after_secs` to `FrameSerializer.InputParams` so all telephony serializers (Twilio, Plivo, Vonage, Telnyx, Exotel, Genesys) expose this setting to callers.

--- a/changelog/4886.added.md
+++ b/changelog/4886.added.md
@@ -1,0 +1,2 @@
+- Added `clear_after_secs` parameter to `SOXRStreamAudioResampler` (default `0.2`) to control how long after inactivity the internal resampler state is cleared. Set to `None` to disable clearing.
+- Added `resampler_clear_after_secs` to `FrameSerializer.InputParams` so all telephony serializers (Twilio, Plivo, Vonage, Telnyx, Exotel, Genesys) expose this setting to callers.

--- a/changelog/4886.added.md
+++ b/changelog/4886.added.md
@@ -1,2 +1,1 @@
 - Added `clear_after_secs` parameter to `SOXRStreamAudioResampler` (default `0.2`) to control how long after inactivity the internal resampler state is cleared. Set to `None` to disable clearing.
-- Added `resampler_clear_after_secs` to `FrameSerializer.InputParams` so all telephony serializers (Twilio, Plivo, Vonage, Telnyx, Exotel, Genesys) expose this setting to callers.

--- a/src/pipecat/audio/resamplers/soxr_stream_resampler.py
+++ b/src/pipecat/audio/resamplers/soxr_stream_resampler.py
@@ -24,8 +24,6 @@ import soxr
 
 from pipecat.audio.resamplers.base_audio_resampler import BaseAudioResampler, SoxrQuality
 
-CLEAR_STREAM_AFTER_SECS = 0.2
-
 
 class SOXRStreamAudioResampler(BaseAudioResampler):
     """Audio resampler implementation using the SoX ResampleStream library.
@@ -40,16 +38,28 @@ class SOXRStreamAudioResampler(BaseAudioResampler):
         - Input must be 16-bit signed PCM audio as raw bytes.
     """
 
-    def __init__(self, *, quality: SoxrQuality = "VHQ", **kwargs):
+    def __init__(
+        self,
+        *,
+        quality: SoxrQuality = "VHQ",
+        clear_after_secs: float | None = 0.2,
+        **kwargs,
+    ):
         """Initialize the resampler.
 
         Args:
             quality: SOXR quality preset. Higher quality means higher CPU cost.
                 One of "VHQ" (default, very high quality), "HQ", "MQ", "LQ",
                 or "QQ" (quick, lowest latency).
+            clear_after_secs: Seconds of inactivity after which the internal
+                resampler state is cleared to avoid audio artefacts from stale
+                history. Set to ``None`` to never clear (recommended for
+                telephony providers that have irregular gaps between chunks).
+                Defaults to ``0.2``.
             **kwargs: Reserved for forward compatibility; currently ignored.
         """
         self._quality = quality
+        self._clear_after_secs = clear_after_secs
         self._in_rate: float | None = None
         self._out_rate: float | None = None
         self._last_resample_time: float = 0
@@ -65,11 +75,10 @@ class SOXRStreamAudioResampler(BaseAudioResampler):
 
     def _maybe_clear_internal_state(self):
         current_time = time.time()
-        time_since_last_resample = current_time - self._last_resample_time
-        # If more than CLEAR_STREAM_AFTER_SECS seconds have passed, clear the resampler state
-        if time_since_last_resample > CLEAR_STREAM_AFTER_SECS:
-            if self._soxr_stream:
-                self._soxr_stream.clear()
+        if self._clear_after_secs is not None:
+            if current_time - self._last_resample_time > self._clear_after_secs:
+                if self._soxr_stream:
+                    self._soxr_stream.clear()
         self._last_resample_time = current_time
 
     def _maybe_initialize_sox_stream(self, in_rate: int, out_rate: int) -> "soxr.ResampleStream":

--- a/src/pipecat/serializers/base_serializer.py
+++ b/src/pipecat/serializers/base_serializer.py
@@ -34,9 +34,14 @@ class FrameSerializer(BaseObject):
         Parameters:
             ignore_rtvi_messages: Whether to ignore RTVI protocol messages during serialization.
                 Defaults to True to prevent RTVI messages from being sent to external transports.
+            resampler_clear_after_secs: Seconds of inactivity after which the stream resampler
+                clears its internal history to avoid audio artefacts from stale state. Set to
+                ``None`` to never clear — recommended for telephony providers (e.g. Genesys) that
+                have irregular gaps between audio chunks. Defaults to ``0.2``.
         """
 
         ignore_rtvi_messages: bool = True
+        resampler_clear_after_secs: float | None = 0.2
 
     def __init__(self, params: InputParams | None = None, **kwargs):
         """Initialize the FrameSerializer.

--- a/src/pipecat/serializers/exotel.py
+++ b/src/pipecat/serializers/exotel.py
@@ -69,8 +69,12 @@ class ExotelFrameSerializer(FrameSerializer):
         self._exotel_sample_rate = self._params.exotel_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
-        self._input_resampler = create_stream_resampler()
-        self._output_resampler = create_stream_resampler()
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.

--- a/src/pipecat/serializers/genesys.py
+++ b/src/pipecat/serializers/genesys.py
@@ -174,10 +174,12 @@ class GenesysAudioHookSerializer(FrameSerializer):
         self._sample_rate = 0  # Pipeline input rate, set in setup()
         self._session_id = str(uuid.uuid4())
 
-        # Use Pipecat's official resampler if needed (SOXR)
-        # Only used for TTS output (16kHz → 8kHz), input goes without resampling
-        self._input_resampler = SOXRStreamAudioResampler()
-        self._output_resampler = SOXRStreamAudioResampler()
+        self._input_resampler = SOXRStreamAudioResampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = SOXRStreamAudioResampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
 
         # Protocol state
         self._client_seq = 0

--- a/src/pipecat/serializers/plivo.py
+++ b/src/pipecat/serializers/plivo.py
@@ -99,8 +99,12 @@ class PlivoFrameSerializer(FrameSerializer):
         self._plivo_sample_rate = self._params.plivo_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
-        self._input_resampler = create_stream_resampler()
-        self._output_resampler = create_stream_resampler()
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
         self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):

--- a/src/pipecat/serializers/telnyx.py
+++ b/src/pipecat/serializers/telnyx.py
@@ -108,8 +108,12 @@ class TelnyxFrameSerializer(FrameSerializer):
         self._telnyx_sample_rate = self._params.telnyx_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
-        self._input_resampler = create_stream_resampler()
-        self._output_resampler = create_stream_resampler()
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
         self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -145,8 +145,12 @@ class TwilioFrameSerializer(FrameSerializer):
         self._twilio_sample_rate = self._params.twilio_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
-        self._input_resampler = create_stream_resampler()
-        self._output_resampler = create_stream_resampler()
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
         self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):

--- a/src/pipecat/serializers/vonage.py
+++ b/src/pipecat/serializers/vonage.py
@@ -61,8 +61,12 @@ class VonageFrameSerializer(FrameSerializer):
         self._vonage_sample_rate = self._params.vonage_sample_rate
         self._sample_rate = 0  # Pipeline input rate
 
-        self._input_resampler = create_stream_resampler()
-        self._output_resampler = create_stream_resampler()
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.


### PR DESCRIPTION
## Summary

  - `SOXRStreamAudioResampler` now accepts a `clear_after_secs` parameter (default 0.2 s, None to disable) controlling how long the resampler waits before clearing its internal history between chunks
  - `FrameSerializer.InputParams` gains a matching `resampler_clear_after_secs` field inherited by all telephony serializers (Twilio, Plivo, Vonage, Telnyx, Exotel, Genesys), which forward it when constructing their resamplers
