### PR TITLE
docs: document service metadata pattern for community integrations

### DIFF
--- a/COMMUNITY_INTEGRATIONS.md
+++ b/COMMUNITY_INTEGRATIONS.md
@@ -408,6 +408,37 @@ async def _update_settings(self, update: TTSSettings) -> dict[str, Any]:
     return changed
 ```
 
+### Service Metadata
+
+A service can describe itself to the rest of the pipeline **at start** by overriding `service_metadata_frame()`. The service broadcasts the returned frame (a `ServiceMetadataFrame` or subtype) right after the `StartFrame`, and processors that care read it to **auto-configure themselves** — so users get correct behavior without wiring it by hand.
+
+Service metadata is a small, growing surface: only a few fields exist today, but the frame types are meant to gain more as more of the framework becomes self-configuring.
+
+The base `ServiceMetadataFrame` carries:
+
+- `service_name` — the broadcasting service's name.
+- `user_turn_strategies` — turn strategies the service recommends. A service that does its own **server-side end-of-turn detection** returns `ExternalUserTurnStrategies()` here; the user aggregator then defers to the service's turn frames instead of running local VAD/smart-turn. The recommendation applies **unless the user passed their own `user_turn_strategies`**, which always wins. `None` leaves the defaults in place.
+
+Subtypes add fields for their service kind:
+
+- **`STTMetadataFrame`** — `ttfs_p99_latency`, the 99th-percentile time from end-of-speech to final transcript, which turn strategies use to tune their timing.
+- **`LLMServiceMetadataFrame`** — `is_realtime_service`, flagging a realtime (speech-to-speech) LLM so the context aggregator auto-enables realtime mode.
+
+The base `STTService` and `LLMService` already return a sensible frame, so most services need nothing here. Override `service_metadata_frame()` — calling `super()` and adjusting the frame — only when your service has something extra to declare, e.g. an STT that detects turns server-side:
+
+```python
+from pipecat.frames.frames import STTMetadataFrame
+from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
+
+def service_metadata_frame(self) -> STTMetadataFrame:
+    # This service defines turn boundaries server-side and emits
+    # UserStarted/StoppedSpeakingFrame, so recommend external turn
+    # strategies; the user aggregator defers to those over local VAD.
+    frame = super().service_metadata_frame()
+    frame.user_turn_strategies = ExternalUserTurnStrategies()
+    return frame
+```
+
 ### Sample Rate Handling
 
 Sample rates are set via PipelineParams and passed to each frame processor at initialization. The pattern is to _not_ set the sample rate value in the constructor of a given service. Instead, use the `start()` method to initialize sample rates from the frame:


### PR DESCRIPTION
Documents the `service_metadata_frame()` / `ServiceMetadataFrame` pattern in `COMMUNITY_INTEGRATIONS.md` so community service maintainers know how their services can describe themselves to the pipeline and participate in the framework's auto-configuration mechanisms (turn-strategy selection, STT latency tuning, realtime-mode detection).

Added as a new **Service Metadata** subsection under Implementation Guidelines, next to **Service Settings** — both are cross-cutting "how your service describes/configures itself" mechanisms. The section explains the base frame's fields (`service_name`, `user_turn_strategies`), the `STTMetadataFrame` / `LLMServiceMetadataFrame` subtypes, when to override, and leaves the door open to future metadata fields.

### Stacked on #4919

This PR is **based on** the branch for #4919 (`pk/realtime-service-mode-autoconfig`), because the doc references `LLMServiceMetadataFrame` and `is_realtime_service`, which that PR introduces. Merge #4919 first; the diff here will then rebase cleanly onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)