### PR TITLE
Only sending Keepalive message if we have an active context.

### DIFF
--- a/changelog/4935.fixed.md
+++ b/changelog/4935.fixed.md
@@ -1,1 +1,1 @@
-- Fixed `InworldTTSService` sending an empty `send_text` keepalive message when there was no active context, which could trigger unwanted server-side generation. The keepalive is now only sent when a context is active.
+- Fixed `InworldTTSService` sending an empty `send_text` keepalive message when there was no active context, which resulted in a server side error from Inworld. The keepalive is now sent only when a context is active.

--- a/changelog/4935.fixed.md
+++ b/changelog/4935.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InworldTTSService` sending an empty `send_text` keepalive message when there was no active context, which could trigger unwanted server-side generation. The keepalive is now only sent when a context is active.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -1127,10 +1127,7 @@ class InworldTTSService(WebsocketTTSService):
                             "contextId": context_id,
                         }
                         logger.trace(f"Sending keepalive for context {context_id}")
-                    else:
-                        keepalive_message = {"send_text": {"text": ""}}
-                        logger.trace("Sending keepalive without context")
-                    await self._websocket.send(json.dumps(keepalive_message))
+                        await self._websocket.send(json.dumps(keepalive_message))
             except websockets.ConnectionClosed as e:
                 logger.warning(f"{self} keepalive error: {e}")
                 break


### PR DESCRIPTION
  ## Summary

  - Fixed `InworldTTSService` sending an empty `send_text` keepalive message when there was no active context, resulting in receiving error from Inworld.
  - The keepalive loop now only sends a message when a context is active; when there's no active context, no message is sent at all.


Fixes https://github.com/pipecat-ai/pipecat/issues/4899