### PR TITLE
fix: exclude previous_text for eleven_v3 in ElevenLabsHttpTTSService

### DIFF
--- a/changelog/4925.fixed.md
+++ b/changelog/4925.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ElevenLabsHttpTTSService` sending `previous_text` with the `eleven_v3` model, which rejects that parameter. ElevenLabs returned a 400 error for every request after the first sentence of a turn, so only the first sentence of a multi-sentence response was spoken.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -62,6 +62,11 @@ ELEVENLABS_MULTILINGUAL_MODELS = {
     "eleven_turbo_v2_5",
 }
 
+# Models that reject the previous_text/next_text context parameters
+ELEVENLABS_CONTEXT_UNSUPPORTED_MODELS = {
+    "eleven_v3",
+}
+
 
 def language_to_elevenlabs_language(language: Language) -> str:
     """Convert a Language enum to ElevenLabs language code.
@@ -1385,8 +1390,8 @@ class ElevenLabsHttpTTSService(TTSService):
             "model_id": model_id,
         }
 
-        # Include previous text as context if available
-        if self._previous_text and model_id != "eleven_v3":
+        # Include previous text as context when the model supports it
+        if self._previous_text and model_id not in ELEVENLABS_CONTEXT_UNSUPPORTED_MODELS:
             payload["previous_text"] = self._previous_text
 
         if self._voice_settings:

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -1386,7 +1386,7 @@ class ElevenLabsHttpTTSService(TTSService):
         }
 
         # Include previous text as context if available
-        if self._previous_text:
+        if self._previous_text and model_id != "eleven_v3":
             payload["previous_text"] = self._previous_text
 
         if self._voice_settings:

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -14,6 +14,7 @@ import pytest
 from websockets.protocol import State
 
 from pipecat.services.elevenlabs.tts import (
+    ElevenLabsHttpTTSService,
     ElevenLabsTTSService,
     _select_alignment,
     _strip_utterance_leading_spaces,
@@ -344,6 +345,57 @@ async def test_keepalive_without_active_context_sends_empty():
     await service._send_keepalive()
 
     assert ws.sent == [{"text": ""}]
+
+
+class _FakeHttpResponse:
+    """Minimal aiohttp response stand-in; the 400 makes run_tts bail after posting."""
+
+    status = 400
+
+    async def text(self):
+        return "rejected"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeHttpSession:
+    """Records the JSON payload of each POST."""
+
+    def __init__(self):
+        self.payloads: list[dict] = []
+
+    def post(self, url, json=None, headers=None, params=None):
+        self.payloads.append(json)
+        return _FakeHttpResponse()
+
+
+async def _http_payload_for_model(model: str) -> dict:
+    session = _FakeHttpSession()
+    service = ElevenLabsHttpTTSService(
+        api_key="test-key",
+        aiohttp_session=session,
+        settings=ElevenLabsHttpTTSService.Settings(voice="test-voice", model=model),
+    )
+    service._previous_text = "Hello!"
+    async for _ in service.run_tts("How can I assist you today?", "ctx-1"):
+        pass
+    return session.payloads[0]
+
+
+@pytest.mark.asyncio
+async def test_http_payload_includes_previous_text_when_supported():
+    payload = await _http_payload_for_model("eleven_turbo_v2_5")
+    assert payload["previous_text"] == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_http_payload_omits_previous_text_for_eleven_v3():
+    payload = await _http_payload_for_model("eleven_v3")
+    assert "previous_text" not in payload
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`ElevenLabsHttpTTSService` automatically includes `previous_text` in the request payload for multi-sentence responses to provide prosody context across sentences. However, ElevenLabs' `eleven_v3` model does not support this parameter and rejects the request with a `400 Bad Request` validation error:

> "Providing previous_text or next_text is not yet supported with the 'eleven_v3' model."

This causes the pipeline to silently drop all sentences after the first in any multi-sentence response when using `eleven_v3`, resulting in premature audio cutoff.

## Root Cause

In `run_tts`, `previous_text` is appended to the payload unconditionally whenever `self._previous_text` is set. Since `eleven_v3` explicitly rejects this parameter, the second TTS call in a multi-sentence response always fails.

## Fix

Conditionally exclude `previous_text` from the payload when the active model is `eleven_v3`:

```python
if self._previous_text and model_id != "eleven_v3":
    payload["previous_text"] = self._previous_text
```

## Testing

Tested with a multi-sentence response ("Hello! How can I assist you today?") using `eleven_v3` — full response now plays correctly without cutoff.

Fixes #4916 