### PR TITLE
fix(bus): buffer BusBridgeProcessor frames received before StartFrame

### DIFF
--- a/src/pipecat/bus/bridge_processor.py
+++ b/src/pipecat/bus/bridge_processor.py
@@ -75,6 +75,8 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
         self._target_task = target_task
         self._bridge = bridge
         self._exclude_frames = exclude_frames or ()
+        self._started = False
+        self._pending_inbound: list[tuple[Frame, FrameDirection]] = []
 
     async def setup(self, setup: FrameProcessorSetup):
         """Subscribe to the bus during processor setup."""
@@ -98,6 +100,11 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
         # Lifecycle frames never cross the bus
         if isinstance(frame, _LIFECYCLE_FRAMES):
             await self.push_frame(frame, direction)
+            if isinstance(frame, StartFrame):
+                self._started = True
+                for pending_frame, pending_direction in self._pending_inbound:
+                    await self.push_frame(pending_frame, pending_direction)
+                self._pending_inbound.clear()
             return
 
         # Urgent transport frames pass through directly. They need to
@@ -143,6 +150,14 @@ class BusBridgeProcessor(FrameProcessor, BusSubscriber):
 
         # If message targeted at someone else, skip
         if message.target and message.target != self._worker_name:
+            return
+
+        # Frames that arrive before our own StartFrame would otherwise be
+        # silently dropped by `push_frame`'s started check (e.g. a bridged
+        # child worker whose `on_activated` fires before this bridge's
+        # StartFrame has arrived). Buffer and replay them once started.
+        if not self._started:
+            self._pending_inbound.append((message.frame, message.direction))
             return
 
         await self.push_frame(message.frame, message.direction)

--- a/tests/test_bridge_processor.py
+++ b/tests/test_bridge_processor.py
@@ -172,6 +172,55 @@ class TestBusBridgeProcessor(unittest.IsolatedAsyncioTestCase):
         self.assertIn("from_child", texts)
         self.assertIn("after_bridge", texts)
 
+    async def test_bus_frame_before_start_is_buffered_and_replayed(self):
+        """A frame arriving via `on_bus_message` before the bridge's own
+        StartFrame is processed must not be dropped: it should be buffered
+        and replayed once StartFrame lands (regression test for #4913 —
+        a bridged child worker's `on_activated` frame, e.g. LLMSetToolsFrame,
+        racing ahead of the parent's StartFrame reaching the bridge)."""
+        from pipecat.frames.frames import EndFrame
+        from pipecat.pipeline.worker import PipelineWorker
+        from pipecat.processors.frame_processor import FrameProcessor
+        from pipecat.workers.runner import WorkerRunner
+
+        class Recorder(FrameProcessor):
+            def __init__(self, observed, **kwargs):
+                super().__init__(**kwargs)
+                self._observed = observed
+
+            async def process_frame(self, frame, direction):
+                await super().process_frame(frame, direction)
+                if isinstance(frame, TextFrame):
+                    self._observed.append(frame.text)
+                await self.push_frame(frame, direction)
+
+        observed: list[str] = []
+        bus = AsyncQueueBus()
+        bridge = BusBridgeProcessor(bus=bus, worker_name="main_task")
+        worker = PipelineWorker(
+            Pipeline([bridge, Recorder(observed)]), cancel_on_idle_timeout=False
+        )
+
+        msg = BusFrameMessage(
+            source="child_task",
+            frame=TextFrame(text="from_child_early"),
+            direction=FrameDirection.DOWNSTREAM,
+        )
+
+        async def inject_before_start_and_end():
+            # Deliver the bus message before the runner even starts the
+            # worker, so it necessarily arrives before the bridge's own
+            # StartFrame is processed.
+            await bridge.on_bus_message(msg)
+            await asyncio.sleep(0.2)
+            await worker.queue_frame(EndFrame())
+
+        runner = WorkerRunner(bus=bus, handle_sigint=False)
+        await runner.add_workers(worker)
+        await asyncio.gather(runner.run(), inject_before_start_and_end())
+
+        self.assertIn("from_child_early", observed)
+
     async def test_skips_own_frames(self):
         """Bridge ignores bus frames from its own worker."""
         bus = AsyncQueueBus()
@@ -208,6 +257,9 @@ class TestBusBridgeProcessor(unittest.IsolatedAsyncioTestCase):
             worker_name="main_task",
             target_task="specific_child",
         )
+        # Simulate an already-started bridge (StartFrame processed) so
+        # matching frames are pushed immediately rather than buffered.
+        processor._started = True
 
         injected = []
         original_push = processor.push_frame


### PR DESCRIPTION
## Summary
  
  - `BusBridgeProcessor.on_bus_message` pushed inbound bus frames directly via `push_frame`, which silently drops any
  frame arriving before the bridge's own `StartFrame` has been processed (`FrameProcessor`'s started check).
  - A `bridged=()` child worker's `on_activated` frames (e.g. `LLMSetToolsFrame` from tool registration) can cross the
  bus and reach the parent's bridge before the parent's `StartFrame` arrives there, since a small child pipeline
  typically finishes starting well before a larger parent pipeline does. The frame was dropped and never replayed,
  leaving the LLM with no tools advertised for the entire session — the model narrates function calls as text instead
  of invoking them.
  - Fix: `BusBridgeProcessor` now buffers frames received via `on_bus_message` before its own `StartFrame` is
  processed, and replays them in order once `StartFrame` lands.
  - Note: `_BusEdgeProcessor` (used for `bridged=` pipeline edges) is not affected — it routes inbound bus frames
  through the owning worker's separate push queue, which has no such started-gate.
  
  Fixes #4913
  
  ## Test plan

  - [x] Added `test_bus_frame_before_start_is_buffered_and_replayed`, reproducing the exact drop scenario from #4913
  (bus message delivered before `StartFrame`) and asserting the frame is still delivered downstream once `StartFrame`
  arrives.
  - [x] Fixed `test_target_task_filtering`, which was implicitly relying on the old (buggy) behavior of pushing before
  `StartFrame` — it now marks the bridge as started to reflect realistic usage.
  - [x] `uv run pytest tests/test_bridge_processor.py tests/test_bus.py tests/test_pipeline_worker_ui_bridge.py` — all
  passing
  - [x] `uv run ruff check` / `uv run ruff format --check` — clean