### PR TITLE
Add voicemail-resume example + VoicemailDetector.reopen_conversation() API

### DIFF
--- a/examples/features/features-voicemail-resume.py
+++ b/examples/features/features-voicemail-resume.py
@@ -154,16 +154,14 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
         # Resume support (the custom state management this example is about):
         #
-        # By default the detector closes its ConversationGate permanently once
+        # By default the detector closes its conversation path permanently once
         # voicemail is detected, which blocks the main LLM from ever hearing the
-        # called party again. We reopen that gate so that if a human picks up
-        # and starts talking after the message, their speech flows back into the
-        # main pipeline and the bot continues a normal conversation.
-        #
-        # The classifier branch stays closed (the call is already classified),
-        # so reopening only restores the live-conversation path.
-        voicemail._conversation_gate._gate_opened = True
-        logger.info("Conversation path reopened — the called party can keep talking.")
+        # called party again. reopen_conversation() restores that path, so if a
+        # human picks up and starts talking after the message, their speech flows
+        # back into the main pipeline and the bot continues a normal conversation.
+        # The classifier branch stays closed (the call is already classified).
+        voicemail.reopen_conversation()
+        logger.info("Conversation path reopened. The called party can keep talking.")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 

--- a/examples/features/features-voicemail-resume.py
+++ b/examples/features/features-voicemail-resume.py
@@ -1,0 +1,183 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Voicemail detection that can resume into a live conversation.
+
+The built-in ``VoicemailDetector`` is designed for "detect voicemail, leave a
+message, hang up": once it classifies the call as voicemail it closes its
+``ConversationGate`` permanently, so the main LLM never hears anything else.
+
+This example shows the small amount of custom state management needed to keep
+the call going if a human picks up *after* the message starts. When voicemail is
+detected we leave the message, then reopen the detector's conversation path so
+that the next thing the called party says flows back to the main LLM and the bot
+continues a normal conversation.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.extensions.voicemail.voicemail_detector import VoicemailDetector
+from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+# The message the bot leaves when it reaches a voicemail system. It invites the
+# called party to jump in, which is what the resume path below handles.
+VOICEMAIL_MESSAGE = (
+    "Hi, this is Jamie calling about your appointment tomorrow. "
+    "Please call me back at 555-0123. If you're there, feel free to jump in."
+)
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+
+    tts = CartesiaTTSService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaTTSService.Settings(
+            voice="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+        ),
+    )
+
+    llm = OpenAILLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAILLMService.Settings(
+            system_instruction=(
+                "You are Jamie, a friendly assistant making an outbound phone call about "
+                "the person's appointment tomorrow. Your responses will be spoken aloud, so "
+                "avoid emojis, bullet points, or other formatting that can't be spoken. If the "
+                "person you called speaks to you, talk with them naturally and briefly about "
+                "their appointment."
+            ),
+        ),
+    )
+    classifier_llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"])
+
+    voicemail = VoicemailDetector(llm=classifier_llm)
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            stt,
+            voicemail.detector(),  # Voicemail detection — between STT and User context aggregator
+            user_aggregator,
+            llm,
+            tts,
+            voicemail.gate(),  # TTS gating — Immediately after the TTS service
+            transport.output(),
+            assistant_aggregator,
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await worker.cancel()
+
+    @voicemail.event_handler("on_conversation_detected")
+    async def on_conversation_detected(processor):
+        logger.info("Conversation detected — a human answered, talking normally.")
+
+    @voicemail.event_handler("on_voicemail_detected")
+    async def on_voicemail_detected(processor):
+        logger.info("Voicemail detected! Leaving a message...")
+
+        # Leave the message. This is pushed straight to TTS, bypassing the main
+        # LLM, just like the standard voicemail example.
+        await processor.push_frame(TTSSpeakFrame(VOICEMAIL_MESSAGE))
+
+        # Resume support (the custom state management this example is about):
+        #
+        # By default the detector closes its ConversationGate permanently once
+        # voicemail is detected, which blocks the main LLM from ever hearing the
+        # called party again. We reopen that gate so that if a human picks up
+        # and starts talking after the message, their speech flows back into the
+        # main pipeline and the bot continues a normal conversation.
+        #
+        # The classifier branch stays closed (the call is already classified),
+        # so reopening only restores the live-conversation path.
+        voicemail._conversation_gate._gate_opened = True
+        logger.info("Conversation path reopened — the called party can keep talking.")
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -266,3 +266,15 @@ suite:
   #
   - bot: features/features-dtmf-menu.py
     scenarios: [dtmf_menu]
+
+  #
+  # Voicemail with resume: the bot reaches a voicemail system, leaves its
+  # message, then a human picks up and starts talking. The bot must drop the
+  # "leave a message" behavior and continue a live conversation (custom state
+  # management that reopens the detector's conversation path). Audio modality,
+  # because the VoicemailDetector keys off real speech-turn (VAD) signals. Run
+  # as a suite (fresh bot per scenario): the detector decides once per process,
+  # so it can't be re-driven against a long-lived bot.
+  #
+  - bot: features/features-voicemail-resume.py
+    scenarios: [voicemail_resume]

--- a/scripts/release-evals/scenarios/voicemail_resume.yaml
+++ b/scripts/release-evals/scenarios/voicemail_resume.yaml
@@ -1,0 +1,49 @@
+name: voicemail_resume
+
+# Voicemail-then-resume, end to end. The bot makes an outbound call, reaches a
+# voicemail system, leaves its message, and then a human picks up and starts
+# talking. The bot must drop the "leave a message" behavior and continue a live
+# conversation.
+#
+# Audio modality: the VoicemailDetector relies on real speech-turn (VAD) signals,
+# so this is tested with synthesized user speech (Kokoro) and the bot's real
+# audio transcribed back (Moonshine). The judge LLM is OpenAI (no local Ollama).
+#
+# Two assertions prove the whole flow:
+#   turn 0 — the bot detects voicemail and leaves its message (spoken aloud).
+#   turn 1 — after the message, a human speaks and the bot resumes a live chat.
+
+user:
+  modality: audio
+  speech:
+    service: kokoro
+    voice: af_heart
+
+judge:
+  modality: audio
+  eval:
+    service: openai
+    model: gpt-4o-mini
+  transcription:
+    service: moonshine
+    model: small-streaming
+
+turns:
+  # Turn 0: the call connects to a voicemail system. The classifier tags this as
+  # VOICEMAIL, the main LLM's reply is suppressed, and after the response delay
+  # the bot speaks its pre-written voicemail message.
+  - user: "You've reached Jordan's voicemail. Please leave a message after the tone."
+    expect:
+      - event: response
+        eval: "the bot leaves a voicemail message: it asks the person to call back (for example, gives a callback number) rather than holding a back-and-forth conversation"
+
+  # Turn 1: a human picks up and talks after the message. Sent shortly after the
+  # bot finishes its voicemail message, by which point the conversation path has
+  # been reopened. The bot should now talk with the caller as a live person.
+  - user: "Oh, hello? Sorry, I just got to the phone. This is Jordan speaking, what's this about?"
+    send_after:
+      event: response
+      delay_ms: 1500
+    expect:
+      - event: response
+        eval: "the bot talks with the caller as a live person — it responds to Jordan and continues the conversation (for example about the appointment), instead of only repeating a leave-a-message voicemail prompt"

--- a/src/pipecat/extensions/voicemail/voicemail_detector.py
+++ b/src/pipecat/extensions/voicemail/voicemail_detector.py
@@ -210,6 +210,15 @@ class ConversationGate(NotifierGate):
         """
         super().__init__(voicemail_notifier, worker_name="conversation_gate")
 
+    def reopen(self) -> None:
+        """Reopen the conversation path after it was closed on voicemail.
+
+        The gate closes permanently when voicemail is detected. Reopening it
+        lets user input reach the main conversation LLM again, so a person who
+        picks up after the bot leaves its message can continue the call.
+        """
+        self._gate_opened = True
+
 
 class ClassificationProcessor(FrameProcessor):
     """Processor that handles LLM classification responses and triggers events.
@@ -706,6 +715,22 @@ VOICEMAIL SYSTEM (respond "VOICEMAIL"):
             The TTSGate processor instance.
         """
         return self._voicemail_gate
+
+    def reopen_conversation(self) -> None:
+        """Reopen the conversation path after voicemail handling.
+
+        By default the detector blocks the main conversation LLM permanently
+        once voicemail is detected. Call this after leaving a voicemail message
+        (for example, from an ``on_voicemail_detected`` handler) to let a person
+        who picks up keep talking to the bot.
+
+        Note:
+            This reopens the path immediately and leaves it open. Audio that
+            arrives after the message (a human, but also later machine prompts on
+            an answering system) will reach the main LLM, so use it when you want
+            the call to continue rather than end after the message.
+        """
+        self._conversation_gate.reopen()
 
     def add_event_handler(self, event_name: str, handler):
         """Add an event handler for voicemail detection events.


### PR DESCRIPTION
## What

Adds a public way to keep an outbound call going after the bot leaves a voicemail message, plus an example and an eval that exercise it.

- **Framework:** new `VoicemailDetector.reopen_conversation()` (and a `ConversationGate.reopen()` helper). By default the detector closes its conversation path permanently once voicemail is detected, so the main LLM never hears the called party again. `reopen_conversation()` restores that path.
- **Example:** `examples/features/features-voicemail-resume.py` shows the pattern: detect voicemail, leave the message, then call `reopen_conversation()` so a human who picks up after the message can continue talking.
- **Eval:** `scripts/release-evals/scenarios/voicemail_resume.yaml` (audio modality, wired into the release manifest) proves the flow: turn 0 leaves the message, turn 1 resumes a live conversation.

## Why

The resume behavior previously required reaching into private state (`voicemail._conversation_gate._gate_opened = True`). That worked but depended on internals with no compatibility promise. This makes it a supported API.

## How verified

- Smoke test: `reopen_conversation()` reopens the conversation gate.
- `voicemail_resume` audio eval passes end to end (Kokoro user speech, Moonshine transcription, OpenAI judge): the bot leaves the message, then talks live with the caller after they speak.

## Known follow-ups (draft, not yet addressed)

Kept out of scope here so the API change stays focused, but flagged for honesty:

1. `reopen_conversation()` reopens immediately and leaves the path open. On a pure voicemail with no human pickup, later machine audio (a second beep, a "mailbox full" prompt) would reach the main LLM. A safer variant could reopen only on the next detected human turn. Documented in the method's docstring for now.
2. The example and scenario still contain em dashes, and the scenario inlines an OpenAI judge instead of reusing the shared `judge_audio.yaml` / `user_audio.yaml` includes (which the rest of the suite uses with a local Ollama judge). Worth aligning before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)