### PR TITLE
Allow direct image uploads for lemonslice avatars

### DIFF
--- a/changelog/4977.added.md
+++ b/changelog/4977.added.md
@@ -1,0 +1,1 @@
+- Added the ability for users to provide a local image to the LemonSlice transport to be used as the avatar image.

--- a/src/pipecat/transports/lemonslice/api.py
+++ b/src/pipecat/transports/lemonslice/api.py
@@ -64,7 +64,7 @@ class LemonSliceApi:
             daily_room_url: Daily room URL to use for the session.
             daily_token: Daily token for authenticating with the room.
             connection_properties: Additional connection properties to pass to the session.
-            extra_properties: Additional top-level keys to merge into the payload.
+            extra_properties: Additional properties to pass to the session.
             api_url: LemonSlice API URL override.
 
         Returns:
@@ -80,9 +80,7 @@ class LemonSliceApi:
         if len(given_sources) == 0:
             raise ValueError("Provide exactly one of agent_id, agent_image_url, or agent_image")
         if len(given_sources) > 1:
-            raise ValueError(
-                "Provide exactly one of agent_id, agent_image_url, or agent_image, not multiple"
-            )
+            raise ValueError("Provide exactly one of agent_id, agent_image_url, or agent_image")
 
         logger.debug(
             f"Creating LemonSlice session: agent_id={agent_id}, "

--- a/src/pipecat/transports/lemonslice/api.py
+++ b/src/pipecat/transports/lemonslice/api.py
@@ -10,10 +10,13 @@ This module provides helper classes for interacting with the LemonSlice API,
 including session creation and termination.
 """
 
+import io
+import json
 from typing import Any
 
 import aiohttp
 from loguru import logger
+from PIL import Image
 
 
 class LemonSliceApi:
@@ -40,6 +43,7 @@ class LemonSliceApi:
         *,
         agent_image_url: str | None = None,
         agent_id: str | None = None,
+        agent_image: Image.Image | None = None,
         agent_prompt: str | None = None,
         idle_timeout: int | None = None,
         daily_room_url: str | None = None,
@@ -48,32 +52,41 @@ class LemonSliceApi:
         extra_properties: dict[str, Any] | None = None,
         api_url: str | None = None,
     ) -> dict:
-        """Create a new session with the specified agent_id or agent_image_url.
+        """Create a new session with the specified agent_id, agent_image_url, or agent_image.
 
         Args:
-            agent_image_url: The URL to an agent image. Provide either agent_id or agent_image_url.
-            agent_id: ID of a LemonSlice agent. Provide either agent_id or agent_image_url.
-            agent_prompt: A high-level system prompt that subtly influences the avatar’s movements, expressions, and emotional demeanor.
+            agent_image_url: URL to an agent image.
+            agent_id: ID of a LemonSlice agent.
+            agent_image: PIL image of the agent.
+            agent_prompt: A high-level system prompt that subtly influences the avatar's
+                movements, expressions, and emotional demeanor.
             idle_timeout: Idle timeout in seconds.
             daily_room_url: Daily room URL to use for the session.
             daily_token: Daily token for authenticating with the room.
             connection_properties: Additional connection properties to pass to the session.
-            extra_properties: Additional properties to pass to the session.
+            extra_properties: Additional top-level keys to merge into the payload.
             api_url: LemonSlice API URL override.
 
         Returns:
             Dictionary containing session_id, room_url, and control_url.
 
         Raises:
-            ValueError: If neither agent_id nor agent_image_url is provided.
+            ValueError: If zero or more than one of agent_id, agent_image_url, or agent_image
+                is provided.
         """
-        if not agent_id and not agent_image_url:
-            raise ValueError("Provide an agent_id or agent_image_url")
-        if agent_id and agent_image_url:
-            raise ValueError("Provide exactly one of agent_id or agent_image_url, not both")
+        given_sources = [
+            source for source in (agent_id, agent_image_url, agent_image) if source is not None
+        ]
+        if len(given_sources) == 0:
+            raise ValueError("Provide exactly one of agent_id, agent_image_url, or agent_image")
+        if len(given_sources) > 1:
+            raise ValueError(
+                "Provide exactly one of agent_id, agent_image_url, or agent_image, not multiple"
+            )
 
         logger.debug(
-            f"Creating LemonSlice session: agent_id={agent_id}, agent_image_url={agent_image_url}"
+            f"Creating LemonSlice session: agent_id={agent_id}, "
+            f"agent_image_url={agent_image_url}, agent_image={'set' if agent_image else None}"
         )
         payload: dict[str, Any] = {"transport_type": "daily"}
         if agent_id is not None:
@@ -95,12 +108,51 @@ class LemonSliceApi:
             payload["properties"] = properties_dict
         if extra_properties:
             payload.update(extra_properties)
+
+        image_bytes: bytes | None = None
+        if agent_image is not None:
+            image_bytes = _encode_image(agent_image)
+
         url = api_url if api_url is not None else self.LEMONSLICE_URL
-        async with self._session.post(url, headers=self._headers, json=payload) as r:
+        response = await self._post(url, payload, image_bytes=image_bytes)
+        logger.debug(f"Created LemonSlice session: {response}")
+        return response
+
+    async def _post(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        *,
+        image_bytes: bytes | None = None,
+    ) -> dict:
+        """POST to the LemonSlice API as JSON or multipart form data.
+
+        Args:
+            url: Request URL.
+            payload: JSON payload for the session request.
+            image_bytes: Optional PNG-encoded image.
+
+        Returns:
+            Parsed JSON response body.
+        """
+        headers = {"x-api-key": self._api_key}
+        if image_bytes is not None:
+            form = aiohttp.FormData()
+            form.add_field("payload", json.dumps(payload), content_type="application/json")
+            form.add_field(
+                "image",
+                image_bytes,
+                filename="image.png",
+                content_type="image/png",
+            )
+            async with self._session.post(url, headers=headers, data=form) as r:
+                r.raise_for_status()
+                return await r.json()
+
+        headers["Content-Type"] = "application/json"
+        async with self._session.post(url, headers=headers, json=payload) as r:
             r.raise_for_status()
-            response = await r.json()
-            logger.debug(f"Created LemonSlice session: {response}")
-            return response
+            return await r.json()
 
     async def end_session(self, session_id: str, control_url: str):
         """End an existing session.
@@ -113,3 +165,10 @@ class LemonSliceApi:
         async with self._session.post(control_url, headers=self._headers, json=payload) as r:
             r.raise_for_status()
             logger.debug(f"Ended LemonSlice session {session_id}")
+
+
+def _encode_image(image: Image.Image) -> bytes:
+    """Encode a PIL image as PNG bytes for a multipart upload."""
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()

--- a/src/pipecat/transports/lemonslice/transport.py
+++ b/src/pipecat/transports/lemonslice/transport.py
@@ -17,7 +17,8 @@ from typing import Any
 import aiohttp
 from daily.daily import AudioData
 from loguru import logger
-from pydantic import BaseModel, ConfigDict
+from PIL import Image
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
@@ -48,8 +49,12 @@ class LemonSliceNewSessionRequest(BaseModel):
     """Request model for creating a new LemonSlice session.
 
     Parameters:
-        agent_image_url: URL to an agent image. Provide either agent_id or agent_image_url.
-        agent_id: ID of a LemonSlice agent. Provide either agent_id or agent_image_url.
+        agent_image_url: URL to an agent image. Provide exactly one of ``agent_image_url``,
+            ``agent_id``, or ``agent_image``.
+        agent_id: ID of a LemonSlice agent. Provide exactly one of ``agent_image_url``,
+            ``agent_id``, or ``agent_image``.
+        agent_image: PIL image uploaded as the agent image. Provide exactly one of
+            ``agent_image_url``, ``agent_id``, or ``agent_image``.
         agent_prompt: A high-level system prompt that subtly influences the avatar's movements,
             expressions, and emotional demeanor.
         idle_timeout: Idle timeout in seconds.
@@ -59,16 +64,33 @@ class LemonSliceNewSessionRequest(BaseModel):
         api_url: Override the LemonSlice API URL.
     """
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
     agent_image_url: str | None = None
     agent_id: str | None = None
+    agent_image: Image.Image | None = None
     agent_prompt: str | None = None
     idle_timeout: int | None = None
     daily_room_url: str | None = None
     daily_token: str | None = None
     lemonslice_properties: dict | None = None
     api_url: str | None = None
+
+    @model_validator(mode="after")
+    def validate_agent_source(self) -> "LemonSliceNewSessionRequest":
+        """Ensure exactly one agent source is provided."""
+        given = [
+            source
+            for source in (self.agent_id, self.agent_image_url, self.agent_image)
+            if source is not None
+        ]
+        if len(given) == 0:
+            raise ValueError("Provide exactly one of agent_id, agent_image_url, or agent_image")
+        if len(given) > 1:
+            raise ValueError(
+                "Provide exactly one of agent_id, agent_image_url, or agent_image, not multiple"
+            )
+        return self
 
 
 class LemonSliceCallbacks(BaseModel):
@@ -125,13 +147,17 @@ class LemonSliceTransportClient:
             params: Optional parameters for LemonSlice operation.
             callbacks: Callback handlers for LemonSlice-related events.
             api_key: API key for authenticating with LemonSlice API.
-            session_request: Optional session creation parameters. If not provided, a default
-                agent will be used.
+            session_request: Session creation parameters.
             session: The aiohttp session for making async HTTP requests.
         """
         self._bot_name = bot_name
         self._api = LemonSliceApi(api_key, session)
-        self._session_request = session_request or LemonSliceNewSessionRequest()
+        if session_request is None:
+            raise ValueError(
+                "session_request is required; provide exactly one of agent_id, "
+                "agent_image_url, or agent_image"
+            )
+        self._session_request = session_request
         self._session_id: str | None = None
         self._control_url: str | None = None
         self._daily_transport_client: DailyTransportClient | None = None
@@ -145,6 +171,7 @@ class LemonSliceTransportClient:
         response = await self._api.create_session(
             agent_image_url=self._session_request.agent_image_url,
             agent_id=self._session_request.agent_id,
+            agent_image=self._session_request.agent_image,
             agent_prompt=self._session_request.agent_prompt,
             idle_timeout=self._session_request.idle_timeout,
             daily_room_url=self._session_request.daily_room_url,
@@ -712,8 +739,8 @@ class LemonSliceTransport(BaseTransport):
             bot_name: The name of the Pipecat bot.
             session: aiohttp session used for async HTTP requests.
             api_key: LemonSlice API key for authentication.
-            session_request: Optional session creation parameters. If not provided, a default
-                agent will be used.
+            session_request: Session creation parameters. Exactly one of agent_id,
+                agent_image_url, or agent_image must be provided.
             params: Optional LemonSlice-specific configuration parameters.
             input_name: Optional name for the input transport.
             output_name: Optional name for the output transport.


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
Adds the ability for users to provide provide a local image to the LemonSlice api to be used as the avatar image.