### PR TITLE
Fix UserBotLatencyObserver never emitting latency with server-side-VAD STTs (e.g. Deepgram Flux)

### DIFF
--- a/changelog/4928.fixed.md
+++ b/changelog/4928.fixed.md
@@ -1,0 +1,8 @@
+- Fixed `UserBotLatencyObserver` never emitting `on_latency_measured` /
+  `on_latency_breakdown` when the pipeline uses a server-side-VAD STT that owns
+  turn-taking via `ExternalUserTurnStrategies` with no VAD analyzer (e.g.
+  Deepgram Flux). The observer now falls back to `UserStoppedSpeakingFrame` when
+  no `VADUserStoppedSpeakingFrame` precedes the bot turn. Because the STT has
+  already finished endpointing by the time that frame arrives, this fallback
+  excludes the endpointing wait and reads lower than VAD-derived latency (which
+  subtracts `stop_secs` to include it), so the two are not directly comparable.

--- a/src/pipecat/observers/user_bot_latency_observer.py
+++ b/src/pipecat/observers/user_bot_latency_observer.py
@@ -24,6 +24,7 @@ from pipecat.frames.frames import (
     FunctionCallResultFrame,
     InterruptionFrame,
     MetricsFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -143,10 +144,19 @@ class LatencyBreakdown(BaseModel):
 class UserBotLatencyObserver(BaseObserver):
     """Observer that tracks user-to-bot response latency.
 
-    Measures the time between when a user stops speaking (VADUserStoppedSpeakingFrame)
-    and when the bot starts speaking (BotStartedSpeakingFrame). Emits events when
-    latency is measured, allowing consumers to log, trace, or otherwise process
-    the latency data.
+    Measures the time between when a user stops speaking and when the bot starts
+    speaking (``BotStartedSpeakingFrame``). Emits events when latency is measured,
+    allowing consumers to log, trace, or otherwise process the latency data.
+
+    The user-stop reference is taken from ``VADUserStoppedSpeakingFrame`` when a
+    VAD analyzer is present (its ``stop_secs`` silence window is subtracted to
+    recover the actual moment the user fell silent). When no VAD frame precedes
+    the turn — e.g. server-side-VAD STTs like Deepgram Flux driven by
+    ``ExternalUserTurnStrategies`` — it falls back to the ``UserStoppedSpeakingFrame``
+    turn-release time. Because the STT has already completed its endpointing by
+    the time that frame arrives, the fallback excludes the endpointing wait and
+    reads lower than VAD-derived latency (which includes it), so the two are not
+    directly comparable.
 
     When ``enable_metrics=True`` in pipeline params, also collects per-service
     latency breakdown (TTFB, text aggregation) and emits an
@@ -233,8 +243,11 @@ class UserBotLatencyObserver(BaseObserver):
             return
 
         # Track speech and pipeline events for latency
-        if isinstance(data.frame, VADUserStartedSpeakingFrame):
-            # Reset when user starts speaking
+        if isinstance(data.frame, (VADUserStartedSpeakingFrame, UserStartedSpeakingFrame)):
+            # Reset when user starts speaking. Both the VAD frame and the
+            # generic turn-start frame are handled so setups without a VAD
+            # analyzer (e.g. server-side-VAD STTs like Deepgram Flux with
+            # ExternalUserTurnStrategies) still reset per turn.
             self._user_stopped_time = None
             self._user_turn_start_time = None
             self._user_turn = None
@@ -249,11 +262,23 @@ class UserBotLatencyObserver(BaseObserver):
             self._user_stopped_time = data.frame.timestamp - data.frame.stop_secs
             self._user_turn_start_time = self._user_stopped_time
         elif isinstance(data.frame, UserStoppedSpeakingFrame):
-            # Measure the user turn duration: from actual user silence to
-            # turn release. Includes VAD silence detection, STT finalization,
-            # and any turn analyzer wait.
             if self._user_stopped_time is not None:
+                # A VAD frame recorded the actual silence start; measure the
+                # user turn duration from there to turn release. Includes VAD
+                # silence detection, STT finalization, and any turn analyzer wait.
                 self._user_turn = time.time() - self._user_stopped_time
+            else:
+                # No VAD frame preceded this turn (e.g. server-side-VAD STTs
+                # like Deepgram Flux with ExternalUserTurnStrategies). Fall back
+                # to turn-release time so on_latency_measured still fires. Note:
+                # by the time this frame arrives the STT has already done its
+                # own endpointing, so — unlike the VAD path, which recovers the
+                # actual silence instant by subtracting stop_secs — this
+                # measurement excludes the endpointing wait and reads lower.
+                # The two are therefore not directly comparable. The actual
+                # silence instant is unknown, so user_turn_secs is left unset.
+                self._user_stopped_time = time.time()
+                self._user_turn_start_time = self._user_stopped_time
         elif isinstance(data.frame, InterruptionFrame):
             # Discard stale metrics from cancelled LLM/TTS cycles
             self._reset_accumulators()

--- a/tests/test_user_bot_latency_observer.py
+++ b/tests/test_user_bot_latency_observer.py
@@ -7,6 +7,7 @@ from pipecat.frames.frames import (
     FunctionCallResultFrame,
     InterruptionFrame,
     MetricsFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -316,6 +317,82 @@ class TestUserBotLatencyObserver(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(breakdowns), 1)
         self.assertIsNone(breakdowns[0].user_turn_secs)
+
+    async def test_latency_measured_without_vad(self):
+        """Test latency is measured from UserStoppedSpeakingFrame when no VAD frame precedes it.
+
+        Covers server-side-VAD STTs (e.g. Deepgram Flux with
+        ExternalUserTurnStrategies) that emit a plain UserStoppedSpeakingFrame
+        rather than a VADUserStoppedSpeakingFrame.
+        """
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        latencies = []
+        breakdowns = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        @observer.event_handler("on_latency_breakdown")
+        async def on_breakdown(obs, breakdown):
+            breakdowns.append(breakdown)
+
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(latencies), 1)
+        self.assertGreater(latencies[0], 0)
+        self.assertLess(latencies[0], 1.0)
+        # No VAD frame means the true turn duration is unknown.
+        self.assertEqual(len(breakdowns), 1)
+        self.assertIsNone(breakdowns[0].user_turn_secs)
+
+    async def test_user_started_resets_measurement(self):
+        """Test that UserStartedSpeakingFrame resets state for the next turn."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        latencies = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        # Two full external-turn cycles produce two separate measurements.
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(latencies), 2)
 
     async def test_no_measurement_without_user_stop(self):
         """Test that BotStartedSpeaking without prior user stop emits nothing."""


### PR DESCRIPTION
## Problem

Fixes #4927.

`UserBotLatencyObserver.on_latency_measured` (the core user→bot response-latency signal) never fires when the pipeline uses an STT that owns turn-taking via `ExternalUserTurnStrategies` with no `VADAnalyzer` (e.g. **Deepgram Flux**).

The observer keyed its user-stop reference exclusively off `VADUserStoppedSpeakingFrame`, which is only ever produced by a `VADAnalyzer`. Flux instead broadcasts a plain `UserStoppedSpeakingFrame` at end-of-turn, so `_user_stopped_time` stayed `None` and both `on_latency_measured` and `on_latency_breakdown` never fired. Because `on_first_bot_speech_latency` is VAD-independent it kept working — making the breakage **silent**: the observer looks healthy but the per-turn latency metric is permanently empty.

## Fix

- Fall back to `UserStoppedSpeakingFrame` when no `VADUserStoppedSpeakingFrame` precedes the bot turn: set `_user_stopped_time` from the turn-release time if it's still `None`.
- Reset per-turn state on `UserStartedSpeakingFrame` as well (not only the `VAD…` variant), so no-VAD setups reset correctly each turn.
- The `VADUserStoppedSpeakingFrame` path is unchanged, so VAD-derived latency keeps its existing semantics.

### Caveat (documented in code + changelog)

The fallback measures from turn release, which happens **after** the STT has already completed its own endpointing. Unlike the VAD path — which recovers the actual silence instant by subtracting `stop_secs` — the fallback therefore **excludes** the endpointing wait and reads **lower** than VAD-derived latency. The two are not directly comparable. Since the actual silence instant is unknown in this path, `LatencyBreakdown.user_turn_secs` is left `None`.

## Testing

Added two unit tests reproducing the frame contract Flux broadcasts (`UserStarted → UserStopped → BotStarted`):

- `test_latency_measured_without_vad` — `on_latency_measured` fires; breakdown has `user_turn_secs=None`.
- `test_user_started_resets_measurement` — two external-turn cycles produce two separate measurements.

All 19 tests in `tests/test_user_bot_latency_observer.py` pass; `ruff check`/`format` clean.

Verified end-to-end against the **real Deepgram Flux service** (no VAD, external turn-taking), streaming synthesized speech through the live STT:

| | Flux emits User Start/Stop | `on_latency_measured` |
|---|---|---|
| **before fix** | ✅ | ❌ 0× |
| **after fix** | ✅ | ✅ 1× (breakdown `user_turn_secs=None`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)