### PR TITLE
Add acefone serializer

### DIFF
--- a/changelog/3756.added.md
+++ b/changelog/3756.added.md
@@ -1,0 +1,1 @@
+- Added `AcefoneFrameSerializer` serializer support to websocket stream from Acefone and Smartlfo.

--- a/src/pipecat/serializers/acefone.py
+++ b/src/pipecat/serializers/acefone.py
@@ -1,0 +1,244 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Acefone/Smartflo Media Streams WebSocket protocol serializer for Pipecat."""
+
+import base64
+import json
+from enum import StrEnum
+from typing import Any
+
+from loguru import logger
+
+from pipecat.audio.dtmf.types import KeypadEntry
+from pipecat.audio.utils import (
+    create_stream_resampler,
+    pcm_to_ulaw,
+    ulaw_to_pcm,
+)
+from pipecat.frames.frames import (
+    AudioRawFrame,
+    CancelFrame,
+    EndFrame,
+    Frame,
+    InputAudioRawFrame,
+    InputDTMFFrame,
+    InterruptionFrame,
+    OutputTransportMessageFrame,
+    OutputTransportMessageUrgentFrame,
+    StartFrame,
+)
+from pipecat.serializers.base_serializer import FrameSerializer
+
+
+class AcefoneMediaFormat(StrEnum):
+    """Wire audio format negotiated with Acefone/Smartflo.
+
+    Parameters:
+        ULAW: 8kHz G.711 μ-law. The default and most common telephony format.
+        PCM: 16-bit signed linear PCM (``slin16``).
+    """
+
+    ULAW = "ulaw"
+    PCM = "slin16"
+
+
+class AcefoneFrameSerializer(FrameSerializer):
+    """Serializer for the Acefone/Smartflo Media Streams WebSocket protocol.
+
+    Converts between Pipecat frames and Acefone's (and the compatible Smartflo)
+    bidirectional audio streaming protocol. It handles audio conversion, DTMF
+    keypad events, interruptions, and optional automatic call termination.
+
+    The wire audio format is configurable via `InputParams.media_format`
+    (`AcefoneMediaFormat.ULAW` by default, or `AcefoneMediaFormat.PCM` for 16-bit
+    linear PCM). Regardless of the wire format, audio is normalized to PCM
+    `InputAudioRawFrame` for the pipeline.
+
+    Unlike REST-based providers, auto hang-up is performed by sending an ``end``
+    event over the same WebSocket connection. When ``auto_hang_up`` is enabled,
+    the serializer emits this event on the first `EndFrame` or `CancelFrame`.
+
+    Note:
+        Reference docs for the wire protocol and events:
+
+        - https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document
+        - https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document
+    """
+
+    class InputParams(FrameSerializer.InputParams):
+        """Configuration parameters for `AcefoneFrameSerializer`.
+
+        Parameters:
+            media_format: Wire audio format exchanged with Acefone/Smartflo.
+                `AcefoneMediaFormat.ULAW` (the default) uses 8kHz μ-law;
+                `AcefoneMediaFormat.PCM` uses 16-bit linear PCM at
+                ``acefone_sample_rate``.
+            acefone_sample_rate: Sample rate used by Acefone/Smartflo, in Hz.
+                Defaults to 8000.
+            sample_rate: Optional override for the pipeline input sample rate. When
+                0 (the default), the rate is taken from the `StartFrame` during setup.
+            stream_sid: The Acefone/Smartflo Media Stream SID. When not provided, it
+                is captured from the incoming ``start`` event.
+            call_sid: The associated Acefone/Smartflo Call SID. Required for auto
+                hang-up.
+            auto_hang_up: Whether to terminate the call (via a WebSocket ``end``
+                event) when an `EndFrame` or `CancelFrame` is processed. Defaults
+                to False.
+            ignore_rtvi_messages: Inherited from `FrameSerializer.InputParams`,
+                defaults to True.
+        """
+
+        media_format: AcefoneMediaFormat = AcefoneMediaFormat.ULAW
+        acefone_sample_rate: int = 8000
+        sample_rate: int = 0
+        stream_sid: str | None = None
+        call_sid: str | None = None
+        auto_hang_up: bool = False
+
+    def __init__(self, params: InputParams | None = None):
+        """Initialize the `AcefoneFrameSerializer`.
+
+        Args:
+            params: Configuration parameters. `stream_sid` and `call_sid` are read
+                from here; `call_sid` is required when `auto_hang_up` is enabled.
+        """
+        params = params or AcefoneFrameSerializer.InputParams()
+        super().__init__(params)
+        self._params: AcefoneFrameSerializer.InputParams = params
+
+        self._stream_sid = self._params.stream_sid
+        self._call_sid = self._params.call_sid
+        self._auto_hang_up = self._params.auto_hang_up
+
+        self._acefone_sample_rate = self._params.acefone_sample_rate
+        self._sample_rate = 0  # Pipeline input rate; resolved in setup().
+
+        self._input_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._output_resampler = create_stream_resampler(
+            clear_after_secs=self._params.resampler_clear_after_secs
+        )
+        self._hangup_attempted = False
+
+    async def setup(self, frame: StartFrame):
+        """Set up the serializer with pipeline configuration.
+
+        Args:
+            frame: The `StartFrame` containing pipeline configuration.
+        """
+        self._sample_rate = self._params.sample_rate or frame.audio_in_sample_rate
+
+    async def serialize(self, frame: Frame) -> str | bytes | None:
+        """Serialize a Pipecat frame to an Acefone WebSocket message.
+
+        Handles conversion of the frame types relevant to the media stream:
+        `AudioRawFrame` becomes a ``media`` event, `InterruptionFrame` becomes a
+        ``clear`` event, and — when `auto_hang_up` is enabled — `EndFrame` and
+        `CancelFrame` become an ``end`` event that terminates the call.
+
+        Args:
+            frame: The Pipecat frame to serialize.
+
+        Returns:
+            The serialized message as a JSON string, or None if the frame isn't
+            handled.
+        """
+        if (
+            self._params.auto_hang_up
+            and not self._hangup_attempted
+            and isinstance(frame, (EndFrame, CancelFrame))
+        ):
+            # Hang up the call using the WebSocket "end" event.
+            self._hangup_attempted = True
+            answer = {"event": "end", "streamSid": self._stream_sid, "call_sid": self._call_sid}
+            return json.dumps(answer)
+        elif isinstance(frame, InterruptionFrame):
+            answer = {"event": "clear", "streamSid": self._stream_sid}
+            return json.dumps(answer)
+        elif isinstance(frame, AudioRawFrame):
+            data = frame.audio
+
+            # Output: convert the pipeline's PCM to Acefone's wire format at
+            # acefone_sample_rate — either resampled PCM or 8kHz μ-law.
+            if self._params.media_format == AcefoneMediaFormat.PCM:
+                serialized_data = await self._output_resampler.resample(
+                    data, frame.sample_rate, self._acefone_sample_rate
+                )
+            else:
+                serialized_data = await pcm_to_ulaw(
+                    data, frame.sample_rate, self._acefone_sample_rate, self._output_resampler
+                )
+            if serialized_data is None or len(serialized_data) == 0:
+                # Ignoring in case we don't have audio.
+                return None
+
+            payload = base64.b64encode(serialized_data).decode("utf-8")
+            answer: dict[str, Any] = {
+                "event": "media",
+                "streamSid": self._stream_sid,
+                "media": {"payload": payload},
+            }
+
+            return json.dumps(answer)
+        elif isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame)):
+            if self.should_ignore_frame(frame):
+                return None
+            return json.dumps(frame.message)
+
+        # Return None for unhandled frames.
+        return None
+
+    async def deserialize(self, data: str | bytes) -> Frame | None:
+        """Deserialize Acefone WebSocket data into a Pipecat frame.
+
+        Handles ``media`` events (audio), ``dtmf`` events (keypad input), and the
+        ``start`` event (captures the stream SID).
+
+        Args:
+            data: The raw WebSocket message from Acefone.
+
+        Returns:
+            The corresponding Pipecat frame, or None if the event isn't handled.
+        """
+        message = json.loads(data)
+
+        if message["event"] == "media":
+            payload_base64 = message["media"]["payload"]
+            payload = base64.b64decode(payload_base64)
+
+            # Input: convert Acefone's wire audio to PCM at the pipeline input
+            # rate — resample when it's already PCM, else decode 8kHz μ-law.
+            if self._params.media_format == AcefoneMediaFormat.PCM:
+                deserialized_data = await self._input_resampler.resample(
+                    payload, self._acefone_sample_rate, self._sample_rate
+                )
+            else:
+                deserialized_data = await ulaw_to_pcm(
+                    payload, self._acefone_sample_rate, self._sample_rate, self._input_resampler
+                )
+            if deserialized_data is None or len(deserialized_data) == 0:
+                # Ignoring in case we don't have audio.
+                return None
+
+            audio_frame = InputAudioRawFrame(
+                audio=deserialized_data, num_channels=1, sample_rate=self._sample_rate
+            )
+            return audio_frame
+        elif message["event"] == "dtmf":
+            digit = message.get("dtmf", {}).get("digit")
+
+            try:
+                return InputDTMFFrame(KeypadEntry(digit))
+            except ValueError:
+                # The digit doesn't match any known keypad entry.
+                logger.info(f"Invalid DTMF digit: {digit}")
+                return None
+        elif message["event"] == "start" and not self._stream_sid:
+            self._stream_sid = message["streamSid"]
+
+        return None

--- a/tests/test_acefone_serializer.py
+++ b/tests/test_acefone_serializer.py
@@ -1,0 +1,340 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the Acefone/Smartflo Media Streams serializer.
+
+Audio round-trips are made deterministic by keeping the wire sample rate equal
+to the pipeline sample rate, which makes the stream resampler an identity
+passthrough (no buffering latency).
+"""
+
+import base64
+import json
+
+import pytest
+
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    InputAudioRawFrame,
+    InputDTMFFrame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    OutputTransportMessageFrame,
+    StartFrame,
+    TextFrame,
+)
+from pipecat.serializers.acefone import AcefoneFrameSerializer, AcefoneMediaFormat
+
+# RTVI message label filtered out by the base serializer.
+RTVI_LABEL = "rtvi-ai"
+
+
+async def _make_serializer(
+    *,
+    media_format: AcefoneMediaFormat = AcefoneMediaFormat.ULAW,
+    wire_rate: int = 8000,
+    pipeline_rate: int = 8000,
+    **params,
+) -> AcefoneFrameSerializer:
+    """Build a serializer and run ``setup()`` so sample rates are resolved.
+
+    ``sample_rate`` is pinned to ``pipeline_rate`` so that, when it matches
+    ``wire_rate``, resampling is an identity passthrough.
+    """
+    serializer = AcefoneFrameSerializer(
+        AcefoneFrameSerializer.InputParams(
+            media_format=media_format,
+            acefone_sample_rate=wire_rate,
+            sample_rate=pipeline_rate,
+            **params,
+        )
+    )
+    await serializer.setup(
+        StartFrame(audio_in_sample_rate=pipeline_rate, audio_out_sample_rate=pipeline_rate)
+    )
+    return serializer
+
+
+class TestAcefoneFrameSerializer:
+    """Tests for AcefoneFrameSerializer."""
+
+    # ==================== Initialization Tests ====================
+
+    def test_create_serializer_default_params(self):
+        """Default params: μ-law wire format, 8kHz, no auto hang-up."""
+        serializer = AcefoneFrameSerializer()
+
+        assert serializer._params.media_format == AcefoneMediaFormat.ULAW
+        assert serializer._params.acefone_sample_rate == 8000
+        assert serializer._params.auto_hang_up is False
+        assert serializer._stream_sid is None
+        assert serializer._hangup_attempted is False
+        # BaseObject initialized (super().__init__ ran).
+        assert serializer.name.startswith("AcefoneFrameSerializer")
+
+    def test_create_serializer_with_custom_params(self):
+        """Custom params are stored on the serializer."""
+        params = AcefoneFrameSerializer.InputParams(
+            media_format=AcefoneMediaFormat.PCM,
+            acefone_sample_rate=16000,
+            stream_sid="MZstream",
+            call_sid="CAcall",
+            auto_hang_up=True,
+        )
+        serializer = AcefoneFrameSerializer(params)
+
+        assert serializer._params.media_format == AcefoneMediaFormat.PCM
+        assert serializer._stream_sid == "MZstream"
+        assert serializer._call_sid == "CAcall"
+        assert serializer._auto_hang_up is True
+
+    def test_media_format_enum_values(self):
+        """The wire-format enum exposes the provider's string codecs."""
+        assert AcefoneMediaFormat.ULAW.value == "ulaw"
+        assert AcefoneMediaFormat.PCM.value == "slin16"
+
+    # ==================== Setup Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_setup_uses_start_frame_rate(self):
+        """When sample_rate is 0, setup adopts the StartFrame's input rate."""
+        serializer = AcefoneFrameSerializer()  # sample_rate defaults to 0
+        await serializer.setup(StartFrame(audio_in_sample_rate=24000, audio_out_sample_rate=24000))
+        assert serializer._sample_rate == 24000
+
+    @pytest.mark.asyncio
+    async def test_setup_respects_sample_rate_override(self):
+        """An explicit sample_rate wins over the StartFrame's rate."""
+        serializer = AcefoneFrameSerializer(AcefoneFrameSerializer.InputParams(sample_rate=16000))
+        await serializer.setup(StartFrame(audio_in_sample_rate=8000, audio_out_sample_rate=8000))
+        assert serializer._sample_rate == 16000
+
+    # ==================== Serialize: Audio ====================
+
+    @pytest.mark.asyncio
+    async def test_serialize_ulaw_audio(self):
+        """Outbound audio is encoded to μ-law in a media event."""
+        serializer = await _make_serializer(stream_sid="MZstream")
+        pcm = bytes(320)  # 160 samples of 16-bit PCM
+
+        result = await serializer.serialize(
+            OutputAudioRawFrame(audio=pcm, sample_rate=8000, num_channels=1)
+        )
+
+        message = json.loads(result)
+        assert message["event"] == "media"
+        assert message["streamSid"] == "MZstream"
+        # μ-law is one byte per 16-bit sample.
+        decoded = base64.b64decode(message["media"]["payload"])
+        assert len(decoded) == len(pcm) // 2
+
+    @pytest.mark.asyncio
+    async def test_serialize_pcm_audio(self):
+        """Outbound audio in PCM mode is sent as raw PCM (identity at equal rate)."""
+        serializer = await _make_serializer(
+            media_format=AcefoneMediaFormat.PCM, wire_rate=16000, pipeline_rate=16000
+        )
+        pcm = bytes(range(0, 256)) * 2  # 512 bytes of PCM
+
+        result = await serializer.serialize(
+            OutputAudioRawFrame(audio=pcm, sample_rate=16000, num_channels=1)
+        )
+
+        message = json.loads(result)
+        assert message["event"] == "media"
+        assert base64.b64decode(message["media"]["payload"]) == pcm
+
+    @pytest.mark.asyncio
+    async def test_serialize_empty_audio_returns_none(self):
+        """Empty audio produces no media event."""
+        serializer = await _make_serializer()
+        result = await serializer.serialize(
+            OutputAudioRawFrame(audio=b"", sample_rate=8000, num_channels=1)
+        )
+        assert result is None
+
+    # ==================== Serialize: Control ====================
+
+    @pytest.mark.asyncio
+    async def test_serialize_interruption(self):
+        """An interruption maps to a clear event (barge-in)."""
+        serializer = await _make_serializer(stream_sid="MZstream")
+        result = await serializer.serialize(InterruptionFrame())
+        assert json.loads(result) == {"event": "clear", "streamSid": "MZstream"}
+
+    @pytest.mark.asyncio
+    async def test_serialize_end_frame_hangs_up_once(self):
+        """With auto_hang_up, an EndFrame emits an end event exactly once."""
+        serializer = await _make_serializer(
+            stream_sid="MZstream", call_sid="CAcall", auto_hang_up=True
+        )
+
+        result = await serializer.serialize(EndFrame())
+        assert json.loads(result) == {
+            "event": "end",
+            "streamSid": "MZstream",
+            "call_sid": "CAcall",
+        }
+        # A subsequent end/cancel does not emit a second hang-up.
+        assert await serializer.serialize(EndFrame()) is None
+
+    @pytest.mark.asyncio
+    async def test_serialize_cancel_frame_hangs_up(self):
+        """A CancelFrame also triggers the end event when auto_hang_up is set."""
+        serializer = await _make_serializer(
+            stream_sid="MZstream", call_sid="CAcall", auto_hang_up=True
+        )
+        result = await serializer.serialize(CancelFrame())
+        assert json.loads(result)["event"] == "end"
+
+    @pytest.mark.asyncio
+    async def test_serialize_end_frame_without_auto_hangup(self):
+        """Without auto_hang_up, an EndFrame is not turned into an end event."""
+        serializer = await _make_serializer(stream_sid="MZstream", auto_hang_up=False)
+        assert await serializer.serialize(EndFrame()) is None
+
+    @pytest.mark.asyncio
+    async def test_serialize_transport_message(self):
+        """Transport messages are forwarded as their raw JSON payload."""
+        serializer = await _make_serializer()
+        frame = OutputTransportMessageFrame(message={"event": "custom", "data": 1})
+        result = await serializer.serialize(frame)
+        assert json.loads(result) == {"event": "custom", "data": 1}
+
+    @pytest.mark.asyncio
+    async def test_serialize_rtvi_message_ignored(self):
+        """RTVI messages are filtered out by the base serializer."""
+        serializer = await _make_serializer()
+        frame = OutputTransportMessageFrame(message={"label": RTVI_LABEL, "type": "x"})
+        assert await serializer.serialize(frame) is None
+
+    @pytest.mark.asyncio
+    async def test_serialize_unhandled_frame_returns_none(self):
+        """Frames the serializer doesn't handle yield None."""
+        serializer = await _make_serializer()
+        assert await serializer.serialize(TextFrame("hello")) is None
+
+    # ==================== Deserialize: Audio ====================
+
+    @pytest.mark.asyncio
+    async def test_deserialize_ulaw_media(self):
+        """Inbound μ-law media becomes a PCM InputAudioRawFrame."""
+        serializer = await _make_serializer()
+        ulaw = bytes(range(0, 160))
+        message = json.dumps(
+            {"event": "media", "media": {"payload": base64.b64encode(ulaw).decode()}}
+        )
+
+        frame = await serializer.deserialize(message)
+
+        assert isinstance(frame, InputAudioRawFrame)
+        assert frame.sample_rate == 8000
+        assert frame.num_channels == 1
+        # μ-law decodes to 16-bit PCM: two bytes per input byte.
+        assert len(frame.audio) == len(ulaw) * 2
+
+    @pytest.mark.asyncio
+    async def test_deserialize_pcm_media(self):
+        """Inbound PCM media is passed through (identity at equal rate)."""
+        serializer = await _make_serializer(
+            media_format=AcefoneMediaFormat.PCM, wire_rate=16000, pipeline_rate=16000
+        )
+        pcm = bytes(range(0, 200)) * 2
+        message = json.dumps(
+            {"event": "media", "media": {"payload": base64.b64encode(pcm).decode()}}
+        )
+
+        frame = await serializer.deserialize(message)
+
+        assert isinstance(frame, InputAudioRawFrame)
+        assert frame.audio == pcm
+        assert frame.sample_rate == 16000
+
+    @pytest.mark.asyncio
+    async def test_deserialize_empty_media_returns_none(self):
+        """A media event carrying no audio yields no frame."""
+        serializer = await _make_serializer()
+        message = json.dumps({"event": "media", "media": {"payload": ""}})
+        assert await serializer.deserialize(message) is None
+
+    # ==================== Deserialize: DTMF ====================
+
+    @pytest.mark.asyncio
+    async def test_deserialize_dtmf_digit(self):
+        """A DTMF event becomes an InputDTMFFrame."""
+        serializer = await _make_serializer()
+        message = json.dumps({"event": "dtmf", "dtmf": {"digit": "5"}})
+
+        frame = await serializer.deserialize(message)
+
+        assert isinstance(frame, InputDTMFFrame)
+        assert frame.button.value == "5"
+
+    @pytest.mark.asyncio
+    async def test_deserialize_dtmf_invalid_digit_returns_none(self):
+        """An unrecognized DTMF digit is dropped."""
+        serializer = await _make_serializer()
+        message = json.dumps({"event": "dtmf", "dtmf": {"digit": "X"}})
+        assert await serializer.deserialize(message) is None
+
+    # ==================== Deserialize: Lifecycle ====================
+
+    @pytest.mark.asyncio
+    async def test_deserialize_start_captures_stream_sid(self):
+        """A start event captures the stream SID when one isn't set."""
+        serializer = await _make_serializer()
+        assert serializer._stream_sid is None
+
+        result = await serializer.deserialize(
+            json.dumps({"event": "start", "streamSid": "MZfromstart"})
+        )
+
+        assert result is None
+        assert serializer._stream_sid == "MZfromstart"
+
+    @pytest.mark.asyncio
+    async def test_deserialize_start_does_not_overwrite_stream_sid(self):
+        """A start event does not clobber an already-configured stream SID."""
+        serializer = await _make_serializer(stream_sid="MZconfigured")
+
+        await serializer.deserialize(json.dumps({"event": "start", "streamSid": "MZfromstart"}))
+
+        assert serializer._stream_sid == "MZconfigured"
+
+    @pytest.mark.asyncio
+    async def test_deserialize_unknown_event_returns_none(self):
+        """Unknown events are ignored."""
+        serializer = await _make_serializer()
+        assert await serializer.deserialize(json.dumps({"event": "mark"})) is None
+
+    # ==================== Round Trip ====================
+
+    @pytest.mark.asyncio
+    async def test_pcm_round_trip(self):
+        """PCM audio survives serialize -> deserialize unchanged at equal rates."""
+        serializer = await _make_serializer(
+            media_format=AcefoneMediaFormat.PCM,
+            wire_rate=16000,
+            pipeline_rate=16000,
+            stream_sid="MZstream",
+        )
+        pcm = bytes(range(0, 256)) * 4
+
+        serialized = await serializer.serialize(
+            OutputAudioRawFrame(audio=pcm, sample_rate=16000, num_channels=1)
+        )
+        payload = json.loads(serialized)["media"]["payload"]
+        frame = await serializer.deserialize(
+            json.dumps({"event": "media", "media": {"payload": payload}})
+        )
+
+        assert isinstance(frame, InputAudioRawFrame)
+        assert frame.audio == pcm
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds `AcefoneFrameSerializer` — a `FrameSerializer` for the **Acefone / Smartflo** (Tata Tele Business Services) bidirectional audio-streaming WebSocket protocol, letting Pipecat bots run over Acefone/Smartflo telephony calls.

- **Bidirectional audio** — 8kHz μ-law (default) or 16-bit linear PCM, selectable via `AcefoneMediaFormat`. Inbound audio is normalized to PCM `InputAudioRawFrame` for the pipeline regardless of wire format.
- **DTMF** keypad input → `InputDTMFFrame`.
- **Interruptions** → `clear` event (barge-in).
- **Optional auto hang-up** — emits an `end` event over the same WebSocket on `EndFrame`/`CancelFrame`. No REST credentials required, unlike Twilio.
- Captures `streamSid` from the incoming `start` event when not supplied.

Follows existing telephony-serializer conventions (Twilio / Telnyx / Genesys): shared `create_stream_resampler` + `pcm_to_ulaw`/`ulaw_to_pcm` helpers, `StrEnum` media format (as in Genesys), and RTVI message filtering via the base class.

Protocol reference:
- https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document
- https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document

## Usage

```python
from pipecat.serializers.acefone import AcefoneFrameSerializer, AcefoneMediaFormat

serializer = AcefoneFrameSerializer(
    AcefoneFrameSerializer.InputParams(
        call_sid=call_sid,              # required when auto_hang_up=True
        auto_hang_up=True,
        media_format=AcefoneMediaFormat.ULAW,   # or AcefoneMediaFormat.PCM (slin16)
    )
)
# pass to a WebSocket transport via serializer=serializer
```

## Testing

- `tests/test_acefone_serializer.py` — 24 unit tests covering init/setup, serialize (μ-law + PCM audio, interruption, auto hang-up dedup, transport/RTVI message filtering), deserialize (μ-law + PCM media, DTMF valid/invalid, `start` SID capture, unknown events), and a PCM round-trip. Run: `uv run pytest tests/test_acefone_serializer.py`.
- `uv run ruff check` and `uv run ruff format --check` pass.

No breaking changes — new module + tests only.
