### PR TITLE
feat(tracing): capture TTS/STT audio and custom metadata in spans

### DIFF
--- a/changelog/4212.added.md
+++ b/changelog/4212.added.md
@@ -1,0 +1,3 @@
+- Added audio capture to TTS and STT OpenTelemetry tracing spans. TTS spans now record the synthesized output audio and STT spans record the user's input audio as `langfuse.media` (base64-encoded), along with `audio.data_size_bytes` and the `output`/`input` attributes, so traces can be played back in Langfuse and similar backends.
+
+- Added a `tracing_metadata: dict[str, Any] | None` constructor parameter to the `TTSService` and `STTService` base classes. When tracing is enabled, each primitive value is attached to every span for that service as a `metadata.<key>` attribute, letting you associate spans with a session, user, or environment by configuring it once per service instance.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -91,6 +91,7 @@ class STTService(AIService):
         keepalive_timeout: float | None = None,
         keepalive_interval: float = 5.0,
         settings: STTSettings | None = None,
+        tracing_metadata: dict[str, Any] | None = None,
         **kwargs,
     ):
         """Initialize the STT service.
@@ -117,6 +118,10 @@ class STTService(AIService):
                 close idle connections (e.g. behind a ServiceSwitcher).
             keepalive_interval: Seconds between idle checks when keepalive is enabled.
             settings: The runtime-updatable settings for the STT service.
+            tracing_metadata: Optional static metadata attached to every STT tracing span as
+                ``metadata.<key>`` attributes (only primitive values are recorded). Useful for
+                associating spans with a session, user, or environment. Has no effect unless
+                tracing is enabled.
             **kwargs: Additional arguments passed to the parent AIService.
         """
         super().__init__(
@@ -150,6 +155,7 @@ class STTService(AIService):
         self._audio_passthrough = audio_passthrough
         self._init_sample_rate = sample_rate
         self._sample_rate = 0
+        self._tracing_metadata: dict[str, Any] | None = tracing_metadata
 
         self._muted: bool = False
         self._user_id: str = ""

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -182,6 +182,8 @@ class TTSService(AIService):
         settings: TTSSettings | None = None,
         # if True, the context ID is reused within an LLM turn
         reuse_context_id_within_turn: bool = True,
+        # Static metadata attached to every TTS tracing span (when tracing is enabled)
+        tracing_metadata: dict[str, Any] | None = None,
         **kwargs,
     ):
         """Initialize the TTS service.
@@ -221,6 +223,10 @@ class TTSService(AIService):
             settings: The runtime-updatable settings for the TTS service.
             reuse_context_id_within_turn: Whether the service should reuse context IDs within the
                 same turn.
+            tracing_metadata: Optional static metadata attached to every TTS tracing span as
+                ``metadata.<key>`` attributes (only primitive values are recorded). Useful for
+                associating spans with a session, user, or environment. Has no effect unless
+                tracing is enabled.
             **kwargs: Additional arguments passed to the parent AIService.
         """
         super().__init__(
@@ -327,6 +333,7 @@ class TTSService(AIService):
         # don't emit a second bot-llm-stopped.
         self._pending_llm_response_end_frames: dict[str, LLMFullResponseEndFrame] = {}
         self._reuse_context_id_within_turn: bool = reuse_context_id_within_turn
+        self._tracing_metadata: dict[str, Any] | None = tracing_metadata
 
         # _turn_context_id:
         #   Set on LLMFullResponseStartFrame and cleared after LLMFullResponseEndFrame

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -11,6 +11,8 @@ attributes to OpenTelemetry spans, following standard semantic conventions
 where applicable and Pipecat-specific conventions for additional context.
 """
 
+import base64
+import json
 from typing import TYPE_CHECKING, Any, Optional
 
 # Import for type checking only
@@ -73,6 +75,8 @@ def add_tts_span_attributes(
     character_count: int | None = None,
     operation_name: str = "tts",
     ttfb: float | None = None,
+    audio_data: bytes | None = None,
+    metadata: dict[str, Any] | None = None,
     **kwargs,
 ) -> None:
     """Add TTS-specific attributes to a span.
@@ -87,6 +91,8 @@ def add_tts_span_attributes(
         character_count: Number of characters in the text.
         operation_name: Name of the operation (default: "tts").
         ttfb: Time to first byte in seconds.
+        audio_data: The synthesized output audio data.
+        metadata: Metadata to add to the span.
         **kwargs: Additional attributes to add.
     """
     # Add standard attributes
@@ -112,6 +118,20 @@ def add_tts_span_attributes(
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
 
+    if audio_data is not None:
+        base64_str = base64.b64encode(audio_data).decode("utf-8")
+        span.set_attribute("audio.data_size_bytes", len(audio_data))
+        span.set_attribute(
+            "langfuse.media",
+            json.dumps({"type": "audio", "data": base64_str, "mediaType": "audio/wav"}),
+        )
+        span.set_attribute("output", base64_str)
+
+    if metadata:
+        for key, value in metadata.items():
+            if isinstance(value, (str, int, float, bool)):
+                span.set_attribute(f"metadata.{key}", value)
+
     # Add any additional keyword arguments as attributes
     for key, value in kwargs.items():
         if isinstance(value, (str, int, float, bool)):
@@ -130,6 +150,8 @@ def add_stt_span_attributes(
     settings: Optional["ServiceSettings"] = None,
     vad_enabled: bool = False,
     ttfb: float | None = None,
+    audio_data: bytes | None = None,
+    metadata: dict[str, Any] | None = None,
     **kwargs,
 ) -> None:
     """Add STT-specific attributes to a span.
@@ -146,6 +168,8 @@ def add_stt_span_attributes(
         settings: Service configuration settings.
         vad_enabled: Whether voice activity detection is enabled.
         ttfb: Time to first byte in seconds.
+        audio_data: The input audio data.
+        metadata: Metadata to add to the span.
         **kwargs: Additional attributes to add.
     """
     # Add standard attributes
@@ -175,6 +199,20 @@ def add_stt_span_attributes(
         for key, value in settings.given_fields().items():
             if isinstance(value, (str, int, float, bool)):
                 span.set_attribute(f"settings.{key}", value)
+
+    if audio_data is not None:
+        base64_str = base64.b64encode(audio_data).decode("utf-8")
+        span.set_attribute("audio.data_size_bytes", len(audio_data))
+        span.set_attribute(
+            "langfuse.media",
+            json.dumps({"type": "audio", "data": base64_str, "mediaType": "audio/wav"}),
+        )
+        span.set_attribute("input", base64_str)
+
+    if metadata:
+        for key, value in metadata.items():
+            if isinstance(value, (str, int, float, bool)):
+                span.set_attribute(f"metadata.{key}", value)
 
     # Add any additional keyword arguments as attributes
     for key, value in kwargs.items():

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -24,8 +24,10 @@ if TYPE_CHECKING:
     from opentelemetry import trace
 
 from pipecat.frames.frames import (
+    AudioRawFrame,
     MetricsFrame,
     TranscriptionFrame,
+    TTSAudioRawFrame,
     TTSStoppedFrame,
     UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
@@ -206,7 +208,15 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
         is_async_generator = inspect.isasyncgenfunction(f)
 
         def end_tts_span(service, context_id, *, interrupted=False):
-            """End the TTS span for ``context_id`` if still open. Idempotent."""
+            """End the TTS span for ``context_id`` if still open. Idempotent.
+
+            Before closing, flush any accumulated output audio onto the
+            span as ``langfuse.media`` (plus ``output`` and
+            ``audio.data_size_bytes``). All TTS span-closing paths funnel
+            through here so the audio is attached regardless of whether
+            the synthesis ended via ``TTSStoppedFrame``, natural
+            completion, removal, or interruption.
+            """
             entry = service._tts_spans.pop(context_id, None)
             if not entry:
                 return
@@ -214,6 +224,20 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 span = entry["span"]
                 if interrupted:
                     span.set_attribute("tts.interrupted", True)
+                audio_chunks = entry.get("audio_chunks") or []
+                if audio_chunks:
+                    try:
+                        settings = getattr(service, "_settings", None)
+                        add_tts_span_attributes(
+                            span=span,
+                            service_name=service.__class__.__name__,
+                            model=_get_model_name(service),
+                            voice_id=getattr(settings, "voice", "unknown"),
+                            operation_name="tts",
+                            audio_data=b"".join(audio_chunks),
+                        )
+                    except Exception as e:
+                        logging.warning(f"Error attaching TTS audio to span: {e}")
                 span.end()
             except Exception as e:
                 logging.warning(f"Error closing TTS span: {e}")
@@ -271,7 +295,11 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                         parent = _get_turn_context(service) or _get_parent_service_context(service)
                         tracer = trace.get_tracer("pipecat")
                         span = tracer.start_span("tts", context=parent)
-                        service._tts_spans[context_id] = {"span": span, "ttfb_recorded": False}
+                        service._tts_spans[context_id] = {
+                            "span": span,
+                            "ttfb_recorded": False,
+                            "audio_chunks": [],
+                        }
 
                         settings = getattr(service, "_settings", None)
                         add_tts_span_attributes(
@@ -281,34 +309,36 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                             voice_id=getattr(settings, "voice", "unknown"),
                             settings=settings,
                             operation_name="tts",
+                            metadata=getattr(service, "_tracing_metadata", None),
                         )
                     except Exception as e:
                         logging.warning(f"Error opening TTS span: {e}")
                 return await orig_create(context_id)
 
             async def traced_append_to_audio_context(context_id, frame):
-                entry = service._tts_spans.get(context_id)
-                if entry and frame is not None:
-                    try:
-                        if isinstance(frame, TTSStoppedFrame):
-                            entry["span"].end()
-                            service._tts_spans.pop(context_id, None)
-                    except Exception as e:
-                        logging.warning(f"Error updating TTS span: {e}")
+                if frame is not None and isinstance(frame, TTSStoppedFrame):
+                    end_tts_span(service, context_id)
                 return await orig_append(context_id, frame)
 
             async def traced_push_frame(frame, direction=FrameDirection.DOWNSTREAM):
                 await orig_push_frame(frame, direction)
                 if not getattr(service, "_tracing_enabled", False):
                     return
-                if not isinstance(frame, MetricsFrame):
+                if not isinstance(frame, (MetricsFrame, TTSAudioRawFrame)):
                     return
                 try:
                     playing_id = getattr(service, "_playing_context_id", None)
                     if playing_id is None:
                         return
                     entry = service._tts_spans.get(playing_id)
-                    if not entry or entry["ttfb_recorded"]:
+                    if not entry:
+                        return
+                    if isinstance(frame, TTSAudioRawFrame):
+                        # Accumulate synthesized audio so it can be flushed
+                        # onto the span as langfuse.media when it closes.
+                        entry["audio_chunks"].append(frame.audio)
+                        return
+                    if entry["ttfb_recorded"]:
                         return
                     for data in frame.data:
                         if isinstance(data, TTFBMetricsData):
@@ -316,15 +346,10 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                             entry["ttfb_recorded"] = True
                             break
                 except Exception as e:
-                    logging.warning(f"Error recording TTS ttfb from MetricsFrame: {e}")
+                    logging.warning(f"Error in TTS push_frame tracing: {e}")
 
             async def traced_remove_audio_context(context_id):
-                entry = service._tts_spans.pop(context_id, None)
-                if entry:
-                    try:
-                        entry["span"].end()
-                    except Exception as e:
-                        logging.warning(f"Error closing TTS span: {e}")
+                end_tts_span(service, context_id)
                 return await orig_remove(context_id)
 
             async def traced_on_audio_context_completed(context_id):
@@ -458,6 +483,63 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
         return _noop_decorator if func is None else _noop_decorator(func)
 
     def decorator(f):
+        def flush_stt_audio(service, span, state):
+            """Flush accumulated input audio onto the STT span before it closes.
+
+            Attaches the user's spoken audio as ``langfuse.media`` (plus
+            ``input`` and ``audio.data_size_bytes``). Called from every
+            span-closing path so the audio is captured whether the span
+            ends on a finalized transcript, on ``UserStoppedSpeakingFrame``,
+            or on the TTFB-timeout path.
+            """
+            audio_chunks = state.get("audio_chunks") or []
+            if not audio_chunks:
+                return
+            try:
+                add_stt_span_attributes(
+                    span=span,
+                    service_name=service.__class__.__name__,
+                    model=_get_model_name(service),
+                    vad_enabled=getattr(service, "vad_enabled", False),
+                    audio_data=b"".join(audio_chunks),
+                )
+            except Exception as e:
+                logging.warning(f"Error attaching STT audio to span: {e}")
+
+        def patch_process_frame(owner):
+            """Wrap ``owner.process_frame`` to accumulate the segment's input audio.
+
+            The user's speech arrives as ``AudioRawFrame`` (specifically
+            ``InputAudioRawFrame``) on the inbound ``process_frame`` path,
+            which is separate from the ``push_frame`` path that drives the
+            span lifecycle. We accumulate audio whenever a segment is
+            active — a span is open, or speech start has been anchored via
+            VAD (``segment_start_time``) — so capture begins at the start
+            of speech when VAD is available rather than only once the
+            first transcript opens the span.
+
+            Idempotent: if a parent class has already been wrapped, skip.
+            """
+            original_process_frame = owner.process_frame
+            if getattr(original_process_frame, "__stt_tracing_process_frame_wrapped__", False):
+                return
+
+            @functools.wraps(original_process_frame)
+            async def patched_process_frame(self, frame, direction):
+                if getattr(self, "_tracing_enabled", False) and isinstance(frame, AudioRawFrame):
+                    try:
+                        state = getattr(self, "_stt_span_state", None)
+                        if state is not None and (
+                            state["span"] is not None or state["segment_start_time"] is not None
+                        ):
+                            state["audio_chunks"].append(frame.audio)
+                    except Exception as e:
+                        logging.warning(f"Error accumulating STT audio: {e}")
+                return await original_process_frame(self, frame, direction)
+
+            setattr(patched_process_frame, "__stt_tracing_process_frame_wrapped__", True)
+            owner.process_frame = patched_process_frame
+
         def patch_push_frame(owner):
             """Wrap ``owner.push_frame`` to drive the STT span lifecycle.
 
@@ -511,6 +593,7 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                         model=_get_model_name(service),
                         settings=settings,
                         vad_enabled=getattr(service, "vad_enabled", False),
+                        metadata=getattr(service, "_tracing_metadata", None),
                     )
                 except Exception as e:
                     logging.warning(f"Error setting STT span baseline attributes: {e}")
@@ -590,12 +673,15 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                     # via the timeout path; re-check.
                     if state["span"] is None:
                         state["segments"] = []
+                        state["audio_chunks"] = []
                         return
                     state["span"].set_attribute("stt.incomplete", True)
+                    flush_stt_audio(service, state["span"], state)
                     state["span"].end()
                     state["span"] = None
                     state["segment_start_time"] = None
                     state["segments"] = []
+                    state["audio_chunks"] = []
                 elif isinstance(frame, MetricsFrame):
                     span = state["span"]
                     if span is None:
@@ -617,16 +703,23 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                     if frame.user_id:
                         span.set_attribute("user_id", frame.user_id)
                     if frame.finalized:
+                        flush_stt_audio(service, span, state)
                         span.end()
                         state["span"] = None
                         state["segment_start_time"] = None
                         state["segments"] = []
+                        state["audio_chunks"] = []
 
             @functools.wraps(original_push_frame)
             async def patched_push_frame(self, frame, direction=FrameDirection.DOWNSTREAM):
                 state = getattr(self, "_stt_span_state", None)
                 if state is None:
-                    state = {"span": None, "segment_start_time": None, "segments": []}
+                    state = {
+                        "span": None,
+                        "segment_start_time": None,
+                        "segments": [],
+                        "audio_chunks": [],
+                    }
                     self._stt_span_state = state
 
                 if getattr(self, "_tracing_enabled", False):
@@ -680,10 +773,12 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                     return
                 try:
                     span = state["span"]
+                    flush_stt_audio(self, span, state)
                     span.end(end_time=int(end_time * 1e9))
                     state["span"] = None
                     state["segment_start_time"] = None
                     state["segments"] = []
+                    state["audio_chunks"] = []
                 except Exception as e:
                     logging.warning(f"Error in STT stop_ttfb_metrics tracing: {e}")
 
@@ -704,6 +799,7 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
 
             def __set_name__(self, owner, attr_name):
                 patch_push_frame(owner)
+                patch_process_frame(owner)
                 patch_stop_ttfb_metrics(owner)
                 setattr(owner, attr_name, f)
 

--- a/tests/test_tracing_service_attributes.py
+++ b/tests/test_tracing_service_attributes.py
@@ -1,0 +1,237 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import base64
+import json
+import threading
+import unittest
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    HAS_OPENTELEMETRY = True
+except ImportError:
+    HAS_OPENTELEMETRY = False
+
+from pipecat.utils.tracing.service_attributes import (
+    add_stt_span_attributes,
+    add_tts_span_attributes,
+)
+
+if HAS_OPENTELEMETRY:
+
+    class _InMemorySpanExporter(SpanExporter):
+        """Simple in-memory span exporter for testing."""
+
+        def __init__(self):
+            """Initialize the exporter."""
+            self._spans = []
+            self._lock = threading.Lock()
+
+        def export(self, spans):
+            """Export spans to memory."""
+            with self._lock:
+                self._spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        def get_finished_spans(self):
+            """Return collected spans."""
+            with self._lock:
+                return list(self._spans)
+
+        def clear(self):
+            """Clear collected spans."""
+            with self._lock:
+                self._spans.clear()
+
+
+@unittest.skipUnless(HAS_OPENTELEMETRY, "opentelemetry not installed")
+class TestTracingServiceAttributes(unittest.TestCase):
+    """Tests for TTS and STT service tracing attributes."""
+
+    def setUp(self):
+        """Set up a fresh provider and exporter for each test."""
+        self._exporter = _InMemorySpanExporter()
+        self._provider = TracerProvider()
+        self._provider.add_span_processor(SimpleSpanProcessor(self._exporter))
+        self._tracer = self._provider.get_tracer("test")
+
+    def tearDown(self):
+        """Shut down the provider to flush spans."""
+        self._provider.shutdown()
+
+    def test_tts_span_with_audio_data(self):
+        """Test that TTS span attributes are set correctly when audio data is provided."""
+        span = self._tracer.start_span("tts_test")
+        audio = b"dummy_audio_bytes"
+        add_tts_span_attributes(
+            span=span,
+            service_name="elevenlabs",
+            model="eleven_monolingual_v1",
+            voice_id="voice-id-123",
+            audio_data=audio,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        # audio.data_size_bytes is set correctly
+        self.assertEqual(target_span.attributes.get("audio.data_size_bytes"), len(audio))
+
+        # output is set to base64 encoded audio string
+        expected_base64 = base64.b64encode(audio).decode("utf-8")
+        self.assertEqual(target_span.attributes.get("output"), expected_base64)
+
+        # langfuse.media is valid base64 JSON with type: audio
+        media_json = target_span.attributes.get("langfuse.media")
+        self.assertIsNotNone(media_json)
+        media_data = json.loads(media_json)
+        self.assertEqual(media_data.get("type"), "audio")
+        self.assertEqual(media_data.get("data"), expected_base64)
+        self.assertEqual(media_data.get("mediaType"), "audio/wav")
+
+    def test_stt_span_with_audio_data(self):
+        """Test that STT span attributes are set correctly when audio data is provided."""
+        span = self._tracer.start_span("stt_test")
+        audio = b"dummy_audio_bytes"
+        add_stt_span_attributes(
+            span=span,
+            service_name="deepgram",
+            model="nova-2",
+            audio_data=audio,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        # audio.data_size_bytes is set correctly
+        self.assertEqual(target_span.attributes.get("audio.data_size_bytes"), len(audio))
+
+        # input is set to base64 encoded audio string
+        expected_base64 = base64.b64encode(audio).decode("utf-8")
+        self.assertEqual(target_span.attributes.get("input"), expected_base64)
+
+        # langfuse.media is valid base64 JSON
+        media_json = target_span.attributes.get("langfuse.media")
+        self.assertIsNotNone(media_json)
+        media_data = json.loads(media_json)
+        self.assertEqual(media_data.get("type"), "audio")
+        self.assertEqual(media_data.get("data"), expected_base64)
+        self.assertEqual(media_data.get("mediaType"), "audio/wav")
+
+    def test_tts_span_with_metadata(self):
+        """Test that custom metadata is flattened and set as span attributes."""
+        span = self._tracer.start_span("tts_test")
+        metadata = {"session_type": "web", "user_tier": "premium"}
+        add_tts_span_attributes(
+            span=span,
+            service_name="elevenlabs",
+            model="eleven_monolingual_v1",
+            voice_id="voice-id-123",
+            metadata=metadata,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        self.assertEqual(target_span.attributes.get("metadata.session_type"), "web")
+        self.assertEqual(target_span.attributes.get("metadata.user_tier"), "premium")
+
+    def test_stt_span_with_metadata(self):
+        """Test that custom metadata is flattened and set as span attributes for STT."""
+        span = self._tracer.start_span("stt_test")
+        metadata = {"session_type": "web", "user_tier": "premium"}
+        add_stt_span_attributes(
+            span=span,
+            service_name="deepgram",
+            model="nova-2",
+            metadata=metadata,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        self.assertEqual(target_span.attributes.get("metadata.session_type"), "web")
+        self.assertEqual(target_span.attributes.get("metadata.user_tier"), "premium")
+
+    def test_metadata_skips_non_primitives(self):
+        """Test that metadata skips non-primitive nested values without throwing errors."""
+        span = self._tracer.start_span("metadata_test")
+        metadata = {"nested": {"a": 1}, "primitive": "allowed"}
+        add_tts_span_attributes(
+            span=span,
+            service_name="elevenlabs",
+            model="eleven_monolingual_v1",
+            voice_id="voice-id-123",
+            metadata=metadata,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        self.assertNotIn("metadata.nested", target_span.attributes)
+        self.assertEqual(target_span.attributes.get("metadata.primitive"), "allowed")
+
+    def test_no_audio_no_media_attribute(self):
+        """Test that attributes related to audio are not set if audio data is not provided."""
+        span = self._tracer.start_span("no_audio_test")
+        add_tts_span_attributes(
+            span=span,
+            service_name="elevenlabs",
+            model="eleven_monolingual_v1",
+            voice_id="voice-id-123",
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        self.assertNotIn("audio.data_size_bytes", target_span.attributes)
+        self.assertNotIn("langfuse.media", target_span.attributes)
+        self.assertNotIn("output", target_span.attributes)
+
+    def test_existing_tts_attributes_unchanged(self):
+        """Test that existing attributes still behave the same as before."""
+        span = self._tracer.start_span("existing_test")
+        add_tts_span_attributes(
+            span=span,
+            service_name="elevenlabs",
+            model="eleven_monolingual_v1",
+            voice_id="voice-id-123",
+            text="hello world",
+            character_count=11,
+            ttfb=0.5,
+        )
+        span.end()
+
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        target_span = spans[0]
+
+        self.assertEqual(target_span.attributes.get("gen_ai.provider.name"), "elevenlabs")
+        self.assertEqual(
+            target_span.attributes.get("gen_ai.request.model"), "eleven_monolingual_v1"
+        )
+        self.assertEqual(target_span.attributes.get("voice_id"), "voice-id-123")
+        self.assertEqual(target_span.attributes.get("text"), "hello world")
+        self.assertEqual(target_span.attributes.get("metrics.character_count"), 11)
+        self.assertEqual(target_span.attributes.get("metrics.ttfb"), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds optional `audio_data` and `metadata` parameters to `add_tts_span_attributes()` and `add_stt_span_attributes()` in `service_attributes.py`, and wires audio accumulation into the `@traced_tts` and `@traced_stt` decorators so these values are populated automatically. When audio is present, spans now include a `*.data_size_bytes` attribute and a base64-encoded `langfuse.media` object (attached as `output` for TTS, `input` for STT). When metadata is present, each primitive value is flattened into its own `metadata.*` span attribute. A new `tracing_metadata` constructor parameter on `TTSService` and `STTService` lets users configure custom metadata once per service instance rather than per call.

## Why was this PR needed?

Fixes #4212. TTS and STT spans only captured timing metrics and basic service attributes — no audio and no path for custom metadata. This made it impossible to listen to synthesized or transcribed audio directly from a Langfuse trace, and hard to correlate spans with external systems using application-specific context (e.g. `user_id`, `call_id`, `session_type`). Investigation confirmed the gap is in `service_attributes.py`: neither `add_tts_span_attributes()` nor `add_stt_span_attributes()` had parameters for audio bytes or a metadata dict, and the existing `**kwargs` escape hatch silently drops non-primitives. Two non-obvious implementation decisions worth noting: (1) all three TTS span-closing paths are consolidated through `end_tts_span` so audio is never dropped on the `TTSStoppedFrame` path; (2) STT audio accumulation is gated on VAD `segment_start_time` when available, not first-transcript arrival, so the full utterance is captured rather than just the tail end.

## What are the relevant issue numbers?

Closes #4212

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior
- [x] All tests passing (62/62)
- [x] Follows project style guide (Google-convention docstrings, type annotations)
- [x] No breaking changes introduced (all new parameters default to `None`)