### PR TITLE
fix(inworld): whitelist contextless keepalive rejection as benign

### DIFF
--- a/changelog/4906.fixed.md
+++ b/changelog/4906.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InworldTTSService` surfacing an `ErrorFrame` during idle periods when the keepalive task sent a contextless `send_text` and Inworld rejected it. The `context_id is required` and `no open context` rejections are now treated as benign (logged at debug level and skipped), matching the existing `Context not found` handling, which prevents spurious failover away from Inworld.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -1058,11 +1058,13 @@ class InworldTTSService(WebsocketTTSService):
 
                 # Handle benign context errors:
                 # - "Context not found" (code 5): keepalive sent after context expired
-                # - "context_id is required": keepalive sent without a context
+                # - "context_id is required" / "no open context": keepalive sent
+                #   without an active context
                 if error_code == 5 and "not found" in error_msg.lower():
                     logger.debug(f"{self}: Context {ctx_id} not found.")
                     continue
-                if "context_id is required" in error_msg.lower():
+                lower_error_msg = error_msg.lower()
+                if "context_id is required" in lower_error_msg or "no open context" in lower_error_msg:
                     logger.debug(f"{self}: Contextless message rejected (benign): {error_msg}")
                     continue
 

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -1056,10 +1056,14 @@ class InworldTTSService(WebsocketTTSService):
                 error_msg = status.get("message", "Unknown error")
                 error_code = status.get("code")
 
-                # Handle "Context not found" error (code 5)
-                # This can happen when a keepalive message is sent but no context is available.
+                # Handle benign context errors:
+                # - "Context not found" (code 5): keepalive sent after context expired
+                # - "context_id is required": keepalive sent without a context
                 if error_code == 5 and "not found" in error_msg.lower():
                     logger.debug(f"{self}: Context {ctx_id} not found.")
+                    continue
+                if "context_id is required" in error_msg.lower():
+                    logger.debug(f"{self}: Contextless message rejected (benign): {error_msg}")
                     continue
 
                 # For other errors, push error frame


### PR DESCRIPTION
## Summary

Fixes #4899.

When the `InworldTTSService` keepalive task fires during an idle period with no active audio context, it sends a `send_text` message without a `contextId`. Inworld rejects this with the error `context_id is required when 0 contexts are open (payload=SEND_TEXT)`. Because that rejection wasn't whitelisted, it propagated as an `ErrorFrame`, causing spurious service errors during idle periods and triggering unwanted failover away from Inworld.

This treats the `context_id is required` rejection as benign in `_receive_messages`, mirroring the existing `Context not found` (code 5) handling — it's logged at debug level and skipped instead of surfacing as an error.

## Changes

- Whitelist Inworld's `context_id is required` keepalive rejection in `InworldTTSService._receive_messages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)