### PR TITLE
Add gpt-realtime Support for Flows With Eval

### DIFF
--- a/examples/flows/food_ordering.py
+++ b/examples/flows/food_ordering.py
@@ -35,7 +35,7 @@ from utils import create_llm
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.evals.transport import EvalTransportParams
-from pipecat.flows import FlowManager, NodeConfig
+from pipecat.flows import ContextStrategy, ContextStrategyConfig, FlowManager, NodeConfig
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -73,6 +73,16 @@ transport_params = {
         audio_out_enabled=True,
     ),
 }
+
+
+# The bot's base persona. Nodes can replace the role message mid-conversation
+# (see create_confirmation_node), so it's shared here for reuse.
+ROLE_MESSAGE = (
+    "You are an order-taking assistant. You must ALWAYS use the available functions to"
+    " progress the conversation. This is a phone conversation and your responses will be"
+    " converted to audio. Keep the conversation friendly, casual, and polite. Avoid"
+    " outputting special characters and emojis."
+)
 
 
 # Type definitions
@@ -180,7 +190,7 @@ async def revise_order(flow_manager: FlowManager) -> tuple[None, NodeConfig]:
     """
     User wants to make changes to their order.
     """
-    return None, create_initial_node()
+    return None, create_revise_node()
 
 
 # Node creation functions
@@ -188,7 +198,7 @@ def create_initial_node() -> NodeConfig:
     """Create the initial node for food type selection."""
     return NodeConfig(
         name="initial",
-        role_message="You are an order-taking assistant. You must ALWAYS use the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Keep the conversation friendly, casual, and polite. Avoid outputting special characters and emojis.",
+        role_message=ROLE_MESSAGE,
         task_messages=[
             {
                 "role": "developer",
@@ -248,9 +258,17 @@ Remember to be friendly and casual.""",
 
 
 def create_confirmation_node() -> NodeConfig:
-    """Create the order confirmation node."""
+    """Create the order confirmation node.
+
+    Replaces the role message mid-conversation: the confirmation specialist
+    persona addresses the user as "boss" (the release evals assert this, as
+    proof the new system instruction reached the LLM).
+    """
     return NodeConfig(
         name="confirm",
+        role_message=ROLE_MESSAGE
+        + ' You are now the order confirmation specialist. Address the user as "boss" in every'
+        " response (e.g. 'Alright, boss!').",
         task_messages=[
             {
                 "role": "developer",
@@ -262,6 +280,27 @@ Be friendly and clear when reading back the order details.""",
             }
         ],
         functions=[complete_order, revise_order],
+    )
+
+
+def create_revise_node() -> NodeConfig:
+    """Create the order revision node: start the order over from scratch.
+
+    Demonstrates two Flows features (both exercised by the release evals):
+    ``respond_immediately=False`` so the bot waits silently for the user, and
+    a RESET context strategy that drops the old order from the context.
+    """
+    return NodeConfig(
+        name="revise",
+        task_messages=[
+            {
+                "role": "developer",
+                "content": "The user is revising their order, starting over from scratch. Wait for them to say what they want instead, then progress via the choose functions as with a new order.",
+            }
+        ],
+        context_strategy=ContextStrategyConfig(strategy=ContextStrategy.RESET),
+        respond_immediately=False,
+        functions=[choose_pizza, choose_sushi],
     )
 
 

--- a/examples/flows/food_ordering_realtime.py
+++ b/examples/flows/food_ordering_realtime.py
@@ -1,0 +1,172 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""The food ordering flow driven by a speech-to-speech (realtime) model.
+
+Same conversation flow as food_ordering.py — the node definitions are imported
+from there — but the LLM is OpenAI Realtime (``gpt-realtime``): audio in, audio
+out, server-side turn detection, and no separate STT/TTS services. Used to
+evaluate Pipecat Flows against realtime models (see scripts/release-evals);
+drive it with the audio-mode ``food_ordering_pizza_realtime`` scenario — the
+service doesn't implement text-driven turns yet, so text-mode scenarios don't
+apply.
+
+Requirements:
+- OPENAI_API_KEY
+"""
+
+import asyncio
+import os
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+from food_ordering import DeliveryEstimateResult, create_initial_node
+from loguru import logger
+
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.flows import FlowManager, flows_tool_options
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.openai.realtime.events import (
+    AudioConfiguration,
+    AudioInput,
+    InputAudioTranscription,
+    SemanticTurnDetection,
+    SessionProperties,
+)
+from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+transport_params = {
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    # Behavioral evals: run with `-t eval` to drive this bot via `pipecat eval`.
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    """Run the food ordering bot on a realtime (speech-to-speech) LLM."""
+    llm = OpenAIRealtimeLLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAIRealtimeLLMService.Settings(
+            session_properties=SessionProperties(
+                audio=AudioConfiguration(
+                    input=AudioInput(
+                        transcription=InputAudioTranscription(),
+                        turn_detection=SemanticTurnDetection(),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    # The realtime service emits its own user-turn frames from server VAD, so
+    # no local VAD on the aggregator; realtime-service mode is auto-detected.
+    context = LLMContext()
+    context_aggregator = LLMContextAggregatorPair(context)
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            context_aggregator.user(),
+            llm,
+            transport.output(),
+            context_aggregator.assistant(),
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    # Define "global" functions available at every node
+    @flows_tool_options(cancel_on_interruption=True)
+    async def get_delivery_estimate(
+        flow_manager: FlowManager,
+    ) -> tuple[DeliveryEstimateResult, None]:
+        """Provide delivery estimate information. Only call this when the user explicitly asks about delivery timing; never call it proactively."""
+        # Simulated slow lookup; with cancel_on_interruption a user barge-in
+        # abandons it (the release evals exercise both the slow completion and
+        # the barge-in cancellation).
+        await asyncio.sleep(4)
+        delivery_time = datetime.now() + timedelta(minutes=30)
+        return DeliveryEstimateResult(
+            time=f"{delivery_time}",
+        ), None
+
+    @flows_tool_options(cancel_on_interruption=True, timeout_secs=3)
+    async def check_daily_special(
+        flow_manager: FlowManager,
+    ) -> tuple[dict, None]:
+        """Look up today's special menu item. Only call this when the user explicitly asks about today's special; never call it proactively."""
+        # Simulated hung backend: never completes, so the per-tool timeout
+        # resolves the call instead (exercised by the release evals).
+        await asyncio.sleep(3600)
+        return {"special": "unavailable"}, None
+
+    # Initialize flow manager
+    flow_manager = FlowManager(
+        worker=worker,
+        llm=llm,
+        context_aggregator=context_aggregator,
+        transport=transport,
+        global_functions=[get_delivery_estimate, check_daily_special],
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info("Client connected")
+        # Kick off the conversation with the initial node
+        await flow_manager.initialize(create_initial_node())
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/release-evals/README.md
+++ b/scripts/release-evals/README.md
@@ -186,6 +186,13 @@ The bots pick their LLM from `$LLM_PROVIDER` (default `openai_responses`;
 (also `google`, `aws`). `llm_switching` needs OpenAI, Google, and Anthropic
 keys all set. `warm_transfer.py` (Daily + a live human agent) isn't covered.
 
+`food_ordering_realtime.py` runs the same flow on a speech-to-speech model
+(OpenAI Realtime / gpt-realtime) with its own audio-mode scenario,
+`food_ordering_pizza_realtime`. The Realtime API supports text input and
+text-only output, but the Pipecat service doesn't implement text-driven turns
+yet, so the text-only flows scenarios don't apply to it for now (see the
+scenario file for details).
+
 ## Adding coverage
 
 - New bot: add an entry to `manifest.yaml` (`bot:` + the `scenarios:` it should run).

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -302,3 +302,13 @@ suite:
   - bot: flows/llm_switching.py
     scenarios: [llm_switching]
 
+  #
+  # Flows + realtime (speech-to-speech) models: the same flow as
+  # food_ordering.py, but the LLM is OpenAI Realtime (gpt-realtime) — audio
+  # in/out, no STT/TTS. Runs its own audio-mode scenario: the service doesn't
+  # implement text-driven turns yet (see the scenario file), so the text-only
+  # flows scenarios don't apply.
+  #
+  - bot: flows/food_ordering_realtime.py
+    scenarios: [food_ordering_pizza_realtime]
+

--- a/scripts/release-evals/scenarios/food_ordering_pizza_realtime.yaml
+++ b/scripts/release-evals/scenarios/food_ordering_pizza_realtime.yaml
@@ -1,0 +1,136 @@
+name: food_ordering_pizza_realtime
+
+# Audio on both sides. The Realtime API itself supports text input items and
+# text-only output modalities, but OpenAIRealtimeLLMService doesn't implement
+# text-driven turns yet: RTVI send-text lands in the service's unimplemented
+# LLMMessagesAppendFrame path, and skip_tts only tags LLMTextFrames for a
+# downstream TTS rather than switching the session to text output. Until that's
+# wired up, drive realtime bots with audio.
+user: !include user_audio.yaml
+judge: !include judge_audio.yaml
+
+# The extended pizza-ordering conversation: beyond the basic order flow (see
+# food_ordering_pizza.yaml), it exercises each Flows-to-realtime integration
+# surface, called out per turn.
+#
+# Assertion style: the mechanics are asserted stepwise via function_call
+# expectations (deterministic), while the bot's spoken behavior is judged ONCE,
+# conversation-wide, on the last judgeable turn. Per-turn response judgments
+# race the node transitions — the model speaks in the same server-created
+# response that makes the function call, before the new node's instructions
+# land — so mid-conversation `response` expectations here are bare arrival
+# checks that only pace the turns.
+turns:
+  # Initial node: LLMRunFrame-driven greeting (no user input yet).
+  - expect:
+      - event: response
+
+  # Node transition: tools swap (LLMSetToolsFrame) + task message append
+  # (LLMMessagesAppendFrame) — the pizza functions only exist on the new node.
+  - user: "I'd like to order a pizza."
+    expect:
+      - event: function_call
+        calls:
+          - name: choose_pizza
+      - event: response
+
+  - user: "A large pepperoni please."
+    expect:
+      - event: function_call
+        calls:
+          - name: select_pizza_order
+            args: { size: large, pizza_type: pepperoni }
+      - event: response
+
+  # The confirmation node replaces the role message (LLMUpdateSettingsFrame →
+  # session instructions): from here on the bot addresses the user as "boss"
+  # (asserted in the final conversation-level judgment).
+  - user: "Could you read my order back one more time?"
+    expect:
+      - event: response
+
+  # Per-tool timeout: check_daily_special hangs and its 3s timeout resolves the
+  # call. A timed-out call doesn't trigger a response (by design), so assert
+  # the call only; the conversation continuing past it is the recovery check.
+  - user: "What's today's special?"
+    expect:
+      - event: function_call
+        calls:
+          - name: check_daily_special
+
+  # Pure delay before sending: room for check_daily_special's timeout to fire
+  # undisturbed (user speech would cancel the call instead, since it's also
+  # cancel_on_interruption). Keep this turn to one sentence — a mid-turn pause
+  # gets split into two turns by the server's semantic turn detection, and the
+  # second half then barges in on the bot's answer.
+  - user: "How long will delivery take?"
+    send_after:
+      delay_ms: 9000
+    expect:
+      - event: function_call
+        calls:
+          - name: get_delivery_estimate
+      - event: response
+
+  # Revision: respond_immediately=False + RESET context strategy
+  # (LLMMessagesUpdateFrame). The model narrates the revise_order call (one
+  # bare response), then the node waits silently for the user — the absent
+  # check is what validates respond_immediately=False. The 14s send delay
+  # lets the previous turn's slow (4s) delivery lookup finish speaking first.
+  - user: "Actually, I want to change my order."
+    send_after:
+      delay_ms: 14000
+    expect:
+      - event: function_call
+        calls:
+          - name: revise_order
+      - event: response
+      - event: response
+        absent: true
+        within_ms: 8000
+
+  - user: "Let's do sushi instead."
+    expect:
+      - event: function_call
+        calls:
+          - name: choose_sushi
+      - event: response
+
+  - user: "Two california rolls please."
+    expect:
+      - event: function_call
+        calls:
+          - name: select_sushi_order
+            args: { count: 2, roll_type: california }
+      - event: response
+
+  # Barge-in during a slow, cancellable tool: the delivery lookup takes 4s and
+  # has cancel_on_interruption, so the next turn's barge-in cancels it.
+  - user: "How long would delivery take now?"
+    expect:
+      - event: function_call
+        calls:
+          - name: get_delivery_estimate
+
+  # The judge holds the whole conversation, so this last judgeable turn also
+  # carries the conversation-wide checks (the terminal turn below tears the
+  # pipeline down before its response reaches the harness).
+  - user: "Never mind, I'll come pick it up myself."
+    send_after:
+      event: function_call
+      delay_ms: 500
+    expect:
+      - event: response
+        eval: >-
+          the bot's final reply acknowledges the user will pick the order up
+          (without stating a new delivery time); AND, considering the entire
+          conversation: the bot addressed the user as 'boss' at least once
+          and stated an estimated delivery time at some point
+
+  # Terminal turn — assert the function call only: end_conversation tears the
+  # pipeline down before the farewell reaches the harness.
+  - user: "That's everything, please confirm my order."
+    expect:
+      - event: function_call
+        calls:
+          - name: complete_order

--- a/src/pipecat/adapters/services/open_ai_realtime_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_realtime_adapter.py
@@ -48,6 +48,15 @@ class OpenAIRealtimeLLMAdapter(BaseLLMAdapter):
     ) -> OpenAIRealtimeLLMInvocationParams:
         """Get OpenAI Realtime-specific LLM invocation parameters from a universal LLM context.
 
+        The effective system instruction combines the service-level
+        ``system_instruction`` (if any) with every "system"/"developer" message
+        in the context, in order. Both are kept — rather than one overriding
+        the other — because in a continuous realtime session the service-level
+        instruction typically carries the bot's persona while context system
+        messages carry evolving task guidance (e.g. Pipecat Flows node task
+        messages), and a ``session.update`` with the combined instructions is
+        the only reliable way to steer the model mid-session.
+
         Args:
             context: The LLM context containing messages, tools, etc.
             system_instruction: Optional system instruction from service settings.
@@ -56,13 +65,11 @@ class OpenAIRealtimeLLMAdapter(BaseLLMAdapter):
             Dictionary of parameters for invoking OpenAI Realtime's API.
         """
         messages = self._from_universal_context_messages(self.get_messages(context))
-        effective_system = self._resolve_system_instruction(
-            messages.system_instruction,
-            system_instruction,
-            discard_context_system=True,
-        )
+        instruction_parts = [
+            part for part in (system_instruction, messages.system_instruction) if part
+        ]
         return {
-            "system_instruction": effective_system,
+            "system_instruction": "\n\n".join(instruction_parts) if instruction_parts else None,
             "messages": messages.messages,
             # NOTE: LLMContext's tools are guaranteed to be a ToolsSchema (or NOT_GIVEN)
             "tools": self.from_standard_tools(context.tools) or [],
@@ -114,24 +121,28 @@ class OpenAIRealtimeLLMAdapter(BaseLLMAdapter):
             for m in copy.deepcopy(universal_context_messages)
             if isinstance(m, dict)
         ]
-        system_instruction = None
-
-        # If we have a "system" message as our first message,
-        # pull that out into session "instructions"
-        if messages and messages[0].get("role") == "system":
-            system = messages.pop(0)
-            content = system.get("content")
-            if isinstance(content, str):
-                system_instruction = content
-            elif isinstance(content, list):
-                system_instruction = content[0].get("text")
-            if not messages:
-                return self.ConvertedMessages(messages=[], system_instruction=system_instruction)
-
-        # Convert any remaining "system"/"developer" messages to "user"
+        # Fold every "system"/"developer" message — wherever it appears — into
+        # the session instructions, preserving order. The Realtime API steers an
+        # ongoing session through session.update `instructions`; keeping all
+        # system-level guidance there (rather than converting it to "user"
+        # conversation items that can only be sent when the conversation is
+        # first seeded) is what lets mid-session prompt updates, like Pipecat
+        # Flows node transitions, actually reach the model.
+        system_parts: list[str] = []
+        remaining: list[dict[str, Any]] = []
         for msg in messages:
             if msg.get("role") in ("system", "developer"):
-                msg["role"] = "user"
+                content = msg.get("content")
+                if isinstance(content, str):
+                    system_parts.append(content)
+                elif isinstance(content, list):
+                    system_parts.append(content[0].get("text"))
+            else:
+                remaining.append(msg)
+        system_instruction = "\n\n".join(system_parts) if system_parts else None
+        messages = remaining
+        if not messages:
+            return self.ConvertedMessages(messages=[], system_instruction=system_instruction)
 
         # If we have just a single "user" item, we can just send it normally
         if len(messages) == 1 and messages[0].get("role") == "user":

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -552,9 +552,18 @@ class LLMContextFrame(Frame):
 
     Parameters:
         context: The LLM context containing messages, tools, and configuration.
+        run_llm: Whether the service should generate a response for this
+            context. ``None`` (the default) leaves it to the service: cascade
+            LLM services run inference on every context frame, while realtime
+            (speech-to-speech) services — whose sessions run continuously —
+            respond only when the frame carries new tool results. ``True``
+            requests a response explicitly (the context aggregators set it for
+            ``LLMRunFrame`` and for message frames with ``run_llm=True``);
+            ``False`` asks the service to only ingest the context.
     """
 
     context: LLMContext
+    run_llm: bool | None = None
 
 
 @dataclass

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -476,21 +476,34 @@ class LLMContextAggregator(FrameProcessor):
         """
         return self._context
 
-    def _get_context_frame(self) -> LLMContextFrame:
+    def _get_context_frame(self, run_llm: bool | None = None) -> LLMContextFrame:
         """Create a context frame with the current context.
+
+        Args:
+            run_llm: Explicit response intent to carry on the frame (see
+                :class:`~pipecat.frames.frames.LLMContextFrame`).
 
         Returns:
             LLMContextFrame containing the current context.
         """
-        return LLMContextFrame(context=self._context)
+        return LLMContextFrame(context=self._context, run_llm=run_llm)
 
-    async def push_context_frame(self, direction: FrameDirection = FrameDirection.DOWNSTREAM):
+    async def push_context_frame(
+        self,
+        direction: FrameDirection = FrameDirection.DOWNSTREAM,
+        run_llm: bool | None = None,
+    ):
         """Push a context frame in the specified direction.
 
         Args:
             direction: The direction to push the frame (upstream or downstream).
+            run_llm: Explicit response intent to carry on the frame. ``True``
+                for pushes triggered by an explicit run request (``LLMRunFrame``,
+                message frames with ``run_llm=True``), so realtime services —
+                which don't respond to every context frame the way cascade
+                services do — know to generate a response.
         """
-        frame = self._get_context_frame()
+        frame = self._get_context_frame(run_llm=run_llm)
         await self.push_frame(frame, direction)
 
     def add_messages(self, messages):
@@ -1111,22 +1124,33 @@ class LLMUserAggregator(LLMContextAggregator):
         return should_mute_frame
 
     async def _handle_llm_run(self, frame: LLMRunFrame):
-        await self.push_context_frame()
+        await self.push_context_frame(run_llm=True)
 
     async def _handle_llm_messages_append(self, frame: LLMMessagesAppendFrame):
         self.add_messages(frame.messages)
-        if frame.run_llm:
-            await self.push_context_frame()
+        await self._push_context_after_messages_change(frame.run_llm)
 
     async def _handle_llm_messages_update(self, frame: LLMMessagesUpdateFrame):
         self.set_messages(frame.messages)
-        if frame.run_llm:
-            await self.push_context_frame()
+        await self._push_context_after_messages_change(frame.run_llm)
 
     async def _handle_llm_messages_transform(self, frame: LLMMessagesTransformFrame):
         self.transform_messages(frame.transform)
-        if frame.run_llm:
-            await self.push_context_frame()
+        await self._push_context_after_messages_change(frame.run_llm)
+
+    async def _push_context_after_messages_change(self, run_llm: bool):
+        """Push the changed context, with response intent matching the request.
+
+        Without a response request (``run_llm=False``), cascade pipelines just
+        keep the change for the next inference, but realtime services hold
+        conversation state server-side — push an ingest-only context frame so
+        the change (new system-level guidance, tool results) reaches the
+        session now rather than at the next response.
+        """
+        if run_llm:
+            await self.push_context_frame(run_llm=True)
+        elif self._realtime_service_mode:
+            await self.push_context_frame(run_llm=False)
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         text = frame.text
@@ -1547,7 +1571,10 @@ class LLMAssistantAggregator(LLMContextAggregator):
             await self.push_frame(frame, direction)
             if self._push_context_on_bot_stopped_speaking and not self._user_speaking:
                 logger.debug(f"{self}: Bot stopped speaking — pushing deferred context frame!")
-                await self.push_context_frame(FrameDirection.UPSTREAM)
+                # The deferred push stands in for a function-result push that
+                # resolved to run_llm=True (see
+                # _maybe_push_context_after_function_result), so keep the intent.
+                await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=True)
         elif isinstance(frame, LLMServiceMetadataFrame):
             # Auto-configure realtime mode on the assistant half too — the
             # broadcast reaches both halves. The assistant only needs the flag
@@ -1611,32 +1638,46 @@ class LLMAssistantAggregator(LLMContextAggregator):
 
         return aggregation
 
-    async def push_context_frame(self, direction: FrameDirection = FrameDirection.DOWNSTREAM):
+    async def push_context_frame(
+        self,
+        direction: FrameDirection = FrameDirection.DOWNSTREAM,
+        run_llm: bool | None = None,
+    ):
         """Push a context frame in the specified direction.
 
         Args:
             direction: The direction to push the frame (upstream or downstream).
+            run_llm: Explicit response intent to carry on the frame (see
+                :class:`~pipecat.frames.frames.LLMContextFrame`).
         """
-        await super().push_context_frame(direction)
+        await super().push_context_frame(direction, run_llm=run_llm)
         self._push_context_on_bot_stopped_speaking = False
 
     async def _handle_llm_run(self, frame: LLMRunFrame):
-        await self.push_context_frame(FrameDirection.UPSTREAM)
+        await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=True)
 
     async def _handle_llm_messages_append(self, frame: LLMMessagesAppendFrame):
         self.add_messages(frame.messages)
-        if frame.run_llm:
-            await self.push_context_frame(FrameDirection.UPSTREAM)
+        await self._push_context_after_messages_change(frame.run_llm)
 
     async def _handle_llm_messages_update(self, frame: LLMMessagesUpdateFrame):
         self.set_messages(frame.messages)
-        if frame.run_llm:
-            await self.push_context_frame(FrameDirection.UPSTREAM)
+        await self._push_context_after_messages_change(frame.run_llm)
 
     async def _handle_llm_messages_transform(self, frame: LLMMessagesTransformFrame):
         self.transform_messages(frame.transform)
-        if frame.run_llm:
-            await self.push_context_frame(FrameDirection.UPSTREAM)
+        await self._push_context_after_messages_change(frame.run_llm)
+
+    async def _push_context_after_messages_change(self, run_llm: bool):
+        """Push the changed context upstream, with matching response intent.
+
+        See :meth:`LLMUserAggregator._push_context_after_messages_change` —
+        same ingest-only push for realtime services, in the upstream direction.
+        """
+        if run_llm:
+            await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=True)
+        elif self._realtime_service_mode:
+            await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=False)
 
     async def _handle_interruptions(self, frame: InterruptionFrame):
         await self._trigger_assistant_turn_stopped(interrupted=True)
@@ -1756,6 +1797,15 @@ class LLMAssistantAggregator(LLMContextAggregator):
 
         if run_llm and not self._user_speaking:
             await self._maybe_push_context_after_function_result()
+        elif not run_llm and is_final and self._realtime_service_mode:
+            # No response requested, but realtime services read tool results out
+            # of the context — push an ingest-only frame so the result reaches
+            # the session now (a ``None`` result is recorded as COMPLETED and
+            # needs delivering too, e.g. a timed-out call). Deferring it risks
+            # it being dropped (a Flows edge function whose transition RESETs
+            # the context) or delivered by a later run_llm=None push that then
+            # triggers a response at the wrong moment.
+            await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=False)
 
         # Call the `on_context_updated` callback once the function call result
         # is added to the context. Also, run this in a separate task to make
@@ -1796,7 +1846,9 @@ class LLMAssistantAggregator(LLMContextAggregator):
             self._push_context_on_bot_stopped_speaking = True
         else:
             logger.debug(f"{self}: Pushing context frame!")
-            await self.push_context_frame(FrameDirection.UPSTREAM)
+            # This push only happens when the function-call result resolved to
+            # run_llm=True, so carry that intent for realtime services.
+            await self.push_context_frame(FrameDirection.UPSTREAM, run_llm=True)
 
     async def _handle_function_call_intermediate_result(
         self, frame: FunctionCallResultFrame, in_progress_frame: FunctionCallInProgressFrame

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -38,6 +38,7 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesAppendFrame,
+    LLMRunFrame,
     LLMServiceMetadataFrame,
     LLMSetToolsFrame,
     LLMTextFrame,
@@ -349,6 +350,10 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         self._context: LLMContext = None
 
         self._llm_needs_conversation_setup = True
+        # The instructions most recently sent in a session.update, used to
+        # detect when a context change (e.g. a Flows node transition appending
+        # system/developer messages) requires a fresh update.
+        self._last_sent_instructions: str | None = None
 
         self._disconnecting = False
         self._api_session_ready = False
@@ -646,7 +651,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         if isinstance(frame, TranscriptionFrame):
             pass
         elif isinstance(frame, LLMContextFrame):
-            await self._handle_context(frame.context)
+            await self._handle_context(frame.context, frame.run_llm)
         elif isinstance(frame, InputAudioRawFrame):
             if not self._audio_input_paused:
                 await self._send_user_audio(frame)
@@ -665,33 +670,102 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
             self._handle_speech_control_params(frame)
         elif isinstance(frame, LLMMessagesAppendFrame):
             await self._handle_messages_append(frame)
+        elif isinstance(frame, LLMRunFrame):
+            # Only reached in pipelines without a user context aggregator: the
+            # aggregator consumes LLMRunFrame and forwards the request as a
+            # context frame with run_llm=True (handled in _handle_context).
+            await self._create_response()
         elif isinstance(frame, LLMSetToolsFrame):
             # Continuous session: no fresh context frame per turn, so sync the
             # registered tool handlers to the new tool set here (the base service
             # only does this on LLMContextFrame).
             self._sync_registered_tool_handlers(frame.tools)
             await self._send_session_update()
-
         await self.push_frame(frame, direction)
 
-    async def _handle_context(self, context: LLMContext):
+    async def _handle_context(self, context: LLMContext, run_llm: bool | None = None):
         if not self._context:
-            # We got our initial context
+            # We got our initial context. The conversation is seeded from it
+            # (and the session configured) in _create_response.
             self._context = context
             # Initialize our bookkeeping of already-completed tool calls in
             # the context
             await self._process_completed_function_calls(send_new_results=False)
-            # Run the LLM at next opportunity
-            await self._create_response()
-        else:
-            # We got an updated context.
-            # This may contain a new user message or tool call result.
-            self._context = context
-            # Send results for newly-completed function calls, if any.
-            await self._process_completed_function_calls(send_new_results=True)
+            if run_llm is not False:
+                # Run the LLM at next opportunity
+                await self._create_response()
+            return
 
-    async def _handle_messages_append(self, frame):
-        logger.error("!!! NEED TO IMPLEMENT MESSAGES APPEND")
+        # We got an updated context. It may carry new system-level guidance
+        # (e.g. a Flows node transition appending task messages), a new user
+        # message, or tool call results.
+        self._context = context
+
+        # If the context's system-level guidance changed, send the session the
+        # new instructions before any response is created below.
+        await self._maybe_refresh_session_instructions()
+
+        # Send results for newly-completed function calls, if any.
+        sent_new_result = await self._process_completed_function_calls(send_new_results=True)
+
+        # Create a response when explicitly requested (run_llm=True — e.g. an
+        # LLMRunFrame driving a Flows node transition), or — for context frames
+        # without explicit intent — when new tool results warrant one.
+        if run_llm or (run_llm is None and sent_new_result):
+            await self._create_response()
+
+    async def _maybe_refresh_session_instructions(self):
+        """Send a session.update if the context-derived instructions changed.
+
+        In a continuous session, system-level guidance that changes
+        mid-conversation (system/developer messages appended by a Flows node
+        transition, an IVR prompt swap, a context reset, ...) can only reach
+        the model through the session's instructions — conversation history is
+        held server-side and is only seeded once.
+        """
+        adapter = self.get_llm_adapter()
+        params = adapter.get_llm_invocation_params(
+            self._context, system_instruction=assert_given(self._settings.system_instruction)
+        )
+        instructions = params["system_instruction"]
+        if instructions and instructions != self._last_sent_instructions:
+            await self._send_session_update()
+
+    async def _handle_messages_append(self, frame: LLMMessagesAppendFrame):
+        """Append messages directly to the server-side conversation.
+
+        Only reached in pipelines without a user context aggregator (the
+        aggregator consumes ``LLMMessagesAppendFrame`` and folds the messages
+        into the context, which arrives here as a context frame instead).
+        Text-only: non-text content is skipped with a warning.
+        """
+        for message in frame.messages:
+            role = message.get("role", "user")
+            content = message.get("content")
+            if isinstance(content, list):
+                content = " ".join(
+                    part.get("text", "")
+                    for part in content
+                    if part.get("type") in ("text", "input_text")
+                )
+            if not isinstance(content, str) or not content:
+                logger.warning(f"{self} skipping non-text appended message: {message}")
+                continue
+            if role in ("system", "developer"):
+                role = "system"
+            item = events.ConversationItem(
+                type="message",
+                role=role,
+                content=[
+                    events.ItemContent(
+                        type="text" if role == "assistant" else "input_text", text=content
+                    )
+                ],
+            )
+            self._messages_added_manually[item.id] = True
+            await self.send_client_event(events.ConversationItemCreateEvent(item=item))
+        if frame.run_llm:
+            await self._create_response()
 
     #
     # websocket communication
@@ -824,6 +898,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         outgoing = self._strip_unsupported_reasoning(settings)
 
         await self.send_client_event(events.SessionUpdateEvent(session=outgoing))
+        self._last_sent_instructions = settings.instructions
 
     #
     # inbound server event handling
@@ -1110,6 +1185,11 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         await self._truncate_current_audio_response()
         await self.broadcast_frame(UserStartedSpeakingFrame)
         await self.broadcast_interruption()
+        # The broadcast only reaches the other processors — it doesn't come
+        # back through our own process_frame — so run the base interruption
+        # handling (cancelling in-flight cancel_on_interruption function
+        # calls) directly.
+        await self._handle_interruptions(InterruptionFrame())
 
     async def _handle_evt_speech_stopped(self, evt):
         # Note: this event is not received when turn detection is disabled,
@@ -1171,7 +1251,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         adapter = self.get_llm_adapter()
 
         # Configure the LLM for this session if needed
-        if self._llm_needs_conversation_setup:
+        if self._llm_needs_conversation_setup and self._context:
             logger.debug(
                 f"Setting up conversation on OpenAI Realtime LLM service with initial messages: {adapter.get_messages_for_logging(self._context)}"
             )
@@ -1201,7 +1281,13 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
             )
         )
 
-    async def _process_completed_function_calls(self, send_new_results: bool):
+    async def _process_completed_function_calls(self, send_new_results: bool) -> bool:
+        """Track completed tool calls in the context, optionally sending new results.
+
+        Returns:
+            Whether any new result was sent to the service. The caller decides
+            whether that warrants creating a response (see _handle_context).
+        """
         # Check for set of completed function calls in the context
         sent_new_result = False
         for message in self._context.get_messages():
@@ -1258,10 +1344,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
                         await self._send_tool_result(tool_call_id, message.get("content"))
                     self._completed_tool_calls.add(tool_call_id)
 
-        # If we reported any new tool call results to the service, trigger
-        # another response
-        if sent_new_result:
-            await self._create_response()
+        return sent_new_result
 
     def _handle_speech_control_params(self, frame: SpeechControlParamsFrame):
         """Auto-size the pre-roll from the upstream VAD's start_secs.

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -2161,8 +2161,8 @@ class TestOpenAIRealtimeGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(params["system_instruction"], "You are helpful.")
         self.assertEqual(len(params["messages"]), 1)
 
-    def test_developer_message_becomes_user(self):
-        """Developer message is converted to user, not extracted as system instruction."""
+    def test_developer_message_folds_into_instructions(self):
+        """A developer message folds into the session instructions."""
         messages: list[LLMStandardMessage] = [
             {"role": "developer", "content": "Extra context."},
             {"role": "user", "content": "Hello"},
@@ -2170,12 +2170,11 @@ class TestOpenAIRealtimeGetLLMInvocationParams(unittest.TestCase):
         context = LLMContext(messages=messages)
         params = self.adapter.get_llm_invocation_params(context)
 
-        self.assertIsNone(params["system_instruction"])
-        # Developer converted to user, then packed with the other user message
+        self.assertEqual(params["system_instruction"], "Extra context.")
         self.assertEqual(len(params["messages"]), 1)
 
-    def test_subsequent_developer_message_becomes_user(self):
-        """Non-initial developer message is converted to user."""
+    def test_subsequent_developer_message_folds_into_instructions(self):
+        """A non-initial developer message also folds into the instructions, in order."""
         messages: list[LLMStandardMessage] = [
             {"role": "system", "content": "You are helpful."},
             {"role": "developer", "content": "Extra context."},
@@ -2183,9 +2182,8 @@ class TestOpenAIRealtimeGetLLMInvocationParams(unittest.TestCase):
         context = LLMContext(messages=messages)
         params = self.adapter.get_llm_invocation_params(context)
 
-        self.assertEqual(params["system_instruction"], "You are helpful.")
-        # Developer message converted to user
-        self.assertEqual(len(params["messages"]), 1)
+        self.assertEqual(params["system_instruction"], "You are helpful.\n\nExtra context.")
+        self.assertEqual(params["messages"], [])
 
     def test_empty_messages(self):
         """Empty messages list returns empty."""
@@ -2195,37 +2193,27 @@ class TestOpenAIRealtimeGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(params["messages"], [])
         self.assertIsNone(params["system_instruction"])
 
-    def test_both_system_instruction_and_system_message_warns(self):
-        """system_instruction + initial system message warns and uses system_instruction."""
+    def test_system_instruction_combines_with_context_system_message(self):
+        """system_instruction + context system message combine, service-level first."""
         messages: list[LLMStandardMessage] = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "Hello"},
         ]
         context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, system_instruction="Be concise.")
 
-        with patch("pipecat.adapters.base_llm_adapter.logger") as mock_logger:
-            params = self.adapter.get_llm_invocation_params(
-                context, system_instruction="Be concise."
-            )
-            mock_logger.warning.assert_called_once()
+        self.assertEqual(params["system_instruction"], "Be concise.\n\nYou are helpful.")
 
-        self.assertEqual(params["system_instruction"], "Be concise.")
-
-    def test_both_system_instruction_and_developer_message_no_warning(self):
-        """system_instruction + initial developer message: no warning, developer becomes user."""
+    def test_system_instruction_combines_with_developer_message(self):
+        """system_instruction + developer message combine, service-level first."""
         messages: list[LLMStandardMessage] = [
             {"role": "developer", "content": "Extra context."},
             {"role": "user", "content": "Hello"},
         ]
         context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, system_instruction="Be concise.")
 
-        with patch("pipecat.adapters.base_llm_adapter.logger") as mock_logger:
-            params = self.adapter.get_llm_invocation_params(
-                context, system_instruction="Be concise."
-            )
-            mock_logger.warning.assert_not_called()
-
-        self.assertEqual(params["system_instruction"], "Be concise.")
+        self.assertEqual(params["system_instruction"], "Be concise.\n\nExtra context.")
 
     def test_system_instruction_only(self):
         """system_instruction without context system message returns system_instruction."""

--- a/tests/test_openai_realtime_context_updates.py
+++ b/tests/test_openai_realtime_context_updates.py
@@ -1,0 +1,275 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for mid-session context updates in OpenAIRealtimeLLMService.
+
+A realtime session runs continuously: conversation history is held server-side
+and seeded only once, so anything that changes mid-conversation has to reach
+the model another way. These tests cover that machinery:
+
+- The adapter folds every "system"/"developer" context message into the
+  session instructions, combined with the service-level ``system_instruction``
+  (so e.g. Pipecat Flows node task messages actually steer the model).
+- An updated context frame refreshes the session instructions when — and only
+  when — they changed.
+- The ``run_llm`` intent on ``LLMContextFrame`` drives response creation: an
+  explicit ``True`` (an ``LLMRunFrame``, e.g. a Flows node transition with
+  ``respond_immediately=True``) creates a response, ``False`` suppresses one,
+  and ``None`` preserves the legacy behavior of responding only to new tool
+  results.
+- The context aggregators mark explicit run requests with ``run_llm=True``.
+"""
+
+from typing import Any
+
+import pytest
+
+from pipecat.adapters.services.open_ai_realtime_adapter import OpenAIRealtimeLLMAdapter
+from pipecat.frames.frames import LLMContextFrame, LLMRunFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+from pipecat.services.openai.realtime import events
+from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+from pipecat.tests.utils import run_test
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _EventRecorder:
+    """Records the client events sent via ``send_client_event``."""
+
+    def __init__(self):
+        self.events: list[Any] = []
+
+    async def __call__(self, event):
+        self.events.append(event)
+
+    def kinds(self) -> list[str]:
+        return [type(e).__name__ for e in self.events]
+
+    def clear(self):
+        self.events.clear()
+
+
+def _make_service(system_instruction: str | None = None):
+    """Construct a service wired to a fake send_client_event. ``__init__`` does no I/O."""
+    settings = (
+        OpenAIRealtimeLLMService.Settings(system_instruction=system_instruction)
+        if system_instruction
+        else None
+    )
+    service = OpenAIRealtimeLLMService(api_key="test-key", settings=settings)
+
+    recorder = _EventRecorder()
+    service.send_client_event = recorder  # type: ignore[method-assign]
+    # Pretend the session finished its handshake so _create_response sends
+    # immediately instead of deferring to session.updated.
+    service._api_session_ready = True
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    # _create_response pushes frames and starts metrics, which need a started
+    # pipeline; stub them out so the handlers can run in isolation.
+    service.push_frame = _noop  # type: ignore[method-assign]
+    service.start_processing_metrics = _noop  # type: ignore[method-assign]
+    service.start_ttfb_metrics = _noop  # type: ignore[method-assign]
+
+    return service, recorder
+
+
+# ---------------------------------------------------------------------------
+# Adapter: system/developer messages fold into the session instructions
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_folds_all_system_and_developer_messages_into_instructions():
+    adapter = OpenAIRealtimeLLMAdapter()
+    context = LLMContext(
+        messages=[
+            {"role": "system", "content": "Persona."},
+            {"role": "user", "content": "hi"},
+            {"role": "developer", "content": "Ask for a name."},
+        ]
+    )
+    params = adapter.get_llm_invocation_params(context, system_instruction="Base.")
+
+    assert params["system_instruction"] == "Base.\n\nPersona.\n\nAsk for a name."
+    # The folded messages must not also be sent as conversation items.
+    assert len(params["messages"]) == 1
+    assert params["messages"][0].role == "user"
+
+
+def test_adapter_without_any_system_content_yields_no_instructions():
+    adapter = OpenAIRealtimeLLMAdapter()
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    params = adapter.get_llm_invocation_params(context)
+    assert params["system_instruction"] is None
+
+
+def test_adapter_folds_list_content_system_messages():
+    adapter = OpenAIRealtimeLLMAdapter()
+    context = LLMContext(
+        messages=[{"role": "system", "content": [{"type": "text", "text": "Persona."}]}]
+    )
+    params = adapter.get_llm_invocation_params(context)
+    assert params["system_instruction"] == "Persona."
+    assert params["messages"] == []
+
+
+# ---------------------------------------------------------------------------
+# Service: instructions refresh + run_llm intent on context frames
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_transition_refreshes_instructions_and_responds():
+    service, recorder = _make_service(system_instruction="Persona.")
+    context = LLMContext(messages=[{"role": "developer", "content": "Greet the user."}])
+
+    # Initial context (e.g. a Flows initial node with respond_immediately=True):
+    # the session is configured and a response created.
+    await service._handle_context(context, run_llm=True)
+    assert recorder.kinds() == ["SessionUpdateEvent", "ResponseCreateEvent"]
+    assert "Greet the user." in recorder.events[0].session.instructions
+    recorder.clear()
+
+    # Node transition: new developer guidance appended, run requested. The new
+    # instructions must reach the session before the response is created.
+    context.add_message({"role": "developer", "content": "Now ask for the order."})
+    await service._handle_context(context, run_llm=True)
+    assert recorder.kinds() == ["SessionUpdateEvent", "ResponseCreateEvent"]
+    instructions = recorder.events[0].session.instructions
+    assert "Persona." in instructions
+    assert "Greet the user." in instructions
+    assert instructions.endswith("Now ask for the order.")
+
+
+@pytest.mark.asyncio
+async def test_unchanged_instructions_send_no_duplicate_session_update():
+    service, recorder = _make_service(system_instruction="Persona.")
+    context = LLMContext(messages=[{"role": "developer", "content": "Greet the user."}])
+    await service._handle_context(context, run_llm=True)
+    recorder.clear()
+
+    # A context update with no new system-level guidance and no run intent
+    # (e.g. a user turn transcription landing in the context).
+    context.add_message({"role": "user", "content": "hello"})
+    await service._handle_context(context)
+    assert recorder.kinds() == []
+
+
+@pytest.mark.asyncio
+async def test_tool_result_triggers_response_without_explicit_intent():
+    service, recorder = _make_service()
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    await service._handle_context(context)
+    recorder.clear()
+
+    context.add_message(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+    )
+    context.add_message({"role": "tool", "content": '{"ok": true}', "tool_call_id": "call_1"})
+    await service._handle_context(context)
+
+    kinds = recorder.kinds()
+    assert "ConversationItemCreateEvent" in kinds  # the function_call_output
+    assert kinds[-1] == "ResponseCreateEvent"
+
+
+@pytest.mark.asyncio
+async def test_run_llm_false_sends_tool_result_without_response():
+    service, recorder = _make_service()
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    await service._handle_context(context)
+    recorder.clear()
+
+    context.add_message(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+    )
+    context.add_message({"role": "tool", "content": '{"ok": true}', "tool_call_id": "call_1"})
+    await service._handle_context(context, run_llm=False)
+
+    kinds = recorder.kinds()
+    assert "ConversationItemCreateEvent" in kinds
+    assert "ResponseCreateEvent" not in kinds
+
+
+@pytest.mark.asyncio
+async def test_run_llm_true_with_tool_result_creates_single_response():
+    """A Flows edge transition delivers the tool result and the run intent on
+    one context frame; only one response must be created."""
+    service, recorder = _make_service()
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    await service._handle_context(context)
+    recorder.clear()
+
+    context.add_message(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+    )
+    context.add_message({"role": "tool", "content": '{"ok": true}', "tool_call_id": "call_1"})
+    await service._handle_context(context, run_llm=True)
+
+    assert recorder.kinds().count("ResponseCreateEvent") == 1
+
+
+# ---------------------------------------------------------------------------
+# Aggregators: explicit run requests are marked on the context frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_aggregator_marks_llm_run_with_run_intent():
+    context = LLMContext()
+    user_aggregator, _ = LLMContextAggregatorPair(context)
+
+    received_down, _ = await run_test(
+        user_aggregator,
+        frames_to_send=[LLMRunFrame()],
+    )
+    context_frame = next(f for f in received_down if isinstance(f, LLMContextFrame))
+    assert context_frame.run_llm is True
+
+
+@pytest.mark.asyncio
+async def test_user_aggregator_turn_context_frames_carry_no_explicit_intent():
+    from pipecat.frames.frames import (
+        TranscriptionFrame,
+        UserStartedSpeakingFrame,
+        UserStoppedSpeakingFrame,
+    )
+    from pipecat.utils.time import time_now_iso8601
+
+    context = LLMContext()
+    user_aggregator, _ = LLMContextAggregatorPair(context)
+
+    received_down, _ = await run_test(
+        user_aggregator,
+        frames_to_send=[
+            UserStartedSpeakingFrame(),
+            TranscriptionFrame(text="hello", user_id="user", timestamp=time_now_iso8601()),
+            UserStoppedSpeakingFrame(),
+        ],
+    )
+    context_frame = next(f for f in received_down if isinstance(f, LLMContextFrame))
+    assert context_frame.run_llm is None


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Related to: https://github.com/pipecat-ai/pipecat-flows/issues/66

Leaving in a draft state for the moment. I need to revise some stuff here but trying to get a general vibe of interest before investing too much time. Frankly this is Fable working off my fairly detailed notes from when I manually hacked together a working version of GPT-realtime working within Pipecat Flows late last year so I wouldn't review it too closely before I revise some of it / deslopify it. 

The general aim is to have an eval setup that covers all the key components of Pipecat Flows to evaluate realtime models against. I think the original assessment in the above issue is correct, that most realtime fall short of what is needed for flows. I think `gpt-realtime` is quite close. The hope being that future models can be evaluated against a simple eval suite of core Flow requirements as the gating mechanism for determine when future realtime / speech to speech models meet the expected criteria.

Here are a list of things supported by Pipecat Flows that specifically need to be supported by realtime models:

- Replacing the tools list: LLMSetToolsFrame
- Replacing the system instruction LLMUpdateSettingsFrame → system_instruction
- Replacing or appending to the conversation context LLMMessagesUpdateFrame / LLMMessagesAppendFrame
- Triggering a completion on demand LLMRunFrame
- Node transitions without immediate response respond_immediately=False
- Tool call interruption / cancellation and per-tool timeouts
- Triggering text to speech exclusively tts_say

Most of this can be modeled I believe, maybe the only two that are a bit tricky being `tts_say` and `respond_immediately=False`

The other obvious addition is getting adding GPT-realtime support withing Flows. I made some modifications to the current evals just to ensure mid-context updates are tracked (like referring to the user as "boss" to ensure validate context updates work). If we want to leave these unaltered and split of a capability focused flow I can do that too.

It currently works roughly as expected, but due to gpt-realtime's tendency to return interim responses, step-wise evaluation is problematic, hence the last step judge setup.