### PR TITLE
AGENTS.md: add a litmus test for future-reader writing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ This applies to everything that documents the code — comments, docstrings, com
 
 - **Leave the current moment out of it.** Detail that feels important while making a change — alternatives considered and not taken, what the code used to do, shorthand that only made sense while the work was in progress — usually isn't worth a future reader's time, and may not even make sense to them. Include it only when they genuinely need it to understand the code as it stands.
 - **Match the weight of the prose to the code.** Keep it general, high-level, and concise. Reserve long comments for architecturally salient pieces, genuinely tricky sections, or decisions non-obvious enough that a reader would otherwise be puzzled. Routine code needs a short note or none at all.
+- **Litmus test for commits, changelogs, and comments:** every sentence must answer "what does the code do now?" — not "what happened while we worked on it." Write comments as if the code had always existed in its current form: a comment earns its place only by stating a constraint or non-obvious decision the code can't show. If a sentence describes a superseded implementation, a rejected alternative, verification performed, or argues the change is correct, delete it. Rationale is allowed only as a trailing note when its absence would puzzle a future reader.
 
 ## Service Implementation
 


### PR DESCRIPTION
Claude continues to rehash decisions in docstrings, commits, and comments. I'm trying another addition to AGENTS.md to avoid this.

## Summary

- Adds a third bullet to *Writing for Future Readers* giving agents (and humans) a concrete drafting-time check: every sentence in a commit, changelog, or comment must answer "what does the code do now?" — not "what happened while we worked on it."
- Comments are to be written as if the code had always existed in its current form; sentences describing superseded implementations, rejected alternatives, verification performed, or arguing correctness get deleted. Rationale is a trailing note reserved for decisions that would otherwise puzzle a future reader.

The existing bullets state the principle; this one makes it checkable while drafting, which is where narrative and justification tend to leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)