### PR TITLE
Fixed flaky timing tests by adding headroom to SleepFrame durations.

### DIFF
--- a/tests/test_user_bot_latency_observer.py
+++ b/tests/test_user_bot_latency_observer.py
@@ -264,7 +264,7 @@ class TestUserBotLatencyObserver(unittest.IsolatedAsyncioTestCase):
 
         frames_to_send = [
             VADUserStoppedSpeakingFrame(),
-            SleepFrame(sleep=0.1),  # Simulate turn analyzer wait
+            SleepFrame(sleep=0.2),  # Simulate turn analyzer wait
             UserStoppedSpeakingFrame(),
             BotStartedSpeakingFrame(),
         ]
@@ -491,7 +491,7 @@ class TestUserBotLatencyObserver(unittest.IsolatedAsyncioTestCase):
                 tool_call_id=tool_call_id,
                 arguments={"location": "Atlanta"},
             ),
-            SleepFrame(sleep=0.1),
+            SleepFrame(sleep=0.2),
             FunctionCallResultFrame(
                 function_name="get_weather",
                 tool_call_id=tool_call_id,


### PR DESCRIPTION
On a loaded CI runner can return slightly early, causing the >= 0.1 assertions to fail intermittently. Increasing the sleep to 0.2s while keeping the assertion at 0.1s gives 100ms of headroom.