### PR TITLE
Add Pipecat Flows behavioral evals to the release eval suite

### DIFF
--- a/examples/flows/README.md
+++ b/examples/flows/README.md
@@ -46,6 +46,22 @@ All examples support multiple LLM providers (OpenAI, Anthropic, Google Gemini, A
 
 The examples define their functions as "direct functions" — async functions whose schema is derived from the signature and docstring — which is the recommended pattern. `food_ordering_advanced_functionschema.py` shows the alternative `FlowsFunctionSchema` approach.
 
+## Evals
+
+Most of these examples are covered by behavioral evals that drive the bot
+end-to-end and assert on which Flows functions fire and what the bot says back.
+The scenarios live in [`scripts/release-evals/`](../../scripts/release-evals/)
+alongside the rest of the release eval suite — see the Flows section of its
+README. To run just the flows bots:
+
+```bash
+scripts/release-evals/run.sh -p flows
+```
+
+Or iterate on a single bot: run it with `-t eval`, then drive one scenario
+against it with
+`pipecat eval run scripts/release-evals/scenarios/<name>.yaml -v`.
+
 ## Learn more
 
 See the [Pipecat Flows guide](https://docs.pipecat.ai/guides/features/pipecat-flows) for a full walkthrough of nodes, functions, context strategies, and actions.

--- a/examples/flows/utils.py
+++ b/examples/flows/utils.py
@@ -18,7 +18,7 @@ def create_llm(provider: str | None = None, model: str | None = None) -> Any:
     """Create an LLM service instance based on environment configuration.
 
     Args:
-        provider: LLM provider name. If None, uses LLM_PROVIDER env var (defaults to 'openai')
+        provider: LLM provider name. If None, uses LLM_PROVIDER env var (defaults to 'openai_responses')
         model: Model name. If None, uses provider's default model
 
     Returns:
@@ -36,7 +36,7 @@ def create_llm(provider: str | None = None, model: str | None = None) -> Any:
               Optionally set AWS_REGION (defaults to us-west-2)
 
     Usage:
-        # Use default provider (from LLM_PROVIDER env var, defaults to OpenAI)
+        # Use default provider (from LLM_PROVIDER env var, defaults to OpenAI Responses)
         llm = create_llm()
 
         # Use specific provider

--- a/scripts/release-evals/README.md
+++ b/scripts/release-evals/README.md
@@ -161,6 +161,31 @@ For function-calling-video bots, a turn can instead register an `image:` that th
 eval transport serves when the bot requests a user image mid-conversation (see
 `describe_image`).
 
+## Flows
+
+The `flows/` bots have their own scenario set asserting on Flows behavior:
+which functions fire, with which args, and what the bot says back. Each
+scenario targets a distinguishing feature of its example — dynamic routing,
+direct and global functions, `FlowsFunctionSchema` constraints, context
+strategies, conditional branching, multi-worker handoff, `LLMSwitcher`.
+
+The scenarios run text-only (no `user:`/`judge:` blocks). To drive a bot's
+real audio pipeline instead, add the shared includes
+(`user: !include user_audio.yaml`, `judge: !include judge_audio.yaml`).
+
+Authoring conventions:
+
+- Each turn asserts the `function_call` plus a `response` eval. The `response`
+  event also paces the run: the harness waits for the bot to finish before
+  sending the next turn.
+- Terminal turns assert only the function call — `end_conversation` tears the
+  pipeline down before the farewell reaches the harness.
+
+The bots pick their LLM from `$LLM_PROVIDER` (default `openai_responses`;
+`hello_world` always uses Google): `LLM_PROVIDER=anthropic ./run.sh -p flows`
+(also `google`, `aws`). `llm_switching` needs OpenAI, Google, and Anthropic
+keys all set. `warm_transfer.py` (Daily + a live human agent) isn't covered.
+
 ## Adding coverage
 
 - New bot: add an entry to `manifest.yaml` (`bot:` + the `scenarios:` it should run).

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -276,3 +276,28 @@ suite:
   #
   - bot: video-avatar/video-avatar-tavus-video-service.py
     scenarios: [capital_question]
+
+  #
+  # Flows: structured-conversation examples (examples/flows/). Text-only
+  # scenarios asserting on node transitions, function calls, and context
+  # strategies. The bots pick their LLM from $LLM_PROVIDER (default
+  # openai_responses; hello_world always uses Google).
+  #
+  - bot: flows/hello_world.py
+    scenarios: [hello_world]
+  - bot: flows/food_ordering.py
+    scenarios: [food_ordering_pizza]
+  - bot: flows/food_ordering_advanced_functionschema.py
+    scenarios: [food_ordering_sushi]
+  - bot: flows/multi_worker_handoff.py
+    scenarios: [multi_worker_handoff]
+  - bot: flows/patient_intake.py
+    scenarios: [patient_intake]
+  - bot: flows/restaurant_reservation.py
+    scenarios: [restaurant_reservation_available, restaurant_reservation_no_availability]
+  - bot: flows/insurance_quote.py
+    scenarios: [insurance_quote]
+  # Constructs and switches between OpenAI, Google, and Anthropic, so all
+  # three API keys must be set.
+  - bot: flows/llm_switching.py
+    scenarios: [llm_switching]

--- a/scripts/release-evals/scenarios/food_ordering_pizza.yaml
+++ b/scripts/release-evals/scenarios/food_ordering_pizza.yaml
@@ -1,0 +1,41 @@
+name: food_ordering_pizza
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the user and offers to take a food order"
+
+  - user: "I'd like to order a pizza."
+    expect:
+      - event: function_call
+        calls:
+          - name: choose_pizza
+      - event: response
+        eval: "the bot asks for pizza details such as size and type"
+
+  - user: "A large pepperoni please."
+    expect:
+      - event: function_call
+        calls:
+          - name: select_pizza_order
+            args: { size: large, pizza_type: pepperoni }
+      - event: response
+        eval: "the bot reads back or confirms a large pepperoni pizza order"
+
+  - user: "How long will delivery take?"
+    expect:
+      - event: function_call
+        calls:
+          - name: get_delivery_estimate
+      - event: response
+        eval: "the bot gives a delivery time estimate"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "That's everything, please confirm my order."
+    expect:
+      - event: function_call
+        calls:
+          - name: complete_order

--- a/scripts/release-evals/scenarios/food_ordering_sushi.yaml
+++ b/scripts/release-evals/scenarios/food_ordering_sushi.yaml
@@ -1,0 +1,33 @@
+name: food_ordering_sushi
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the user and offers to take a food order"
+
+  - user: "I'll have sushi."
+    expect:
+      - event: function_call
+        calls:
+          - name: choose_sushi
+      - event: response
+        eval: "the bot asks for sushi details such as roll type and count"
+
+  - user: "Three California rolls, please."
+    expect:
+      - event: function_call
+        calls:
+          - name: select_sushi_order
+            args: { count: 3, type: california }
+      - event: response
+        eval: "the bot reads back or confirms an order of three California rolls"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "Yes, that's correct, go ahead."
+    expect:
+      - event: function_call
+        calls:
+          - name: complete_order

--- a/scripts/release-evals/scenarios/hello_world.yaml
+++ b/scripts/release-evals/scenarios/hello_world.yaml
@@ -1,0 +1,17 @@
+name: hello_world
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot says hello and asks what the user's favorite color is"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "My favorite color is blue."
+    expect:
+      - event: function_call
+        calls:
+          - name: record_favorite_color
+            args: { color: blue }

--- a/scripts/release-evals/scenarios/insurance_quote.yaml
+++ b/scripts/release-evals/scenarios/insurance_quote.yaml
@@ -1,0 +1,47 @@
+name: insurance_quote
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the customer and begins helping with an insurance quote"
+
+  - user: "I'm thirty years old."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_age
+            args: { age: 30 }
+      - event: response
+        eval: "the bot asks about the customer's marital status"
+
+  # The quote-calculation node immediately calls calculate_quote and reads the
+  # quote back, so both calls land on this turn (no separate "what's my quote?").
+  - user: "I'm married."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_marital_status
+            args: { marital_status: married }
+      - event: function_call
+        calls:
+          - name: calculate_quote
+      - event: response
+        eval: "the bot explains the insurance quote, including a monthly premium"
+
+  - user: "Can you raise the coverage to five hundred thousand with a two thousand dollar deductible?"
+    expect:
+      - event: function_call
+        calls:
+          - name: update_coverage
+      - event: response
+        eval: "the bot explains the updated quote after the coverage change"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "Great, I'm all set."
+    expect:
+      - event: function_call
+        calls:
+          - name: end_quote

--- a/scripts/release-evals/scenarios/llm_switching.yaml
+++ b/scripts/release-evals/scenarios/llm_switching.yaml
@@ -1,0 +1,52 @@
+# Requires OPENAI_API_KEY, GOOGLE_API_KEY, and ANTHROPIC_API_KEY — the bot
+# constructs all three and switches between them (no AWS, so no Bedrock creds).
+name: llm_switching
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the user"
+
+  - user: "Please switch to the Anthropic model."
+    expect:
+      - event: function_call
+        calls:
+          - name: switch_llm
+            args: { llm: Anthropic }
+      - event: response
+        eval: "the bot confirms it switched the language model"
+
+  - user: "What's the weather in San Francisco?"
+    expect:
+      - event: function_call
+        calls:
+          - name: get_current_weather
+      - event: response
+        eval: "the bot reports the current weather conditions and temperature"
+
+  - user: "Now switch to Google."
+    expect:
+      - event: function_call
+        calls:
+          - name: switch_llm
+            args: { llm: Google }
+      - event: response
+        eval: "the bot confirms it switched the language model"
+
+  - user: "And what's the weather in Paris?"
+    expect:
+      - event: function_call
+        calls:
+          - name: get_current_weather
+      - event: response
+        eval: "the bot reports the current weather conditions and temperature"
+
+  - user: "Can you summarize our conversation so far?"
+    expect:
+      - event: function_call
+        calls:
+          - name: summarize_conversation
+      - event: response
+        eval: "the bot gives a summary of the conversation that mentions the weather"

--- a/scripts/release-evals/scenarios/multi_worker_handoff.yaml
+++ b/scripts/release-evals/scenarios/multi_worker_handoff.yaml
@@ -1,0 +1,41 @@
+name: multi_worker_handoff
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the user and offers to answer questions or book a table"
+
+  - user: "I'd like to book a table."
+    expect:
+      - event: function_call
+        calls:
+          - name: transfer_to_reservation
+      - event: response
+        eval: "the bot asks how many people are in their party"
+
+  - user: "There will be two of us."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_party_size
+            args: { size: 2 }
+      - event: response
+        eval: "the bot asks what time they would like to dine"
+
+  - user: "We'd like to come at six PM."
+    expect:
+      - event: function_call
+        calls:
+          - name: check_availability
+      - event: response
+        eval: "the bot confirms a reservation is available at the requested time"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "No, that's all, thank you."
+    expect:
+      - event: function_call
+        calls:
+          - name: end_reservation

--- a/scripts/release-evals/scenarios/patient_intake.yaml
+++ b/scripts/release-evals/scenarios/patient_intake.yaml
@@ -1,0 +1,61 @@
+name: patient_intake
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot introduces itself and asks for the patient's date of birth"
+
+  - user: "My birthday is January first, nineteen eighty-three."
+    expect:
+      - event: function_call
+        calls:
+          - name: verify_birthday
+            args: { birthday: "1983-01-01" }
+      - event: response
+        eval: "the bot asks what prescriptions or medications the patient is taking"
+
+  - user: "I take Lipitor, twenty milligrams."
+    expect:
+      - event: function_call
+        calls:
+          - name: record_prescriptions
+      - event: response
+        eval: "the bot asks about the patient's allergies"
+
+  - user: "I'm allergic to penicillin."
+    expect:
+      - event: function_call
+        calls:
+          - name: record_allergies
+      - event: response
+        eval: "the bot asks about the patient's medical conditions"
+
+  - user: "I have high blood pressure."
+    expect:
+      - event: function_call
+        calls:
+          - name: record_conditions
+      - event: response
+        eval: "the bot asks what brings the patient in for their visit"
+
+  - user: "I'm here for a routine checkup."
+    expect:
+      - event: function_call
+        calls:
+          - name: record_visit_reasons
+      - event: response
+        eval: "the bot reviews or summarizes the collected information and asks the patient to confirm"
+
+  # confirm_information's node immediately calls complete_intake to end — both fire
+  # here with no further user turn and no judgeable text, so we assert the calls
+  # only (the end node tears down before any farewell).
+  - user: "Yes, that's all correct."
+    expect:
+      - event: function_call
+        calls:
+          - name: confirm_information
+      - event: function_call
+        calls:
+          - name: complete_intake

--- a/scripts/release-evals/scenarios/restaurant_reservation_available.yaml
+++ b/scripts/release-evals/scenarios/restaurant_reservation_available.yaml
@@ -1,0 +1,33 @@
+name: restaurant_reservation_available
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the customer and asks how many people are in their party"
+
+  - user: "There will be two of us."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_party_size
+            args: { size: 2 }
+      - event: response
+        eval: "the bot asks what time they would like to dine"
+
+  - user: "We'd like to come at six PM."
+    expect:
+      - event: function_call
+        calls:
+          - name: check_availability
+      - event: response
+        eval: "the bot confirms a reservation is available at the requested time"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "No, that's all, thank you."
+    expect:
+      - event: function_call
+        calls:
+          - name: end_conversation

--- a/scripts/release-evals/scenarios/restaurant_reservation_no_availability.yaml
+++ b/scripts/release-evals/scenarios/restaurant_reservation_no_availability.yaml
@@ -1,0 +1,41 @@
+name: restaurant_reservation_no_availability
+
+judge: !include judge_text.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the customer and asks how many people are in their party"
+
+  - user: "Two people, please."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_party_size
+            args: { size: 2 }
+      - event: response
+        eval: "the bot asks what time they would like to dine"
+
+  - user: "We'd like to come at seven PM."
+    expect:
+      - event: function_call
+        calls:
+          - name: check_availability
+      - event: response
+        eval: "the bot says the requested time is unavailable and offers alternative times"
+
+  - user: "Okay, let's come at six PM instead."
+    expect:
+      - event: function_call
+        calls:
+          - name: check_availability
+      - event: response
+        eval: "the bot confirms a reservation is available at the new time"
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell llm_response reaches the harness.
+  - user: "No, that's everything, thanks."
+    expect:
+      - event: function_call
+        calls:
+          - name: end_conversation


### PR DESCRIPTION
## Summary

- Ports the behavioral eval suite from the pipecat-flows repo into the release evals, now that Flows is part of Pipecat.
- Nine text-mode scenarios in `scripts/release-evals/scenarios/` drive the `examples/flows/` bots and assert on which Flows functions fire (with which args) and what the bot says back. Together they cover node transitions, direct/global functions, `FlowsFunctionSchema` constraints, context strategies, conditional branching, multi-worker handoff, and `LLMSwitcher`.
- Adds a Flows section to the release-evals manifest and README (coverage, authoring conventions, `LLM_PROVIDER` selection, `llm_switching` key requirements) and an Evals pointer in `examples/flows/README.md`.

The scenarios were copied verbatim — the ported examples differ from the flows repo only in import paths, so no adaptation was needed.

## Testing

- `scripts/release-evals/run.sh -p flows` — passes 9/9 (needs a local Ollama with `gemma2:9b` as the judge, plus the bots' API keys in `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)