### PR TITLE
fix(sambanova): correct _process_context return annotation

### DIFF
--- a/src/pipecat/services/sambanova/llm.py
+++ b/src/pipecat/services/sambanova/llm.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
-from openai import AsyncStream
-from openai.types.chat import ChatCompletionChunk
 
 from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
 from pipecat.frames.frames import (
@@ -138,7 +136,7 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
         return params
 
     @traced_llm  # type: ignore
-    async def _process_context(self, context: LLMContext) -> AsyncStream[ChatCompletionChunk]:
+    async def _process_context(self, context: LLMContext):
         """Process OpenAI LLM context and stream chat completion chunks.
 
         This method handles the streaming response from SambaNova API, including
@@ -147,9 +145,6 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
 
         Args:
             context: OpenAI LLM context containing conversation state and tools.
-
-        Returns:
-            Async stream of chat completion chunks.
         """
         functions_list = []
         arguments_list = []


### PR DESCRIPTION

<!-- The repo PR template is a single prompt: "describe the changes; reference the
     issue if any." There is no issue to reference (self-found). Body below fills it. -->

`SambaNovaLLMService._process_context` was annotated to return
`AsyncStream[ChatCompletionChunk]` and its docstring carried a matching
`Returns:` clause, but the method never returns or yields a value. Like every
other provider's `_process_context` override, it consumes the completion stream
internally (iterating the stream, pushing `LLMTextFrame`s and metrics) and ends
by running any function calls, so it returns `None`.

Every sibling override (`openai/base_llm.py`, `anthropic/llm.py`,
`google/llm.py`, `aws/llm.py`, `xai/llm.py`, `perplexity/llm.py`,
`nvidia/llm.py`, and both `openai/responses/llm.py` overrides) declares
`async def _process_context(self, context: LLMContext):` with no return
annotation. SambaNova was the only outlier.

This drops the inaccurate return annotation and the `Returns:` docstring clause
so the signature matches the `None`-returning body and the other providers, and
removes the now-unused `AsyncStream` / `ChatCompletionChunk` imports (they were
imported solely for that annotation). No runtime behavior changes.

No changelog fragment: this is an internal type-annotation and docstring
correction on a private method, with no user-facing impact (per CONTRIBUTING's
"When to Skip Changelog Entries").
