### PR TITLE
Share auto-hang-up lifecycle across telephony serializers

### DIFF
--- a/changelog/5014.added.md
+++ b/changelog/5014.added.md
@@ -1,0 +1,1 @@
+- Added `AutoHangupFrameSerializer` for implementing once-only automatic call termination in telephony serializers.

--- a/src/pipecat/serializers/base_telephony.py
+++ b/src/pipecat/serializers/base_telephony.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Shared lifecycle behavior for telephony frame serializers."""
+
+from abc import abstractmethod
+
+from pipecat.frames.frames import CancelFrame, EndFrame, Frame
+from pipecat.serializers.base_serializer import FrameSerializer
+
+
+class AutoHangupFrameSerializer(FrameSerializer):
+    """Base serializer for providers supporting automatic call termination."""
+
+    def __init__(self, params: FrameSerializer.InputParams | None = None, **kwargs):
+        """Initialize automatic call termination state.
+
+        Args:
+            params: Configuration parameters.
+            **kwargs: Additional arguments passed to :class:`FrameSerializer`.
+        """
+        super().__init__(params=params, **kwargs)
+        self._hangup_attempted = False
+
+    async def _maybe_hang_up(self, frame: Frame, *, enabled: bool) -> bool:
+        """Attempt to terminate the call for an enabled terminal frame.
+
+        Args:
+            frame: Frame being serialized.
+            enabled: Whether automatic call termination is enabled.
+
+        Returns:
+            True if the terminal frame was consumed.
+        """
+        if not enabled or not isinstance(frame, (EndFrame, CancelFrame)):
+            return False
+
+        if not self._hangup_attempted:
+            self._hangup_attempted = True
+            await self._hang_up_call()
+
+        return True
+
+    @abstractmethod
+    async def _hang_up_call(self) -> None:
+        """Terminate the active provider call."""
+        pass

--- a/src/pipecat/serializers/plivo.py
+++ b/src/pipecat/serializers/plivo.py
@@ -16,8 +16,6 @@ from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.audio.utils import create_stream_resampler, pcm_to_ulaw, ulaw_to_pcm
 from pipecat.frames.frames import (
     AudioRawFrame,
-    CancelFrame,
-    EndFrame,
     Frame,
     InputAudioRawFrame,
     InputDTMFFrame,
@@ -27,9 +25,10 @@ from pipecat.frames.frames import (
     StartFrame,
 )
 from pipecat.serializers.base_serializer import FrameSerializer
+from pipecat.serializers.base_telephony import AutoHangupFrameSerializer
 
 
-class PlivoFrameSerializer(FrameSerializer):
+class PlivoFrameSerializer(AutoHangupFrameSerializer):
     """Serializer for Plivo Audio Streaming WebSocket protocol.
 
     This serializer handles converting between Pipecat frames and Plivo's WebSocket
@@ -105,7 +104,6 @@ class PlivoFrameSerializer(FrameSerializer):
         self._output_resampler = create_stream_resampler(
             clear_after_secs=self._params.resampler_clear_after_secs
         )
-        self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.
@@ -127,13 +125,7 @@ class PlivoFrameSerializer(FrameSerializer):
         Returns:
             Serialized data as string or bytes, or None if the frame isn't handled.
         """
-        if (
-            self._params.auto_hang_up
-            and not self._hangup_attempted
-            and isinstance(frame, (EndFrame, CancelFrame))
-        ):
-            self._hangup_attempted = True
-            await self._hang_up_call()
+        if await self._maybe_hang_up(frame, enabled=self._params.auto_hang_up):
             return None
         elif isinstance(frame, InterruptionFrame):
             answer = {"event": "clearAudio", "streamId": self._stream_id}

--- a/src/pipecat/serializers/telnyx.py
+++ b/src/pipecat/serializers/telnyx.py
@@ -23,8 +23,6 @@ from pipecat.audio.utils import (
 )
 from pipecat.frames.frames import (
     AudioRawFrame,
-    CancelFrame,
-    EndFrame,
     Frame,
     InputAudioRawFrame,
     InputDTMFFrame,
@@ -32,9 +30,10 @@ from pipecat.frames.frames import (
     StartFrame,
 )
 from pipecat.serializers.base_serializer import FrameSerializer
+from pipecat.serializers.base_telephony import AutoHangupFrameSerializer
 
 
-class TelnyxFrameSerializer(FrameSerializer):
+class TelnyxFrameSerializer(AutoHangupFrameSerializer):
     """Serializer for Telnyx WebSocket protocol.
 
     This serializer handles converting between Pipecat frames and Telnyx's WebSocket
@@ -114,7 +113,6 @@ class TelnyxFrameSerializer(FrameSerializer):
         self._output_resampler = create_stream_resampler(
             clear_after_secs=self._params.resampler_clear_after_secs
         )
-        self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.
@@ -139,13 +137,7 @@ class TelnyxFrameSerializer(FrameSerializer):
         Raises:
             ValueError: If an unsupported encoding is specified.
         """
-        if (
-            self._params.auto_hang_up
-            and not self._hangup_attempted
-            and isinstance(frame, (EndFrame, CancelFrame))
-        ):
-            self._hangup_attempted = True
-            await self._hang_up_call()
+        if await self._maybe_hang_up(frame, enabled=self._params.auto_hang_up):
             return None
         elif isinstance(frame, InterruptionFrame):
             answer = {"event": "clear"}

--- a/src/pipecat/serializers/twilio.py
+++ b/src/pipecat/serializers/twilio.py
@@ -16,8 +16,6 @@ from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.audio.utils import create_stream_resampler, pcm_to_ulaw, ulaw_to_pcm
 from pipecat.frames.frames import (
     AudioRawFrame,
-    CancelFrame,
-    EndFrame,
     Frame,
     InputAudioRawFrame,
     InputDTMFFrame,
@@ -27,6 +25,7 @@ from pipecat.frames.frames import (
     StartFrame,
 )
 from pipecat.serializers.base_serializer import FrameSerializer
+from pipecat.serializers.base_telephony import AutoHangupFrameSerializer
 
 
 def _build_call_resource_url(
@@ -54,7 +53,7 @@ def _build_call_resource_url(
     return f"{root}/2010-04-01/Accounts/{account_sid}/Calls/{call_sid}.json"
 
 
-class TwilioFrameSerializer(FrameSerializer):
+class TwilioFrameSerializer(AutoHangupFrameSerializer):
     """Serializer for Twilio Media Streams WebSocket protocol.
 
     This serializer handles converting between Pipecat frames and Twilio's WebSocket
@@ -153,7 +152,6 @@ class TwilioFrameSerializer(FrameSerializer):
         self._output_resampler = create_stream_resampler(
             clear_after_secs=self._params.resampler_clear_after_secs
         )
-        self._hangup_attempted = False
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.
@@ -175,13 +173,7 @@ class TwilioFrameSerializer(FrameSerializer):
         Returns:
             Serialized data as string or bytes, or None if the frame isn't handled.
         """
-        if (
-            self._params.auto_hang_up
-            and not self._hangup_attempted
-            and isinstance(frame, (EndFrame, CancelFrame))
-        ):
-            self._hangup_attempted = True
-            await self._hang_up_call()
+        if await self._maybe_hang_up(frame, enabled=self._params.auto_hang_up):
             return None
         elif isinstance(frame, InterruptionFrame):
             answer = {"event": "clear", "streamSid": self._stream_sid}

--- a/tests/test_telephony_serializer.py
+++ b/tests/test_telephony_serializer.py
@@ -1,0 +1,214 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for shared telephony serializer lifecycle behavior."""
+
+import asyncio
+import json
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.frames.frames import CancelFrame, EndFrame, Frame, InterruptionFrame, TextFrame
+from pipecat.serializers.base_telephony import AutoHangupFrameSerializer
+from pipecat.serializers.plivo import PlivoFrameSerializer
+from pipecat.serializers.telnyx import TelnyxFrameSerializer
+from pipecat.serializers.twilio import TwilioFrameSerializer
+
+
+class _TestAutoHangupFrameSerializer(AutoHangupFrameSerializer):
+    """Minimal serializer used to exercise automatic hang-up behavior."""
+
+    def __init__(self):
+        super().__init__()
+        self.hang_up = AsyncMock()
+
+    async def serialize(self, frame: Frame) -> str | bytes | None:
+        return None
+
+    async def deserialize(self, data: str | bytes) -> Frame | None:
+        return None
+
+    async def _hang_up_call(self) -> None:
+        await self.hang_up()
+
+
+@pytest.mark.asyncio
+async def test_auto_hangup_ignores_non_terminal_frame():
+    serializer = _TestAutoHangupFrameSerializer()
+
+    handled = await serializer._maybe_hang_up(TextFrame(text="hello"), enabled=True)
+
+    assert handled is False
+    serializer.hang_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame", [EndFrame(), CancelFrame()])
+async def test_auto_hangup_ignores_terminal_frame_when_disabled(frame: Frame):
+    serializer = _TestAutoHangupFrameSerializer()
+
+    handled = await serializer._maybe_hang_up(frame, enabled=False)
+
+    assert handled is False
+    serializer.hang_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame", [EndFrame(), CancelFrame()])
+async def test_auto_hangup_handles_terminal_frame(frame: Frame):
+    serializer = _TestAutoHangupFrameSerializer()
+
+    handled = await serializer._maybe_hang_up(frame, enabled=True)
+
+    assert handled is True
+    serializer.hang_up.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_auto_hangup_attempts_once_for_mixed_terminal_frames():
+    serializer = _TestAutoHangupFrameSerializer()
+
+    first_handled = await serializer._maybe_hang_up(EndFrame(), enabled=True)
+    second_handled = await serializer._maybe_hang_up(CancelFrame(), enabled=True)
+
+    assert first_handled is True
+    assert second_handled is True
+    serializer.hang_up.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_auto_hangup_marks_attempt_before_awaiting_provider_io():
+    serializer = _TestAutoHangupFrameSerializer()
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def delayed_hang_up():
+        started.set()
+        await finish.wait()
+
+    serializer.hang_up.side_effect = delayed_hang_up
+    first = asyncio.create_task(serializer._maybe_hang_up(EndFrame(), enabled=True))
+    await started.wait()
+
+    second_handled = await serializer._maybe_hang_up(CancelFrame(), enabled=True)
+    finish.set()
+    first_handled = await first
+
+    assert first_handled is True
+    assert second_handled is True
+    serializer.hang_up.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_auto_hangup_does_not_retry_after_provider_error():
+    serializer = _TestAutoHangupFrameSerializer()
+    serializer.hang_up.side_effect = RuntimeError("provider error")
+
+    with pytest.raises(RuntimeError, match="provider error"):
+        await serializer._maybe_hang_up(EndFrame(), enabled=True)
+
+    handled = await serializer._maybe_hang_up(CancelFrame(), enabled=True)
+
+    assert handled is True
+    serializer.hang_up.assert_awaited_once_with()
+
+
+def _twilio_serializer(*, auto_hang_up: bool = True) -> TwilioFrameSerializer:
+    params = TwilioFrameSerializer.InputParams(auto_hang_up=auto_hang_up)
+    return TwilioFrameSerializer(
+        "stream-id",
+        call_sid="call-id",
+        account_sid="account-id",
+        auth_token="auth-token",
+        params=params,
+    )
+
+
+def _telnyx_serializer(*, auto_hang_up: bool = True) -> TelnyxFrameSerializer:
+    params = TelnyxFrameSerializer.InputParams(auto_hang_up=auto_hang_up)
+    return TelnyxFrameSerializer(
+        "stream-id",
+        "PCMU",
+        "PCMU",
+        call_control_id="call-control-id",
+        api_key="api-key",
+        params=params,
+    )
+
+
+def _plivo_serializer(*, auto_hang_up: bool = True) -> PlivoFrameSerializer:
+    params = PlivoFrameSerializer.InputParams(auto_hang_up=auto_hang_up)
+    return PlivoFrameSerializer(
+        "stream-id",
+        call_id="call-id",
+        auth_id="auth-id",
+        auth_token="auth-token",
+        params=params,
+    )
+
+
+SerializerFactory = Callable[..., AutoHangupFrameSerializer]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_twilio_serializer, _telnyx_serializer, _plivo_serializer])
+@pytest.mark.parametrize("frame", [EndFrame(), CancelFrame()])
+async def test_provider_auto_hangup_handles_terminal_frame(
+    factory: SerializerFactory, frame: Frame
+):
+    serializer = factory()
+    serializer._hang_up_call = AsyncMock()
+
+    result = await serializer.serialize(frame)
+
+    assert result is None
+    serializer._hang_up_call.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_twilio_serializer, _telnyx_serializer, _plivo_serializer])
+async def test_provider_auto_hangup_attempts_once(factory: SerializerFactory):
+    serializer = factory()
+    serializer._hang_up_call = AsyncMock()
+
+    await serializer.serialize(EndFrame())
+    await serializer.serialize(CancelFrame())
+
+    serializer._hang_up_call.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_twilio_serializer, _telnyx_serializer, _plivo_serializer])
+async def test_provider_auto_hangup_can_be_disabled(factory: SerializerFactory):
+    serializer = factory(auto_hang_up=False)
+    serializer._hang_up_call = AsyncMock()
+
+    result = await serializer.serialize(EndFrame())
+
+    assert result is None
+    serializer._hang_up_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("factory", "expected"),
+    [
+        (_twilio_serializer, {"event": "clear", "streamSid": "stream-id"}),
+        (_telnyx_serializer, {"event": "clear"}),
+        (_plivo_serializer, {"event": "clearAudio", "streamId": "stream-id"}),
+    ],
+)
+async def test_provider_interruption_serialization_is_unchanged(
+    factory: SerializerFactory, expected: dict[str, str]
+):
+    serializer = factory()
+
+    result = await serializer.serialize(InterruptionFrame())
+
+    assert isinstance(result, str)
+    assert json.loads(result) == expected


### PR DESCRIPTION
## Summary

  - Adds `AutoHangupFrameSerializer` to share terminal-frame handling across REST-based telephony serializers
  - Migrates Twilio, Telnyx, and Plivo while preserving their provider-specific hang-up behavior
  - Prevents repeated or concurrent `EndFrame` and `CancelFrame` processing from triggering duplicate hang-up attempts
  - Leaves Genesys, Exotel, Vonage, and non-telephony serializers unchanged

  ## Testing

  - Added lifecycle tests covering terminal-frame detection, disabled handling, duplicate attempts, concurrency, and provider errors
  - Added regression coverage for Twilio, Telnyx, and Plivo
  - Verified Genesys and Protobuf serializer behavior remains unchanged
  - Ran 59 focused tests, Ruff lint, and Ruff formatting checks

  ## Fixes

  - Fixes #5013