### PR TITLE
Raise a clear error when LLM context conversion fails (#4828)

### DIFF
--- a/changelog/4990.fixed.md
+++ b/changelog/4990.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Anthropic and AWS Bedrock LLM adapters silently discarding the entire conversation when a single message failed to convert to the provider's format (e.g. a malformed image data URL). The Anthropic, AWS Bedrock, and Gemini adapters now raise `LLMContextConversionError`, surfacing the real cause instead of a misleading downstream API error.

--- a/src/pipecat/adapters/base_llm_adapter.py
+++ b/src/pipecat/adapters/base_llm_adapter.py
@@ -36,11 +36,9 @@ class LLMContextConversionError(Exception):
     Adapters that transform context messages into a provider-specific format
     raise this from their conversion routine, wrapping the underlying error
     (preserved as ``__cause__``). Its message identifies the failure as a
-    context-mapping problem, so a malformed message surfaces as its true cause
-    rather than as a misleading downstream API error (e.g. an "at least one
-    message is required" rejection produced by sending an empty message list).
-    The corresponding LLM service catches this and surfaces it in the
-    ``ErrorFrame`` it pushes upstream.
+    context-mapping problem and carries the underlying cause. The corresponding
+    LLM service catches this and surfaces it in the ``ErrorFrame`` it pushes
+    upstream.
     """
 
     def __init__(self, cause: Exception):

--- a/src/pipecat/adapters/base_llm_adapter.py
+++ b/src/pipecat/adapters/base_llm_adapter.py
@@ -30,6 +30,28 @@ from pipecat.processors.aggregators.llm_context import (
 TLLMInvocationParams = TypeVar("TLLMInvocationParams", bound=Mapping[str, Any])
 
 
+class LLMContextConversionError(Exception):
+    """Raised when converting a universal ``LLMContext`` to a provider's message format fails.
+
+    Adapters that transform context messages into a provider-specific format
+    raise this from their conversion routine, wrapping the underlying error
+    (preserved as ``__cause__``). Its message identifies the failure as a
+    context-mapping problem, so a malformed message surfaces as its true cause
+    rather than as a misleading downstream API error (e.g. an "at least one
+    message is required" rejection produced by sending an empty message list).
+    The corresponding LLM service catches this and surfaces it in the
+    ``ErrorFrame`` it pushes upstream.
+    """
+
+    def __init__(self, cause: Exception):
+        """Initialize the error.
+
+        Args:
+            cause: The underlying exception raised during message conversion.
+        """
+        super().__init__(f"Error mapping context messages to provider format: {cause}")
+
+
 class BaseLLMAdapter(ABC, Generic[TLLMInvocationParams]):
     """Abstract base class for LLM provider adapters.
 

--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -16,7 +16,7 @@ from anthropic.types.message_param import MessageParam
 from anthropic.types.tool_union_param import ToolUnionParam
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import BaseLLMAdapter
+from pipecat.adapters.base_llm_adapter import BaseLLMAdapter, LLMContextConversionError
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.processors.aggregators.llm_context import (
@@ -163,12 +163,14 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
             if extracted is not None:
                 system = extracted
 
-        # Convert remaining messages to Anthropic format
-        messages = []
+        # Convert remaining messages to Anthropic format. A malformed message
+        # is wrapped and re-raised so it surfaces as its real cause instead of
+        # silently emptying the conversation (which would later trip a
+        # misleading "empty messages" API error).
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:
-            logger.error(f"Error mapping messages: {e}")
+            raise LLMContextConversionError(e) from e
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as Anthropic doesn't support system or developer input messages.

--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -163,10 +163,9 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
             if extracted is not None:
                 system = extracted
 
-        # Convert remaining messages to Anthropic format. A malformed message
-        # is wrapped and re-raised so it surfaces as its real cause instead of
-        # silently emptying the conversation (which would later trip a
-        # misleading "empty messages" API error).
+        # Convert remaining messages to Anthropic format. A conversion failure
+        # (e.g. a malformed message) is wrapped so it surfaces with its
+        # underlying cause.
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -129,10 +129,9 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
         if remaining and not isinstance(remaining[0], LLMSpecificMessage):
             system = self._extract_initial_system(remaining, system_instruction=system_instruction)
 
-        # Convert remaining messages to Bedrock format. A malformed message
-        # is wrapped and re-raised so it surfaces as its real cause instead of
-        # silently emptying the conversation (which would later trip a
-        # misleading "must start with a user message" API error).
+        # Convert remaining messages to Bedrock format. A conversion failure
+        # (e.g. a malformed message) is wrapped so it surfaces with its
+        # underlying cause.
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:

--- a/src/pipecat/adapters/services/bedrock_adapter.py
+++ b/src/pipecat/adapters/services/bedrock_adapter.py
@@ -14,7 +14,7 @@ from typing import Any, TypedDict, cast
 
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import BaseLLMAdapter
+from pipecat.adapters.base_llm_adapter import BaseLLMAdapter, LLMContextConversionError
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.processors.aggregators.llm_context import (
@@ -129,12 +129,14 @@ class AWSBedrockLLMAdapter(BaseLLMAdapter[AWSBedrockLLMInvocationParams]):
         if remaining and not isinstance(remaining[0], LLMSpecificMessage):
             system = self._extract_initial_system(remaining, system_instruction=system_instruction)
 
-        # Convert remaining messages to Bedrock format
-        messages = []
+        # Convert remaining messages to Bedrock format. A malformed message
+        # is wrapped and re-raised so it surfaces as its real cause instead of
+        # silently emptying the conversation (which would later trip a
+        # misleading "must start with a user message" API error).
         try:
             messages = [self._from_universal_context_message(m) for m in remaining]
         except Exception as e:
-            logger.error(f"Error mapping messages: {e}")
+            raise LLMContextConversionError(e) from e
 
         # Convert any subsequent "system"/"developer"-role messages to "user"-role
         # messages, as AWS Bedrock doesn't support system or developer input messages.

--- a/src/pipecat/adapters/services/gemini_adapter.py
+++ b/src/pipecat/adapters/services/gemini_adapter.py
@@ -14,7 +14,7 @@ from typing import Any, TypedDict, cast
 from loguru import logger
 from openai import NotGiven
 
-from pipecat.adapters.base_llm_adapter import BaseLLMAdapter
+from pipecat.adapters.base_llm_adapter import BaseLLMAdapter, LLMContextConversionError
 from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.processors.aggregators.llm_context import (
     LLMContext,
@@ -263,40 +263,45 @@ class GeminiLLMAdapter(BaseLLMAdapter[GeminiLLMInvocationParams]):
         tool_call_id_to_name_mapping = {}
         thought_signature_dicts = []
 
-        # Process each message, converting to Google format as needed
-        for message in remaining_messages:
-            # We have a Google-specific message; this may either be a
-            # thought-signature-containing message that we need to handle in a
-            # special way, or a message already in Google format that we can
-            # use directly
-            if isinstance(message, LLMSpecificMessage):
-                if (
-                    isinstance(message.message, dict)
-                    and message.message.get("type") == "thought_signature"
-                ):
-                    thought_signature_dicts.append(message.message)
+        # Process each message, converting to Google format as needed. A
+        # malformed message is wrapped and re-raised so it surfaces as its real
+        # cause instead of a bare, context-free error.
+        try:
+            for message in remaining_messages:
+                # We have a Google-specific message; this may either be a
+                # thought-signature-containing message that we need to handle in a
+                # special way, or a message already in Google format that we can
+                # use directly
+                if isinstance(message, LLMSpecificMessage):
+                    if (
+                        isinstance(message.message, dict)
+                        and message.message.get("type") == "thought_signature"
+                    ):
+                        thought_signature_dicts.append(message.message)
+                        continue
+
+                    # Fall back to assuming that the message is already in Google
+                    # format
+                    messages.append(message.message)
                     continue
 
-                # Fall back to assuming that the message is already in Google
-                # format
-                messages.append(message.message)
-                continue
+                # We have a standard universal context message; convert it to
+                # Google format
+                result = self._from_standard_message(
+                    message,
+                    params=self.MessageConversionParams(
+                        tool_call_id_to_name_mapping=tool_call_id_to_name_mapping,
+                    ),
+                )
 
-            # We have a standard universal context message; convert it to
-            # Google format
-            result = self._from_standard_message(
-                message,
-                params=self.MessageConversionParams(
-                    tool_call_id_to_name_mapping=tool_call_id_to_name_mapping,
-                ),
-            )
+                if result.content:
+                    messages.append(result.content)
 
-            if result.content:
-                messages.append(result.content)
-
-            # Merge tool call ID to name mapping
-            if result.tool_call_id_to_name_mapping:
-                tool_call_id_to_name_mapping.update(result.tool_call_id_to_name_mapping)
+                # Merge tool call ID to name mapping
+                if result.tool_call_id_to_name_mapping:
+                    tool_call_id_to_name_mapping.update(result.tool_call_id_to_name_mapping)
+        except Exception as e:
+            raise LLMContextConversionError(e) from e
 
         # Apply thought signatures to the corresponding messages
         self._apply_thought_signatures_to_messages(thought_signature_dicts, messages)

--- a/src/pipecat/adapters/services/gemini_adapter.py
+++ b/src/pipecat/adapters/services/gemini_adapter.py
@@ -264,8 +264,8 @@ class GeminiLLMAdapter(BaseLLMAdapter[GeminiLLMInvocationParams]):
         thought_signature_dicts = []
 
         # Process each message, converting to Google format as needed. A
-        # malformed message is wrapped and re-raised so it surfaces as its real
-        # cause instead of a bare, context-free error.
+        # conversion failure (e.g. a malformed message) is wrapped so it
+        # surfaces with its underlying cause.
         try:
             for message in remaining_messages:
                 # We have a Google-specific message; this may either be a

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -20,6 +20,7 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from pipecat.adapters.base_llm_adapter import LLMContextConversionError
 from pipecat.adapters.services.anthropic_adapter import (
     AnthropicLLMAdapter,
     AnthropicLLMInvocationParams,
@@ -501,6 +502,8 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
             raise
         except httpx.TimeoutException:
             await self._call_event_handler("on_completion_timeout")
+        except LLMContextConversionError as e:
+            await self.push_error(error_msg=str(e), exception=e)
         except Exception as e:
             await self.push_error(error_msg=f"Unknown error occurred: {e}", exception=e)
         finally:

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -20,6 +20,7 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from pipecat.adapters.base_llm_adapter import LLMContextConversionError
 from pipecat.adapters.services.bedrock_adapter import (
     AWSBedrockLLMAdapter,
     AWSBedrockLLMInvocationParams,
@@ -567,6 +568,8 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
             raise
         except (TimeoutError, ReadTimeoutError):
             await self._call_event_handler("on_completion_timeout")
+        except LLMContextConversionError as e:
+            await self.push_error(error_msg=str(e), exception=e)
         except Exception as e:
             await self.push_error(error_msg=f"Unknown error occurred: {e}", exception=e)
         finally:

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -21,6 +21,7 @@ from loguru import logger
 from PIL import Image
 from pydantic import BaseModel, Field
 
+from pipecat.adapters.base_llm_adapter import LLMContextConversionError
 from pipecat.adapters.services.gemini_adapter import GeminiLLMAdapter
 from pipecat.frames.frames import (
     AssistantImageRawFrame,
@@ -606,6 +607,8 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
             await self.run_function_calls(function_calls)
         except DeadlineExceeded:
             await self._call_event_handler("on_completion_timeout")
+        except LLMContextConversionError as e:
+            await self.push_error(error_msg=str(e), exception=e)
         except Exception as e:
             await self.push_error(error_msg=f"Unknown error occurred: {e}", exception=e)
         finally:

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -373,7 +373,7 @@ class TestGeminiGetLLMInvocationParams(unittest.TestCase):
         self.adapter = GeminiLLMAdapter()
 
     def test_malformed_message_raises_conversion_error(self):
-        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        """Test that a malformed message raises LLMContextConversionError, preserving the underlying cause."""
         # A data URL with no comma has no base64 payload, so the adapter's
         # url.split(",")[1] raises IndexError during conversion.
         malformed_message = {
@@ -754,7 +754,7 @@ class TestAnthropicGetLLMInvocationParams(unittest.TestCase):
         self.adapter = AnthropicLLMAdapter()
 
     def test_malformed_message_raises_conversion_error(self):
-        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        """Test that a malformed message raises LLMContextConversionError, preserving the underlying cause."""
         # A data URL with no comma has no base64 payload, so the adapter's
         # url.split(",")[1] raises IndexError during conversion.
         malformed_message = {
@@ -1140,7 +1140,7 @@ class TestAWSBedrockGetLLMInvocationParams(unittest.TestCase):
         self.adapter = AWSBedrockLLMAdapter()
 
     def test_malformed_message_raises_conversion_error(self):
-        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        """Test that a malformed message raises LLMContextConversionError, preserving the underlying cause."""
         # A data URL with no comma has no base64 payload, so the adapter's
         # url.split(",")[1] raises IndexError during conversion.
         malformed_message = {

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -27,6 +27,7 @@ For Gemini adapter:
 6. Multiple system instructions: first extracted, later ones converted to user messages
 7. system_instruction overrides context system message, with conflict warnings
 8. Developer messages are converted to user
+9. Malformed messages raise LLMContextConversionError (preserving the underlying cause)
 
 For Anthropic adapter:
 1. LLMStandardMessage objects are converted to Anthropic MessageParam format
@@ -37,6 +38,7 @@ For Anthropic adapter:
 6. Empty text content is converted to "(empty)"
 7. system_instruction overrides context system message, with conflict warnings
 8. Developer messages are converted to user
+9. Malformed messages raise LLMContextConversionError (preserving the underlying cause)
 
 For AWS Bedrock adapter:
 1. LLMStandardMessage objects are converted to AWS Bedrock format
@@ -47,6 +49,7 @@ For AWS Bedrock adapter:
 6. Empty text content is converted to "(empty)"
 7. system_instruction overrides context system message, with conflict warnings
 8. Developer messages are converted to user
+9. Malformed messages raise LLMContextConversionError (preserving the underlying cause)
 
 For OpenAI Responses adapter:
 1. LLMContext messages are converted to Responses API input items
@@ -68,6 +71,7 @@ from unittest.mock import patch
 
 from google.genai.types import Content, Part
 
+from pipecat.adapters.base_llm_adapter import LLMContextConversionError
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.anthropic_adapter import AnthropicLLMAdapter
@@ -367,6 +371,26 @@ class TestGeminiGetLLMInvocationParams(unittest.TestCase):
     def setUp(self) -> None:
         """Sets up a common adapter instance for all tests."""
         self.adapter = GeminiLLMAdapter()
+
+    def test_malformed_message_raises_conversion_error(self):
+        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        # A data URL with no comma has no base64 payload, so the adapter's
+        # url.split(",")[1] raises IndexError during conversion.
+        malformed_message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64"}},
+            ],
+        }
+        context = LLMContext(messages=[malformed_message])
+
+        with self.assertRaises(LLMContextConversionError) as ctx:
+            self.adapter.get_llm_invocation_params(context)
+
+        # The underlying cause is preserved for debugging.
+        self.assertIsInstance(ctx.exception.__cause__, IndexError)
+        self.assertIn("Error mapping context messages to provider format", str(ctx.exception))
 
     def test_standard_messages_converted_to_gemini_format(self):
         """Test that LLMStandardMessage objects are converted to Gemini Content format."""
@@ -728,6 +752,26 @@ class TestAnthropicGetLLMInvocationParams(unittest.TestCase):
     def setUp(self) -> None:
         """Sets up a common adapter instance for all tests."""
         self.adapter = AnthropicLLMAdapter()
+
+    def test_malformed_message_raises_conversion_error(self):
+        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        # A data URL with no comma has no base64 payload, so the adapter's
+        # url.split(",")[1] raises IndexError during conversion.
+        malformed_message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64"}},
+            ],
+        }
+        context = LLMContext(messages=[malformed_message])
+
+        with self.assertRaises(LLMContextConversionError) as ctx:
+            self.adapter.get_llm_invocation_params(context, enable_prompt_caching=False)
+
+        # The underlying cause is preserved for debugging.
+        self.assertIsInstance(ctx.exception.__cause__, IndexError)
+        self.assertIn("Error mapping context messages to provider format", str(ctx.exception))
 
     def test_standard_messages_converted_to_anthropic_format(self):
         """Test that LLMStandardMessage objects are converted to Anthropic MessageParam format."""
@@ -1094,6 +1138,26 @@ class TestAWSBedrockGetLLMInvocationParams(unittest.TestCase):
     def setUp(self) -> None:
         """Sets up a common adapter instance for all tests."""
         self.adapter = AWSBedrockLLMAdapter()
+
+    def test_malformed_message_raises_conversion_error(self):
+        """Test that a malformed message raises LLMContextConversionError instead of dropping the conversation."""
+        # A data URL with no comma has no base64 payload, so the adapter's
+        # url.split(",")[1] raises IndexError during conversion.
+        malformed_message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64"}},
+            ],
+        }
+        context = LLMContext(messages=[malformed_message])
+
+        with self.assertRaises(LLMContextConversionError) as ctx:
+            self.adapter.get_llm_invocation_params(context)
+
+        # The underlying cause is preserved for debugging.
+        self.assertIsInstance(ctx.exception.__cause__, IndexError)
+        self.assertIn("Error mapping context messages to provider format", str(ctx.exception))
 
     def test_standard_messages_converted_to_aws_bedrock_format(self):
         """Test that LLMStandardMessage objects are converted to AWS Bedrock format."""


### PR DESCRIPTION
## Problem

When converting a universal `LLMContext` to a provider's message format, a single malformed message (e.g. an image data URL with no comma) was handled inconsistently and confusingly:

- **Anthropic / AWS Bedrock** caught the error, logged it, and continued with an **empty message list** — silently dropping the whole conversation. The developer then saw a misleading downstream API error (`messages: at least one message is required` / `A conversation must start with a user message`).
- **Gemini** propagated the raw error (`list index out of range`) — accurate but obscure.

Fixes #4828. See [this comment](https://github.com/pipecat-ai/pipecat/issues/4828#issuecomment-4918955932) for the proposed approach: aim for a consistent *developer* experience, not just a consistent internal interface.

## Change

The three adapters that transform messages (Anthropic, AWS Bedrock, Gemini) now wrap the underlying error in a new `LLMContextConversionError` and raise it. The Anthropic, AWS, and Google services catch it and surface its message directly, so the developer consistently sees the real cause:

```
ErrorFrame(fatal=False): Error mapping context messages to provider format: list index out of range
```

The underlying exception is preserved as `__cause__`, and the error stays non-fatal (the pipeline keeps running), as before.

## OpenAI / OpenAI Responses: intentionally unchanged

Their adapters pass messages through without this conversion, so they can't raise it. Notably, **OpenAI Responses already pinpoints the problem server-side**, so nothing more is needed there:

```
ErrorFrame(fatal=False): Error during inference: Error code: 400 - Invalid 'input[3].content[1].image_url'.
Expected a base64-encoded data URL with an image MIME type
(e.g. 'data:image/png;base64,aW1nIGJ5dGVzIGhlcmU='), but got a value without the ',' separator.
```

## Supersedes

- #4989
- #4954

## Testing

- Added `test_malformed_message_raises_conversion_error` to the Anthropic, Gemini, and AWS Bedrock adapter test classes.
- `uv run pytest tests/test_get_llm_invocation_params.py` — 121 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
