### PR TITLE
Reverting inworld keepalive changes and fixing ruff format.

### DIFF
--- a/changelog/4935.fixed.md
+++ b/changelog/4935.fixed.md
@@ -1,1 +1,0 @@
-- Fixed `InworldTTSService` sending an empty `send_text` keepalive message when there was no active context, which resulted in a server side error from Inworld. The keepalive is now sent only when a context is active.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -1044,7 +1044,10 @@ class InworldTTSService(WebsocketTTSService):
                     logger.debug(f"{self}: Context {ctx_id} not found.")
                     continue
                 lower_error_msg = error_msg.lower()
-                if "context_id is required" in lower_error_msg or "no open context" in lower_error_msg:
+                if (
+                    "context_id is required" in lower_error_msg
+                    or "no open context" in lower_error_msg
+                ):
                     logger.debug(f"{self}: Contextless message rejected (benign): {error_msg}")
                     continue
 
@@ -1113,7 +1116,10 @@ class InworldTTSService(WebsocketTTSService):
                             "contextId": context_id,
                         }
                         logger.trace(f"Sending keepalive for context {context_id}")
-                        await self._websocket.send(json.dumps(keepalive_message))
+                    else:
+                        keepalive_message = {"send_text": {"text": ""}}
+                        logger.trace("Sending keepalive without context")
+                    await self._websocket.send(json.dumps(keepalive_message))
             except websockets.ConnectionClosed as e:
                 logger.warning(f"{self} keepalive error: {e}")
                 break


### PR DESCRIPTION
I thought might had some logic on the Inworld server, and since we were sending an invalid message without the context ID, it wouldn't help keep the connection alive. 

But it would probably still help keep the connection alive through load balancers, NAT devices, and firewalls....

Reverting the changes from this previous [PR](https://github.com/pipecat-ai/pipecat/pull/4935).