### PR TITLE
Add language_code streaming parameter to AssemblyAISTTService

### DIFF
--- a/changelog/4889.added.md
+++ b/changelog/4889.added.md
@@ -1,0 +1,1 @@
+- Added a `language_code` streaming parameter to `AssemblyAISTTService` for declaring the audio language (e.g. `"es"`, `"fr"`). On U3 Pro models a tier-1 code (`en`/`es`/`fr`/`de`/`it`/`pt`) steers transcription toward that language. It is mutually exclusive with `language_detection` and is not sent unless set, so existing behavior is unchanged.

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -124,6 +124,13 @@ class AssemblyAISTTSettings(STTSettings):
         prompt: Optional text prompt to guide the transcription. Only
             used when model is "u3-rt-pro".
         language_detection: Enable automatic language detection.
+        language_code: Customer-declared audio language as an ISO code (e.g.
+            "en", "es", "fr"). On U3 Pro models, a tier-1 code
+            ("en"/"es"/"fr"/"de"/"it"/"pt") steers transcription toward that
+            language; other supported codes are "de", "tr", "nl", "sv", "no",
+            "da", "fi", "hi", "vi", "ar", "he", "ja", "ur", "zh". Mutually
+            exclusive with ``language_detection``. Defaults to None (not sent;
+            no steering).
         format_turns: Whether to format transcript turns.
         speaker_labels: Enable speaker diarization.
         vad_threshold: VAD confidence threshold (0.0–1.0) for classifying
@@ -178,6 +185,7 @@ class AssemblyAISTTSettings(STTSettings):
     keyterms_prompt: list[str] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     prompt: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     language_detection: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    language_code: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     format_turns: bool | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     speaker_labels: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     vad_threshold: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -288,6 +296,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             keyterms_prompt=None,
             prompt=None,
             language_detection=None,
+            language_code=None,
             format_turns=True,
             speaker_labels=None,
             vad_threshold=None,
@@ -416,6 +425,16 @@ class AssemblyAISTTService(WebsocketSTTService):
             logger.warning(
                 "mode is only supported by U3 Pro models and will be ignored "
                 f"for model '{default_settings.model}'."
+            )
+
+        # language_code (declared language / steering) and language_detection
+        # (auto-detect) are mutually exclusive: you can't both declare a language
+        # and ask the server to detect one.
+        if default_settings.language_code is not None and default_settings.language_detection:
+            logger.warning(
+                "language_code and language_detection are both set; these are "
+                "mutually exclusive (declaring a language vs. auto-detecting it). "
+                "Both will be sent to AssemblyAI as-is."
             )
 
         # 6. Configure pipecat turn mode (mutates default_settings)
@@ -640,6 +659,7 @@ class AssemblyAISTTService(WebsocketSTTService):
             "max_turn_silence": s.max_turn_silence,
             "prompt": s.prompt,
             "language_detection": s.language_detection,
+            "language_code": s.language_code,
             "format_turns": s.format_turns,
             "speaker_labels": s.speaker_labels,
             "vad_threshold": s.vad_threshold,

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -7,9 +7,11 @@
 """Tests for the AssemblyAI streaming STT service connection parameters."""
 
 import asyncio
+import io
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from loguru import logger
 
 from pipecat.services.assemblyai.stt import AssemblyAISTTService, is_u3_pro_model
 
@@ -401,6 +403,55 @@ def test_mode_values_accepted(value):
         settings=AssemblyAISTTService.Settings(mode=value),
     )
     assert _query(service)["mode"] == [value]
+
+
+# --- language_code ---
+
+
+def test_language_code_omitted_by_default():
+    # Unset means "not sent" — no steering, current behavior preserved.
+    service = AssemblyAISTTService(api_key="test-key")
+    assert "language_code" not in _query(service)
+
+
+def test_language_code_sent_when_set():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(language_code="es"),
+    )
+    assert _query(service)["language_code"] == ["es"]
+
+
+def test_language_code_sent_for_universal_streaming():
+    # language_code is not U3 Pro-only; it is forwarded for any model.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(
+            model="universal-streaming-english",
+            language_code="en",
+        ),
+    )
+    assert _query(service)["language_code"] == ["en"]
+
+
+def test_language_code_with_language_detection_warns():
+    # language_code and language_detection are mutually exclusive; setting both
+    # warns but still forwards both (the server is the source of truth).
+    sink = io.StringIO()
+    handler_id = logger.add(sink, level="WARNING", format="{message}")
+    try:
+        service = AssemblyAISTTService(
+            api_key="test-key",
+            settings=AssemblyAISTTService.Settings(
+                language_code="es",
+                language_detection=True,
+            ),
+        )
+    finally:
+        logger.remove(handler_id)
+    assert _query(service)["language_code"] == ["es"]
+    assert _query(service)["language_detection"] == ["true"]
+    assert "mutually exclusive" in sink.getvalue()
 
 
 # --- update_agent_context() ---


### PR DESCRIPTION
## Summary

Adds a `language_code` streaming parameter to `AssemblyAISTTService`, exposing AssemblyAI's connection-time `language_code` query parameter so callers can declare the audio language.

On U3 Pro models, a tier-1 code (`en`/`es`/`fr`/`de`/`it`/`pt`) steers transcription toward that language; the other supported codes (`tr`, `nl`, `sv`, `no`, `da`, `fi`, `hi`, `vi`, `ar`, `he`, `ja`, `ur`, `zh`) are forwarded as well. Unset (the default) sends nothing — no steering — so **existing behavior is unchanged**.

```python
service = AssemblyAISTTService(
    api_key=...,
    settings=AssemblyAISTTService.Settings(language_code="es"),
)
```

## Details

- New `language_code: str | None` field on `AssemblyAISTTService.Settings`, defaulting to "not sent" (consistent with the other optional connection params).
- Forwarded as a `language_code` query param in `_build_ws_url()`. It is not model-gated — `language_code` is a top-level API parameter the server accepts across models, and the server decides which steering applies.
- Typed as `str` rather than a closed `Literal` for forward-compatibility as AssemblyAI adds languages; the supported set is documented in the docstring.
- Warns when both `language_code` and `language_detection` are set, since declaring a language and auto-detecting one are mutually exclusive. Both are still forwarded as-is.

## Test plan

- New unit tests in `tests/test_assemblyai_stt.py`: omitted by default, sent when set, forwarded for non-U3-Pro models, and the `language_detection` conflict warning.
- `uv run pytest tests/test_assemblyai_stt.py` — 63 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)