### PR TITLE
fix(flows): skip LLM run when setting a node on an inactive worker

### DIFF
--- a/changelog/4980.added.md
+++ b/changelog/4980.added.md
@@ -1,0 +1,4 @@
+Added `absent: true` to eval scenario expectations: the expectation passes only
+when no event of the given type arrives within the `within_ms` budget, and
+fails as soon as one does. Useful for duplicate-output regressions, e.g.
+asserting a bot responds exactly once after a multi-worker handoff.

--- a/changelog/4980.fixed.md
+++ b/changelog/4980.fixed.md
@@ -1,0 +1,5 @@
+Fixed duplicate assistant responses after a multi-worker handoff: `FlowManager`
+no longer triggers an LLM completion when setting a node on a worker that was
+just deactivated via `activate_worker(deactivate_self=True)`. The deactivated
+worker's node change still updates context; only the newly activated worker
+responds.

--- a/changelog/4980.fixed.md
+++ b/changelog/4980.fixed.md
@@ -1,5 +1,11 @@
-Fixed duplicate assistant responses after a multi-worker handoff: `FlowManager`
-no longer triggers an LLM completion when setting a node on a worker that was
-just deactivated via `activate_worker(deactivate_self=True)`. The deactivated
-worker's node change still updates context; only the newly activated worker
-responds.
+Fixed multi-worker handoff bugs in `FlowManager` when setting a node on a
+worker that was just deactivated via `activate_worker(deactivate_self=True)`:
+
+- No LLM completion is triggered on the deactivated worker, which previously
+  produced duplicate assistant responses.
+- The deactivated worker no longer writes its node's tools and messages into
+  the shared context. Those directly queued frames bypass the bus activation
+  gate and race with the newly activated worker's activation frames; when they
+  landed last they clobbered the active worker's tool list (e.g. removing its
+  transfer function, so control could never return). The node's messages and
+  tools are applied when the worker sets a node again on reactivation.

--- a/examples/flows/multi_worker_handoff.py
+++ b/examples/flows/multi_worker_handoff.py
@@ -176,7 +176,10 @@ def build_reservation_worker(
             name="party_size",
             role_message=(
                 "You are a reservation assistant for La Maison, an upscale French "
-                "restaurant. Be casual and friendly. This is a voice conversation, "
+                "restaurant. Your only job is collecting reservation details. If "
+                "the user asks about anything else (weather, menu, general "
+                "questions), call the transfer_to_router tool instead of answering "
+                "yourself. Be casual and friendly. This is a voice conversation, "
                 "so avoid special characters and emojis."
             ),
             task_messages=[
@@ -288,7 +291,18 @@ def build_reservation_worker(
         await worker.activate_worker(
             ROUTER_NAME,
             args=LLMWorkerActivationArgs(
-                messages=[{"role": "developer", "content": reason}],
+                messages=[
+                    {
+                        "role": "developer",
+                        "content": (
+                            f"{reason}. Address this, then offer to continue. If the "
+                            "user returns to their reservation (for example by asking "
+                            "to continue booking or answering a booking question), "
+                            "call the transfer_to_reservation tool instead of "
+                            "collecting reservation details yourself."
+                        ),
+                    }
+                ],
             ),
             deactivate_self=True,
         )

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -302,11 +302,3 @@ suite:
   - bot: flows/llm_switching.py
     scenarios: [llm_switching]
 
-  #
-  # Realtime: speech-to-speech services (examples/realtime/). Audio-mode
-  # scenarios; the service's own turn detection is part of what's under test.
-  #
-  # Gemini Live server-driven turns + supplemental local Silero VAD (the RTVI
-  # mix). Asserts one response per turn and no stalled/dropped follow-up turn.
-  - bot: realtime/realtime-gemini-live-supplemental-vad.py
-    scenarios: [gemini_vad_coexistence]

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -290,7 +290,7 @@ suite:
   - bot: flows/food_ordering_advanced_functionschema.py
     scenarios: [food_ordering_sushi]
   - bot: flows/multi_worker_handoff.py
-    scenarios: [multi_worker_handoff]
+    scenarios: [multi_worker_handoff, multi_worker_handoff_no_duplicate]
   - bot: flows/patient_intake.py
     scenarios: [patient_intake]
   - bot: flows/restaurant_reservation.py
@@ -301,3 +301,12 @@ suite:
   # three API keys must be set.
   - bot: flows/llm_switching.py
     scenarios: [llm_switching]
+
+  #
+  # Realtime: speech-to-speech services (examples/realtime/). Audio-mode
+  # scenarios; the service's own turn detection is part of what's under test.
+  #
+  # Gemini Live server-driven turns + supplemental local Silero VAD (the RTVI
+  # mix). Asserts one response per turn and no stalled/dropped follow-up turn.
+  - bot: realtime/realtime-gemini-live-supplemental-vad.py
+    scenarios: [gemini_vad_coexistence]

--- a/scripts/release-evals/scenarios/multi_worker_handoff_no_duplicate.yaml
+++ b/scripts/release-evals/scenarios/multi_worker_handoff_no_duplicate.yaml
@@ -50,3 +50,16 @@ turns:
       - event: response
         absent: true
         within_ms: 40000
+
+  # Regression for the follow-up bug (same PR): the deactivated reservation
+  # worker's deferred node change used to write its node's tools into the
+  # shared context, removing transfer_to_reservation from the router's tool
+  # list. Returning to the booking then never handed control back to the
+  # reservation worker.
+  - user: "Okay, back to my booking. Six PM, please."
+    expect:
+      - event: function_call
+        calls:
+          - name: transfer_to_reservation
+      - event: response
+        eval: "the bot continues the reservation, for example by asking or confirming the party size or the time"

--- a/scripts/release-evals/scenarios/multi_worker_handoff_no_duplicate.yaml
+++ b/scripts/release-evals/scenarios/multi_worker_handoff_no_duplicate.yaml
@@ -1,0 +1,52 @@
+# Regression eval for https://github.com/pipecat-ai/pipecat/issues/4979.
+#
+# When the reservation worker hands back to the router (transfer_to_router),
+# only the newly activated router may respond. Before the fix, FlowManager
+# also queued a completion on the just-deactivated reservation worker (its
+# returned next node has respond_immediately=True and directly queued frames
+# bypass the bus activation gate), so the bot answered twice, back to back,
+# with near-identical content. The final `absent: true` expectation fails if
+# any second response arrives after the router's answer.
+#
+# Audio mode on purpose: text mode's send-text path currently double-runs
+# bridged workers in this multi-worker bot (a separate issue), which would
+# trip the absence check for the wrong reason.
+name: multi_worker_handoff_no_duplicate
+
+user: !include user_audio.yaml
+judge: !include judge_audio.yaml
+
+turns:
+  - expect:
+      - event: response
+        eval: "the bot greets the user and offers to answer questions or book a table"
+
+  - user: "I'd like to book a table."
+    expect:
+      - event: function_call
+        calls:
+          - name: transfer_to_reservation
+      - event: response
+        eval: "the bot asks how many people are in their party"
+
+  - user: "There will be five of us."
+    expect:
+      - event: function_call
+        calls:
+          - name: collect_party_size
+            args: { size: 5 }
+      - event: response
+        eval: "the bot asks what time they would like to dine"
+
+  # The off-topic question makes the reservation worker hand back to the
+  # router. Exactly one response may follow: the router's.
+  - user: "Before that, can you tell me the weather in Paris?"
+    expect:
+      - event: function_call
+        calls:
+          - name: transfer_to_router
+      - event: response
+        eval: "the bot deflects or declines the weather question and offers to continue helping"
+      - event: response
+        absent: true
+        within_ms: 40000

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -1142,6 +1142,9 @@ class EvalSession:
         deadline = anchor + (budget_ms / 1000.0)
         self._last_match_text = ""
 
+        if expectation.absent:
+            return await self._match_absent(expectation, deadline, budget_ms, turn_idx, exp_idx)
+
         aggregates = expectation.event in ("response", "llm_response", "tts_response") and (
             expectation.text_contains is not None or expectation.eval is not None
         )
@@ -1207,6 +1210,38 @@ class EvalSession:
             # sentences don't run together (e.g. "...that. The weather...").
             aggregate += " "
             last_reason = reason
+
+    async def _match_absent(
+        self,
+        expectation: EvalExpectation,
+        deadline: float,
+        budget_ms: int,
+        turn_idx: int,
+        exp_idx: int,
+    ) -> EvalAssertionFailure | None:
+        """Inverted match: pass when NO event of this type arrives before the deadline.
+
+        The budget is the whole point here — the expectation holds the turn open
+        for ``within_ms`` and succeeds only if the event type stays absent for
+        that entire window. An arriving event fails immediately with its content
+        in the reason, so a duplicate-output regression shows what the bot said.
+        """
+        self._debug(f"match: expecting NO {expectation.event!r} for {budget_ms}ms")
+        try:
+            event = await self._next_matching_event(expectation.event, deadline)
+        except TimeoutError:
+            # The quiet window held: absence confirmed.
+            self._last_match_text = f"no {expectation.event!r} for {budget_ms}ms"
+            return None
+        return EvalAssertionFailure(
+            turn_index=turn_idx,
+            expectation_index=exp_idx,
+            event_name=expectation.event,
+            reason=(
+                f"expected no {expectation.event!r} within {budget_ms}ms, "
+                f"but one arrived: {self._match_summary(event)}"
+            ),
+        )
 
     async def _next_matching_event(self, event_type: str, deadline: float) -> dict:
         """Pop events from the queue until one of ``event_type`` arrives.

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -682,7 +682,7 @@ def _parse_expectation(e: Any, path: Path, turn_idx: int, exp_idx: int) -> EvalE
         # An absent expectation matches on event type only: content and call
         # checks describe an event that must arrive, which contradicts absence.
         conflicting = [
-            key for key in ("text_contains", "eval", "calls", "name", "args") if e.get(key)
+            key for key in ("text_contains", "eval", "calls", "name", "args") if key in e
         ]
         if conflicting:
             raise ValueError(

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -57,6 +57,20 @@ Supported expectation fields (per event):
                                must satisfy, evaluated by a judge LLM (see
                                :mod:`pipecat.evals.judge`).
 
+    absent: true               invert the expectation: assert that NO event of
+                               this type arrives before the ``within_ms`` budget
+                               expires (default 60s — set ``within_ms`` explicitly
+                               to keep the quiet-window wait short). Matches on
+                               event type only, so it cannot be combined with
+                               ``text_contains``, ``eval:``, or ``calls:``. Used
+                               for duplicate-output regressions::
+
+                                   - event: response
+                                     eval: "answers the question"
+                                   - event: response
+                                     absent: true
+                                     within_ms: 30000
+
 Instead of ``user:``, a turn may press DTMF keys with ``dtmf:`` (the two are
 mutually exclusive — you press keys or you talk)::
 
@@ -211,6 +225,11 @@ class EvalExpectation:
             must satisfy. Evaluated by a judge LLM. Only meaningful on the
             bot-generated text events: ``response``, ``llm_response``, and
             ``tts_response``.
+        absent: When True, the expectation is inverted: it passes only when NO
+            event of this type arrives before the ``within_ms`` budget expires,
+            and fails as soon as one does. Matches on event type only;
+            ``text_contains``, ``eval``, and ``calls`` are not allowed alongside
+            it.
     """
 
     event: str
@@ -218,6 +237,7 @@ class EvalExpectation:
     text_contains: str | None = None
     calls: list[EvalFunctionCall] | None = None
     eval: str | None = None
+    absent: bool = False
 
 
 @dataclass
@@ -653,7 +673,24 @@ def _parse_expectation(e: Any, path: Path, turn_idx: int, exp_idx: int) -> EvalE
             "unlikely to be meaningful."
         )
 
-    calls = _parse_function_calls(e, event, path, turn_idx, exp_idx)
+    absent = e.get("absent", False)
+    if not isinstance(absent, bool):
+        raise ValueError(
+            f"{path}: turn #{turn_idx} expectation #{exp_idx} 'absent:' must be a boolean"
+        )
+    if absent:
+        # An absent expectation matches on event type only: content and call
+        # checks describe an event that must arrive, which contradicts absence.
+        conflicting = [
+            key for key in ("text_contains", "eval", "calls", "name", "args") if e.get(key)
+        ]
+        if conflicting:
+            raise ValueError(
+                f"{path}: turn #{turn_idx} expectation #{exp_idx} 'absent: true' "
+                f"cannot be combined with {', '.join(repr(k) for k in conflicting)}"
+            )
+
+    calls = _parse_function_calls(e, event, path, turn_idx, exp_idx) if not absent else None
 
     return EvalExpectation(
         event=event,
@@ -661,6 +698,7 @@ def _parse_expectation(e: Any, path: Path, turn_idx: int, exp_idx: int) -> EvalE
         text_contains=e.get("text_contains"),
         calls=calls,
         eval=criterion,
+        absent=absent,
     )
 
 

--- a/src/pipecat/flows/manager.py
+++ b/src/pipecat/flows/manager.py
@@ -593,6 +593,13 @@ class FlowManager:
 
         Used to manually transition between nodes in a flow.
 
+        If the manager's worker is inactive (e.g. it just handed off via
+        ``activate_worker(deactivate_self=True)``), only internal state is
+        updated: no context update and no completion reach the shared
+        context. Call ``set_node_from_config()`` again on reactivation
+        (typically from ``on_activated``) to apply the node's messages and
+        tools; see ``examples/flows/multi_worker_handoff.py``.
+
         Args:
             node_config: Configuration for the new node.
 
@@ -609,10 +616,18 @@ class FlowManager:
         1. Execute pre-actions (if any)
         2. Set up messages (role and task)
         3. Register node functions
-        4. Update LLM context with messages and tools
+        4. Update LLM context with messages and tools (skipped when the
+           worker is inactive)
         5. Update state (current node and functions)
-        6. Trigger LLM completion with new context
+        6. Trigger LLM completion with new context (skipped when the worker
+           is inactive)
         7. Execute post-actions (if any)
+
+        When the worker is inactive, steps 4 and 6 are skipped because their
+        directly queued frames bypass the bus activation gate and would race
+        with the newly activated worker's frames in the shared context. The
+        node's messages and tools are applied when a node is set again on
+        reactivation.
 
         Args:
             node_id: Identifier for the new node.

--- a/src/pipecat/flows/manager.py
+++ b/src/pipecat/flows/manager.py
@@ -692,15 +692,25 @@ class FlowManager:
                         stacklevel=2,
                     )
 
-            # Update LLM context
-            await self._update_llm_context(
-                role_message=role_message,
-                role_messages=role_messages if not role_message else None,
-                task_messages=node_config["task_messages"],
-                functions=formatted_tools,
-                strategy=node_config.get("context_strategy"),
-            )
-            logger.debug("Updated LLM context")
+            # Update LLM context. Skip the update if the worker is inactive
+            # (e.g. it just handed off via
+            # activate_worker(deactivate_self=True)): _update_llm_context
+            # queues frames directly, bypassing the bus activation gate, so
+            # they land in the shared context and race with the newly
+            # activated worker's own activation frames. When the inactive
+            # worker's frames land last, they clobber the active worker's
+            # tools and messages (e.g. remove its transfer function from the
+            # tool list). The node's messages and tools are applied when the
+            # worker sets a node again on reactivation.
+            if self._worker.active:
+                await self._update_llm_context(
+                    role_message=role_message,
+                    role_messages=role_messages if not role_message else None,
+                    task_messages=node_config["task_messages"],
+                    functions=formatted_tools,
+                    strategy=node_config.get("context_strategy"),
+                )
+                logger.debug("Updated LLM context")
 
             # Update state
             self._current_node = node_id

--- a/src/pipecat/flows/manager.py
+++ b/src/pipecat/flows/manager.py
@@ -706,9 +706,13 @@ class FlowManager:
             self._current_node = node_id
             self._current_functions = new_functions
 
-            # Trigger completion with new context
+            # Trigger completion with new context. Skip the run if the worker
+            # is inactive (e.g. it just handed off via
+            # activate_worker(deactivate_self=True)): directly queued frames
+            # bypass the bus activation gate, so running here would produce a
+            # duplicate completion alongside the newly activated worker's.
             respond_immediately = node_config.get("respond_immediately", True)
-            if respond_immediately:
+            if respond_immediately and self._worker.active:
                 await self._worker.queue_frames([LLMRunFrame()])
 
             # Execute post-actions if any

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -202,6 +202,42 @@ class _FakeJudge:
         return JudgeVerdict(verdict=v, reason=f"({v})", raw_response="")
 
 
+class TestMatchAbsent(unittest.IsolatedAsyncioTestCase):
+    """An ``absent: true`` expectation passes on a quiet window, fails on arrival."""
+
+    async def test_absent_passes_when_no_event_arrives(self):
+        import time
+
+        s = _session()
+        expectation = EvalExpectation(event="llm_response", absent=True)
+        failure = await s._match_and_verify(expectation, time.monotonic(), 100, 0, 0)
+        self.assertIsNone(failure)
+        self.assertIn("no 'llm_response'", s._last_match_text)
+
+    async def test_absent_fails_when_event_arrives(self):
+        import time
+
+        s = _session()
+        s._queue.put_nowait({"type": "llm_response", "text": "I repeat myself"})
+        expectation = EvalExpectation(event="llm_response", absent=True)
+        failure = await s._match_and_verify(expectation, time.monotonic(), 100, 3, 2)
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure.turn_index, 3)
+        self.assertEqual(failure.expectation_index, 2)
+        self.assertIn("I repeat myself", failure.reason)
+
+    async def test_absent_ignores_other_event_types(self):
+        import time
+
+        s = _session()
+        # Unrelated events in the window must not trip the absence check.
+        s._queue.put_nowait({"type": "user_stopped_speaking"})
+        s._queue.put_nowait({"type": "tts_response", "text": "spoken"})
+        expectation = EvalExpectation(event="llm_response", absent=True)
+        failure = await s._match_and_verify(expectation, time.monotonic(), 100, 0, 0)
+        self.assertIsNone(failure)
+
+
 class TestEvaluateAggregate(unittest.IsolatedAsyncioTestCase):
     """The pass/fail/continue decision over accumulated response text."""
 

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -144,6 +144,59 @@ class TestEvalsScenarioParser(unittest.TestCase):
         self.assertEqual(exp.text_contains, "bar")
         self.assertEqual(exp.eval, "is friendly")
         self.assertIsNone(exp.calls)
+        self.assertFalse(exp.absent)
+
+    def test_absent_expectation_parsed(self):
+        s = EvalScenario.load(
+            _write(
+                """
+                name: absent
+                turns:
+                  - user: "x"
+                    expect:
+                      - event: llm_response
+                        eval: "answers"
+                      - event: llm_response
+                        absent: true
+                        within_ms: 5000
+                """
+            )
+        )
+        exp = s.turns[0].expect[1]
+        self.assertTrue(exp.absent)
+        self.assertEqual(exp.within_ms, 5000)
+
+    def test_absent_rejects_content_checks(self):
+        for extra in ('eval: "repeats itself"', 'text_contains: "again"'):
+            with self.assertRaises(ValueError):
+                EvalScenario.load(
+                    _write(
+                        f"""
+                        name: bad_absent
+                        turns:
+                          - user: "x"
+                            expect:
+                              - event: llm_response
+                                absent: true
+                                {extra}
+                        """
+                    )
+                )
+
+    def test_absent_must_be_boolean(self):
+        with self.assertRaises(ValueError):
+            EvalScenario.load(
+                _write(
+                    """
+                    name: bad_absent_type
+                    turns:
+                      - user: "x"
+                        expect:
+                          - event: llm_response
+                            absent: "yes please"
+                    """
+                )
+            )
 
     def test_function_call_name_args_shorthand(self):
         """A single function_call uses the ``name:``/``args:`` shorthand."""

--- a/tests/test_flows_manager.py
+++ b/tests/test_flows_manager.py
@@ -1038,6 +1038,37 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(self.mock_task.queue_frames.called)
         mock_llm_run_frame.assert_called_once()
 
+    @patch("pipecat.flows.manager.LLMRunFrame")
+    async def test_no_completion_on_inactive_worker(self, mock_llm_run_frame):
+        """Test that setting a node on a deactivated worker skips the LLM run.
+
+        After a multi-worker handoff (activate_worker(deactivate_self=True)),
+        the handing-off worker may still get a next node from an edge function.
+        Running a completion on it would duplicate the newly activated
+        worker's response.
+        """
+        flow_manager = FlowManager(
+            worker=self.mock_task,
+            llm=self.mock_llm,
+            context_aggregator=self.mock_context_aggregator,
+        )
+        await flow_manager.initialize()
+
+        self.mock_task.active = False
+        self.mock_task.queue_frames.reset_mock()
+        mock_llm_run_frame.reset_mock()
+
+        await flow_manager.set_node_from_config(
+            {
+                "task_messages": [{"role": "developer", "content": "Test"}],
+                "functions": [],
+            },
+        )
+
+        # Context still updates, but no completion is triggered
+        self.assertTrue(self.mock_task.queue_frames.called)
+        mock_llm_run_frame.assert_not_called()
+
     async def test_get_current_context(self):
         """Test getting current conversation context."""
         flow_manager = FlowManager(

--- a/tests/test_flows_manager.py
+++ b/tests/test_flows_manager.py
@@ -1040,12 +1040,15 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
     @patch("pipecat.flows.manager.LLMRunFrame")
     async def test_no_completion_on_inactive_worker(self, mock_llm_run_frame):
-        """Test that setting a node on a deactivated worker skips the LLM run.
+        """Test that setting a node on a deactivated worker queues nothing.
 
         After a multi-worker handoff (activate_worker(deactivate_self=True)),
         the handing-off worker may still get a next node from an edge function.
-        Running a completion on it would duplicate the newly activated
-        worker's response.
+        Directly queued frames bypass the bus activation gate and land in the
+        shared context, so a completion would duplicate the newly activated
+        worker's response, and a context update would race with (and can
+        clobber) that worker's tools and messages, e.g. removing its transfer
+        function from the tool list.
         """
         flow_manager = FlowManager(
             worker=self.mock_task,
@@ -1060,14 +1063,18 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         await flow_manager.set_node_from_config(
             {
+                "name": "inactive_node",
                 "task_messages": [{"role": "developer", "content": "Test"}],
                 "functions": [],
             },
         )
 
-        # Context still updates, but no completion is triggered
-        self.assertTrue(self.mock_task.queue_frames.called)
+        # No frames at all: no context update, no completion
+        self.mock_task.queue_frames.assert_not_called()
         mock_llm_run_frame.assert_not_called()
+
+        # Internal state still tracks the new node
+        self.assertEqual(flow_manager.current_node, "inactive_node")
 
     async def test_get_current_context(self):
         """Test getting current conversation context."""


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #4979.

After a multi-worker handoff (`activate_worker(deactivate_self=True)`), an edge function can still return a next node for the handing-off worker. `FlowManager._set_node` then interacted badly with the shared context in two ways, because directly queued frames bypass the bus activation gate:

1. It queued an `LLMRunFrame` (`respond_immediately` defaults to `True`), so the deactivated worker ran a completion against the same shared context as the newly activated worker, producing 2-3 near-identical assistant responses back to back. Reproducible with `examples/flows/multi_worker_handoff.py` by triggering `transfer_to_router` mid-reservation (see the issue for a transcript).
2. It queued the node's `LLMSetToolsFrame` / `LLMMessagesAppendFrame`, which race with the newly activated worker's activation frames. When the inactive worker's frames land last, they replace the active worker's tool list (in the example: `transfer_to_reservation` disappears, so control can never return to the reservation flow) and append a stale node instruction. Found via T-2640 after the first fix landed: the duplicates were gone but the hand-back never happened.

**Fix:** when the worker is inactive, `_set_node` skips both the completion AND the context update. Only internal state (`_current_node` / `_current_functions`) is updated. The behavioral contract (per review): callers apply the node's messages and tools by setting a node again on reactivation, which is what `LLMWorker.on_activated` in the example already does. This is stated in the `set_node_from_config` docstring.

**Example fixes** (`examples/flows/multi_worker_handoff.py`): two prompt gaps made transfers unreliable even with the manager fixed. The hand-back activation message now tells the router to call `transfer_to_reservation` when the user returns to the booking, and the reservation worker's role message now says to hand off off-topic questions instead of answering them.

**Regression eval:** added `scripts/release-evals/scenarios/multi_worker_handoff_no_duplicate.yaml` (registered in the manifest for `flows/multi_worker_handoff.py`). It drives the bot to the `transfer_to_router` handoff, asserts exactly one response follows, then (new) drives the user back to the booking and asserts `transfer_to_reservation` fires again. Expressing "exactly one" needed a small harness addition:

- New `absent: true` expectation field: passes only when NO event of the given type arrives within the `within_ms` budget; fails as soon as one does, with the arriving event's content in the failure reason. Matches on event type only (combining it with `text_contains`/`eval`/`calls` is a parse error). Documented in the scenario module docstring.

**Local verification (audio mode, real end-to-end runs against the example bot):**

- Full branch: 4 consecutive passes of the extended scenario, plus the base `multi_worker_handoff` scenario.
- Without the run gate (`main`'s `manager.py`): FAILS on the absence check, capturing the duplicate response.
- Without the context-update gate: FAILS on the return turn; the log shows the router calling `transfer_to_router` (a reservation-node tool), i.e. its tool list really was clobbered. The race is timing-dependent, so single passing runs without this gate do occur.
- Without the prompt fixes: FAILS on the return turn; the router books the table itself instead of transferring.

**Tests:** `test_no_completion_on_inactive_worker` (flows manager) now asserts an inactive worker's node set queues nothing at all, plus `absent` parse and match tests in `test_evals_scenario.py` / `test_evals_harness.py`. All tests across the three files pass.

**Note on modality:** the regression scenario is audio mode on purpose. While verifying, I found that text mode's `send-text` path double-runs bridged workers in this multi-worker bot (interleaved duplicate `llm_response` text and doubled function calls even with this fix applied). That is a separate pre-existing bug, not addressed here; the scenario comment mentions it and I'll file it separately.

**Open questions for review:**

- Post-actions: when the worker is inactive and `respond_immediately` is `True`, post-actions still execute immediately (unchanged behavior). Should they be deferred instead, since no inference runs?
- Broader design: should `PipelineWorker` drop or hold `LLMRunFrame` while inactive in general? Directly queued frames bypass the bus activation gate by design, so any other direct-queue path could reproduce this class of bug.
