### PR TITLE
Fixed transform ordering and phone/replacements bugs in voice formatters

### DIFF
--- a/src/pipecat/utils/text/transforms/phone.py
+++ b/src/pipecat/utils/text/transforms/phone.py
@@ -13,10 +13,12 @@ from pipecat.frames.frames import AggregationType
 # Matches common phone formats: (123) 456-7890, 123-456-7890, 123.456.7890,
 # +1 800 555 1234, etc.
 _PHONE_RE = re.compile(
+    r"(?<!\d)"  # not preceded by a digit (no partial match inside a longer number)
     r"(\+?1[\s.\-]?)?"  # optional country code
     r"(\(?\d{3}\)?[\s.\-]?)"  # area code
     r"(\d{3}[\s.\-]?)"  # exchange
     r"(\d{4})"  # subscriber
+    r"(?!\d)"  # not followed by a digit
 )
 
 

--- a/src/pipecat/utils/text/transforms/replacements.py
+++ b/src/pipecat/utils/text/transforms/replacements.py
@@ -23,6 +23,9 @@ def replace_text(
     Rules are applied in the order provided. Whether the resulting transform is
     alphanumeric-preserving depends on the replacements supplied.
 
+    Patterns are compiled at construction time so invalid regex patterns raise
+    :exc:`re.error` immediately rather than during live TTS processing.
+
     Args:
         replacements: Ordered list of ``(regex_pattern, replacement_string)`` pairs.
 
@@ -38,10 +41,11 @@ def replace_text(
         ])
         tts = CartesiaTTSService(text_transforms=[("*", transform)])
     """
+    compiled = [(re.compile(pattern), replacement) for pattern, replacement in replacements]
 
     async def _transform(text: str, aggregation_type: str | AggregationType) -> str:
-        for pattern, replacement in replacements:
-            text = re.sub(pattern, replacement, text)
+        for pattern, replacement in compiled:
+            text = pattern.sub(replacement, text)
         return text
 
     return _transform

--- a/src/pipecat/utils/text/transforms/voice_formatter.py
+++ b/src/pipecat/utils/text/transforms/voice_formatter.py
@@ -81,24 +81,20 @@ class VoiceFormatter:
 
             self._transforms.append(_strip_markdown)
 
+        # email_to_speech must run before expand_phone_numbers (phone regex matches
+        # digit-only domains) and before normalize_acronyms (all-caps local parts get
+        # letter-spaced, breaking the email pattern).
+        if email_to_speech:
+            from pipecat.utils.text.transforms.email import email_to_speech as _email_to_speech
+
+            self._transforms.append(_email_to_speech)
+
         if expand_phone_numbers:
             from pipecat.utils.text.transforms.phone import (
                 expand_phone_numbers as _expand_phone_numbers,
             )
 
             self._transforms.append(_expand_phone_numbers)
-
-        if normalize_acronyms:
-            from pipecat.utils.text.transforms.acronyms import (
-                normalize_acronyms as _normalize_acronyms,
-            )
-
-            self._transforms.append(_normalize_acronyms)
-
-        if email_to_speech:
-            from pipecat.utils.text.transforms.email import email_to_speech as _email_to_speech
-
-            self._transforms.append(_email_to_speech)
 
         if normalize_dates:
             from pipecat.utils.text.transforms.dates import normalize_dates as _normalize_dates
@@ -117,10 +113,19 @@ class VoiceFormatter:
 
             self._transforms.append(_expand_percentages)
 
+        # expand_units must run before normalize_acronyms: uppercase unit abbreviations
+        # like "MB" or "MPH" would be letter-spaced first and then not recognized.
         if expand_units:
             from pipecat.utils.text.transforms.units import expand_units as _expand_units
 
             self._transforms.append(_expand_units)
+
+        if normalize_acronyms:
+            from pipecat.utils.text.transforms.acronyms import (
+                normalize_acronyms as _normalize_acronyms,
+            )
+
+            self._transforms.append(_normalize_acronyms)
 
         if expand_numbers:
             from pipecat.utils.text.transforms.numbers import expand_numbers as _expand_numbers

--- a/tests/test_voice_formatting.py
+++ b/tests/test_voice_formatting.py
@@ -72,6 +72,12 @@ class TestExpandPhoneNumbers(unittest.IsolatedAsyncioTestCase):
         result = await expand_phone_numbers(text, "*")
         self.assertEqual(result, text)
 
+    async def test_no_match_inside_longer_digit_sequence(self):
+        # A 16-digit credit card number must not be treated as a phone number.
+        text = "Card 4111111111111111 is invalid"
+        result = await expand_phone_numbers(text, "*")
+        self.assertEqual(result, text)
+
 
 class TestNormalizeAcronyms(unittest.IsolatedAsyncioTestCase):
     async def test_nasa(self):
@@ -244,6 +250,22 @@ class TestVoiceFormatter(unittest.IsolatedAsyncioTestCase):
     async def test_expand_numbers_enabled(self):
         formatter = VoiceFormatter(expand_numbers=True, number_digit_cutoff=2025)
         self.assertIn("forty-two", await formatter("Room 42", "*"))
+
+    async def test_all_caps_email_not_mangled_by_acronym_expander(self):
+        # email_to_speech must run before normalize_acronyms so all-caps addresses
+        # like USER@EXAMPLE.COM are detected before letters are spaced out.
+        formatter = VoiceFormatter()
+        result = await formatter("Contact USER@EXAMPLE.COM today", "*")
+        self.assertIn("at", result)
+        self.assertNotIn("@", result)
+
+    async def test_uppercase_unit_not_broken_by_acronym_expander(self):
+        # expand_units must run before normalize_acronyms so "100 MB" is expanded
+        # to "100 megabytes" before "MB" gets letter-spaced to "M B".
+        formatter = VoiceFormatter()
+        result = await formatter("100 MB file", "*")
+        self.assertIn("megabytes", result)
+        self.assertNotIn("M B", result)
 
 
 class TestExpandCurrency(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- Move email_to_speech before expand_phone_numbers and normalize_acronyms:
    all-caps addresses (USER@EXAMPLE.COM) were letter-spaced before the email
    regex could match them, and digit-only domains were consumed by the phone
    pattern first.

- Move expand_units before normalize_acronyms: uppercase unit abbreviations
    like "MB" or "MPH" were letter-spaced to "M B" / "M P H" before the unit
    regex could match them.

- Add (?<!\d)/(?!\d) boundaries to _PHONE_RE so 16-digit sequences (credit
    card numbers, account numbers) are no longer matched as phone numbers.

- Pre-compile patterns in replace_text() at construction time so invalid
    regex patterns raise immediately rather than during live TTS processing.