### PR TITLE
fix(cli): include video extras in generated projects

### DIFF
--- a/changelog/5031.fixed.md
+++ b/changelog/5031.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `pipecat init` omitting the video avatar provider's extra from the generated project's `pipecat-ai` dependency. Choosing Tavus, HeyGen, or Simli produced a `bot.py` importing that service while `pyproject.toml` requested only the transport and cascade extras, so the scaffolded bot failed to import after a fresh `uv sync`.

--- a/src/pipecat/cli/generators/project.py
+++ b/src/pipecat/cli/generators/project.py
@@ -344,6 +344,9 @@ class ProjectGenerator:
         elif self.config.realtime_service:
             services["realtime"] = self.config.realtime_service
 
+        if self.config.video_service:
+            services["video"] = self.config.video_service
+
         # Extract all required extras
         extras = ServiceLoader.extract_extras_for_services(services)
 

--- a/tests/cli/test_project_generation.py
+++ b/tests/cli/test_project_generation.py
@@ -3,6 +3,7 @@
 import ast
 import shutil
 import subprocess
+import tomllib
 
 import pytest
 
@@ -39,8 +40,6 @@ def validate_python_syntax(file_path):
 
 def validate_pyproject_toml(file_path):
     """Validate that pyproject.toml is valid TOML and has required fields."""
-    import tomllib
-
     with open(file_path, "rb") as f:
         data = tomllib.load(f)
 
@@ -554,20 +553,31 @@ def test_project_generation(config_data, temp_output_dir):
 
     # Verify video service dependencies and imports
     if config.video_service:
+        with open(pyproject_file, "rb") as f:
+            dependencies = tomllib.load(f)["project"]["dependencies"]
+        pipecat_dependency = next(
+            dependency for dependency in dependencies if dependency.startswith("pipecat-ai[")
+        )
+        pipecat_extras = set(pipecat_dependency.split("[", 1)[1].split("]", 1)[0].split(","))
+        video_extras = {
+            "tavus_video": "tavus",
+            "heygen_video": "heygen",
+            "simli_video": "simli",
+        }
+
         # Video services should be in bot.py
         if config.video_service == "tavus_video":
             assert "TavusVideoService" in bot_content, "TavusVideoService should be imported"
-            assert "tavus" in pyproject_content, "tavus extra should be in dependencies"
         elif config.video_service == "heygen_video":
             assert "HeyGenVideoService" in bot_content, "HeyGenVideoService should be imported"
-            assert "heygen" in pyproject_content, "heygen extra should be in dependencies"
             assert "LiveAvatarNewSessionRequest" in bot_content, (
                 "LiveAvatarNewSessionRequest should be imported for HeyGen"
             )
             assert "ServiceType" in bot_content, "ServiceType should be imported for HeyGen"
         elif config.video_service == "simli_video":
             assert "SimliVideoService" in bot_content, "SimliVideoService should be imported"
-            assert "simli" in pyproject_content, "simli extra should be in dependencies"
+
+        assert video_extras[config.video_service] in pipecat_extras
 
         # Video service should be initialized in bot.py
         assert "video" in bot_content.lower(), "video service variable should be present"


### PR DESCRIPTION
## Summary

- Include the selected video service when resolving generated Pipecat extras.
- Parse the generated Pipecat dependency in project-generation tests, so provider names in project names cannot mask a missing extra.

## Root cause

Generated bot imports included the selected video provider, but the generated server dependency list resolved extras without that service.

## Validation

- `python -m pytest tests/cli -q` (310 passed)
- `ruff check` and `ruff format --check`
- Generated Tavus, HeyGen, and Simli project manifests each contain the matching provider extra.
