### PR TITLE
Only emit a TTSTextFrame when frame_text is non-empty.

### DIFF
--- a/changelog/4930.fixed.md
+++ b/changelog/4930.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `AggregatedFrameSequencer` duplicating a word and misattributing its context in TTS word-timestamp mode (Cartesia, ElevenLabs, etc.) when a whitespace-only token was force-completed. 

--- a/src/pipecat/utils/context/aggregated_frame_sequencer.py
+++ b/src/pipecat/utils/context/aggregated_frame_sequencer.py
@@ -215,24 +215,23 @@ class AggregatedFrameSequencer:
             active.includes_inter_frame_spaces if active else False
         )
 
-        frame_text = (
-            active.tracker.get_word_for_frame() if (active and active.tracker) else word
-        ) or word
+        frame_text = active.tracker.get_word_for_frame() if (active and active.tracker) else word
         raw_text = active.tracker.get_llm_consumed() if (active and active.tracker) else None
         suppress = active.tracker.suppress_in_context() if (active and active.tracker) else False
         emit_context_id = active.context_id if active else context_id
 
-        # logger.debug(f"{self._name} Word '{word}' → frame_text='{frame_text}', raw='{raw_text}'")
-        frames: list[Frame] = [
-            self._build_word_frame(
-                frame_text,
-                pts,
-                emit_context_id,
-                raw_text=raw_text,
-                suppress_in_context=suppress,
-                includes_inter_frame_spaces=slot_ifs,
+        frames: list[Frame] = []
+        if frame_text:
+            frames.append(
+                self._build_word_frame(
+                    frame_text,
+                    pts,
+                    emit_context_id,
+                    raw_text=raw_text,
+                    suppress_in_context=suppress,
+                    includes_inter_frame_spaces=slot_ifs,
+                )
             )
-        ]
 
         if active and active.tracker and not suppress:
             frames.append(self._build_progress_frame(active, pts))

--- a/tests/test_aggregated_frame_sequencer.py
+++ b/tests/test_aggregated_frame_sequencer.py
@@ -388,9 +388,9 @@ class TestProcessWordForcesComplete(unittest.TestCase):
         self.assertTrue(any(f is skipped for f in result))
 
     def test_whitespace_slot_force_complete_skips_emission(self):
-        """When a whitespace-only slot is force-completed, no frame should be
-        emitted for it — get_word_for_frame() returns "" for that slot, so the
-        `or word` fallback must not substitute the incoming word instead."""
+        """When a whitespace-only slot is force-completed, get_word_for_frame()
+        returns an empty string for it, so no frame should be emitted for that
+        slot."""
         seq = _seq()
         seq.register_spoken(_spoken_frame(" "), "ctx1", _tracker(" "), True)
         seq.register_spoken(_spoken_frame("World"), "ctx2", _tracker("World"), True)

--- a/tests/test_aggregated_frame_sequencer.py
+++ b/tests/test_aggregated_frame_sequencer.py
@@ -387,6 +387,23 @@ class TestProcessWordForcesComplete(unittest.TestCase):
         result = seq.process_word("world", pts=50, context_id="ctx2")
         self.assertTrue(any(f is skipped for f in result))
 
+    def test_whitespace_slot_force_complete_skips_emission(self):
+        """When a whitespace-only slot is force-completed, no frame should be
+        emitted for it — get_word_for_frame() returns "" for that slot, so the
+        `or word` fallback must not substitute the incoming word instead."""
+        seq = _seq()
+        seq.register_spoken(_spoken_frame(" "), "ctx1", _tracker(" "), True)
+        seq.register_spoken(_spoken_frame("World"), "ctx2", _tracker("World"), True)
+
+        # Word for ctx2 arrives, forcing ctx1 (whitespace) to complete
+        result = seq.process_word("World", pts=10, context_id="ctx2")
+        word_frames = [f for f in result if isinstance(f, TTSTextFrame)]
+
+        # Should only emit ONE frame with ctx2, not a duplicate with ctx1
+        self.assertEqual(len(word_frames), 1)
+        self.assertEqual(word_frames[0].text, "World")
+        self.assertEqual(word_frames[0].context_id, "ctx2")
+
 
 # ---------------------------------------------------------------------------
 # force_complete


### PR DESCRIPTION
## Summary

  - Fixed `AggregatedFrameSequencer.process_word` emitting a duplicate `TTSTextFrame` when a whitespace-only slot was force-completed. In word-timestamp TTS mode (Cartesia, ElevenLabs, etc.)
  - Added a regression test (`test_whitespace_slot_force_complete_skips_emission`) covering this case.

Fixes https://github.com/pipecat-ai/pipecat/issues/4831