### PR TITLE
Refine the dev-runner startup banner

### DIFF
--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -104,6 +104,7 @@ import os
 import secrets
 import sys
 import time
+import unicodedata
 import uuid
 from contextlib import asynccontextmanager
 from http import HTTPMethod
@@ -348,6 +349,23 @@ def _style_banner_line(text: str) -> str:
     return text
 
 
+def _display_width(text: str) -> int:
+    """Return the number of terminal columns ``text`` occupies.
+
+    Counts East-Asian wide/fullwidth characters (including emoji such as the
+    banner's warning marker) as two columns, and combining marks and variation
+    selectors as zero, so bordered lines align regardless of how a terminal
+    sizes wide glyphs.
+    """
+    width = 0
+    for ch in text:
+        # Combining marks and variation selectors (VS1-VS16) add no width.
+        if unicodedata.combining(ch) or 0xFE00 <= ord(ch) <= 0xFE0F:
+            continue
+        width += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return width
+
+
 def _print_dev_runner_banner():
     """Print a bordered banner identifying this as the development runner.
 
@@ -358,16 +376,17 @@ def _print_dev_runner_banner():
     lines = [
         "PIPECAT DEVELOPMENT RUNNER",
         "",
-        "⚠️  For development purposes only.",
+        "🚧 For development purposes only.",
         "",
         "Learn about running bots locally and in production:",
         "https://docs.pipecat.ai/pipecat/deployment/overview",
     ]
-    width = max(len(line) for line in lines)
+    width = max(_display_width(line) for line in lines)
     print()
     print(_style_banner_line("╭" + "─" * (width + 2) + "╮"))
     for line in lines:
-        print(_style_banner_line(f"│ {line.ljust(width)} │"))
+        padding = " " * (width - _display_width(line))
+        print(_style_banner_line(f"│ {line}{padding} │"))
     print(_style_banner_line("╰" + "─" * (width + 2) + "╯"))
 
 

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -372,7 +372,7 @@ def _print_dev_runner_banner():
     doesn't compete with the connection details that follow.
     """
     lines = [
-        "ᓚᘏᗢ💻 PIPECAT DEVELOPMENT RUNNER",
+        "ᓚᘏᗢ PIPECAT DEVELOPMENT RUNNER",
         "",
         "Learn about running bots locally and in production:",
         "https://docs.pipecat.ai/pipecat/deployment/overview",

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -352,10 +352,9 @@ def _style_banner_line(text: str) -> str:
 def _display_width(text: str) -> int:
     """Return the number of terminal columns ``text`` occupies.
 
-    Counts East-Asian wide/fullwidth characters (including emoji such as the
-    banner's warning marker) as two columns, and combining marks and variation
-    selectors as zero, so bordered lines align regardless of how a terminal
-    sizes wide glyphs.
+    Counts East-Asian wide/fullwidth characters (including emoji) as two
+    columns, and combining marks and variation selectors as zero, so bordered
+    lines align regardless of how a terminal sizes wide glyphs.
     """
     width = 0
     for ch in text:
@@ -369,14 +368,11 @@ def _display_width(text: str) -> int:
 def _print_dev_runner_banner():
     """Print a bordered banner identifying this as the development runner.
 
-    It points out the runner is for development purposes only and links to the
-    deployment docs. Rendered dim so it doesn't compete with the connection
-    details that follow.
+    Names the runner and links to the deployment docs. Rendered dim so it
+    doesn't compete with the connection details that follow.
     """
     lines = [
-        "PIPECAT DEVELOPMENT RUNNER",
-        "",
-        "🚧 For development purposes only.",
+        "ᓚᘏᗢ💻 PIPECAT DEVELOPMENT RUNNER",
         "",
         "Learn about running bots locally and in production:",
         "https://docs.pipecat.ai/pipecat/deployment/overview",


### PR DESCRIPTION
Follow-up to #5060, refining the just-added startup banner in two ways.

**Cross-terminal alignment** — the marker rendered as 1 cell in some terminals (macOS Terminal.app) and 2 in others (iTerm2), so the box's right border drifted. Pad each line by its *display width* (a small `_display_width` helper) instead of code-point length. This keeps any wide glyph (the 💻 below included) aligned everywhere.

**Friendlier tone** — the `⚠️`/`🚧` "caution" marker read as "this framework is half-baked" on someone's first bot run. Replace it with Pipecat's cat (`ᓚᘏᗢ`) and drop the redundant "for development purposes only" line; the title still names it the development runner and links to the deployment docs.

```
╭─────────────────────────────────────────────────────╮
│ ᓚᘏᗢ PIPECAT DEVELOPMENT RUNNER                     │
│                                                     │
│ Learn about running bots locally and in production: │
│ https://docs.pipecat.ai/pipecat/deployment/overview │
╰─────────────────────────────────────────────────────╯
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)