### PR TITLE
Add endpoint_latency_adjustment_level support to SonioxSTTService

### DIFF
--- a/changelog/4894.added.md
+++ b/changelog/4894.added.md
@@ -1,0 +1,1 @@
+- Added `endpoint_latency_adjustment_level` to `SonioxSTTService.Settings`, exposing Soniox's endpoint-detection latency control (integer 0–3; higher finalizes turns sooner at some cost to accuracy). Takes effect when Soniox endpoint detection is active (`vad_force_turn_endpoint=False`).

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -235,6 +235,11 @@ class SonioxSTTSettings(STTSettings):
         endpoint_latency_adjustment_level: Reduces endpoint latency vs. the default (0-3); higher
             finalizes sooner but may reduce accuracy.
         client_reference_id: Client reference ID to use for transcription.
+
+    The ``max_endpoint_delay_ms``, ``endpoint_sensitivity`` and
+    ``endpoint_latency_adjustment_level`` settings only take effect when
+    ``vad_force_turn_endpoint=False``; otherwise Soniox endpoint detection is
+    disabled and these settings are ignored.
     """
 
     language_hints: list[Language] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -232,6 +232,8 @@ class SonioxSTTSettings(STTSettings):
         enable_language_identification: Whether to enable language identification.
         max_endpoint_delay_ms: Max ms before endpoint detection finalizes the turn (500-3000).
         endpoint_sensitivity: Endpoint detection sensitivity (-1.0 to 1.0); higher finalizes sooner.
+        endpoint_latency_adjustment_level: Reduces endpoint latency vs. the default (0-3); higher
+            finalizes sooner but may reduce accuracy.
         client_reference_id: Client reference ID to use for transcription.
     """
 
@@ -244,6 +246,9 @@ class SonioxSTTSettings(STTSettings):
     )
     max_endpoint_delay_ms: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     endpoint_sensitivity: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    endpoint_latency_adjustment_level: int | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
     client_reference_id: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
@@ -315,6 +320,7 @@ class SonioxSTTService(WebsocketSTTService):
             enable_language_identification=False,
             max_endpoint_delay_ms=None,
             endpoint_sensitivity=None,
+            endpoint_latency_adjustment_level=None,
             client_reference_id=None,
         )
 
@@ -529,6 +535,7 @@ class SonioxSTTService(WebsocketSTTService):
                 "enable_endpoint_detection": enable_endpoint_detection,
                 "max_endpoint_delay_ms": s.max_endpoint_delay_ms,
                 "endpoint_sensitivity": s.endpoint_sensitivity,
+                "endpoint_latency_adjustment_level": s.endpoint_latency_adjustment_level,
                 "sample_rate": self.sample_rate,
                 "language_hints": _prepare_language_hints(assert_given(s.language_hints)),
                 "language_hints_strict": s.language_hints_strict,


### PR DESCRIPTION
## Summary

Adds support for Soniox's `endpoint_latency_adjustment_level` endpoint-detection parameter to `SonioxSTTService`, following the same pattern as the existing `max_endpoint_delay_ms` and `endpoint_sensitivity` settings.

The parameter reduces endpoint latency compared to default endpointing behavior. Accepts integer levels 0–3, where higher values finalize turns sooner at the cost of some accuracy. It only takes effect when Soniox endpoint detection is active (i.e. `vad_force_turn_endpoint=False`).

See: https://soniox.com/docs/stt/rt/endpoint-detection

## Changes

- Added `endpoint_latency_adjustment_level` field to `SonioxSTTSettings` (runtime-updatable; reconnects on change)
- Wired it into the connect-time config message sent to Soniox

🤖 Generated with [Claude Code](https://claude.com/claude-code)