### PR TITLE
fix(tts): recover from zero-audio context completion

### DIFF
--- a/changelog/5026.fixed.md
+++ b/changelog/5026.fixed.md
@@ -1,0 +1,1 @@
+- Fixed TTS contexts that complete without audio so they resume frame processing and report a non-fatal error.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1497,6 +1497,7 @@ class TTSService(AIService):
         running = True
         timestamps_started = False
         should_push_stop_frame = False
+        received_audio = False
         while running:
             try:
                 frame = await asyncio.wait_for(queue.get(), timeout=self._stop_frame_timeout_s)
@@ -1515,6 +1516,7 @@ class TTSService(AIService):
                     )
                     continue
                 elif isinstance(frame, TTSAudioRawFrame):
+                    received_audio = True
                     # Set the word-timestamp baseline once, on the first audio chunk.
                     if not timestamps_started:
                         await self.stop_ttfb_metrics()
@@ -1559,6 +1561,12 @@ class TTSService(AIService):
             await self.push_frame(TTSStoppedFrame(context_id=context_id))
 
         await self._maybe_reset_word_timestamps(context_id)
+
+        if not received_audio:
+            await self._maybe_resume_frame_processing()
+            await self.push_error_frame(
+                ErrorFrame(error=f"{self} produced no audio for context {context_id}")
+            )
 
     async def on_audio_context_interrupted(self, context_id: str):
         """Called when an audio context is cancelled due to an interruption.

--- a/tests/test_tts_frame_ordering.py
+++ b/tests/test_tts_frame_ordering.py
@@ -42,6 +42,7 @@ from pipecat.frames.frames import (
     AggregatedTextFrame,
     ControlFrame,
     DataFrame,
+    ErrorFrame,
     Frame,
     InterruptionFrame,
     LLMAssistantPushAggregationFrame,
@@ -295,6 +296,31 @@ class MockWebSocketPauseTTSServiceNoAudio(TTSService):
             yield
 
 
+class MockWebSocketPauseTTSServiceEmptyContext(TTSService):
+    """Simulates a WebSocket TTS service that completes without audio."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            push_start_frame=True,
+            push_text_frames=False,
+            pause_frame_processing=True,
+            sample_rate=_SAMPLE_RATE,
+            **kwargs,
+        )
+
+    def can_generate_metrics(self) -> bool:
+        return False
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        async def _complete_context():
+            await asyncio.sleep(0.01)
+            await self.remove_audio_context(context_id)
+
+        self.create_task(_complete_context(), name=f"mock_ws_pause_empty_{context_id}")
+        if False:
+            yield
+
+
 class _MockWordTimestampHttpTTSService(TTSService):
     """HTTP-style TTS: yields audio synchronously, calls add_word_timestamps first.
 
@@ -534,6 +560,7 @@ async def test_websocket_tts_with_pause_frame_ordering():
     tts = MockWebSocketPauseTTSService()
     frames_received = await run_test(tts, frames_to_send=_make_frames_no_sleep())
     _assert_group_ordering(frames_received[0], _GROUPS)
+    assert not any(isinstance(frame, ErrorFrame) for frames in frames_received for frame in frames)
 
 
 @pytest.mark.asyncio
@@ -1266,6 +1293,34 @@ async def test_no_deadlock_on_interrupt_before_audio_simple():
     assert any(f.label == "after_interrupt" for f in foo_frames), (
         "FooFrame after interruption was not received — possible deadlock"
     )
+
+
+@pytest.mark.asyncio
+async def test_empty_audio_context_resumes_processing_and_pushes_error():
+    """A completed empty paused context must not block the pipeline or hide the failure."""
+    tts = MockWebSocketPauseTTSServiceEmptyContext()
+
+    frames_received = await asyncio.wait_for(
+        run_test(
+            tts,
+            frames_to_send=[
+                LLMFullResponseStartFrame(),
+                TextFrame(text="Hello."),
+                LLMFullResponseEndFrame(),
+                FooFrame(label="after_empty_context"),
+            ],
+        ),
+        timeout=3.0,
+    )
+
+    assert any(
+        isinstance(frame, FooFrame) and frame.label == "after_empty_context"
+        for frame in frames_received[0]
+    )
+    errors = [frame for frame in frames_received[1] if isinstance(frame, ErrorFrame)]
+    assert len(errors) == 1
+    assert errors[0].fatal is False
+    assert "produced no audio for context" in errors[0].error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- resume paused frame processing when a TTS audio context completes without emitting audio
- report the zero-audio completion as a non-fatal `ErrorFrame` so fallback handling can run
- add regression coverage for both empty and normal audio contexts

Fixes #5026.

## Evaluation

Autoresearch with Weco identified the `received_audio` guard and resume/error recovery direction. I reduced that result to the narrow production change above, added repository tests, and independently revalidated the cleaned patch.

[Public Weco trajectory](https://dashboard.weco.ai/share/rDifdtFAOtGbZ6OxCm8wd8SuOV3VdKAp)

The strict production-path evaluator measures elapsed time from a ready zero-audio TTS context until frame processing resumes, a non-fatal error activates fallback, and all Pipecat tasks are cleaned up:

- current `main`: `2200.000 ms` capped timeout sentinel
- reviewed Weco step: `285.787 ms`
- cleaned PR patch: `288.834 ms` (`86.9%` lower than the baseline sentinel)

The timeout sentinel is accepted only for the exact pinned upstream source. Any modified candidate must complete the recovery, fallback, ordering, and cleanup gates to emit a metric.

## Validation

- `uv run pytest tests/test_tts_frame_ordering.py` (`32 passed`)
- `uvx ruff check --fix .`
- `uv run pyright src/pipecat/services/tts_service.py tests/test_tts_frame_ordering.py`
- strict source-scope and zero-audio recovery evaluator
- independent code review
