### PR TITLE
Local review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,107 +1,76 @@
 ---
 name: code-review
-description: Automated code review for pull requests using multiple specialized agents
+description: Multi-agent review of a GitHub pull request for bugs, performance issues, repository convention alignment, and docstring quality. Posts validated findings as inline review comments.
 disable-model-invocation: true
-allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*)
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr review:*)
 ---
 
-Provide a code review for the given pull request.
+Runs a multi-agent review of a GitHub pull request and posts validated findings as inline comments.
 
-**Agent assumptions (applies to all agents and subagents):**
+Use the `gh` CLI to interact with GitHub. Do not use web fetch.
 
-- All tools are functional and will work without error. Do not test tools or make exploratory calls. Make sure this is clear to every subagent that is launched.
-- Only call a tool if it is required to complete the task. Every tool call should have a clear purpose.
+Create a todo list before starting.
 
-To do this, follow these steps precisely:
+## 1. Preflight
 
-1. Launch a haiku agent to check if any of the following are true:
-   - The pull request is closed
-   - The pull request is a draft
-   - The pull request does not need code review (e.g. automated PR, trivial change that is obviously correct)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by claude)
+Launch a Haiku agent to check whether any of the following is true:
 
-   If any condition is true, stop and do not proceed.
+- the pull request is closed,
+- the pull request is a draft,
+- the pull request does not need code review (e.g. an automated PR, or a trivial change that is obviously correct),
+- Claude has already commented on this PR (check `gh pr view <PR> --comments` for comments left by Claude).
 
-Note: Still review Claude generated PR's.
+If any condition is true, stop and do not proceed.
 
-2. Launch a haiku agent to return a list of file paths (not their contents) for all relevant CLAUDE.md files including:
-   - The root CLAUDE.md file, if it exists
-   - Any CLAUDE.md files in directories containing files modified by the pull request
+Review Claude-generated PRs as normal — being authored by Claude is not a reason to skip.
 
-3. Launch a sonnet agent to view the pull request and return a summary of the changes
+## 2. Scope the review
 
-4. Launch 4 agents in parallel to independently review the changes. Each agent should return the list of issues, where each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug"). The agents should do the following:
+Read the PR with `gh pr view <PR>` and `gh pr diff <PR>`.
 
-   Agents 1 + 2: CLAUDE.md compliance sonnet agents
-   Audit changes for CLAUDE.md compliance in parallel. Note: When evaluating CLAUDE.md compliance for a file, you should only consider CLAUDE.md files that share a file path with the file or parents.
+Record the PR's head commit SHA — findings are anchored to it, and the permalink format in step 4 requires it.
 
-   Agent 3: Opus bug agent (parallel subagent with agent 4)
-   Scan for obvious bugs. Focus only on the diff itself without reading extra context. Flag only significant bugs; ignore nitpicks and likely false positives. Do not flag issues that you cannot validate without looking at context outside of the git diff.
+Use the PR title and description to write a one-paragraph **intent summary** describing what the PR is trying to accomplish. Do not launch an agent for this.
 
-   Agent 4: Opus bug agent (parallel subagent with agent 3)
-   Look for problems that exist in the introduced code. This could be security issues, incorrect logic, etc. Only look for issues that fall within the changed code.
+The **scope recipe** to hand every agent is `gh pr diff <PR>` together with the recorded head SHA, so all agents review identically-scoped changes.
 
-   **CRITICAL: We only want HIGH SIGNAL issues.** Flag issues where:
-   - The code will fail to compile or parse (syntax errors, type errors, missing imports, unresolved references)
-   - The code will definitely produce wrong results regardless of inputs (clear logic errors)
-   - Clear, unambiguous CLAUDE.md violations where you can quote the exact rule being broken
+## 3. Review
 
-   Do NOT flag:
-   - Code style or quality concerns
-   - Potential issues that depend on specific inputs or state
-   - Subjective suggestions or improvements
+Read `.claude/skills/review-policy.md` and apply it, passing it the scope recipe, the changed file list, and the intent summary.
 
-   If you are not certain an issue is real, do not flag it. False positives erode trust and waste reviewer time.
+## 4. Post the review
 
-   In addition to the above, each subagent should be told the PR title and description. This will help provide context regarding the author's intent.
+First, assemble the complete list of comments you plan to leave and check that you are comfortable with every one. This list is for you only — do not post it anywhere.
 
-5. For each issue found in the previous step by agents 3 and 4, launch parallel subagents to validate the issue. These subagents should get the PR title and description along with a description of the issue. The agent's job is to review the issue to validate that the stated issue is truly an issue with high confidence. For example, if an issue such as "variable is not defined" was flagged, the subagent's job would be to validate that is actually true in the code. Another example would be CLAUDE.md issues. The agent should validate that the CLAUDE.md rule that was violated is scoped for this file and is actually violated. Use Opus subagents for bugs and logic issues, and sonnet agents for CLAUDE.md violations.
+If no findings survived validation, post a summary comment with `gh pr comment`:
 
-6. Filter out any issues that were not validated in step 5. This step will give us our list of high signal issues for our review.
-
-7. If issues were found, skip to step 8 to post comments.
-
-   If NO issues were found, post a summary comment using `gh pr comment` (if `--comment` argument is provided):
-   "No issues found. Checked for bugs and CLAUDE.md compliance."
-
-8. Create a list of all comments that you plan on leaving. This is only for you to make sure you are comfortable with the comments. Do not post this list anywhere.
-
-9. Post inline comments for each issue using `gh pr review` with inline comments. For each comment:
-   - Provide a brief description of the issue
-   - For small, self-contained fixes, include a committable suggestion block
-   - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
-   - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely. If follow up steps are required, do not leave a committable suggestion.
-
-   **IMPORTANT: Only post ONE comment per unique issue. Do not post duplicate comments.**
-
-Use this list when evaluating issues in Steps 4 and 5 (these are false positives, do NOT flag):
-
-- Pre-existing issues
-- Something that appears to be a bug but is actually correct
-- Pedantic nitpicks that a senior engineer would not flag
-- Issues that a linter will catch (do not run the linter to verify)
-- General code quality concerns (e.g., lack of test coverage, general security issues) unless explicitly required in CLAUDE.md
-- Issues mentioned in CLAUDE.md but explicitly silenced in the code (e.g., via a lint ignore comment)
-
-Notes:
-
-- Use gh CLI to interact with GitHub (e.g., fetch pull requests, create comments). Do not use web fetch.
-- Create a todo list before starting.
-- You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md, include a link to it).
-- If no issues are found, post a comment with the following format:
-
----
-
+```markdown
 ## Code review
 
-No issues found. Checked for bugs and CLAUDE.md compliance.
+No issues found. Checked for bugs, performance, and repository convention compliance.
+```
 
----
+Otherwise, post one inline comment per finding using `gh pr review`. For each comment:
 
-- When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview won't render correctly: `https://github.com/OWNER/REPO/blob/FULL_SHA/path/to/file.py#L10-L15`
-  - Requires full git sha
-  - You must provide the full sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment will be directly rendered in Markdown.
-  - Repo name must match the repo you're code reviewing
-  - # sign after the file name
-  - Line range format is L[start]-L[end]
-  - Provide at least 1 line of context before and after, centered on the line you are commenting about (eg. if you are commenting about lines 5-6, you should link to `L4-7`)
+- lead with the severity (**High** / **Medium** / **Low**),
+- give a brief description of the issue,
+- cite and link the source of any rule you invoke (e.g. the `AGENTS.md` or `CLAUDE.md` it came from),
+- for small, self-contained fixes, include a committable suggestion block,
+- for larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block,
+- never post a committable suggestion unless committing it fixes the issue entirely. If follow-up steps are required, do not leave a suggestion block.
+
+**Post only ONE comment per unique issue. Do not post duplicate comments.**
+
+When linking to code, follow this format precisely, otherwise the Markdown preview won't render correctly:
+
+`https://github.com/OWNER/REPO/blob/FULL_SHA/path/to/file.py#L10-L15`
+
+- requires the full git SHA — command substitution such as `$(git rev-parse HEAD)` will not work, since the comment is rendered directly as Markdown,
+- the repo name must match the repo being reviewed,
+- `#` sign after the file name,
+- line range format is `L[start]-L[end]`,
+- provide at least 1 line of context before and after, centered on the line being commented on (e.g. to comment on lines 5-6, link `L4-L7`).
+
+## 5. Report completion
+
+Respond in chat with the number of findings posted in each category, and a link to the review. Do not paste the full review into chat.

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: local-review
+description: Multi-agent review of the current branch's local changes (uncommitted + outgoing commits) for bugs, performance issues, Pipecat/CLAUDE.md style alignment, and docstring quality. Writes findings to .local_review.md instead of applying fixes or posting comments.
+disable-model-invocation: true
+---
+
+Runs a multi-agent review of the current branch's local changes and writes findings to `.local_review.md`. Read-only — it never edits code, commits, or touches GitHub.
+
+**Agent assumptions (applies to all reviewers and validators):** all tools are functional and will work without error. Do not test tools or make exploratory calls. Only invoke a tool when it is required to complete the task.
+
+## Review philosophy
+
+Review the code as though you are the final approving reviewer.
+
+Prefer missing a questionable issue over reporting a false positive.
+
+Only report findings that you are confident an experienced reviewer would raise because they are:
+
+- a correctness bug,
+- a concrete performance regression,
+- a documented repository convention violation, or
+- a docstring issue required by `AGENTS.md` or `CLAUDE.md`.
+
+Do **not** report:
+
+- speculative or hypothetical bugs,
+- future maintainability concerns,
+- missing tests,
+- subjective style preferences,
+- issues a formatter or linter would already catch,
+- or concerns outside the scope of the current diff unless explicitly required by repository guidance.
+
+## Severity
+
+Assign every finding one of these levels, and use it consistently across reviewers and validators:
+
+- **High** — will produce incorrect behavior, a crash, or a security issue; or violates a hard/unambiguous repository rule.
+- **Medium** — a real but non-catastrophic issue: a concrete performance regression, or a violation of an established repository convention that isn't safety-critical.
+- **Low** — a docstring or minor convention issue with no behavioral impact.
+
+## Steps
+
+### 1. Scope the review
+
+Determine what "the current branch's changes" means.
+
+- Compute the merge base using `git merge-base main HEAD`.
+- If `main` does not exist locally, fall back to `origin/main`.
+- If neither can be resolved, stop and ask the user which branch should be used as the comparison base.
+
+Record the resolved base commit SHA — every reviewer in step 3 must scope its diff to this exact SHA so all three agree on what "the diff" is.
+
+Collect:
+
+- committed changes using `git diff <base>...HEAD`
+- unstaged changes using `git diff`
+- staged changes using `git diff --cached`
+- untracked files via `git status --porcelain`, reading their contents since they are part of the branch even though they do not appear in `git diff`
+
+If there are no committed, staged, unstaged, or untracked changes, stop and tell the user there is nothing to review.
+
+### 2. Gather context
+
+Do this directly without launching reviewer agents.
+
+- Build the list of changed files, grouped by kind (services, examples, tests, processors, other).
+- For every changed file, locate all applicable `AGENTS.md` and `CLAUDE.md` files in its directory hierarchy (nearest first) and collect their contents.
+- Read enough of the diff to produce a one-paragraph summary describing the intent of the branch. This summary will be passed to every reviewer so they can distinguish intentional behavior from defects.
+
+### 3. Launch three Sonnet reviewer agents in parallel
+
+Each reviewer receives:
+
+- the branch intent summary,
+- the applicable `AGENTS.md` / `CLAUDE.md` contents,
+- the complete list of changed files,
+- the resolved base commit SHA from step 1, with instructions to reproduce the exact same diff scope themselves (`git diff <base>...HEAD`, plus staged, unstaged, and untracked changes) — every reviewer must review identically-scoped changes.
+
+Reviewers should inspect only the portions of the diff relevant to their specialty. They may read additional repository context only when necessary to investigate or confirm a suspected issue.
+
+Repository instructions from `AGENTS.md` and `CLAUDE.md` always take precedence over general engineering judgment when the two conflict.
+
+#### Reviewer 1 — Correctness
+
+Start with the changed code and its immediate surrounding context. Look for obvious correctness bugs introduced by the diff, including:
+
+- incorrect logic,
+- off-by-one errors,
+- broken conditions,
+- missing cases,
+- parse or runtime errors,
+- incorrect async usage visible locally.
+
+Then, only where a locally-visible issue is suspected but needs confirmation, inspect additional repository context to check for issues such as:
+
+- broken assumptions about callers or callees,
+- misuse of framework primitives,
+- incorrect processor behavior,
+- incorrect task creation,
+- frame direction mistakes,
+- security issues,
+- violations of framework invariants.
+
+Do not go looking for contextual issues that have no local symptom in the diff — that's out of scope for this reviewer.
+
+#### Reviewer 2 — Repository Conventions & Docstrings
+
+Review the diff against documented repository conventions from `AGENTS.md` and `CLAUDE.md`, including framework usage, inheritance, constructors, metrics hooks, frame handling, dataclass/Pydantic conventions, deprecation conventions, example structure, and other documented project practices — and, as part of the same pass, review new and modified public APIs for compliance with the repository's documented docstring conventions (missing required sections, incorrect Google-style formatting, incorrect dataclass vs. Pydantic documentation, missing or malformed deprecation directives, inaccurate documentation caused by the current diff).
+
+Only report findings covered by an explicit documented rule or a well-established repository pattern.
+
+Every finding must quote the relevant rule.
+
+#### Reviewer 3 — Performance
+
+Look for concrete performance regressions introduced by the diff, such as:
+
+- unnecessary repeated work,
+- inefficient algorithms,
+- blocking operations in async code,
+- redundant I/O,
+- avoidable allocations,
+- incorrect data structure choices.
+
+Ignore pre-existing patterns that the diff did not modify.
+
+### 4. Independently validate every finding
+
+Findings must be validated before being included in the report, but validation is batched per reviewer rather than launched per finding, to avoid re-loading the same context once per issue: launch one independent Sonnet validator per reviewer from step 3 (so at most three validator agents, run in parallel), and give each validator the full list of findings from its corresponding reviewer plus the same base SHA / diff-scoping instructions from step 3. Each validator checks every finding it receives against the actual code in a single pass.
+
+Validators must verify the actual code rather than trusting the original reviewer's description, and must judge each finding independently — one bad finding in the batch should not affect judgment of the others.
+
+Discard findings that are:
+
+- speculative,
+- subjective,
+- duplicates,
+- pre-existing and untouched by the diff,
+- already intentionally suppressed,
+- automatically handled by formatting or linting,
+- or cannot be confirmed with high confidence.
+
+### 5. Deduplicate findings
+
+Merge duplicate or overlapping findings before writing the report.
+
+If multiple reviewers identify the same underlying issue, report it only once using the clearest explanation.
+
+### 6. Write `.local_review.md`
+
+Overwrite the file if it already exists.
+
+Use the following structure:
+
+```markdown
+# Local Review — <branch name>
+
+Reviewed <base>..HEAD plus uncommitted changes, generated <date>.
+
+## Summary
+
+<1–3 sentence summary describing the branch>
+
+## Bugs & Correctness
+
+- [ ] **High** — `path/to/file.py:123`
+
+  Description.
+
+  Suggested fix: ...
+
+## Performance
+
+- [ ] **Medium** — `path/to/file.py:87`
+
+  Description.
+
+  Suggested fix: ...
+
+## Repository Conventions & Docstrings
+
+- [ ] **Low** — `path/to/file.py:45`
+
+  Description.
+
+  Rule:
+
+  > "<quoted rule>"
+
+  Source: `path/to/AGENTS.md`
+```
+
+Omit any section with zero validated findings.
+
+If no findings remain after validation, still write the report containing:
+
+- the Summary, and
+- a single line stating **"No issues found."**
+
+### 7. Report completion
+
+Respond in chat with:
+
+- the number of findings in each category,
+- the location of `.local_review.md`.
+
+Do **not** paste the report into chat.
+
+If `.local_review.md` is not ignored by Git, suggest adding it to `.gitignore`, but do not modify the repository.
+
+## Notes
+
+- This skill never edits reviewed code.
+- This skill never commits changes.
+- This skill never interacts with GitHub.
+- The only file it writes is `.local_review.md`.
+- Re-running the skill overwrites the report, making it safe to use repeatedly while iterating on a branch.

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -1,56 +1,21 @@
 ---
 name: local-review
-description: Multi-agent review of the current branch's local changes (uncommitted + outgoing commits) for bugs, performance issues, Pipecat/CLAUDE.md style alignment, and docstring quality. Writes findings to .local_review.md instead of applying fixes or posting comments.
+description: Multi-agent review of the current branch's local changes (uncommitted + outgoing commits) for bugs, performance issues, repository convention alignment, and docstring quality. Writes findings to .local_review.md instead of applying fixes or posting comments.
 disable-model-invocation: true
 ---
 
 Runs a multi-agent review of the current branch's local changes and writes findings to `.local_review.md`. Read-only — it never edits code, commits, or touches GitHub.
 
-**Agent assumptions (applies to all reviewers and validators):** all tools are functional and will work without error. Do not test tools or make exploratory calls. Only invoke a tool when it is required to complete the task.
+Create a todo list before starting.
 
-## Review philosophy
-
-Review the code as though you are the final approving reviewer.
-
-Prefer missing a questionable issue over reporting a false positive.
-
-Only report findings that you are confident an experienced reviewer would raise because they are:
-
-- a correctness bug,
-- a concrete performance regression,
-- a documented repository convention violation, or
-- a docstring issue required by `AGENTS.md` or `CLAUDE.md`.
-
-Do **not** report:
-
-- speculative or hypothetical bugs,
-- future maintainability concerns,
-- missing tests,
-- subjective style preferences,
-- issues a formatter or linter would already catch,
-- or concerns outside the scope of the current diff unless explicitly required by repository guidance.
-
-## Severity
-
-Assign every finding one of these levels, and use it consistently across reviewers and validators:
-
-- **High** — will produce incorrect behavior, a crash, or a security issue; or violates a hard/unambiguous repository rule.
-- **Medium** — a real but non-catastrophic issue: a concrete performance regression, or a violation of an established repository convention that isn't safety-critical.
-- **Low** — a docstring or minor convention issue with no behavioral impact.
-
-## Steps
-
-### 1. Scope the review
+## 1. Scope the review
 
 Determine what "the current branch's changes" means.
 
-- Compute the merge base using `git merge-base main HEAD`.
-- If `main` does not exist locally, fall back to `origin/main`.
-- If neither can be resolved, stop and ask the user which branch should be used as the comparison base.
+- Compute the merge base against the repo's main branch: try `git merge-base main HEAD`, then `master`, then `origin/main`, then `origin/master`.
+- If none can be resolved, stop and ask the user which branch should be used as the comparison base.
 
-Record the resolved base commit SHA — every reviewer in step 3 must scope its diff to this exact SHA so all three agree on what "the diff" is.
-
-Collect:
+Record the resolved base commit SHA. Collect:
 
 - committed changes using `git diff <base>...HEAD`
 - unstaged changes using `git diff`
@@ -59,98 +24,17 @@ Collect:
 
 If there are no committed, staged, unstaged, or untracked changes, stop and tell the user there is nothing to review.
 
-### 2. Gather context
+Read enough of the changes to write a one-paragraph **intent summary** describing what the branch is trying to accomplish.
 
-Do this directly without launching reviewer agents.
+The **scope recipe** to hand every agent is the four collection commands above, with `<base>` replaced by the resolved SHA so all agents review identically-scoped changes.
 
-- Build the list of changed files, grouped by kind (services, examples, tests, processors, other).
-- For every changed file, locate all applicable `AGENTS.md` and `CLAUDE.md` files in its directory hierarchy (nearest first) and collect their contents.
-- Read enough of the diff to produce a one-paragraph summary describing the intent of the branch. This summary will be passed to every reviewer so they can distinguish intentional behavior from defects.
+## 2. Review
 
-### 3. Launch three Sonnet reviewer agents in parallel
+Read `.claude/skills/review-policy.md` and apply it, passing it the scope recipe, the changed file list, and the intent summary.
 
-Each reviewer receives:
+## 3. Write `.local_review.md`
 
-- the branch intent summary,
-- the applicable `AGENTS.md` / `CLAUDE.md` contents,
-- the complete list of changed files,
-- the resolved base commit SHA from step 1, with instructions to reproduce the exact same diff scope themselves (`git diff <base>...HEAD`, plus staged, unstaged, and untracked changes) — every reviewer must review identically-scoped changes.
-
-Reviewers should inspect only the portions of the diff relevant to their specialty. They may read additional repository context only when necessary to investigate or confirm a suspected issue.
-
-Repository instructions from `AGENTS.md` and `CLAUDE.md` always take precedence over general engineering judgment when the two conflict.
-
-#### Reviewer 1 — Correctness
-
-Start with the changed code and its immediate surrounding context. Look for obvious correctness bugs introduced by the diff, including:
-
-- incorrect logic,
-- off-by-one errors,
-- broken conditions,
-- missing cases,
-- parse or runtime errors,
-- incorrect async usage visible locally.
-
-Then, only where a locally-visible issue is suspected but needs confirmation, inspect additional repository context to check for issues such as:
-
-- broken assumptions about callers or callees,
-- misuse of framework primitives,
-- incorrect processor behavior,
-- incorrect task creation,
-- frame direction mistakes,
-- security issues,
-- violations of framework invariants.
-
-Do not go looking for contextual issues that have no local symptom in the diff — that's out of scope for this reviewer.
-
-#### Reviewer 2 — Repository Conventions & Docstrings
-
-Review the diff against documented repository conventions from `AGENTS.md` and `CLAUDE.md`, including framework usage, inheritance, constructors, metrics hooks, frame handling, dataclass/Pydantic conventions, deprecation conventions, example structure, and other documented project practices — and, as part of the same pass, review new and modified public APIs for compliance with the repository's documented docstring conventions (missing required sections, incorrect Google-style formatting, incorrect dataclass vs. Pydantic documentation, missing or malformed deprecation directives, inaccurate documentation caused by the current diff).
-
-Only report findings covered by an explicit documented rule or a well-established repository pattern.
-
-Every finding must quote the relevant rule.
-
-#### Reviewer 3 — Performance
-
-Look for concrete performance regressions introduced by the diff, such as:
-
-- unnecessary repeated work,
-- inefficient algorithms,
-- blocking operations in async code,
-- redundant I/O,
-- avoidable allocations,
-- incorrect data structure choices.
-
-Ignore pre-existing patterns that the diff did not modify.
-
-### 4. Independently validate every finding
-
-Findings must be validated before being included in the report, but validation is batched per reviewer rather than launched per finding, to avoid re-loading the same context once per issue: launch one independent Sonnet validator per reviewer from step 3 (so at most three validator agents, run in parallel), and give each validator the full list of findings from its corresponding reviewer plus the same base SHA / diff-scoping instructions from step 3. Each validator checks every finding it receives against the actual code in a single pass.
-
-Validators must verify the actual code rather than trusting the original reviewer's description, and must judge each finding independently — one bad finding in the batch should not affect judgment of the others.
-
-Discard findings that are:
-
-- speculative,
-- subjective,
-- duplicates,
-- pre-existing and untouched by the diff,
-- already intentionally suppressed,
-- automatically handled by formatting or linting,
-- or cannot be confirmed with high confidence.
-
-### 5. Deduplicate findings
-
-Merge duplicate or overlapping findings before writing the report.
-
-If multiple reviewers identify the same underlying issue, report it only once using the clearest explanation.
-
-### 6. Write `.local_review.md`
-
-Overwrite the file if it already exists.
-
-Use the following structure:
+Overwrite the file if it already exists. Use the following structure:
 
 ```markdown
 # Local Review — <branch name>
@@ -163,7 +47,7 @@ Reviewed <base>..HEAD plus uncommitted changes, generated <date>.
 
 ## Bugs & Correctness
 
-- [ ] **High** — `path/to/file.py:123`
+- [ ] **High** — `path/to/file:123`
 
   Description.
 
@@ -171,7 +55,7 @@ Reviewed <base>..HEAD plus uncommitted changes, generated <date>.
 
 ## Performance
 
-- [ ] **Medium** — `path/to/file.py:87`
+- [ ] **Medium** — `path/to/file:87`
 
   Description.
 
@@ -179,7 +63,7 @@ Reviewed <base>..HEAD plus uncommitted changes, generated <date>.
 
 ## Repository Conventions & Docstrings
 
-- [ ] **Low** — `path/to/file.py:45`
+- [ ] **Low** — `path/to/file:45`
 
   Description.
 
@@ -192,19 +76,11 @@ Reviewed <base>..HEAD plus uncommitted changes, generated <date>.
 
 Omit any section with zero validated findings.
 
-If no findings remain after validation, still write the report containing:
+If no findings remain after validation, still write the report containing the Summary and a single line stating **"No issues found."**
 
-- the Summary, and
-- a single line stating **"No issues found."**
+## 4. Report completion
 
-### 7. Report completion
-
-Respond in chat with:
-
-- the number of findings in each category,
-- the location of `.local_review.md`.
-
-Do **not** paste the report into chat.
+Respond in chat with the number of findings in each category and the location of `.local_review.md`. Do **not** paste the report into chat.
 
 If `.local_review.md` is not ignored by Git, suggest adding it to `.gitignore`, but do not modify the repository.
 

--- a/.claude/skills/review-policy.md
+++ b/.claude/skills/review-policy.md
@@ -1,0 +1,154 @@
+# Review policy
+
+Shared review policy for the `local-review` and `code-review` skills. The calling skill establishes the **review scope** and owns the output; everything between those two points is defined here.
+
+Before applying this policy, the calling skill must have produced:
+
+- **scope recipe** — verbatim instructions any agent can follow to reproduce the exact set of changes under review, including a pinned base commit SHA,
+- **changed files** — the complete list, and
+- **intent summary** — one paragraph describing what the change is trying to accomplish.
+
+## Agent assumptions
+
+Applies to every reviewer and validator launched below.
+
+All tools are functional and will work without error. Do not test tools or make exploratory calls. Only invoke a tool when it is required to complete the task. Make this clear to every agent that is launched.
+
+## Review philosophy
+
+Review the code as though you are the final approving reviewer.
+
+Prefer missing a questionable issue over reporting a false positive.
+
+Only report findings that you are confident an experienced reviewer would raise because they are:
+
+- a correctness bug,
+- a concrete performance regression,
+- a documented repository convention violation, or
+- a docstring issue required by `AGENTS.md` or `CLAUDE.md`.
+
+Do **not** report:
+
+- speculative or hypothetical bugs,
+- issues that depend on specific inputs or state to manifest,
+- something that appears to be a bug but is actually correct,
+- future maintainability concerns,
+- missing tests,
+- subjective style preferences or general code quality concerns,
+- pedantic nitpicks a senior engineer would not raise,
+- issues a formatter or linter would already catch — do not run the linter to verify,
+- issues covered by repository guidance but explicitly silenced in the code (e.g. a lint-ignore comment),
+- pre-existing issues the change did not touch,
+- or concerns outside the review scope unless explicitly required by repository guidance.
+
+If you are not certain an issue is real, do not flag it. False positives erode trust and waste reviewer time.
+
+## Severity
+
+Assign every finding one of these levels, and use it consistently across reviewers and validators:
+
+- **High** — will produce incorrect behavior, a crash, or a security issue; or violates a hard/unambiguous repository rule.
+- **Medium** — a real but non-catastrophic issue: a concrete performance regression, or a violation of an established repository convention that isn't safety-critical.
+- **Low** — a docstring or minor convention issue with no behavioral impact.
+
+## 1. Gather context
+
+Do this directly, without launching agents.
+
+- Build the list of changed files, grouped by kind as makes sense for this repo (e.g. source, tests, docs, config, other).
+- For every changed file, locate all applicable `AGENTS.md` and `CLAUDE.md` files in its directory hierarchy (nearest first) and collect their **contents**. A convention file applies to a given file only if it sits in that file's directory or one of its parents.
+- Confirm the intent summary reflects the change as a whole. Every reviewer receives it so they can distinguish intentional behavior from defects.
+
+## 2. Launch three reviewers in parallel
+
+Each reviewer receives:
+
+- the intent summary,
+- the applicable `AGENTS.md` / `CLAUDE.md` contents,
+- the complete list of changed files, and
+- the scope recipe, with instructions to reproduce the review scope themselves so that every reviewer reviews identically-scoped changes.
+
+Reviewers should inspect only the portions of the change relevant to their specialty. They may read additional repository context only when necessary to investigate or confirm a suspected issue.
+
+Repository instructions from `AGENTS.md` and `CLAUDE.md` always take precedence over general engineering judgment when the two conflict.
+
+### Reviewer 1 — Correctness (Opus)
+
+Start with the changed code and its immediate surrounding context. Look for obvious correctness bugs introduced by the change, including:
+
+- incorrect logic,
+- off-by-one errors,
+- broken conditions,
+- missing cases,
+- parse or runtime errors,
+- security issues,
+- incorrect async/concurrency usage visible locally.
+
+Then, only where a locally-visible issue is suspected but needs confirmation, inspect additional repository context to check for issues such as:
+
+- broken assumptions about callers or callees,
+- misuse of framework or library primitives,
+- incorrect handling of shared or mutable state,
+- incorrect task creation,
+- violations of documented architectural invariants.
+
+Do not go looking for contextual issues that have no local symptom in the change — that's out of scope for this reviewer.
+
+### Reviewer 2 — Repository conventions & docstrings (Sonnet)
+
+Review the change against documented repository conventions from `AGENTS.md` and `CLAUDE.md`, including framework and library usage, class and API design, established idioms already present in this codebase, deprecation conventions, and other documented project practices — and, as part of the same pass, review new and modified public APIs for compliance with whatever docstring conventions this repo documents (missing required sections, incorrect formatting for the documented docstring style, missing or malformed deprecation directives, inaccurate documentation caused by the change).
+
+Only report findings covered by an explicit documented rule or a well-established repository pattern.
+
+Every finding must quote the relevant rule and name the file it came from.
+
+### Reviewer 3 — Performance (Sonnet)
+
+Look for concrete performance regressions introduced by the change, such as:
+
+- unnecessary repeated work,
+- inefficient algorithms,
+- blocking operations in async code,
+- redundant I/O,
+- avoidable allocations,
+- incorrect data structure choices.
+
+Ignore pre-existing patterns that the change did not modify.
+
+## 3. Independently validate every finding
+
+Findings must be validated before reaching the output, but validation is batched per reviewer rather than launched per finding, to avoid re-loading the same context once per issue.
+
+Launch one independent validator per reviewer that produced findings (so at most three, run in parallel), each receiving the full list of findings from its corresponding reviewer plus the same scope recipe given to reviewers. Match the validator's model to its reviewer's: **Opus** validates correctness findings, **Sonnet** validates convention, docstring, and performance findings.
+
+Each validator checks every finding it receives against the actual code in a single pass. Validators must verify the code itself rather than trusting the original reviewer's description, and must judge each finding independently — one bad finding in the batch must not affect judgment of the others.
+
+Discard findings that are:
+
+- speculative,
+- subjective,
+- duplicates,
+- pre-existing and untouched by the change,
+- already intentionally suppressed,
+- automatically handled by formatting or linting,
+- or cannot be confirmed with high confidence.
+
+For convention findings, the validator must confirm both that the quoted rule is scoped to the file in question and that it is actually violated.
+
+## 4. Deduplicate
+
+Merge duplicate or overlapping findings before handing them to the calling skill's output step.
+
+If multiple reviewers identify the same underlying issue, report it only once, using the clearest explanation.
+
+## 5. Hand off
+
+Return the surviving findings to the calling skill, each carrying:
+
+- a severity,
+- a file path and line number,
+- a description,
+- a suggested fix, and
+- for convention and docstring findings, the quoted rule and its source file.
+
+The calling skill owns everything from here.


### PR DESCRIPTION
## Summary

  Adds a `local-review` Claude Code skill: a read-only, multi-agent reviewer for a branch's local changes (committed, staged, unstaged, and untracked), invoked explicitly rather than automatically.
  - Scopes the review to `git merge-base main HEAD` and diffs committed, staged, unstaged, and untracked changes against it.
  - Runs three parallel reviewer agents — correctness, repository conventions & docstrings (checked against the relevant `AGENTS.md`/`CLAUDE.md` files), and performance.
  - Independently validates every finding with a second pass of agents before including it, to cut down on false positives.
  - Writes results to `.local_review.md` (summary + findings by category, or "No issues found."), overwriting on each run. Never edits code, commits, or touches GitHub.
