### PR TITLE
Re-raise message-conversion errors instead of dropping the whole conversation (#4828)

### DIFF
--- a/changelog/4954.fixed.md
+++ b/changelog/4954.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where a single malformed message (such as an invalid image data URL) would silently drop the entire conversation in the Anthropic and AWS Bedrock adapters. The conversion error is now raised instead of swallowed.

--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -168,7 +168,11 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:
+            # Re-raise instead of swallowing: returning an empty message list here
+            # silently drops the entire conversation context (see Gemini adapter,
+            # which lets these errors propagate).
             logger.error(f"Error mapping messages: {e}")
+            raise
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as Anthropic doesn't support system or developer input messages.

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -134,7 +134,11 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:
+            # Re-raise instead of swallowing: returning an empty message list here
+            # silently drops the entire conversation context (see Gemini adapter,
+            # which lets these errors propagate).
             logger.error(f"Error mapping messages: {e}")
+            raise
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as AWS Bedrock doesn't support system or developer input messages.

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -761,6 +761,26 @@ class TestAnthropicGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(assistant_msg["role"], "assistant")
         self.assertEqual(assistant_msg["content"], "I'm doing well, thank you!")
 
+    def test_malformed_image_url_raises_instead_of_dropping_context(self):
+        """A malformed data URL should surface an error, not silently drop the
+        entire conversation. Previously the broad except returned empty messages,
+        so the LLM ran with no context at all."""
+        messages: list[LLMStandardMessage] = [
+            {"role": "user", "content": "important earlier context"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    # No comma, so url.split(",")[1] raises during conversion.
+                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64"}},
+                ],
+            },
+        ]
+        context = LLMContext(messages=messages)
+
+        with self.assertRaises(IndexError):
+            self.adapter.get_llm_invocation_params(context, enable_prompt_caching=False)
+
     def test_llm_specific_message_filtering(self):
         """Test that Anthropic-specific messages are included and others are filtered out."""
         # Create anthropic-specific message content


### PR DESCRIPTION
Fixes #4828.

In `AnthropicLLMAdapter._from_universal_context_messages`, the conversion loop is wrapped in a broad `except` that logs and then leaves `messages` as an empty list:

```python
messages = []
try:
    messages = [self._from_universal_context_message(m) for m in remaining]
except Exception as e:
    logger.error(f"Error mapping messages: {e}")
```

So one bad message drops the **entire** conversation silently. It is easy to hit: the image path does `url.split(",")[1]` on a `data:` URL, and a malformed data URL (no comma) raises `IndexError`, which gets swallowed. The result is the model running with no context, or a later confusing "messages cannot be empty" error. The Gemini adapter converts in a plain loop and lets these errors propagate, so the behavior is inconsistent across providers.

The fix re-raises after logging so the caller sees the real error. `bedrock_adapter.py` had the same copy of this swallow, so I fixed both in one go.

Added a test in `tests/test_get_llm_invocation_params.py` (a malformed image data URL now raises instead of returning empty messages). `pytest tests/test_get_llm_invocation_params.py -k "Anthropic or Bedrock"` gives 26 passed; the new test fails on `main`.

One thing worth a maintainer call: this makes a bad message fail loud rather than degrade silently. If you would rather skip only the offending message and keep the valid ones, happy to switch to that.