### PR TITLE
Add bug report guardrails for unverified AI-generated reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -68,7 +68,7 @@ body:
       description: >
         A small, runnable script that shows the bug: a single-file bot, or a test
         using `run_test()` from `pipecat.tests.utils`. Reports without runnable code
-        get the `needs-repro` label and are closed after 14 days if none is provided.
+        get the `needs-repro` label and are closed after 30 days if none is provided.
         If you truly can't reproduce it in code (e.g. it only happens on rare live
         calls), say so here and include everything you have: logs, timestamps,
         session IDs, and your pipeline setup.
@@ -123,7 +123,7 @@ body:
         AI tools are welcome for writing up a report, but a human must stand behind
         it. See the "Filing Bug Reports" section in CONTRIBUTING.md.
       options:
-        - label: I have personally reproduced this issue on the `main` branch.
+        - label: I have personally reproduced this issue on the latest Pipecat release (or `main`).
           required: true
         - label: I have searched existing issues for this bug.
           required: true

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -62,6 +62,35 @@ body:
       required: true
 
   - type: textarea
+    id: minimal-repro
+    attributes:
+      label: Minimal reproducible example
+      description: >
+        A small, runnable script that shows the bug: a single-file bot, or a test
+        using `run_test()` from `pipecat.tests.utils`. Reports without runnable code
+        get the `needs-repro` label and are closed after 14 days if none is provided.
+        If you truly can't reproduce it in code (e.g. it only happens on rare live
+        calls), say so here and include everything you have: logs, timestamps,
+        session IDs, and your pipeline setup.
+      render: python
+      placeholder: |
+        # A minimal bot or run_test() snippet that triggers the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra-evidence
+    attributes:
+      label: Eval scenario or recordings (optional)
+      description: >
+        Optional, but reports with these get looked at first. A failing
+        `pipecat eval` scenario YAML (see `src/pipecat/evals/`), and/or a link to an
+        audio recording that demonstrates the issue when the bug is audible
+        (interruptions, latency, garbled audio, wrong turn-taking).
+    validations:
+      required: false
+
+  - type: textarea
     id: expected
     attributes:
       label: Expected behavior
@@ -85,3 +114,18 @@ body:
       render: shell
     validations:
       required: false
+
+  - type: checkboxes
+    id: accountability
+    attributes:
+      label: Before you submit
+      description: >
+        AI tools are welcome for writing up a report, but a human must stand behind
+        it. See the "Filing Bug Reports" section in CONTRIBUTING.md.
+      options:
+        - label: I have personally reproduced this issue on the latest Pipecat release (or `main`).
+          required: true
+        - label: I have searched existing issues for this bug.
+          required: true
+        - label: If AI tools helped write this report, I have verified the behavior myself and will personally answer follow-up questions.
+          required: true

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -123,7 +123,7 @@ body:
         AI tools are welcome for writing up a report, but a human must stand behind
         it. See the "Filing Bug Reports" section in CONTRIBUTING.md.
       options:
-        - label: I have personally reproduced this issue on the latest Pipecat release (or `main`).
+        - label: I have personally reproduced this issue on the `main` branch.
           required: true
         - label: I have searched existing issues for this bug.
           required: true

--- a/.github/workflows/needs-repro.yaml
+++ b/.github/workflows/needs-repro.yaml
@@ -1,0 +1,32 @@
+name: Close issues waiting on a reproduction
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only issues labeled `needs-repro` are eligible; everything else is untouched.
+          only-issue-labels: "needs-repro"
+          days-before-issue-stale: 14
+          days-before-issue-close: 0
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # Any activity on the issue (e.g. a comment with the repro) resets the
+          # 14-day clock, so only silent issues are closed.
+          close-issue-message: >
+            Closing this issue because no runnable reproduction was added within 14
+            days of the `needs-repro` label. See the "Filing Bug Reports" section of
+            CONTRIBUTING.md for what we need. If you can provide a minimal
+            reproduction (or logs, timestamps, and session IDs for issues that can't
+            be reproduced in code), please comment and we'll reopen it.
+          close-issue-label: "closed-needs-repro"
+          labels-to-remove-when-stale: "needs-repro"

--- a/.github/workflows/needs-repro.yaml
+++ b/.github/workflows/needs-repro.yaml
@@ -17,14 +17,14 @@ jobs:
           # Only issues labeled `needs-repro` are eligible; everything else is untouched.
           only-issue-labels: "needs-repro"
           stale-issue-message: ""
-          days-before-issue-stale: 14
+          days-before-issue-stale: 30
           days-before-issue-close: 0
           days-before-pr-stale: -1
           days-before-pr-close: -1
           # Any activity on the issue (e.g. a comment with the repro) resets the
-          # 14-day clock, so only silent issues are closed.
+          # 30-day clock, so only silent issues are closed.
           close-issue-message: >
-            Closing this issue because no runnable reproduction was added within 14
+            Closing this issue because no runnable reproduction was added within 30
             days of the `needs-repro` label. See the "Filing Bug Reports" section of
             CONTRIBUTING.md for what we need. If you can provide a minimal
             reproduction (or logs, timestamps, and session IDs for issues that can't

--- a/.github/workflows/needs-repro.yaml
+++ b/.github/workflows/needs-repro.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           # Only issues labeled `needs-repro` are eligible; everything else is untouched.
           only-issue-labels: "needs-repro"
+          stale-issue-message: ""
           days-before-issue-stale: 14
           days-before-issue-close: 0
           days-before-pr-stale: -1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ Reports that appear machine-generated and unverified may be closed with a single
 
 Reports without a runnable reproduction get the `needs-repro` label and one comment asking for it. If no reproduction (or a clear explanation of why one isn't possible) is added within 30 days, the issue is closed automatically. Closed issues can always be reopened once a reproduction is available.
 
+If you respond on a `needs-repro` issue, any comment resets the 30-day clock. When a maintainer reviews your response and confirms it includes a runnable reproduction, they relabel the issue `repro-provided`, which takes it out of the auto-close pool and into the review queue. If what you added still isn't a runnable reproduction, the `needs-repro` label stays and the clock keeps running.
+
 ## Changelog Entries
 
 Every pull request that makes a user-facing change should include a changelog entry. We use a changelog fragment system to avoid merge conflicts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,33 @@ git push origin your-branch-name
 
 Our maintainers will review your PR, and once everything is good, your contributions will be merged!
 
+## Filing Bug Reports
+
+A good bug report is one a maintainer can act on. The single most useful thing you can include is a **minimal runnable reproduction**: a small single-file bot, or a test using `run_test()` from `pipecat.tests.utils`, that shows the bug.
+
+### What we require
+
+- A minimal reproducible example (runnable code, not just prose). If the bug truly can't be captured in code (for example, it only shows up on rare live calls), say so and include everything you have: logs, timestamps, session IDs, and your pipeline setup.
+- Confirmation that you reproduced the issue yourself on the latest release or `main`.
+
+### What gets your report looked at faster
+
+- A failing [behavioral eval](src/pipecat/evals/) scenario that demonstrates the bug.
+- An audio recording, when the bug is audible (interruptions, latency, garbled audio, wrong turn-taking).
+
+### AI-assisted reports
+
+Using AI tools to help write a report is fine. Submitting AI output you haven't verified is not. If you file a report:
+
+- You must have observed the behavior yourself.
+- You must be able to personally answer follow-up questions about it.
+
+Reports that appear machine-generated and unverified may be closed with a single request for justification. Repeat submissions of unverified reports may lead to being blocked from the repository.
+
+### Triage of incomplete reports
+
+Reports without a runnable reproduction get the `needs-repro` label and one comment asking for it. If no reproduction (or a clear explanation of why one isn't possible) is added within 14 days, the issue is closed automatically. Closed issues can always be reopened once a reproduction is available.
+
 ## Changelog Entries
 
 Every pull request that makes a user-facing change should include a changelog entry. We use a changelog fragment system to avoid merge conflicts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ A good bug report is one a maintainer can act on. The single most useful thing y
 ### What we require
 
 - A minimal reproducible example (runnable code, not just prose). If the bug truly can't be captured in code (for example, it only shows up on rare live calls), say so and include everything you have: logs, timestamps, session IDs, and your pipeline setup.
-- Confirmation that you reproduced the issue yourself on the `main` branch.
+- Confirmation that you reproduced the issue yourself on the latest Pipecat release (or `main`).
 
 ### What gets your report looked at faster
 
@@ -61,7 +61,7 @@ Reports that appear machine-generated and unverified may be closed with a single
 
 ### Triage of incomplete reports
 
-Reports without a runnable reproduction get the `needs-repro` label and one comment asking for it. If no reproduction (or a clear explanation of why one isn't possible) is added within 14 days, the issue is closed automatically. Closed issues can always be reopened once a reproduction is available.
+Reports without a runnable reproduction get the `needs-repro` label and one comment asking for it. If no reproduction (or a clear explanation of why one isn't possible) is added within 30 days, the issue is closed automatically. Closed issues can always be reopened once a reproduction is available.
 
 ## Changelog Entries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ A good bug report is one a maintainer can act on. The single most useful thing y
 ### What we require
 
 - A minimal reproducible example (runnable code, not just prose). If the bug truly can't be captured in code (for example, it only shows up on rare live calls), say so and include everything you have: logs, timestamps, session IDs, and your pipeline setup.
-- Confirmation that you reproduced the issue yourself on the latest release or `main`.
+- Confirmation that you reproduced the issue yourself on the `main` branch.
 
 ### What gets your report looked at faster
 


### PR DESCRIPTION
## What this does

We're getting a growing number of AI-generated bug reports. The problem isn't AI-written text (some AI-polished reports describe real bugs); it's **unverified, low-effort reports** that burn maintainer triage time. This PR raises the bar on verification instead of trying to detect AI text, following the pattern that CPython, Kubernetes, and Node.js converged on: AI tools are allowed, but a human must stand behind the report.

## Changes

**Bug report template** (`.github/ISSUE_TEMPLATE/1-bug_report.yml`):
- New required field: a runnable minimal reproduction (single-file bot or a `run_test()` snippet). Free-text repro steps are the field LLMs fake best; runnable code is the field they fake worst.
- New optional field: a failing `pipecat eval` scenario and/or audio recording. Framed as a fast lane (looked at first), not a gate, so we don't wall out real users who've never touched the eval harness.
- New required checkboxes: reproduced on main, searched existing issues, and if AI helped write the report, the reporter verified the behavior and will personally answer follow-ups.

**CONTRIBUTING.md**: new "Filing Bug Reports" section documenting the requirements, the fast lane, the AI-assisted-reports policy, and the triage flow. This gives maintainers something to link instead of writing bespoke replies to bots.

**New workflow** (`.github/workflows/needs-repro.yaml`): `actions/stale` scoped to the `needs-repro` label only. Issues get one templated comment asking for a repro; 14 days of silence closes them with a polite reopen path. All other issues are untouched.

## Setup needed before merge

- [ ] Create the `needs-repro` and `closed-needs-repro` labels in the repo.
- [ ] Maintainer agreement on the triage flow (label + one templated comment, don't argue with bots).

## Open questions (why this is a draft)

- Is requiring a runnable repro too strict for hard-to-reproduce live-call bugs? The template offers an escape hatch (explain why + provide logs/session IDs), but wording could be softened.
- 14-day close window: too short? too long?
- Should the question/troubleshooting templates get the same checkboxes?

