### PR TITLE
Fixed adapters silently discarding the entire conversation history

### DIFF
--- a/changelog/4989.fixed.md
+++ b/changelog/4989.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the Anthropic and AWS Bedrock adapters dropping an entire conversation history whenever a single message failed to convert (e.g. a malformed image URL). Each adapter now skips only the message that fails to convert and keeps the rest of the context intact.

--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -163,12 +163,14 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
             if extracted is not None:
                 system = extracted
 
-        # Convert remaining messages to Anthropic format
+        # Convert remaining messages to Anthropic format, skipping any message
+        # that fails to convert so it doesn't discard the rest of the history.
         messages = []
-        try:
-            messages = [self._from_universal_context_message(m) for m in remaining]
-        except Exception as e:
-            logger.error(f"Error mapping messages: {e}")
+        for m in remaining:
+            try:
+                messages.append(self._from_universal_context_message(m))
+            except Exception as e:
+                logger.warning(f"Skipping message that failed to convert: {e}")
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as Anthropic doesn't support system or developer input messages.

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -129,12 +129,14 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
         if remaining and not isinstance(remaining[0], LLMSpecificMessage):
             system = self._extract_initial_system(remaining, system_instruction=system_instruction)
 
-        # Convert remaining messages to Bedrock format
+        # Convert remaining messages to Bedrock format, skipping any message
+        # that fails to convert so it doesn't discard the rest of the history.
         messages = []
-        try:
-            messages = [self._from_universal_context_message(m) for m in remaining]
-        except Exception as e:
-            logger.error(f"Error mapping messages: {e}")
+        for m in remaining:
+            try:
+                messages.append(self._from_universal_context_message(m))
+            except Exception as e:
+                logger.warning(f"Skipping message that failed to convert: {e}")
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as AWS Bedrock doesn't support system or developer input messages.

--- a/tests/test_llm_adapter_message_conversion_errors.py
+++ b/tests/test_llm_adapter_message_conversion_errors.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A single malformed message must not silently discard the rest of the
+conversation context: the Anthropic and AWS Bedrock adapters should skip
+only the message that fails to convert and keep the rest of the history.
+"""
+
+import unittest
+
+from pipecat.adapters.services.anthropic_adapter import AnthropicLLMAdapter
+from pipecat.adapters.services.bedrock_adapter import AWSBedrockLLMAdapter
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+# A `data:` URL with no comma: `url.split(",")[1]` raises IndexError while
+# extracting the base64 payload. Surrounded by valid messages of different
+# roles so a merge of adjacent same-role messages can't mask a dropped message.
+_MESSAGES_WITH_ONE_MALFORMED = [
+    {"role": "user", "content": "What's in this image?"},
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64"},
+            }
+        ],
+    },
+    {"role": "assistant", "content": "Here is a description."},
+]
+
+
+class TestAnthropicMessageConversionErrors(unittest.TestCase):
+    def setUp(self):
+        self.adapter = AnthropicLLMAdapter()
+
+    def test_malformed_message_is_skipped_and_rest_are_kept(self):
+        context = LLMContext(messages=_MESSAGES_WITH_ONE_MALFORMED)
+
+        params = self.adapter.get_llm_invocation_params(context, enable_prompt_caching=False)
+
+        self.assertEqual(len(params["messages"]), 2)
+        self.assertEqual(params["messages"][0]["role"], "user")
+        self.assertEqual(params["messages"][1]["role"], "assistant")
+
+    def test_valid_messages_are_not_affected(self):
+        context = LLMContext(messages=[{"role": "user", "content": "hello"}])
+
+        params = self.adapter.get_llm_invocation_params(context, enable_prompt_caching=False)
+
+        self.assertEqual(len(params["messages"]), 1)
+
+
+class TestBedrockMessageConversionErrors(unittest.TestCase):
+    def setUp(self):
+        self.adapter = AWSBedrockLLMAdapter()
+
+    def test_malformed_message_is_skipped_and_rest_are_kept(self):
+        context = LLMContext(messages=_MESSAGES_WITH_ONE_MALFORMED)
+
+        params = self.adapter.get_llm_invocation_params(context)
+
+        self.assertEqual(len(params["messages"]), 2)
+        self.assertEqual(params["messages"][0]["role"], "user")
+        self.assertEqual(params["messages"][1]["role"], "assistant")
+
+    def test_valid_messages_are_not_affected(self):
+        context = LLMContext(messages=[{"role": "user", "content": "hello"}])
+
+        params = self.adapter.get_llm_invocation_params(context)
+
+        self.assertEqual(len(params["messages"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixed `AnthropicLLMAdapter` and `AWSBedrockLLMAdapter` silently discarding the entire conversation history when a single message failed to convert
  - Fixes #4828 