### PR TITLE
Updating elevenlabs default model to eleven_flash_v2_5

### DIFF
--- a/changelog/4999.changed.md
+++ b/changelog/4999.changed.md
@@ -1,0 +1,1 @@
+- Changed the default ElevenLabs TTS model from `eleven_turbo_v2_5` to `eleven_flash_v2_5` in `ElevenLabsTTSService` and `ElevenLabsHttpTTSService`, since `eleven_turbo_v2_5` is now deprecated by ElevenLabs. This only affects users who don't explicitly set a `model`.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -465,7 +465,7 @@ class ElevenLabsTTSService(WebsocketTTSService):
                     Use ``settings=ElevenLabsTTSService.Settings(voice=...)`` instead.
                     Will be removed in 2.0.0.
 
-            model: TTS model to use (e.g., "eleven_turbo_v2_5").
+            model: TTS model to use (e.g., "eleven_flash_v2_5").
 
                 .. deprecated:: 0.0.105
                     Use ``settings=ElevenLabsTTSService.Settings(model=...)`` instead.
@@ -520,7 +520,7 @@ class ElevenLabsTTSService(WebsocketTTSService):
 
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="eleven_turbo_v2_5",
+            model="eleven_flash_v2_5",
             voice=None,
             language=None,
             stability=None,
@@ -1105,7 +1105,7 @@ class ElevenLabsHttpTTSService(TTSService):
                     Will be removed in 2.0.0.
 
             aiohttp_session: aiohttp ClientSession for HTTP requests.
-            model: TTS model to use (e.g., "eleven_turbo_v2_5").
+            model: TTS model to use (e.g., "eleven_flash_v2_5").
 
                 .. deprecated:: 0.0.105
                     Use ``settings=ElevenLabsHttpTTSService.Settings(model=...)`` instead.
@@ -1136,7 +1136,7 @@ class ElevenLabsHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="eleven_turbo_v2_5",
+            model="eleven_flash_v2_5",
             voice=None,
             language=None,
             optimize_streaming_latency=None,

--- a/src/pipecat/services/settings.py
+++ b/src/pipecat/services/settings.py
@@ -180,7 +180,7 @@ class ServiceSettings:
     # -- common fields -------------------------------------------------------
 
     model: str | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
-    """AI model identifier (e.g. ``"gpt-4o"``, ``"eleven_turbo_v2_5"``).
+    """AI model identifier (e.g. ``"gpt-4o"``, ``"eleven_flash_v2_5"``).
 
     Defaults to ``NOT_GIVEN`` for delta mode.  In store mode, set to a
     model string or ``None`` if the service has no model concept.

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -388,7 +388,7 @@ async def _http_payload_for_model(model: str) -> dict:
 
 @pytest.mark.asyncio
 async def test_http_payload_includes_previous_text_when_supported():
-    payload = await _http_payload_for_model("eleven_turbo_v2_5")
+    payload = await _http_payload_for_model("eleven_flash_v2_5")
     assert payload["previous_text"] == "Hello!"
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -299,7 +299,7 @@ class TestRoundtrip:
     def test_from_mapping_then_apply_update(self):
         """Simulate the real flow: dict arrives via frame, gets converted, applied."""
         # Simulating current service state
-        current = TTSSettings(model="eleven_turbo_v2_5", voice="alice", language="en")
+        current = TTSSettings(model="eleven_flash_v2_5", voice="alice", language="en")
         current.extra = {"stability": 0.5, "speed": 1.0}
 
         # Incoming dict-based update


### PR DESCRIPTION
## Summary

Changed the default ElevenLabs TTS model from `eleven_turbo_v2_5` to `eleven_flash_v2_5` in `ElevenLabsTTSService` and `ElevenLabsHttpTTSService`, since `eleven_turbo_v2_5` is now deprecated by ElevenLabs. This only affects users who don't explicitly set a `model`.