### PR TITLE
Add speed, cloned voice, and word timestamps to SonioxTTSService

### DIFF
--- a/changelog/4947.added.2.md
+++ b/changelog/4947.added.2.md
@@ -1,0 +1,1 @@
+- `SonioxTTSService` now supports cloned voices: pass the voice UUID as `voice`.

--- a/changelog/4947.added.md
+++ b/changelog/4947.added.md
@@ -1,0 +1,1 @@
+- Added a `speed` setting (0.7-1.3) to `SonioxTTSService`.

--- a/changelog/4947.changed.md
+++ b/changelog/4947.changed.md
@@ -1,1 +1,1 @@
-- ⚠️ `SonioxTTSService` now emits word-aligned `TTSTextFrame`s by default, so context reflects only what was spoken on interruption. Pass `return_timestamps=False` to keep the previous behavior (full sentence text pushed up front).
+- ⚠️ `SonioxTTSService` now emits word-aligned `TTSTextFrame`s instead of pushing each sentence's full text up front, so the context reflects only what was actually spoken on interruption.

--- a/changelog/4947.changed.md
+++ b/changelog/4947.changed.md
@@ -1,0 +1,1 @@
+- ⚠️ `SonioxTTSService` now emits word-aligned `TTSTextFrame`s by default, so context reflects only what was spoken on interruption. Pass `return_timestamps=False` to keep the previous behavior (full sentence text pushed up front).

--- a/changelog/soniox-tts-new-parameters.added.md
+++ b/changelog/soniox-tts-new-parameters.added.md
@@ -1,3 +1,5 @@
 - Added a `speed` setting (0.7-1.3) to `SonioxTTSService`.
 
 - `SonioxTTSService` now supports cloned voices: pass the voice UUID as `voice`.
+
+- `SonioxTTSService` now emits word-aligned `TTSTextFrame`s (disable with `return_timestamps=False`), so context reflects only what was spoken on interruption.

--- a/changelog/soniox-tts-new-parameters.added.md
+++ b/changelog/soniox-tts-new-parameters.added.md
@@ -1,5 +1,0 @@
-- Added a `speed` setting (0.7-1.3) to `SonioxTTSService`.
-
-- `SonioxTTSService` now supports cloned voices: pass the voice UUID as `voice`.
-
-- `SonioxTTSService` now emits word-aligned `TTSTextFrame`s (disable with `return_timestamps=False`), so context reflects only what was spoken on interruption.

--- a/changelog/soniox-tts-new-parameters.added.md
+++ b/changelog/soniox-tts-new-parameters.added.md
@@ -1,0 +1,3 @@
+- Added a `speed` setting (0.7-1.3) to `SonioxTTSService`.
+
+- `SonioxTTSService` now supports cloned voices: pass the voice UUID as `voice`.

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -18,7 +18,7 @@ import asyncio
 import base64
 import json
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import websockets
@@ -35,7 +35,7 @@ from pipecat.frames.frames import (
     TTSAudioRawFrame,
     TTSStoppedFrame,
 )
-from pipecat.services.settings import TTSSettings
+from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import TextAggregationMode, WebsocketTTSService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
@@ -122,13 +122,19 @@ def language_to_soniox_tts_language(language: Language) -> str | None:
 class SonioxTTSSettings(TTSSettings):
     """Settings for SonioxTTSService.
 
-    ``voice``, ``model``, and ``language`` travel in the per-stream
+    ``voice``, ``model``, ``language``, and ``speed`` travel in the per-stream
     config message, so changing any of them does not require reconnecting the
     WebSocket. The current context is flushed so the next stream opens with the
     new values.
+
+    Parameters:
+        voice: Voice name (e.g. ``"Adrian"``) or the UUID of a cloned voice in
+            the project owning the API key.
+        speed: Speech rate multiplier in the range 0.7-1.3. ``None`` leaves it
+            unset and uses the Soniox server default (1.0).
     """
 
-    pass
+    speed: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class SonioxTTSService(WebsocketTTSService):
@@ -180,6 +186,7 @@ class SonioxTTSService(WebsocketTTSService):
             model="tts-rt-v1",
             voice="Adrian",
             language=Language.EN,
+            speed=None,
         )
 
         # Settings delta (canonical API, always wins)
@@ -347,7 +354,7 @@ class SonioxTTSService(WebsocketTTSService):
         if not changed:
             return changed
 
-        if changed.keys() & {"voice", "model", "language"}:
+        if changed.keys() & {"voice", "model", "language", "speed"}:
             if self._turn_context_id and self.audio_context_available(self._turn_context_id):
                 await self.flush_audio(context_id=self._turn_context_id)
             # Assign a new turn context ID so subsequent sentences in this turn
@@ -427,6 +434,8 @@ class SonioxTTSService(WebsocketTTSService):
         }
         if s.language is not None:
             config["language"] = s.language
+        if s.speed is not None:
+            config["speed"] = s.speed
         if self._audio_format.startswith("pcm_"):
             config["sample_rate"] = self.sample_rate
         return config
@@ -483,8 +492,12 @@ class SonioxTTSService(WebsocketTTSService):
             error_code = msg.get("error_code")
             if error_code is not None:
                 error_message = msg.get("error_message", "")
+                error_type = msg.get("error_type", "")
                 await self.push_error(
-                    error_msg=f"Soniox TTS error {error_code} (stream {stream_id}): {error_message}"
+                    error_msg=(
+                        f"Soniox TTS error {error_code} {error_type} "
+                        f"(stream {stream_id}): {error_message}"
+                    )
                 )
                 if stream_id and self.audio_context_available(stream_id):
                     await self.append_to_audio_context(

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -162,6 +162,7 @@ class SonioxTTSService(WebsocketTTSService):
         audio_format: str = "pcm_s16le",
         settings: Settings | None = None,
         text_aggregation_mode: TextAggregationMode | None = None,
+        return_timestamps: bool = True,
         **kwargs,
     ):
         """Initialize the Soniox TTS service.
@@ -179,6 +180,10 @@ class SonioxTTSService(WebsocketTTSService):
                 deprecated parameters, ``settings`` values take precedence.
             text_aggregation_mode: How to aggregate incoming text before
                 synthesis. Defaults to ``TextAggregationMode.SENTENCE``.
+            return_timestamps: Request character-level timestamps from Soniox and
+                emit timestamp-aligned ``TTSTextFrame``s, so the conversation
+                context reflects only what was actually spoken on interruption.
+                When ``False``, the full text of each sentence is pushed up front.
             **kwargs: Additional arguments passed to the parent service.
         """
         # Initialize default_settings
@@ -195,9 +200,9 @@ class SonioxTTSService(WebsocketTTSService):
 
         super().__init__(
             text_aggregation_mode=text_aggregation_mode,
-            # Soniox doesn't expose alignment data, so TTSTextFrames can be
-            # pushed immediately by the base class.
-            push_text_frames=True,
+            # With timestamps we emit word-aligned TTSTextFrames as audio plays;
+            # without them the base class pushes each sentence's text up front.
+            push_text_frames=not return_timestamps,
             # We push TTSStoppedFrame ourselves when Soniox sends `terminated`.
             push_stop_frames=False,
             # Let the base class create audio contexts and emit TTSStartedFrame.
@@ -210,6 +215,7 @@ class SonioxTTSService(WebsocketTTSService):
 
         self._api_key = api_key
         self._url = url
+        self._return_timestamps = return_timestamps
 
         # Init-only audio format (not runtime-updatable).
         self._audio_format = audio_format
@@ -217,6 +223,10 @@ class SonioxTTSService(WebsocketTTSService):
         # Tracks which context_ids have had their per-stream config sent.
         # Soniox rejects duplicate config for the same stream_id.
         self._configured_contexts: set[str] = set()
+
+        # Per-stream word still being assembled across timestamp messages (a word's
+        # characters can arrive split across messages). stream_id -> (word, start_s).
+        self._partials: dict[str, tuple[str, float]] = {}
 
         self._receive_task: asyncio.Task | None = None
         self._keepalive_task: asyncio.Task | None = None
@@ -334,6 +344,7 @@ class SonioxTTSService(WebsocketTTSService):
         """Cancel the active Soniox stream when the bot is interrupted."""
         await self.stop_all_metrics()
         await self._close_stream(context_id)
+        self._partials.pop(context_id, None)
         await super().on_audio_context_interrupted(context_id)
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
@@ -414,6 +425,7 @@ class SonioxTTSService(WebsocketTTSService):
         finally:
             await self.remove_active_audio_context()
             self._configured_contexts.clear()
+            self._partials.clear()
             self._websocket = None
             await self._call_event_handler("on_disconnected")
 
@@ -436,6 +448,8 @@ class SonioxTTSService(WebsocketTTSService):
             config["language"] = s.language
         if s.speed is not None:
             config["speed"] = s.speed
+        if self._return_timestamps:
+            config["return_timestamps"] = True
         if self._audio_format.startswith("pcm_"):
             config["sample_rate"] = self.sample_rate
         return config
@@ -473,6 +487,53 @@ class SonioxTTSService(WebsocketTTSService):
                 logger.warning(f"{self}: unexpected keepalive error: {e}")
                 break
 
+    def _is_chinese_or_japanese_language(self) -> bool:
+        """Whether the current language is written without spaces between words.
+
+        Chinese and Japanese never use spaces, so their timestamps are emitted per
+        character.
+        """
+        language = self._settings.language
+        if language is None:
+            return False
+        code = language.value if isinstance(language, Language) else str(language)
+        return code.split("-")[0].lower() in ("zh", "ja")
+
+    def _to_word_times(self, stream_id: str, timestamps: dict[str, Any]) -> list[tuple[str, float]]:
+        """Turn one Soniox timestamp message into ``(word, start_seconds)`` tuples.
+
+        Soniox emits two parallel arrays::
+
+            characters:                    ["H", "i", " ", "y", "o", "u"]
+            character_start_times_seconds: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+
+        which this turns into::
+
+            [("Hi", 0.1), ("you", 0.4)]
+        """
+        chars = timestamps.get("characters", [])
+        starts = timestamps.get("character_start_times_seconds", [])
+        if len(chars) != len(starts):
+            logger.error(f"{self}: Soniox timestamp mismatch: {len(chars)} vs {len(starts)}")
+            return []
+
+        if self._is_chinese_or_japanese_language():
+            return [(c, t) for c, t in zip(chars, starts) if c.isalnum()]
+
+        current_word, word_start_time = self._partials.get(stream_id, ("", 0.0))
+        words_with_start_times: list[tuple[str, float]] = []
+        for char, start in zip(chars, starts):
+            if char == " ":
+                if current_word:
+                    words_with_start_times.append((current_word, word_start_time))
+                    current_word = ""
+            else:
+                if not current_word:  # first character of a new word
+                    word_start_time = start
+                current_word += char
+        self._partials[stream_id] = (current_word, word_start_time)
+        return words_with_start_times
+
     async def _receive_messages(self):
         """Handle incoming WebSocket messages from Soniox.
 
@@ -504,15 +565,21 @@ class SonioxTTSService(WebsocketTTSService):
                         stream_id, TTSStoppedFrame(context_id=stream_id)
                     )
                     await self.remove_audio_context(stream_id)
+                self._partials.pop(stream_id, None)
                 self._configured_contexts.discard(stream_id)
                 continue
 
             if msg.get("terminated"):
                 if stream_id and self.audio_context_available(stream_id):
+                    # Emit the buffered final word (no trailing space closed it).
+                    final_word, start = self._partials.get(stream_id, ("", 0.0))
+                    if final_word:
+                        await self.add_word_timestamps([(final_word, start)], stream_id)
                     await self.append_to_audio_context(
                         stream_id, TTSStoppedFrame(context_id=stream_id)
                     )
                     await self.remove_audio_context(stream_id)
+                self._partials.pop(stream_id, None)
                 self._configured_contexts.discard(stream_id)
                 continue
 
@@ -522,6 +589,18 @@ class SonioxTTSService(WebsocketTTSService):
                 audio = base64.b64decode(audio_b64)
                 frame = TTSAudioRawFrame(audio, self.sample_rate, 1, context_id=stream_id)
                 await self.append_to_audio_context(stream_id, frame)
+
+            timestamps = msg.get("timestamps")
+            if timestamps and stream_id and self.audio_context_available(stream_id):
+                words_with_start_times = self._to_word_times(stream_id, timestamps)
+                if words_with_start_times:
+                    await self.add_word_timestamps(
+                        words_with_start_times,
+                        stream_id,
+                        includes_inter_frame_spaces=(
+                            True if self._is_chinese_or_japanese_language() else None
+                        ),
+                    )
 
             # audio_end is informational; the real end-of-stream signal is
             # `terminated`, handled above.

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -162,7 +162,6 @@ class SonioxTTSService(WebsocketTTSService):
         audio_format: str = "pcm_s16le",
         settings: Settings | None = None,
         text_aggregation_mode: TextAggregationMode | None = None,
-        return_timestamps: bool = True,
         **kwargs,
     ):
         """Initialize the Soniox TTS service.
@@ -180,10 +179,6 @@ class SonioxTTSService(WebsocketTTSService):
                 deprecated parameters, ``settings`` values take precedence.
             text_aggregation_mode: How to aggregate incoming text before
                 synthesis. Defaults to ``TextAggregationMode.SENTENCE``.
-            return_timestamps: Request character-level timestamps from Soniox and
-                emit timestamp-aligned ``TTSTextFrame``s, so the conversation
-                context reflects only what was actually spoken on interruption.
-                When ``False``, the full text of each sentence is pushed up front.
             **kwargs: Additional arguments passed to the parent service.
         """
         # Initialize default_settings
@@ -200,9 +195,9 @@ class SonioxTTSService(WebsocketTTSService):
 
         super().__init__(
             text_aggregation_mode=text_aggregation_mode,
-            # With timestamps we emit word-aligned TTSTextFrames as audio plays;
-            # without them the base class pushes each sentence's text up front.
-            push_text_frames=not return_timestamps,
+            # We emit word-aligned TTSTextFrames from Soniox timestamps as audio
+            # plays, so the base class must not push each sentence's text up front.
+            push_text_frames=False,
             # We push TTSStoppedFrame ourselves when Soniox sends `terminated`.
             push_stop_frames=False,
             # Let the base class create audio contexts and emit TTSStartedFrame.
@@ -215,7 +210,6 @@ class SonioxTTSService(WebsocketTTSService):
 
         self._api_key = api_key
         self._url = url
-        self._return_timestamps = return_timestamps
 
         # Init-only audio format (not runtime-updatable).
         self._audio_format = audio_format
@@ -448,8 +442,8 @@ class SonioxTTSService(WebsocketTTSService):
             config["language"] = s.language
         if s.speed is not None:
             config["speed"] = s.speed
-        if self._return_timestamps:
-            config["return_timestamps"] = True
+        # Character-level timestamps drive the word-aligned TTSTextFrames.
+        config["return_timestamps"] = True
         if self._audio_format.startswith("pcm_"):
             config["sample_rate"] = self.sample_rate
         return config

--- a/tests/test_soniox_tts.py
+++ b/tests/test_soniox_tts.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from pipecat.services.settings import TTSSettings
+from pipecat.services.soniox.tts import SonioxTTSService
+from pipecat.utils.context.word_completion_tracker import WordCompletionTracker
+from pipecat.utils.string import TextPartForConcatenation, concatenate_aggregated_text
+
+
+def _service(language: str | None) -> SonioxTTSService:
+    service = SonioxTTSService.__new__(SonioxTTSService)
+    service._name = "SonioxTTSService#0"
+    service._settings = TTSSettings(language=language)
+    service._partials = {}
+    return service
+
+
+def _timestamps(text: str, start: float = 0.0) -> dict:
+    chars = list(text)
+    return {
+        "characters": chars,
+        "character_start_times_seconds": [round(start + i * 0.1, 1) for i in range(len(chars))],
+    }
+
+
+def test_soniox_english_characters_assemble_into_words():
+    service = _service("en")
+
+    assert service._to_word_times("s1", _timestamps("Hi world. ")) == [
+        ("Hi", 0.0),
+        ("world.", 0.3),
+    ]
+
+
+def test_soniox_english_partial_word_carries_across_messages():
+    service = _service("en")
+
+    assert service._to_word_times("s1", _timestamps("Hel")) == []
+    assert service._to_word_times("s1", _timestamps("lo you ", start=0.3)) == [
+        ("Hello", 0.0),
+        ("you", 0.6),
+    ]
+
+
+def test_soniox_english_final_partial_word_is_buffered_for_terminated():
+    service = _service("en")
+
+    assert service._to_word_times("s1", _timestamps("Hi you")) == [("Hi", 0.0)]
+    # The receive loop flushes this buffered word when Soniox sends `terminated`.
+    assert service._partials["s1"] == ("you", 0.3)
+
+
+def test_soniox_streams_buffer_partial_words_independently():
+    service = _service("en")
+
+    service._to_word_times("s1", _timestamps("Hel"))
+    service._to_word_times("s2", _timestamps("wor", start=1.0))
+
+    assert service._partials["s1"] == ("Hel", 0.0)
+    assert service._partials["s2"] == ("wor", 1.0)
+
+    assert service._to_word_times("s1", _timestamps("lo ", start=0.3)) == [("Hello", 0.0)]
+    assert service._to_word_times("s2", _timestamps("ld ", start=1.3)) == [("world", 1.0)]
+
+
+def test_soniox_timestamp_length_mismatch_returns_empty():
+    service = _service("en")
+
+    assert (
+        service._to_word_times(
+            "s1", {"characters": ["H", "i"], "character_start_times_seconds": [0.0]}
+        )
+        == []
+    )
+    assert "s1" not in service._partials
+
+
+def test_soniox_japanese_timestamps_emit_per_character():
+    service = _service("ja")
+
+    assert service._to_word_times("s1", _timestamps("こんにちは、私")) == [
+        ("こ", 0.0),
+        ("ん", 0.1),
+        ("に", 0.2),
+        ("ち", 0.3),
+        ("は", 0.4),
+        ("私", 0.6),
+    ]
+    assert "s1" not in service._partials
+
+
+def test_soniox_chinese_timestamps_emit_per_character():
+    service = _service("zh")
+
+    assert service._to_word_times("s1", _timestamps("你好，世界。")) == [
+        ("你", 0.0),
+        ("好", 0.1),
+        ("世", 0.3),
+        ("界", 0.4),
+    ]
+
+
+def test_soniox_japanese_tokens_concatenate_without_spaces():
+    service = _service("ja")
+    tokens = service._to_word_times("s1", _timestamps("こんにちは、私"))
+
+    includes_inter_frame_spaces = service._is_chinese_or_japanese_language()
+    assert (
+        concatenate_aggregated_text(
+            [
+                TextPartForConcatenation(
+                    word, includes_inter_part_spaces=includes_inter_frame_spaces
+                )
+                for word, _start in tokens
+            ]
+        )
+        == "こんにちは私"
+    )
+
+
+def test_soniox_japanese_punctuation_recovered_by_word_tracker():
+    # CJK tokens drop punctuation (isalnum filter), which is safe: the frame
+    # sequencer's WordCompletionTracker matches tokens by alphanumeric content
+    # only and commits spans of the original text, sweeping adjacent punctuation
+    # into each consumed span.
+    text = "こんにちは、私はAIです。"
+    service = _service("ja")
+    tokens = service._to_word_times("s1", _timestamps(text))
+
+    tracker = WordCompletionTracker(text)
+    complete = False
+    for word, _start in tokens:
+        complete = tracker.add_word_and_check_complete(word)
+
+    assert complete
+    assert tracker.get_accumulated_user_facing_text() == text


### PR DESCRIPTION
Three additions to `SonioxTTSService`:

- **`speed`** setting (0.7-1.3) for voice speed.
- **`voice`** accepts a cloned-voice UUID (existing field; clearer `voice_not_found` error).
- **`return_timestamps`** (on by default). Emits word-aligned `TTSTextFrame`s so context reflects only what was spoken on interruption. Chinese/Japanese emit per character, other languages group on spaces. Set `return_timestamps=False` for the old sentence-level behavior.

