### PR TITLE
fix(aggregators): fix double LLM run on parallel tool calls with a lagging sibling

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1401,6 +1401,12 @@ class LLMAssistantAggregator(LLMContextAggregator):
         self._paired_user_aggregator = _paired_user_aggregator
 
         self._function_calls_in_progress: dict[str, FunctionCallInProgressFrame | None] = {}
+        # Sibling tool_call_ids announced together in the same
+        # FunctionCallsStartedFrame, keyed by tool_call_id. Used to detect
+        # the last-to-complete call in a parallel-tool-call group even when
+        # a sibling hasn't reached FunctionCallInProgressFrame yet (siblings
+        # run as independent tasks with no ordering guarantee between them).
+        self._function_call_siblings: dict[str, tuple[str, ...]] = {}
         self._function_calls_image_results: dict[str, UserImageRawFrame] = {}
         self._context_updated_tasks: set[asyncio.Task] = set()
 
@@ -1659,8 +1665,10 @@ class LLMAssistantAggregator(LLMContextAggregator):
     async def _handle_function_calls_started(self, frame: FunctionCallsStartedFrame):
         function_names = [f"{f.function_name}:{f.tool_call_id}" for f in frame.function_calls]
         logger.debug(f"{self} FunctionCallsStartedFrame: {function_names}")
+        tool_call_ids = tuple(f.tool_call_id for f in frame.function_calls)
         for function_call in frame.function_calls:
             self._function_calls_in_progress[function_call.tool_call_id] = None
+            self._function_call_siblings[function_call.tool_call_id] = tool_call_ids
 
     async def _handle_function_call_in_progress(self, frame: FunctionCallInProgressFrame):
         logger.debug(
@@ -1742,17 +1750,27 @@ class LLMAssistantAggregator(LLMContextAggregator):
                 # to complete. If group_id is set, only consider sibling calls;
                 # otherwise always execute as soon as we receive the result.
                 if group_id:
+                    # Siblings are tracked by tool_call_id presence in
+                    # `_function_calls_in_progress` (removed only once their
+                    # result is processed), not by whether they've already
+                    # reached FunctionCallInProgressFrame. Parallel calls run
+                    # as independent tasks, so a fast sibling's result can
+                    # arrive before a slow sibling's in-progress frame does;
+                    # filtering on the in-progress value would treat that
+                    # slow sibling as already done and run the LLM early.
+                    siblings = self._function_call_siblings.get(frame.tool_call_id, ())
                     run_llm = not any(
-                        f is not None
-                        and f.group_id == group_id
-                        # We are now able to receive "updates", so the current
-                        # frame can still be in the in progress list, and we need to
-                        # ignore it.
-                        and f.tool_call_id != frame.tool_call_id
-                        for f in self._function_calls_in_progress.values()
+                        tool_call_id != frame.tool_call_id
+                        and tool_call_id in self._function_calls_in_progress
+                        for tool_call_id in siblings
                     )
                 else:
                     run_llm = True
+
+        if is_final:
+            # Safe to drop this call's own sibling-group entry now that the
+            # last-to-complete check above has used it.
+            self._function_call_siblings.pop(frame.tool_call_id, None)
 
         if run_llm and not self._user_speaking:
             await self._maybe_push_context_after_function_result()
@@ -1825,6 +1843,10 @@ class LLMAssistantAggregator(LLMContextAggregator):
         """
         is_async = not in_progress_frame.cancel_on_interruption
         del self._function_calls_in_progress[frame.tool_call_id]
+        # Note: `_function_call_siblings[frame.tool_call_id]` is intentionally
+        # left in place here — `_handle_function_call_result` still needs it
+        # (after this call returns) to look up this call's own sibling group
+        # for the last-to-complete check. It's popped there once that's done.
 
         result = json.dumps(frame.result, ensure_ascii=False) if frame.result else "COMPLETED"
 
@@ -1847,6 +1869,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
             # Update context with the function call cancellation
             self._update_function_call_result(frame.function_name, frame.tool_call_id, "CANCELLED")
             del self._function_calls_in_progress[frame.tool_call_id]
+            self._function_call_siblings.pop(frame.tool_call_id, None)
 
     async def _handle_user_image_frame(self, frame: UserImageRawFrame):
         image_appended = False

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1180,6 +1180,69 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         )
         assert json.loads(context.messages[-1]["content"]) == {"conditions": "Sunny"}
 
+    async def test_parallel_function_calls_run_llm_once_when_sibling_lags(self):
+        """Regression test for #4908: a fast sibling's result must not run
+        the LLM early just because a slower sibling hasn't reached
+        FunctionCallInProgressFrame yet. Both calls share a group_id (as
+        happens with group_parallel_tools=True), and call A's full
+        in-progress/result cycle completes -- with the pipeline fully
+        draining in between, so the "another result queued" dedup can't
+        mask the bug -- before call B even announces in-progress."""
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        group_id = "group-1"
+        frames_to_send = [
+            FunctionCallsStartedFrame(
+                function_calls=[
+                    FunctionCallFromLLM(
+                        context=context, tool_call_id="A", function_name="set_field", arguments={}
+                    ),
+                    FunctionCallFromLLM(
+                        context=context,
+                        tool_call_id="B",
+                        function_name="slow_validate",
+                        arguments={},
+                    ),
+                ]
+            ),
+            FunctionCallInProgressFrame(
+                function_name="set_field",
+                tool_call_id="A",
+                arguments={},
+                cancel_on_interruption=True,
+                group_id=group_id,
+            ),
+            FunctionCallResultFrame(
+                function_name="set_field",
+                tool_call_id="A",
+                arguments={},
+                result={"ok": True},
+            ),
+            # Let the pipeline fully drain A's result before B announces.
+            SleepFrame(sleep=0.05),
+            FunctionCallInProgressFrame(
+                function_name="slow_validate",
+                tool_call_id="B",
+                arguments={},
+                cancel_on_interruption=True,
+                group_id=group_id,
+            ),
+            FunctionCallResultFrame(
+                function_name="slow_validate",
+                tool_call_id="B",
+                arguments={},
+                result={"ok": True},
+            ),
+        ]
+        expected_down_frames = []
+        expected_up_frames = [LLMContextFrame]
+        await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            expected_up_frames=expected_up_frames,
+        )
+
     async def test_function_call_on_context_updated(self):
         context_updated = False
 


### PR DESCRIPTION
## Summary

  `_function_calls_in_progress` on `f is not None`, treating a sibling as "done" the moment it was merely announced
  (`FunctionCallsStartedFrame`, seeded with value `None`) but hadn't yet reached `FunctionCallInProgressFrame`.
  - `LLMService._run_parallel_function_calls` runs each parallel call as an independent `asyncio.Task` with no
  ordering guarantee between them. A fast sibling's full in-progress → result cycle can complete before a slow
  sibling's task even gets to broadcast its own in-progress frame.
  - Net effect: the guard sees no pending sibling, runs the LLM after the fast call, then runs it again after the slow
  call finishes — two LLM completions (often two near-identical spoken responses) for what should be one turn.
  - Fix: track pending siblings by tool_call_id presence in `_function_calls_in_progress` (only removed once a result
  is actually processed) instead of by whether an in-progress frame was recorded. A new `_function_call_siblings` map
  records each call's batch membership from `FunctionCallsStartedFrame`, and the guard checks against that.
  - Also fixes a follow-on bug caught by the new test while implementing: the sibling-map entry for the *finishing*
  call itself must not be cleared until after the guard has used it to look up its own sibling group.

  Fixes #4908

  ## Test plan
  
  - [x] Added `test_parallel_function_calls_run_llm_once_when_sibling_lags`, reproducing the race with a real
  inter-call drain gap (`SleepFrame`) so the existing "another result queued" dedup can't mask it — asserts exactly
  one `LLMContextFrame` is pushed upstream for two parallel calls.
  - [x] `uv run pytest tests/test_context_aggregators_universal.py tests/test_llm_response.py
  tests/test_llm_service.py` — 98/98 passing
  - [x] `uv run ruff check` / `uv run ruff format --check` — clean
  - [x] Manually reproduced the original bug against a standalone script mirroring the issue's frame trace (confirmed
  double `Pushing context frame!` / double `LLMContextFrame` push before the fix, single push after)