### PR TITLE
fix(google): finalize final STT transcripts

### DIFF
--- a/changelog/5018.fixed.md
+++ b/changelog/5018.fixed.md
@@ -1,0 +1,1 @@
+- Fixed Google STT final results waiting for the fallback turn-stop timeout instead of finalizing immediately.

--- a/src/pipecat/services/google/stt.py
+++ b/src/pipecat/services/google/stt.py
@@ -999,6 +999,7 @@ class GoogleSTTService(STTService):
                                 time_now_iso8601(),
                                 primary_language,
                                 result=result,
+                                finalized=True,
                             )
                         )
                         await self.stop_processing_metrics()

--- a/tests/test_google_stt.py
+++ b/tests/test_google_stt.py
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Google STT streaming response handling."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from pipecat.frames.frames import InterimTranscriptionFrame, TranscriptionFrame
+from pipecat.services.google.stt import GoogleSTTService
+
+
+class AsyncResponses:
+    """Minimal async iterator for Google streaming responses."""
+
+    def __init__(self, responses):
+        self._responses = iter(responses)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._responses)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def result(*, transcript: str, is_final: bool):
+    return SimpleNamespace(
+        alternatives=[SimpleNamespace(transcript=transcript)],
+        is_final=is_final,
+    )
+
+
+@pytest.mark.asyncio
+async def test_google_final_result_emits_finalized_transcription_frame():
+    service = object.__new__(GoogleSTTService)
+    service._stream_start_time = int(time.time() * 1000)
+    service._user_id = "user"
+    service._last_transcript_was_final = False
+    service._get_language_codes = lambda: ["en-US"]
+
+    frames = []
+    transcriptions = []
+
+    async def push_frame(frame):
+        frames.append(frame)
+
+    async def stop_processing_metrics():
+        pass
+
+    async def handle_transcription(transcript, is_final, language=None):
+        transcriptions.append((transcript, is_final, language))
+
+    service.push_frame = push_frame
+    service.stop_processing_metrics = stop_processing_metrics
+    service._handle_transcription = handle_transcription
+
+    responses = AsyncResponses(
+        [
+            SimpleNamespace(results=[result(transcript="hel", is_final=False)]),
+            SimpleNamespace(results=[result(transcript="hello", is_final=True)]),
+        ]
+    )
+
+    await service._process_responses(responses)
+
+    assert isinstance(frames[0], InterimTranscriptionFrame)
+    assert isinstance(frames[1], TranscriptionFrame)
+    assert frames[1].finalized is True
+    assert transcriptions == [("hello", True, "en-US")]


### PR DESCRIPTION
## Summary

- Mark final Google streaming recognition results as `finalized=True` before they reach tracing and turn-stop consumers.
- Add an async regression test covering interim and final Google responses.
- Add a changelog fragment for the user-visible latency fix.

Fixes #5018.

## Why

`GoogleSTTService` emits a `TranscriptionFrame` for `is_final` results but currently leaves `finalized=False`. Both turn-stop strategies therefore miss their finalized-transcript fast path and wait for the Google TTFS fallback timer even though the final transcript has already arrived.

The frame is marked at construction time so the existing tracing wrapper and downstream strategies observe the correct contract, matching Azure's final-result behavior.

## Measured impact

The issue reporter's isolated strategy harness measured:

| Case | Dispatch after VAD stop |
| --- | ---: |
| Current Google final | 1371.1 ms |
| Finalized Google result | 702.1 ms |

That removes about 669 ms (48.8%) from this path.

Their end-to-end LiveKit pipeline measured:

| Metric | Stock | Finalized result | Change |
| --- | ---: | ---: | ---: |
| Median | 2799 ms | 2239 ms | -560 ms (-20.0%) |
| p95 | 2939 ms | 2389 ms | -550 ms (-18.7%) |

The strict local evaluator uses a hardware-independent contract metric:

- baseline: `google_stt_finalized_frame=0`
- candidate: `google_stt_finalized_frame=1`

## Autoresearch

I ran autoresearch with Weco against a strict evaluator that allows only `finalized=True` on the final Google `TranscriptionFrame`, rejects changes to interim semantics, compares the normalized full-file AST with the baseline, and runs the focused upstream turn-stop suite. The 14-step search converged on this one-line production change.

Public trajectory: https://dashboard.weco.ai/share/O9KhWTa6PQA5zZfZDDyhPsXHZK0Nivo7

## Behavioral note

Google can emit multiple final segments for one long utterance. Marking those segments finalized gives Google the same fast-path behavior as Azure and can dispatch during a long pause when the turn analyzer judges the fragment complete. Issue #5018 documents this trade-off and interruption recovery behavior.

## Validation

- `uvx ruff check --fix .`
- strict evaluator: 31 passed; `google_stt_finalized_frame=1`; contract pass
- `uv run pytest tests/test_google_stt.py tests/test_user_turn_stop_strategy.py -q`: 27 passed
- `uv run towncrier build --draft --version Unreleased`
- `git diff --check`
