### PR TITLE
Document the GPL-3.0 license of the in-process piper-tts dependency

### DIFF
--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -46,6 +46,14 @@ class PiperTTSService(TTSService):
     Provides local text-to-speech synthesis using Piper voice models. Automatically
     downloads voice models if not already present and resamples audio output to
     match the configured sample rate.
+
+    .. note::
+        This service runs Piper in-process via the ``piper-tts`` package (the
+        ``piper`` extra), which is **GPL-3.0 licensed**. Distributing an
+        application that includes it may subject the application to the GPL's
+        source-disclosure terms. To keep Piper out of your application's
+        license scope, use :class:`PiperHttpTTSService` instead, which talks to
+        a separately installed Piper HTTP server.
     """
 
     Settings = PiperTTSSettings


### PR DESCRIPTION
## Summary

The `piper` extra installs `piper-tts>=1.3.0`, which is GPL-3.0 licensed (the project moved to [piper1-gpl](https://github.com/OHF-Voice/piper1-gpl); the earlier MIT line is unmaintained). Applications that bundle the in-process `PiperTTSService` and are distributed to third parties may be subject to the GPL's source-disclosure terms — something easy to miss when installing an extra.

This PR adds a `.. note::` to the `PiperTTSService` docstring calling out the license and pointing at `PiperHttpTTSService`, which talks to a separately installed Piper HTTP server and therefore keeps Piper out of the application's license scope.

Documentation-only; no behavior or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)