### PR TITLE
Default NvidiaTTSSettings.synthesis_mode to NOT_GIVEN

### DIFF
--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -94,7 +94,7 @@ class NvidiaTTSSettings(TTSSettings):
     """
 
     quality: int | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
-    synthesis_mode: NvidiaTTSSynthesisMode = NvidiaTTSSynthesisMode.PER_SENTENCE
+    synthesis_mode: NvidiaTTSSynthesisMode | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 @dataclass
@@ -209,6 +209,7 @@ class NvidiaTTSService(TTSService):
             voice="Magpie-Multilingual.EN-US.Aria",
             language=Language.EN_US,
             quality=20,
+            synthesis_mode=NvidiaTTSSynthesisMode.PER_SENTENCE,
         )
 
         # 2. Apply direct init arg overrides (deprecated)


### PR DESCRIPTION
- No changelog needed because #4742 hasn't shipped yet.

## Summary

`NvidiaTTSSettings.synthesis_mode` defaulted to a concrete `NvidiaTTSSynthesisMode.PER_SENTENCE`, breaking the settings-delta contract: every `ServiceSettings` field must default to `NOT_GIVEN` so that an empty or partial delta is a no-op. A concrete default overwrites the corresponding store value whenever `apply_update()` is applied with a partial delta.

This was caught by `test_service_init.py::test_delta_defaults_are_not_given[NvidiaTTSSettings]`.

## Fix

Mirror the sibling `quality` field:

- Default `synthesis_mode` to `NOT_GIVEN` on the dataclass.
- Set the concrete `PER_SENTENCE` default in `NvidiaTTSService.__init__`, so the constructed store stays complete.

## Testing

Verified both invariants the test suite enforces:

- `test_delta_defaults_are_not_given[NvidiaTTSSettings]` — bare `NvidiaTTSSettings()` now has every field `NOT_GIVEN`.
- `test_service_settings_complete[NvidiaTTSService]` — a constructed service still has no `NOT_GIVEN` fields, with `synthesis_mode` resolving to `per_sentence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)