### PR TITLE
Add Vertex variants of the Gemini thinking examples

### DIFF
--- a/examples/thinking/thinking-functions-google-vertex.py
+++ b/examples/thinking/thinking-functions-google-vertex.py
@@ -24,13 +24,33 @@ from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
-from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.google.vertex.llm import GoogleVertexLLMService
+from pipecat.services.llm_service import FunctionCallParams
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
 from pipecat.workers.runner import WorkerRunner
 
 load_dotenv(override=True)
+
+
+async def check_flight_status(params: FunctionCallParams, flight_number: str):
+    """Check the status of a flight. Returns status (e.g., "on time", "delayed") and departure time.
+
+    Args:
+        flight_number (str): The flight number, e.g. "AA100".
+    """
+    await params.result_callback({"status": "delayed", "departure_time": "14:30"})
+
+
+async def book_taxi(params: FunctionCallParams, time: str):
+    """Book a taxi for a given time. Returns status (e.g., "done").
+
+    Args:
+        time (str): The time to book the taxi for, e.g. "15:00".
+    """
+    await params.result_callback({"status": "done"})
+
 
 # We use lambdas to defer transport parameter creation until the transport
 # type is selected at runtime.
@@ -66,13 +86,16 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
-    llm = GoogleLLMService(
-        api_key=os.environ["GOOGLE_API_KEY"],
-        # To use a more powerful (slower) reasoning model, uncomment the pro
-        # model and the thinking_level line below.
-        # model="gemini-3.1-pro-preview",
-        settings=GoogleLLMService.Settings(
-            thinking=GoogleLLMService.ThinkingConfig(
+    llm = GoogleVertexLLMService(
+        credentials=os.environ["GOOGLE_VERTEX_TEST_CREDENTIALS"],
+        project_id=os.environ["GOOGLE_CLOUD_PROJECT_ID"],
+        location=os.environ["GOOGLE_CLOUD_LOCATION"],
+        # location="global",  # Gemini 3.x may need "global" (comment out env location above)
+        settings=GoogleVertexLLMService.Settings(
+            # To use a more powerful (slower) reasoning model, uncomment the pro
+            # model below, plus the thinking_level and location="global" lines.
+            # model="gemini-3.1-pro-preview",
+            thinking=GoogleVertexLLMService.ThinkingConfig(
                 thinking_budget=-1,  # Dynamic thinking (default model, Gemini 2.5)
                 # thinking_level="low",  # Gemini 3.x (comment out thinking_budget above)
                 include_thoughts=True,
@@ -81,7 +104,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
-    context = LLMContext()
+    context = LLMContext(tools=[check_flight_status, book_taxi])
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
         user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
@@ -114,14 +137,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         # Kick off the conversation.
         context.add_message({"role": "developer", "content": "Say hello briefly."})
         # Replace the above with one of these example prompts to demonstrate
-        # thinking.
-        # These examples come from Gemini and Anthropic docs.
+        # thinking and function calling.
+        # This example comes from Gemini docs.
         # context.add_message(
         #     {
         #         "role": "user",
-        #         "content": "Analogize photosynthesis and growing up. Keep your answer concise.",
-        #         # "content": "Compare and contrast electric cars and hybrid cars."
-        #         # "content": "Are there an infinite number of prime numbers such that n mod 4 == 3?"
+        #         "content": "Check the status of flight AA100 and, if it's delayed, book me a taxi 2 hours before its departure time.",
         #     }
         # )
         await worker.queue_frames([LLMRunFrame()])

--- a/examples/thinking/thinking-functions-google.py
+++ b/examples/thinking/thinking-functions-google.py
@@ -88,10 +88,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     llm = GoogleLLMService(
         api_key=os.environ["GOOGLE_API_KEY"],
-        # model="gemini-3-pro-preview", # A more powerful reasoning model, but slower
+        # To use a more powerful (slower) reasoning model, uncomment the pro
+        # model and the thinking_level line below.
+        # model="gemini-3.1-pro-preview",
         settings=GoogleLLMService.Settings(
             thinking=GoogleLLMService.ThinkingConfig(
-                thinking_budget=-1,  # Dynamic thinking
+                thinking_budget=-1,  # Dynamic thinking (default model, Gemini 2.5)
+                # thinking_level="low",  # Gemini 3.x (comment out thinking_budget above)
                 include_thoughts=True,
             ),
             system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",

--- a/examples/thinking/thinking-google-vertex.py
+++ b/examples/thinking/thinking-google-vertex.py
@@ -24,7 +24,7 @@ from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
-from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.google.vertex.llm import GoogleVertexLLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -66,13 +66,16 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
-    llm = GoogleLLMService(
-        api_key=os.environ["GOOGLE_API_KEY"],
-        # To use a more powerful (slower) reasoning model, uncomment the pro
-        # model and the thinking_level line below.
-        # model="gemini-3.1-pro-preview",
-        settings=GoogleLLMService.Settings(
-            thinking=GoogleLLMService.ThinkingConfig(
+    llm = GoogleVertexLLMService(
+        credentials=os.environ["GOOGLE_VERTEX_TEST_CREDENTIALS"],
+        project_id=os.environ["GOOGLE_CLOUD_PROJECT_ID"],
+        location=os.environ["GOOGLE_CLOUD_LOCATION"],
+        # location="global",  # Gemini 3.x may need "global" (comment out env location above)
+        settings=GoogleVertexLLMService.Settings(
+            # To use a more powerful (slower) reasoning model, uncomment the pro
+            # model below, plus the thinking_level and location="global" lines.
+            # model="gemini-3.1-pro-preview",
+            thinking=GoogleVertexLLMService.ThinkingConfig(
                 thinking_budget=-1,  # Dynamic thinking (default model, Gemini 2.5)
                 # thinking_level="low",  # Gemini 3.x (comment out thinking_budget above)
                 include_thoughts=True,


### PR DESCRIPTION
## Summary
- Adds Google Vertex AI variants of the two Gemini thinking examples
  (`thinking-google-vertex.py`, `thinking-functions-google-vertex.py`),
  mirroring their non-Vertex counterparts but using `GoogleVertexLLMService`.
- Refreshes the commented-out "more powerful model" option in the existing
  Gemini thinking examples: `gemini-3-pro-preview` → `gemini-3.1-pro-preview`
  (the former is retired), plus a matching commented `thinking_level` line,
  since Gemini 3.x uses `thinking_level` rather than the 2.5-era `thinking_budget`.
- The Vertex examples pair that with a commented `location="global"`, since
  Gemini 3.x isn't served from regional Vertex endpoints.

## Verification
- `ruff format`/`ruff check` pass.
- Constructed the Vertex service both ways (default 2.5 path and the uncommented
  Gemini-3 path) — both build.
- Ran a live inference on the default path (`gemini-2.5-flash` + `thinking_budget=-1`)
  against Vertex — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)