### PR TITLE
Fixing function call issues found by [Detail Bug]

### DIFF
--- a/changelog/4988.fixed.2.md
+++ b/changelog/4988.fixed.2.md
@@ -1,0 +1,1 @@
+- Fixed `ToolsSchemaAdapter` and `LLMContextAdapter` dropping a `ToolsSchema`'s `custom_tools` (e.g. Gemini's built-in `google_search` tool) when serializing an `LLMContext` for network bus transport, which broke provider-specific tools for distributed/multi-worker setups.

--- a/changelog/4988.fixed.md
+++ b/changelog/4988.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `_send_tool_result()` in the OpenAI, Inworld, and xAI (Grok) realtime LLM services double-JSON-encoding tool call results before sending them back to the model. Tool results were being serialized twice, so the model would receive a JSON string containing an escaped JSON string instead of the actual result.

--- a/src/pipecat/bus/adapters/llm_context_adapter.py
+++ b/src/pipecat/bus/adapters/llm_context_adapter.py
@@ -10,9 +10,8 @@ from typing import Any
 
 from openai import NOT_GIVEN as OPENAI_NOT_GIVEN
 
-from pipecat.adapters.schemas.function_schema import FunctionSchema
-from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.bus.adapters.base import DeserializeFunc, SerializeFunc, TypeAdapter
+from pipecat.bus.adapters.tools_schema_adapter import ToolsSchemaAdapter
 from pipecat.processors.aggregators.llm_context import (
     LLMContext,
     LLMSpecificMessage,
@@ -26,6 +25,10 @@ class LLMContextAdapter(TypeAdapter):
     The ``NOT_GIVEN`` sentinel is preserved across serialization: missing
     keys are restored as ``NOT_GIVEN`` on deserialization.
     """
+
+    def __init__(self) -> None:
+        """Initialize the adapter."""
+        self._tools_schema_adapter = ToolsSchemaAdapter()
 
     def serialize(self, obj: Any, serialize_value: SerializeFunc) -> dict[str, Any]:
         """Serialize an ``LLMContext`` to a JSON-compatible dict.
@@ -42,7 +45,7 @@ class LLMContextAdapter(TypeAdapter):
             "messages": [self._serialize_message(m, serialize_value) for m in obj.messages],
         }
         if not isinstance(obj.tools, NotGiven):
-            result["tools"] = self._serialize_tools(obj.tools)
+            result["tools"] = self._tools_schema_adapter.serialize(obj.tools, serialize_value)
         if not isinstance(obj.tool_choice, NotGiven):
             result["tool_choice"] = serialize_value(obj.tool_choice)
         return result
@@ -67,7 +70,11 @@ class LLMContextAdapter(TypeAdapter):
             A new ``LLMContext`` instance.
         """
         messages = [self._deserialize_message(m, deserialize_value) for m in data["messages"]]
-        tools = self._deserialize_tools(data["tools"]) if "tools" in data else OPENAI_NOT_GIVEN
+        tools = (
+            self._tools_schema_adapter.deserialize(data["tools"], deserialize_value)
+            if "tools" in data
+            else OPENAI_NOT_GIVEN
+        )
         tool_choice = (
             deserialize_value(data["tool_choice"]) if "tool_choice" in data else OPENAI_NOT_GIVEN
         )
@@ -89,20 +96,3 @@ class LLMContextAdapter(TypeAdapter):
                 message=deserialize_value(data["message"]),
             )
         return deserialize_value(data)
-
-    def _serialize_tools(self, tools: Any) -> list[dict[str, Any]]:
-        return [tool.to_default_dict() for tool in tools.standard_tools]
-
-    def _deserialize_tools(self, data: list[dict[str, Any]]) -> Any:
-        tools = []
-        for item in data:
-            params = item.get("parameters", {})
-            tools.append(
-                FunctionSchema(
-                    name=item["name"],
-                    description=item.get("description", ""),
-                    properties=params.get("properties", {}),
-                    required=params.get("required", []),
-                )
-            )
-        return ToolsSchema(standard_tools=tools)

--- a/src/pipecat/bus/adapters/tools_schema_adapter.py
+++ b/src/pipecat/bus/adapters/tools_schema_adapter.py
@@ -50,7 +50,8 @@ class ToolsSchemaAdapter(TypeAdapter):
             target_type: Unused. ``ToolsSchema`` is always the target.
 
         Returns:
-            A new ``ToolsSchema`` instance.
+            A new ``ToolsSchema`` instance, including ``custom_tools`` if
+            present in ``data``.
         """
         tools = []
         for item in data["standard_tools"]:

--- a/src/pipecat/bus/adapters/tools_schema_adapter.py
+++ b/src/pipecat/bus/adapters/tools_schema_adapter.py
@@ -9,7 +9,7 @@
 from typing import Any
 
 from pipecat.adapters.schemas.function_schema import FunctionSchema
-from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.bus.adapters.base import DeserializeFunc, SerializeFunc, TypeAdapter
 
 
@@ -24,9 +24,17 @@ class ToolsSchemaAdapter(TypeAdapter):
             serialize_value: Callback to recursively serialize nested values.
 
         Returns:
-            A dict with a ``standard_tools`` list.
+            A dict with a ``standard_tools`` list and, if present, a
+            ``custom_tools`` mapping.
         """
-        return {"standard_tools": [tool.to_default_dict() for tool in obj.standard_tools]}
+        result: dict[str, Any] = {
+            "standard_tools": [tool.to_default_dict() for tool in obj.standard_tools]
+        }
+        if obj.custom_tools:
+            result["custom_tools"] = {
+                adapter_type.value: tools for adapter_type, tools in obj.custom_tools.items()
+            }
+        return result
 
     def deserialize(
         self,
@@ -55,4 +63,7 @@ class ToolsSchemaAdapter(TypeAdapter):
                     required=params.get("required", []),
                 )
             )
-        return ToolsSchema(standard_tools=tools)
+        custom_tools = None
+        if "custom_tools" in data:
+            custom_tools = {AdapterType(key): value for key, value in data["custom_tools"].items()}
+        return ToolsSchema(standard_tools=tools, custom_tools=custom_tools)

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -1184,6 +1184,6 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=tool_call_id,
-            output=json.dumps(result, ensure_ascii=False),
+            output=result,
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -1363,6 +1363,6 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=tool_call_id,
-            output=json.dumps(result, ensure_ascii=False),
+            output=result,
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))

--- a/src/pipecat/services/xai/realtime/llm.py
+++ b/src/pipecat/services/xai/realtime/llm.py
@@ -1038,6 +1038,6 @@ class GrokRealtimeLLMService(LLMService[GrokRealtimeLLMAdapter]):
         item = events.ConversationItem(
             type="function_call_output",
             call_id=tool_call_id,
-            output=json.dumps(result, ensure_ascii=False),
+            output=result,
         )
         await self.send_client_event(events.ConversationItemCreateEvent(item=item))

--- a/tests/test_bus_json_serializer.py
+++ b/tests/test_bus_json_serializer.py
@@ -1,0 +1,99 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Unit tests for JSONMessageSerializer's ToolsSchema/LLMContext adapters."""
+
+import unittest
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
+from pipecat.bus.serializers.json import JSONMessageSerializer
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+
+class TestToolsSchemaCustomToolsRoundTrip(unittest.TestCase):
+    """Bus adapters must preserve `ToolsSchema.custom_tools` (e.g. Gemini's
+    `google_search`) when a frame crosses a network bus (Redis/pgmq), not
+    just the in-process case.
+    """
+
+    def setUp(self):
+        self.serializer = JSONMessageSerializer()
+        self.standard_tool = FunctionSchema(
+            name="get_weather",
+            description="Get the weather",
+            properties={"location": {"type": "string"}},
+            required=["location"],
+        )
+
+    def test_tools_schema_preserves_custom_tools(self):
+        tools = ToolsSchema(
+            standard_tools=[self.standard_tool],
+            custom_tools={AdapterType.GEMINI: [{"google_search": {}}]},
+        )
+
+        data = self.serializer._serialize_value(tools)
+        restored = self.serializer._deserialize_value(data)
+
+        self.assertIsInstance(restored, ToolsSchema)
+        self.assertEqual(len(restored.standard_tools), 1)
+        self.assertEqual(restored.standard_tools[0].name, "get_weather")
+        self.assertEqual(restored.custom_tools, {AdapterType.GEMINI: [{"google_search": {}}]})
+
+    def test_tools_schema_without_custom_tools_round_trips_to_none(self):
+        tools = ToolsSchema(standard_tools=[self.standard_tool])
+
+        data = self.serializer._serialize_value(tools)
+        restored = self.serializer._deserialize_value(data)
+
+        self.assertIsNone(restored.custom_tools)
+
+    def test_llm_context_tools_preserve_custom_tools(self):
+        tools = ToolsSchema(
+            standard_tools=[self.standard_tool],
+            custom_tools={AdapterType.OPENAI: [{"type": "web_search"}]},
+        )
+        context = LLMContext(messages=[{"role": "user", "content": "hi"}], tools=tools)
+
+        data = self.serializer._serialize_value(context)
+        restored = self.serializer._deserialize_value(data)
+
+        self.assertIsInstance(restored, LLMContext)
+        self.assertEqual(
+            restored.tools.custom_tools, {AdapterType.OPENAI: [{"type": "web_search"}]}
+        )
+
+    def test_bytes_round_trip_through_serialize_deserialize(self):
+        """End-to-end sanity check that the full JSON encode/decode cycle preserves custom_tools.
+
+        Mirrors an `LLMContextFrame` crossing a network bus (Redis/pgmq).
+        """
+        from pipecat.bus.messages import BusFrameMessage
+        from pipecat.frames.frames import LLMContextFrame
+        from pipecat.processors.frame_processor import FrameDirection
+
+        tools = ToolsSchema(
+            standard_tools=[self.standard_tool],
+            custom_tools={AdapterType.GEMINI: [{"google_search": {}}]},
+        )
+        context = LLMContext(messages=[{"role": "user", "content": "hi"}], tools=tools)
+        message = BusFrameMessage(
+            source="worker-a",
+            frame=LLMContextFrame(context=context),
+            direction=FrameDirection.DOWNSTREAM,
+        )
+
+        raw = self.serializer.serialize(message)
+        restored_message = self.serializer.deserialize(raw)
+
+        self.assertEqual(
+            restored_message.frame.context.tools.custom_tools,
+            {AdapterType.GEMINI: [{"google_search": {}}]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_realtime_tool_result_encoding.py
+++ b/tests/test_realtime_tool_result_encoding.py
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""The context aggregator stores tool call results as already JSON-encoded
+strings. `_send_tool_result()` on the realtime LLM services must send that
+string through unchanged, not re-encode it with another `json.dumps()`
+(which would turn `{"temp": 72}` into the string literal `"{\\"temp\\": 72}"`).
+"""
+
+import unittest
+from unittest.mock import AsyncMock
+
+from pipecat.services.inworld.realtime.llm import InworldRealtimeLLMService
+from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+from pipecat.services.xai.realtime.llm import GrokRealtimeLLMService
+
+
+class TestOpenAIRealtimeToolResultEncoding(unittest.IsolatedAsyncioTestCase):
+    async def test_send_tool_result_passes_through_pre_encoded_json(self):
+        service = OpenAIRealtimeLLMService(api_key="test")
+        service.send_client_event = AsyncMock()
+
+        already_encoded = '{"temperature": 72}'
+        await service._send_tool_result("call_123", already_encoded)
+
+        sent_event = service.send_client_event.call_args.args[0]
+        self.assertEqual(sent_event.item.output, already_encoded)
+
+    async def test_send_tool_result_preserves_completed_sentinel(self):
+        service = OpenAIRealtimeLLMService(api_key="test")
+        service.send_client_event = AsyncMock()
+
+        await service._send_tool_result("call_123", "COMPLETED")
+
+        sent_event = service.send_client_event.call_args.args[0]
+        self.assertEqual(sent_event.item.output, "COMPLETED")
+
+
+class TestInworldRealtimeToolResultEncoding(unittest.IsolatedAsyncioTestCase):
+    async def test_send_tool_result_passes_through_pre_encoded_json(self):
+        service = InworldRealtimeLLMService(api_key="test")
+        service.send_client_event = AsyncMock()
+
+        already_encoded = '{"temperature": 72}'
+        await service._send_tool_result("call_123", already_encoded)
+
+        sent_event = service.send_client_event.call_args.args[0]
+        self.assertEqual(sent_event.item.output, already_encoded)
+
+
+class TestXAIRealtimeToolResultEncoding(unittest.IsolatedAsyncioTestCase):
+    async def test_send_tool_result_passes_through_pre_encoded_json(self):
+        service = GrokRealtimeLLMService(api_key="test")
+        service.send_client_event = AsyncMock()
+
+        already_encoded = '{"temperature": 72}'
+        await service._send_tool_result("call_123", already_encoded)
+
+        sent_event = service.send_client_event.call_args.args[0]
+        self.assertEqual(sent_event.item.output, already_encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixed `_send_tool_result()` in the OpenAI, Inworld, and xAI (Grok) realtime LLM services double-JSON-encoding tool call results
  - Fixes #4835
  - Fixes #4826 
- Fixed `ToolsSchemaAdapter` and `LLMContextAdapter` dropping `ToolsSchema.custom_tools` (e.g. Gemini's `google_search`) when serializing for network bus transport (`RedisBus`, `PgmqBus`). An `LLMContextFrame` crossing the bus in a distributed worker setup now preserves provider-specific tools, matching the in-process (`AsyncQueueBus`) behavior.
  - Fixes #4833 
 