### PR TITLE
Honor a leading "No replacement." in the deprecation registry generator

### DIFF
--- a/scripts/deprecations/deprecations.json
+++ b/scripts/deprecations/deprecations.json
@@ -470,8 +470,8 @@
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
-      "relation": "use_existing",
-      "replacement": "InputAudioRawFrame",
+      "relation": "none",
+      "replacement": null,
       "message": "No replacement; the parameter is ignored. Will be removed in 2.0.0. The processor no longer needs a transport reference — audio input and audio-streaming start are driven by frames (:class:`InputAudioRawFrame` and :class:`InputTransportStartAudioStreamingFrame`) pushed downstream. For client-ready audio gating, set ``audio_in_stream_on_start=False`` on the transport params.",
       "location": "pipecat/processors/frameworks/rtvi/processor.py"
     },
@@ -2274,9 +2274,9 @@
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
-      "relation": "use_existing",
-      "replacement": "api_version",
-      "message": "No longer used. Mem0 2.0.0 removed the ``api_version`` / ``output_format`` parameters from the client. Will be removed in 2.0.0.",
+      "relation": "none",
+      "replacement": null,
+      "message": "No replacement. Mem0 2.0.0 removed the ``api_version`` / ``output_format`` parameters from the client. Will be removed in 2.0.0.",
       "location": "pipecat/services/mem0/memory.py"
     },
     {

--- a/scripts/deprecations/scan.py
+++ b/scripts/deprecations/scan.py
@@ -51,6 +51,11 @@ FIRST_REFERENCE_RE = re.compile(
 NO_REPLACEMENT_RE = re.compile(
     r"no replacement|no longer|always|discontinued|unmaintained", re.IGNORECASE
 )
+# An explicit, leading "No replacement" — the convention's authoritative signal
+# that nothing replaces the deprecated thing (from CONTRIBUTING.md: "lead with
+# `No replacement.`"). No trailing period required, so "No replacement — ..." or
+# "No replacement; ..." also match.
+NO_REPLACEMENT_LEAD_RE = re.compile(r"^\s*no replacement\b", re.IGNORECASE)
 # The removal version stated in a directive body ("... will be removed in 2.0.0.").
 REMOVAL_RE = re.compile(r"removed in (\d+\.\d+\.\d+)", re.IGNORECASE)
 _DIRECTIVE_VERSION_RE = re.compile(r"v?\d+\.\d+\.\d+")
@@ -191,7 +196,13 @@ def directive_removal(body: str) -> str | None:
 
 
 def first_reference(body: str) -> str | None:
-    """The first role/backtick reference in a directive body — the replacement."""
+    """The first role/backtick reference in a directive body — the replacement.
+
+    Returns ``None`` when the body leads with an explicit "No replacement.", so
+    contextual role/backtick references after it aren't mistaken for a replacement.
+    """
+    if NO_REPLACEMENT_LEAD_RE.match(body):
+        return None
     match = FIRST_REFERENCE_RE.search(body)
     if not match:
         return None
@@ -203,6 +214,10 @@ _FIRST_REF_IS_MODULE_RE = re.compile(r"^[^`]*:mod:`")
 
 def relation_for(body: str, replacement: str | None) -> str:
     """Classify the migration relation from the directive's leading verb/target."""
+    if NO_REPLACEMENT_LEAD_RE.match(body):
+        # An explicit leading "No replacement." overrides any relation verb that
+        # appears later in contextual prose (e.g. "... merged into X years ago").
+        return "none"
     low = body.lower()
     if re.search(r"\brenamed to\b", low):
         return "rename"

--- a/src/pipecat/flows/types.py
+++ b/src/pipecat/flows/types.py
@@ -42,10 +42,10 @@ class FlowResult(TypedDict, total=False):
     """Optional convention TypedDict for ``status``/``error`` results.
 
     .. deprecated:: 1.5.0
-        No replacement. FlowResult is no longer required or referenced by any
-        handler type, and Pipecat's upstream function-call-result contract is
-        Any — define your own TypedDict or return any JSON-serializable value.
-        Will be removed in 2.0.0.
+        No replacement. ``FlowResult`` is no longer required or referenced by
+        any handler type, and Pipecat's upstream function-call-result contract
+        is ``Any`` — define your own ``TypedDict`` or return any
+        JSON-serializable value. Will be removed in 2.0.0.
 
     Parameters:
         status: Status of the function execution.

--- a/src/pipecat/services/mem0/memory.py
+++ b/src/pipecat/services/mem0/memory.py
@@ -49,7 +49,7 @@ class Mem0MemoryService(FrameProcessor):
             api_version: API version to use for Mem0 client operations.
 
                 .. deprecated:: 1.4.0
-                    No longer used. Mem0 2.0.0 removed the ``api_version`` /
+                    No replacement. Mem0 2.0.0 removed the ``api_version`` /
                     ``output_format`` parameters from the client. Will be
                     removed in 2.0.0.
 

--- a/tests/test_deprecation_markers.py
+++ b/tests/test_deprecation_markers.py
@@ -77,6 +77,31 @@ def test_directives_state_removal_version():
     )
 
 
+def test_no_replacement_directive_extracts_no_replacement():
+    """A directive leading with "No replacement." records none — even with backticks.
+
+    The first-reference rule treats the first backtick/role token as the
+    replacement, so a no-replacement body may freely backtick contextual symbols
+    (the deprecated thing itself, related types) without one being mistaken for a
+    replacement, as long as it leads with the explicit marker.
+    """
+    body = (
+        "No replacement. ``FlowResult`` is no longer referenced by any handler; "
+        "the upstream contract is ``Any``. Will be removed in 2.0.0."
+    )
+    assert dscan.first_reference(body) is None
+    assert dscan.relation_for(body, dscan.first_reference(body)) == "none"
+
+    # An incidental relation verb in later prose doesn't override the marker.
+    moved = "No replacement. The old behavior moved to a different layer entirely."
+    assert dscan.relation_for(moved, dscan.first_reference(moved)) == "none"
+
+    # A real replacement is still extracted as before.
+    use = "Use :class:`Foo` instead. Will be removed in 2.0.0."
+    assert dscan.first_reference(use) == "Foo"
+    assert dscan.relation_for(use, "Foo") == "use_existing"
+
+
 # --- @deprecated decorator message consistency -------------------------------
 
 


### PR DESCRIPTION
A `.. deprecated::` body that leads with "No replacement." now records no replacement, instead of mis-extracting the first backticked reference after it. That makes backticks safe in such bodies, so restore the ones in FlowResult's directive and reword mem0's `api_version` directive to lead with "No replacement.", which stops it recording itself as its own replacement.