### PR TITLE
Instantiate services inside the test, not during collection

### DIFF
--- a/tests/test_service_init.py
+++ b/tests/test_service_init.py
@@ -112,24 +112,23 @@ def _try_instantiate(cls):
     return cls(**kwargs)
 
 
-def _discover_service_classes():
-    """Return concrete service classes that can be instantiated with dummy args."""
-    result = []
-    for cls in sorted(_all_subclasses(AIService), key=lambda c: c.__qualname__):
+def _concrete_service_classes():
+    """Return concrete (non-abstract) service classes under pipecat.services.
+
+    Pure class-hierarchy walk with no instantiation, so collection stays fast.
+    Construction happens inside the test, which skips services that can't be
+    built with dummy args (e.g. those that need real credentials).
+    """
+    return [
+        cls
+        for cls in sorted(_all_subclasses(AIService), key=lambda c: c.__qualname__)
         # Skip abstract base classes defined in framework modules.
-        if cls.__module__ in _BASE_MODULES:
-            continue
-        try:
-            svc = _try_instantiate(cls)
-        except Exception:
-            continue
-        if hasattr(svc, "_settings"):
-            result.append(cls)
-    return result
+        if cls.__module__ not in _BASE_MODULES
+    ]
 
 
-ALL_SERVICE_CLASSES = _discover_service_classes()
-assert ALL_SERVICE_CLASSES, "No service classes could be instantiated"
+ALL_SERVICE_CLASSES = _concrete_service_classes()
+assert ALL_SERVICE_CLASSES, "No service classes discovered"
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +169,9 @@ def test_service_settings_complete(service_cls):
     try:
         svc = _try_instantiate(service_cls)
     except Exception:
-        pytest.skip("Cannot re-instantiate (environment issue)")
+        pytest.skip("Cannot instantiate with dummy args (needs real args or credentials)")
+    if not hasattr(svc, "_settings"):
+        pytest.skip("Service has no _settings")
     for f in fields(svc._settings):
         if f.name == "extra":
             continue


### PR DESCRIPTION
## Summary

`tests/test_service_init.py` was slow to collect (~85s) because it built
`ALL_SERVICE_CLASSES` by **instantiating every concrete service at import time**.
pytest constructed ~125 services up front, and six Google services
(`GoogleSTTService`, `GoogleTTSService`, `GoogleHttpTTSService`, `GeminiTTSService`,
`GoogleVertexLLMService`, `GeminiLiveVertexLLMService`) have no required `__init__`
args, so they fall back to Application Default Credentials and each block ~12s on
the GCE metadata-server probe before failing. That ~72s ran during collection, so
even selecting a single unrelated test paid the full cost.

## Change

- Discover concrete service classes by walking the class hierarchy only (no
  instantiation), so collection stays fast.
- Move construction into `test_service_settings_complete`, which already
  `pytest.skip`s services that can't be built with dummy args.

## Result

- Collection: ~85s -> ~8s (now just the unavoidable module imports).
- Services that need real credentials now show up as **skipped** rather than being
  silently excluded from the parametrization, which is more honest.
- The ~12s-per-service cost for the Google services only applies when their
  specific `test_service_settings_complete` param runs, isolated from collection
  and from every other test.
