### PR TITLE
Fix word completion tracker stalling on space-before-punctuation

### DIFF
--- a/src/pipecat/utils/context/word_completion_tracker.py
+++ b/src/pipecat/utils/context/word_completion_tracker.py
@@ -274,6 +274,19 @@ class WordCompletionTracker:
         if chars_for_frame > 0:
             self._llm_pos = self._segment_map.llm_pos
 
+        # On completion, snap the tts/user-facing cursors to end-of-text. The
+        # frame's final word may be separated from its terminal punctuation by a
+        # space -- French typography puts one before ? ! : ; ("Comment ça va ?").
+        # advance_by_alnums stops at that space, so the cursor otherwise stalls
+        # just before the punctuation: get_remaining_user_facing_text() never
+        # empties and the segment reports "in-progress" forever, dropping it on
+        # RTVI clients that commit text on the "completed" status. Mirrors the
+        # llm_pos sweep-to-end below; only trailing non-alnum remains once every
+        # expected alnum char has been consumed.
+        if self.is_complete:
+            self._tts_pos = len(self._tts_text)
+            self._user_facing_pos = len(self._user_facing_text)
+
         if self._llm_text is not None:
             if self.is_complete:
                 # Final word: sweep all remaining llm_text from prev_llm_pos so

--- a/tests/test_word_completion_tracker.py
+++ b/tests/test_word_completion_tracker.py
@@ -1960,5 +1960,57 @@ class TestWordCompletionTrackerTransformAtEndOfUtterance(unittest.TestCase):
         self.assertTrue(tracker.is_complete)
 
 
+class TestWordCompletionTrackerSpaceBeforePunctuation(unittest.TestCase):
+    """Typography that separates a word from its terminal punctuation by a space.
+
+    French (and other locales) put a space before ``?`` ``!`` ``:`` ``;`` --
+    e.g. "Comment ça va ?". advance_by_alnums stops at that space, so once the
+    final alnum word is spoken the cursor must still be snapped to end-of-text:
+    otherwise the remaining text never empties, the segment stays "in-progress"
+    forever, and RTVI clients that commit captions on the "completed" status
+    drop the sentence when the next one begins.
+    """
+
+    def test_question_mark_completes_and_empties_remaining(self):
+        tracker = WordCompletionTracker("Comment ça va ?")
+        tracker.add_word_and_check_complete("Comment")
+        tracker.add_word_and_check_complete("ça")
+        self.assertTrue(tracker.add_word_and_check_complete("va"))
+        self.assertEqual(tracker.get_remaining_user_facing_text(strip=False), "")
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), "Comment ça va ?")
+
+    def test_exclamation_mark_completes_and_empties_remaining(self):
+        tracker = WordCompletionTracker("Bonjour !")
+        self.assertTrue(tracker.add_word_and_check_complete("Bonjour"))
+        self.assertEqual(tracker.get_remaining_user_facing_text(strip=False), "")
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), "Bonjour !")
+
+    def test_no_break_space_before_question_mark(self):
+        tracker = WordCompletionTracker("Ça va ?")
+        tracker.add_word_and_check_complete("Ça")
+        self.assertTrue(tracker.add_word_and_check_complete("va"))
+        self.assertEqual(tracker.get_remaining_user_facing_text(strip=False), "")
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), "Ça va ?")
+
+    def test_user_facing_text_carries_trailing_mark(self):
+        tracker = WordCompletionTracker(
+            "Comment ça va ?",
+            user_facing_text="Comment ça va ?",
+        )
+        tracker.add_word_and_check_complete("Comment")
+        tracker.add_word_and_check_complete("ça")
+        self.assertTrue(tracker.add_word_and_check_complete("va"))
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), "Comment ça va ?")
+
+    def test_english_trailing_punctuation_unchanged(self):
+        """The no-space English case still completes exactly as before."""
+        tracker = WordCompletionTracker("How are you?")
+        tracker.add_word_and_check_complete("How")
+        tracker.add_word_and_check_complete("are")
+        self.assertTrue(tracker.add_word_and_check_complete("you"))
+        self.assertEqual(tracker.get_remaining_user_facing_text(strip=False), "")
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), "How are you?")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
French (and similar) typography puts a space before `?` `!` `:` `;`, e.g. "Comment ça va ?". `advance_by_alnums` stops at that space, so once the last word is spoken the cursor stalls just before the punctuation: the frame never reports complete and RTVI clients that commit on the completed status drop the caption.

Snap the tts/user-facing cursors to end-of-text on completion, mirroring the existing llm_pos sweep. Only trailing non-alnum can remain at that point.

Without this, the sentence stays stuck as in-progress and is dropped once the next one starts, instead of committing as a finished caption.
