### PR TITLE
fix(gemini-live): capture tool result attributes on the llm_tool_result span

### DIFF
--- a/changelog/5051.fixed.md
+++ b/changelog/5051.fixed.md
@@ -1,0 +1,7 @@
+- Fixed the Gemini Live `llm_tool_result` trace span never capturing any tool
+  result attributes. The tracing decorator read the decorated `_tool_result`
+  method's first positional argument as a dict of result fields, but that
+  argument is the `tool_call_id` string, so `tool.call_id`,
+  `tool.function_name`, `tool.result`, and `tool.result_status` were silently
+  dropped. The decorator now reads the method's positional arguments
+  (`tool_call_id`, `tool_call_name`, `result`) directly.

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -1107,25 +1107,31 @@ def traced_gemini_live(operation: str) -> Callable:
                                         operation_attrs["tool.arguments"] = str(call.args)[:1000]
 
                         elif operation == "llm_tool_result" and len(args) >= 3:
-                            # _tool_result(self, tool_call_id, tool_name, result); its
-                            # positional args, in order. ``result`` is Gemini's already-
-                            # built FunctionResponse.response payload (a dict).
-                            tool_call_id, tool_name, result = args[0], args[1], args[2]
-                            if tool_call_id:
-                                operation_attrs["tool.call_id"] = tool_call_id
-                            if tool_name:
-                                operation_attrs["tool.function_name"] = tool_name
-                            if isinstance(result, dict):
-                                result_str = json.dumps(result)
-                                if len(result_str) > 2000:  # larger limit for results
-                                    result_str = result_str[:2000] + "..."
-                                operation_attrs["tool.result"] = result_str
-                                if "error" in result:
-                                    operation_attrs["tool.result_status"] = "error"
-                                elif "success" in result:
-                                    operation_attrs["tool.result_status"] = "success"
-                                else:
-                                    operation_attrs["tool.result_status"] = "completed"
+                            # _tool_result(self, tool_call_id, tool_call_name, result); its
+                            # positional args, in order. ``result`` is expected to be
+                            # Gemini's FunctionResponse.response payload (a dict), but is
+                            # validated at runtime rather than assumed.
+                            tool_call_id, tool_call_name, result = args[0], args[1], args[2]
+                            try:
+                                if tool_call_id:
+                                    operation_attrs["tool.call_id"] = tool_call_id
+                                if tool_call_name:
+                                    operation_attrs["tool.function_name"] = tool_call_name
+                                if isinstance(result, dict):
+                                    result_str = json.dumps(result)
+                                    if len(result_str) > 2000:  # larger limit for results
+                                        result_str = result_str[:2000] + "..."
+                                    operation_attrs["tool.result"] = result_str
+                                    if "error" in result:
+                                        operation_attrs["tool.result_status"] = "error"
+                                    elif "success" in result:
+                                        operation_attrs["tool.result_status"] = "success"
+                                    else:
+                                        operation_attrs["tool.result_status"] = "completed"
+                            except Exception as e:
+                                logging.warning(
+                                    f"Error capturing tool result attributes for tracing: {e}"
+                                )
 
                         elif operation == "llm_response" and args:
                             # Extract usage and response metadata from turn complete event

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -1106,49 +1106,26 @@ def traced_gemini_live(operation: str) -> Callable:
                                     except Exception:
                                         operation_attrs["tool.arguments"] = str(call.args)[:1000]
 
-                        elif operation == "llm_tool_result" and args:
-                            # Extract tool result information
-                            tool_result_message = args[0] if args else None
-                            if tool_result_message and isinstance(tool_result_message, dict):
-                                # Extract the tool call information
-                                tool_call_id = tool_result_message.get("tool_call_id")
-                                tool_call_name = tool_result_message.get("tool_call_name")
-                                result_content = tool_result_message.get("content")
-
-                                if tool_call_id:
-                                    operation_attrs["tool.call_id"] = tool_call_id
-                                if tool_call_name:
-                                    operation_attrs["tool.function_name"] = tool_call_name
-
-                                # Parse and capture the result
-                                if result_content:
-                                    try:
-                                        result = json.loads(result_content)
-                                        # Serialize the result, truncating if too long
-                                        result_str = json.dumps(result)
-                                        if len(result_str) > 2000:  # Larger limit for results
-                                            result_str = result_str[:2000] + "..."
-                                        operation_attrs["tool.result"] = result_str
-
-                                        # Add result status/success indicator if present
-                                        if isinstance(result, dict):
-                                            if "error" in result:
-                                                operation_attrs["tool.result_status"] = "error"
-                                            elif "success" in result:
-                                                operation_attrs["tool.result_status"] = "success"
-                                            else:
-                                                operation_attrs["tool.result_status"] = "completed"
-
-                                    except json.JSONDecodeError:
-                                        operation_attrs["tool.result"] = (
-                                            f"Invalid JSON: {str(result_content)[:500]}"
-                                        )
-                                        operation_attrs["tool.result_status"] = "parse_error"
-                                    except Exception as e:
-                                        operation_attrs["tool.result"] = (
-                                            f"Error processing result: {str(e)}"
-                                        )
-                                        operation_attrs["tool.result_status"] = "processing_error"
+                        elif operation == "llm_tool_result" and len(args) >= 3:
+                            # _tool_result(self, tool_call_id, tool_name, result); its
+                            # positional args, in order. ``result`` is Gemini's already-
+                            # built FunctionResponse.response payload (a dict).
+                            tool_call_id, tool_name, result = args[0], args[1], args[2]
+                            if tool_call_id:
+                                operation_attrs["tool.call_id"] = tool_call_id
+                            if tool_name:
+                                operation_attrs["tool.function_name"] = tool_name
+                            if isinstance(result, dict):
+                                result_str = json.dumps(result)
+                                if len(result_str) > 2000:  # larger limit for results
+                                    result_str = result_str[:2000] + "..."
+                                operation_attrs["tool.result"] = result_str
+                                if "error" in result:
+                                    operation_attrs["tool.result_status"] = "error"
+                                elif "success" in result:
+                                    operation_attrs["tool.result_status"] = "success"
+                                else:
+                                    operation_attrs["tool.result_status"] = "completed"
 
                         elif operation == "llm_response" and args:
                             # Extract usage and response metadata from turn complete event

--- a/tests/test_gemini_live_tracing.py
+++ b/tests/test_gemini_live_tracing.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    HAS_OPENTELEMETRY = True
+except ImportError:
+    HAS_OPENTELEMETRY = False
+
+from pipecat.utils.tracing.service_decorators import traced_gemini_live
+
+
+class _StubGeminiLiveService:
+    """Minimal stand-in for the Gemini Live service.
+
+    Exposes only the attributes the ``traced_gemini_live`` decorator reads, and
+    a ``_tool_result`` method decorated exactly as the real service decorates it
+    — same operation, same positional signature ``(tool_call_id, tool_name,
+    tool_result_message)``.
+    """
+
+    def __init__(self):
+        self._tracing_enabled = True
+        self._tracing_context = None
+        self._settings = None
+        self._model_name = "gemini-live-test"
+
+    @traced_gemini_live(operation="llm_tool_result")
+    async def _tool_result(self, tool_call_id, tool_name, tool_result_message):
+        """No-op body; the decorator is what we're exercising."""
+        return None
+
+
+@unittest.skipUnless(HAS_OPENTELEMETRY, "opentelemetry not installed")
+class TestGeminiLiveToolResultTracing(unittest.IsolatedAsyncioTestCase):
+    """Tests for the ``llm_tool_result`` branch of ``traced_gemini_live``.
+
+    Regression coverage for the decorator reading the decorated method's
+    positional arguments (``tool_call_id``, ``tool_call_name``, ``result``).
+    The previous implementation treated ``args[0]`` — actually the
+    ``tool_call_id`` string — as a dict of result fields, so it captured
+    nothing and every ``tool.*`` attribute silently went missing from the span.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Wire an in-memory span exporter into the global tracer provider.
+
+        OpenTelemetry only allows the global tracer provider to be set once per
+        process, and the decorator resolves its tracer via
+        ``trace.get_tracer("pipecat")`` — so we install the provider once and
+        clear the exporter between tests rather than re-setting it.
+        """
+        cls._exporter = InMemorySpanExporter()
+        processor = SimpleSpanProcessor(cls._exporter)
+        existing = trace.get_tracer_provider()
+        # Attach to whatever provider is already installed (another test may
+        # have set one), since it can't be replaced once set; otherwise install
+        # our own.
+        if isinstance(existing, TracerProvider):
+            existing.add_span_processor(processor)
+        else:
+            provider = TracerProvider()
+            provider.add_span_processor(processor)
+            trace.set_tracer_provider(provider)
+
+    def setUp(self):
+        self._exporter.clear()
+
+    def _tool_result_span(self):
+        spans = self._exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1, "expected exactly one llm_tool_result span")
+        span = spans[0]
+        self.assertEqual(span.name, "llm_tool_result")
+        return span
+
+    async def test_captures_tool_result_attributes(self):
+        """The call_id, function name, and result payload land on the span.
+
+        These are passed positionally, exactly as the real service calls
+        ``_tool_result(tool_call_id, tool_name, tool_result_message)``.
+        """
+        service = _StubGeminiLiveService()
+
+        await service._tool_result("call-123", "get_weather", {"temperature": 72})
+
+        attrs = self._tool_result_span().attributes
+        self.assertEqual(attrs["tool.call_id"], "call-123")
+        self.assertEqual(attrs["tool.function_name"], "get_weather")
+        self.assertIn('"temperature": 72', attrs["tool.result"])
+        self.assertEqual(attrs["tool.result_status"], "completed")
+
+    async def test_result_status_error(self):
+        """An ``error`` key in the result dict marks the span as errored."""
+        service = _StubGeminiLiveService()
+
+        await service._tool_result("call-err", "lookup", {"error": "not found"})
+
+        self.assertEqual(self._tool_result_span().attributes["tool.result_status"], "error")
+
+    async def test_result_status_success(self):
+        """A ``success`` key in the result dict marks the span as succeeded."""
+        service = _StubGeminiLiveService()
+
+        await service._tool_result("call-ok", "lookup", {"success": True, "value": 1})
+
+        self.assertEqual(self._tool_result_span().attributes["tool.result_status"], "success")
+
+    async def test_long_result_is_truncated(self):
+        """Result payloads over the 2000-char limit are truncated with an ellipsis."""
+        service = _StubGeminiLiveService()
+
+        await service._tool_result("call-big", "dump", {"blob": "x" * 5000})
+
+        result = self._tool_result_span().attributes["tool.result"]
+        self.assertTrue(result.endswith("..."))
+        self.assertLessEqual(len(result), 2003)
+
+    async def test_non_dict_result_omits_result_attribute(self):
+        """A non-dict result still records call_id/name but no result payload."""
+        service = _StubGeminiLiveService()
+
+        await service._tool_result("call-str", "echo", "just a string")
+
+        attrs = self._tool_result_span().attributes
+        self.assertEqual(attrs["tool.call_id"], "call-str")
+        self.assertEqual(attrs["tool.function_name"], "echo")
+        self.assertNotIn("tool.result", attrs)
+        self.assertNotIn("tool.result_status", attrs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The Gemini Live `llm_tool_result` span is emitted with **none** of its `tool.*` attributes, so tool results never show up in traces.

`traced_gemini_live`'s `llm_tool_result` branch reads the result from `args[0]`:

```python
tool_result_message = args[0] if args else None
if tool_result_message and isinstance(tool_result_message, dict):
    ...
```

But the decorated method is:

```python
async def _tool_result(self, tool_call_id: str, tool_name: str, tool_result_message: dict[str, Any]):
```

so `args[0]` is the `tool_call_id` **string**, not the result dict (which is `args[2]`). The `isinstance(..., dict)` guard fails and the entire extraction is skipped — the span gets no `tool.call_id`, `tool.function_name`, `tool.result`, or `tool.result_status`.

There's a second, related mismatch even if the index were fixed: the code reads `tool_result_message.get("content")` / `.get("tool_call_id")` / `.get("tool_call_name")`, but `args[2]` is the already-built `FunctionResponse.response` payload from `GeminiLLMAdapter.to_function_response_dict(...)` — it has none of those keys; it *is* the result.

## Fix

Read the decorated method's positional args in order and serialize the response payload directly:

```python
elif operation == "llm_tool_result" and len(args) >= 3:
    tool_call_id, tool_name, result = args[0], args[1], args[2]
    if tool_call_id:
        operation_attrs["tool.call_id"] = tool_call_id
    if tool_name:
        operation_attrs["tool.function_name"] = tool_name
    if isinstance(result, dict):
        result_str = json.dumps(result)
        if len(result_str) > 2000:
            result_str = result_str[:2000] + "..."
        operation_attrs["tool.result"] = result_str
        if "error" in result:
            operation_attrs["tool.result_status"] = "error"
        elif "success" in result:
            operation_attrs["tool.result_status"] = "success"
        else:
            operation_attrs["tool.result_status"] = "completed"
```

The `llm_tool_result` span now carries `tool.call_id`, `tool.function_name`, `tool.result`, and `tool.result_status`.

Scope is intentionally minimal — only the `llm_tool_result` extraction changes. Happy to add a unit test for the decorator (in-memory span exporter) if you'd like one.
