### PR TITLE
Add Flows to the API reference sidebar

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -22,6 +22,7 @@ Quick Links
    Audio <api/pipecat.audio>
    Clocks <api/pipecat.clocks>
    Extensions <api/pipecat.extensions>
+   Flows <api/pipecat.flows>
    Frames <api/pipecat.frames>
    Metrics <api/pipecat.metrics>
    Observers <api/pipecat.observers>


### PR DESCRIPTION
## Summary

- Add `Flows` to the API reference sidebar (the `docs/api/index.rst` toctree) so the `pipecat.flows` pages are discoverable in the navigation at [reference-server.pipecat.ai](https://reference-server.pipecat.ai/).
- After Flows moved into core Pipecat (#4882), its reference pages are generated and reachable by direct URL (e.g. `/en/latest/api/pipecat.flows.html`), but the hand-curated, `:hidden:` toctree didn't list them — so Flows was missing from the left-nav. Entry added alphabetically between Extensions and Frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)