### PR TITLE
Fix YAML octal/hex corruption of unquoted DTMF sequences in eval scenarios

### DIFF
--- a/changelog/4887.fixed.md
+++ b/changelog/4887.fixed.md
@@ -1,0 +1,1 @@
+- Fixed eval scenarios silently corrupting unquoted DTMF turns with leading zeros or a hex prefix. YAML 1.1 parsed `dtmf: 012` as octal (`10`) and `dtmf: 0x10` as hex before validation, sending the wrong keypresses; the scenario loader now resolves only plain-decimal scalars as integers, so leading-zero sequences keep their digits and `dtmf: 123` still works.

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -123,6 +123,7 @@ relative to the scenario file's directory. This is handy for sharing the
     judge: !include judge_audio.yaml
 """
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -132,6 +133,37 @@ from loguru import logger
 from yamlinclude import YamlIncludeConstructor
 
 from pipecat.audio.dtmf.types import KeypadEntry
+
+
+class _ScenarioLoader(yaml.SafeLoader):
+    """SafeLoader that resolves only plain-decimal numeric scalars as ints.
+
+    PyYAML's SafeLoader follows YAML 1.1, which reinterprets unquoted numeric
+    scalars as octal (``010`` -> 8), hex (``0x10`` -> 16), or binary before
+    application code sees them. For DTMF that silently rewrites the digit
+    sequence the user typed (``dtmf: 012`` would load as ``10``). Dropping those
+    resolvers and keeping only plain decimal means ``dtmf: 123`` still loads as
+    an int (so the unquoted-digits convenience works), while leading-zero, hex,
+    and binary tokens stay strings and reach DTMF validation with their digits
+    intact. No scenario field wants an octal/hex literal, so this is safe
+    document-wide.
+    """
+
+
+# Strip the inherited int resolvers (which match octal/hex/binary/sexagesimal)
+# and register a decimal-only replacement. Underscores stay allowed to match
+# YAML's grouping syntax (e.g. ``1_000``); a leading zero (``012``) no longer
+# matches, so such tokens load as strings.
+_ScenarioLoader.yaml_implicit_resolvers = {
+    ch: [(tag, rx) for tag, rx in resolvers if tag != "tag:yaml.org,2002:int"]
+    for ch, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+yaml.add_implicit_resolver(
+    "tag:yaml.org,2002:int",
+    re.compile(r"^[-+]?(?:0|[1-9][0-9_]*)$"),
+    list("-+0123456789"),
+    Loader=_ScenarioLoader,
+)
 
 # Events whose payloads carry bot-generated text the judge can sensibly
 # evaluate. Asserting ``eval:`` on anything else (user transcripts, tool
@@ -326,7 +358,7 @@ class EvalScenario:
         # scenarios can share judge/user config. Includes resolve relative to the
         # scenario file's directory. Register the constructor on a private loader
         # subclass (not the global SafeLoader) so it has no global side effects.
-        class _Loader(yaml.SafeLoader):
+        class _Loader(_ScenarioLoader):
             pass
 
         YamlIncludeConstructor.add_to_loader_class(loader_class=_Loader, base_dir=str(path.parent))

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -252,6 +252,22 @@ class TestEvalsScenarioParser(unittest.TestCase):
         s = EvalScenario.load(_write("name: dtmf\nturns: [{dtmf: 123}]\n"))
         self.assertEqual(s.turns[0].dtmf, "123")
 
+    def test_dtmf_unquoted_leading_zero_preserved(self):
+        """A leading zero must stay literal digits, not be read as YAML octal.
+
+        YAML 1.1 would otherwise parse `012` as octal 10, silently sending the
+        wrong keys; the scenario loader resolves only plain decimal as int.
+        """
+        for seq in ("012", "010", "007", "0420", "000"):
+            s = EvalScenario.load(_write(f"name: dtmf\nturns: [{{dtmf: {seq}}}]\n"))
+            self.assertEqual(s.turns[0].dtmf, seq)
+
+    def test_dtmf_unquoted_hex_rejected(self):
+        """A hex-looking token isn't read as a number; `x` fails validation."""
+        with self.assertRaises(ValueError) as cm:
+            EvalScenario.load(_write("name: bad\nturns: [{dtmf: 0x10}]\n"))
+        self.assertIn("invalid keypad entry", str(cm.exception))
+
     def test_dtmf_invalid_entry_rejected(self):
         with self.assertRaises(ValueError) as cm:
             EvalScenario.load(_write('name: bad\nturns: [{dtmf: "1A"}]\n'))


### PR DESCRIPTION
## Summary

The eval scenario loader parses YAML with PyYAML's `SafeLoader`, which follows YAML 1.1 numeric rules. Those rules reinterpret unquoted numeric scalars as octal (`010` → 8), hex (`0x10` → 16), and binary *before* `_parse_dtmf` sees them. A DTMF turn like `dtmf: 012` was therefore silently stored as `"10"` (and `0420` → `"272"`, `007` → `"7"`), sending the wrong keypresses while still passing validation — a silent corruption that's confusing to debug.

This fixes the root cause at the loader: a dedicated `_ScenarioLoader` subclass strips the octal/hex/binary int resolvers and registers a decimal-only replacement. So:

- `dtmf: 123` still loads as `"123"` (the unquoted-digits convenience is preserved)
- `dtmf: 012` / `010` / `007` / `0420` / `000` now stay literal strings → correct keypresses
- `dtmf: 0x10` stays a string and fails DTMF validation with a clear `invalid keypad entry 'x'` error instead of silently becoming `"16"`
- `delay_ms`, floats, bools, underscored and negative ints all resolve normally

No scenario field wants an octal/hex literal, so resolving only plain decimal is safe document-wide.

## Testing

- Added `test_dtmf_unquoted_leading_zero_preserved` and `test_dtmf_unquoted_hex_rejected` to `tests/test_evals_scenario.py`
- Full eval suite passes (`tests/test_evals_scenario.py`, `test_evals_harness.py`, `test_evals_serializer.py` — 100 tests)
- `ruff check` / `ruff format` clean

Fixes #4870

🤖 Generated with [Claude Code](https://claude.com/claude-code)