### PR TITLE
Ignore user turn inference triggers while user is speaking

### DIFF
--- a/changelog/5029.fixed.md
+++ b/changelog/5029.fixed.md
@@ -1,0 +1,1 @@
+- Fixed user turn inference being triggered while the user is speaking.

--- a/src/pipecat/turns/user_turn_controller.py
+++ b/src/pipecat/turns/user_turn_controller.py
@@ -8,6 +8,8 @@
 
 import asyncio
 
+from loguru import logger
+
 from pipecat.frames.frames import (
     Frame,
     InterimTranscriptionFrame,
@@ -303,6 +305,13 @@ class UserTurnController(BaseObject):
         # Inference-triggered fires only while a turn is active. The turn
         # remains active afterward — only `on_user_turn_stopped` flips state.
         if not self._user_turn:
+            return
+
+        if self._user_speaking:
+            logger.debug(
+                f"{self}: User turn inference trigger ignored while user is speaking "
+                f"(strategy: {strategy})"
+            )
             return
 
         # Re-arm the stop watchdog so a stuck turn (inference fired but

--- a/tests/test_user_turn_controller.py
+++ b/tests/test_user_turn_controller.py
@@ -164,6 +164,42 @@ class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(events, ["inference_triggered", "stopped"])
 
+    async def test_inference_trigger_dropped_while_user_speaking(self):
+        """Inference and finalization wait until the user is no longer speaking."""
+        stop = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+        controller = UserTurnController(
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=[stop],
+            )
+        )
+
+        await controller.setup(self.task_manager)
+
+        events: list[str] = []
+
+        @controller.event_handler("on_user_turn_inference_triggered")
+        async def on_user_turn_inference_triggered(controller, strategy):
+            events.append("inference_triggered")
+
+        @controller.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(controller, strategy, params):
+            events.append("stopped")
+
+        await controller.process_frame(VADUserStartedSpeakingFrame())
+
+        # A stop decision can resolve after the user has resumed speaking.
+        # Neither inference nor finalization should proceed until a fresh
+        # decision arrives after the user falls silent.
+        await stop.trigger_user_turn_stopped()
+        self.assertEqual(events, [])
+
+        await controller.process_frame(VADUserStoppedSpeakingFrame())
+        await stop.trigger_user_turn_stopped()
+        self.assertEqual(events, ["inference_triggered", "stopped"])
+
+        await controller.cleanup()
+
     async def test_deferred_wrapper_skips_stopped(self):
         """A deferred() wrapper drops the inner strategy's on_user_turn_stopped event."""
         wrapped = deferred(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`UserTurnController._trigger_user_turn_stop()` already ignores a stop while `_user_speaking` is true. This applies the same live-speaking guard to `_trigger_user_turn_inference_triggered()`.

A stop strategy commonly emits inference-triggered and stopped together. Without the matching guard, inference can begin even though the paired stop is ignored because the user is still speaking. The controller now ignores and logs the inference trigger in that state. A fresh trigger after the user becomes silent proceeds normally.

The regression test covers both sides: inference and stop are ignored during live speech, then both fire after silence.

Tested with:

- `uv run pytest tests/test_user_turn_controller.py` — 10 passed
- `uv run ruff check src/pipecat/turns/user_turn_controller.py tests/test_user_turn_controller.py`
- `uv run ruff format --check src/pipecat/turns/user_turn_controller.py tests/test_user_turn_controller.py`

AI-assisted: this change was prepared with AI assistance and reviewed by me before submission.