### PR TITLE
feat(turns): recover from user_turn_stop_timeout when the LLM emits no completion marker

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1100,6 +1100,22 @@ class UserTurnInferenceCompletedFrame(SystemFrame):
 
 
 @dataclass
+class UserTurnStopTimeoutFrame(SystemFrame):
+    """Frame indicating that the user turn was finalized by the safety timeout.
+
+    Broadcast by the user aggregator when a user turn ends because
+    ``user_turn_stop_timeout`` elapsed (the ``on_user_turn_stopped`` strategy is
+    ``None``) rather than because a stop strategy fired. Turn-completion-aware
+    LLM services consume this to recover when the model never produced a
+    completion marker (✓/○/◐) for the turn — without it, such a turn ends with
+    no response and the bot goes silent. Consumers should treat an absent
+    completion as "no answer was generated" and decide whether to re-prompt.
+    """
+
+    pass
+
+
+@dataclass
 class VADUserStartedSpeakingFrame(SystemFrame):
     """Frame emitted when VAD definitively detects user started speaking.
 

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -70,6 +70,7 @@ from pipecat.frames.frames import (
     UserSpeakingFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    UserTurnStopTimeoutFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
@@ -1273,6 +1274,15 @@ class LLMUserAggregator(LLMContextAggregator):
             return
 
         await self._maybe_emit_user_turn_stopped(strategy)
+
+        # A ``None`` strategy means the turn was finalized by
+        # ``user_turn_stop_timeout``, not by a stop strategy. Signal downstream
+        # turn-completion-aware services so they can recover if the LLM never
+        # produced a completion marker this turn (otherwise the turn ends with
+        # no response). Broadcast after the turn text is flushed so a re-prompt
+        # runs against the full context.
+        if strategy is None:
+            await self.broadcast_frame(UserTurnStopTimeoutFrame)
 
     async def _on_reset_aggregation(
         self, controller: UserTurnController, strategy: BaseUserTurnStartStrategy

--- a/src/pipecat/turns/user_turn_completion_mixin.py
+++ b/src/pipecat/turns/user_turn_completion_mixin.py
@@ -30,6 +30,7 @@ from pipecat.frames.frames import (
     LLMTextFrame,
     UserStartedSpeakingFrame,
     UserTurnInferenceCompletedFrame,
+    UserTurnStopTimeoutFrame,
     VADUserStartedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
@@ -183,6 +184,13 @@ class UserTurnCompletionConfig:
         incomplete_long_timeout: Seconds to wait after long incomplete (◐) before prompting.
         incomplete_short_prompt: Custom prompt when short timeout expires.
         incomplete_long_prompt: Custom prompt when long timeout expires.
+        reprompt_on_turn_stop_timeout: When True, if a user turn is finalized by
+            the aggregator's ``user_turn_stop_timeout`` safety net and the LLM
+            never produced a completion marker (✓/○/◐) for the turn, force a
+            single re-prompt (using ``incomplete_short_prompt``) so the model
+            commits to a response instead of the turn ending silently. Skipped
+            when a ✓ was already voiced this turn or an ○/◐ re-prompt is already
+            pending. Defaults to False (no behavior change).
     """
 
     instructions: str | None = None
@@ -190,6 +198,7 @@ class UserTurnCompletionConfig:
     incomplete_long_timeout: float = 10.0
     incomplete_short_prompt: str | None = None
     incomplete_long_prompt: str | None = None
+    reprompt_on_turn_stop_timeout: bool = False
 
     @property
     def completion_instructions(self) -> str:
@@ -358,6 +367,37 @@ class UserTurnCompletionLLMServiceMixin(FrameProcessor):
             # Timeout was cancelled (user spoke or interruption)
             pass
 
+    async def _maybe_reprompt_on_turn_stop_timeout(self):
+        """Force one re-prompt when a turn times out with no completion.
+
+        Triggered by ``UserTurnStopTimeoutFrame`` — the user turn was finalized
+        by the aggregator's ``user_turn_stop_timeout`` safety net (no stop
+        strategy fired). If turn-completion filtering is active and the LLM never
+        produced a ✓ this turn, the turn would otherwise end with no response and
+        the bot goes silent. Re-prompt with the short incomplete prompt so the
+        model commits to a ✓ answer.
+
+        Opt-in via ``UserTurnCompletionConfig.reprompt_on_turn_stop_timeout``.
+        Skipped when a ✓ was already voiced this turn or an ○/◐ re-prompt is
+        already pending (that path drives the recovery instead).
+        """
+        if not self._user_turn_completion_config.reprompt_on_turn_stop_timeout:
+            return
+        if self._user_turn_completion_voiced:
+            return
+        if self._incomplete_timeout_task and not self._incomplete_timeout_task.done():
+            return
+
+        logger.debug(
+            "User turn stop timeout with no completion marker — re-prompting for a ✓ response"
+        )
+        await self._turn_reset()
+        prompt = self._user_turn_completion_config.short_prompt
+        await self.push_frame(
+            LLMMessagesAppendFrame(messages=[{"role": "developer", "content": prompt}])
+        )
+        await self.push_frame(LLMRunFrame())
+
     async def _turn_reset(self):
         """Reset turn completion state between responses.
 
@@ -378,6 +418,18 @@ class UserTurnCompletionLLMServiceMixin(FrameProcessor):
                 "The system prompt may be missing turn completion instructions."
             )
             await self.push_frame(LLMTextFrame(self._turn_text_buffer))
+        elif self._turn_marker is None:
+            # No marker AND no text: the model returned an empty / marker-less
+            # completion, so nothing is pushed and the turn produces no response.
+            # Warn so this failure mode is visible — it otherwise looks like the
+            # bot silently ignored the user. If turns then stall on the
+            # user_turn_stop_timeout, enable
+            # ``UserTurnCompletionConfig.reprompt_on_turn_stop_timeout``.
+            logger.warning(
+                f"{self}: filter_incomplete_user_turns is enabled but the LLM returned an "
+                "empty completion with no turn marker (✓/○/◐); no response will be produced "
+                "for this turn."
+            )
 
         self._turn_text_buffer = ""
         self._turn_marker = None
@@ -417,6 +469,14 @@ class UserTurnCompletionLLMServiceMixin(FrameProcessor):
 
         # Pass frame to parent
         await super().process_frame(frame, direction)
+
+        # The user turn was finalized by user_turn_stop_timeout (no stop
+        # strategy fired). Recover if the LLM never produced a completion for
+        # the turn. Handled after forwarding so downstream consumers still see
+        # the timeout frame before any re-prompt runs. Opt-in — see
+        # UserTurnCompletionConfig.reprompt_on_turn_stop_timeout.
+        if isinstance(frame, UserTurnStopTimeoutFrame):
+            await self._maybe_reprompt_on_turn_stop_timeout()
 
     async def push_frame(self, frame: Frame, direction: FrameDirection = FrameDirection.DOWNSTREAM):
         """Push a frame downstream, resetting turn state at end of each LLM response.


### PR DESCRIPTION
## Problem

When turn-completion filtering is active (`FilterIncompleteUserTurnStrategies`, or the deprecated `filter_incomplete_user_turns=True`), a user turn that is finalized by the aggregator's `user_turn_stop_timeout` safety net **never triggers a generation**, so the bot can go silent for the rest of the turn.

Flow today:

- The only forced-answer mechanism is the incomplete (`○`/`◐`) re-prompt timer in `UserTurnCompletionLLMServiceMixin`.
- That timer is cancelled the instant the user resumes speaking (`VADUserStartedSpeakingFrame`) and on each new response start.
- It is **never armed at all** when an inference returns an empty / marker-less completion (0 tokens, or text without `✓`/`○`/`◐`).

So the sequence "`○` armed → user resumes → timer cancelled → next inference returns an empty completion" leaves the turn with no pending re-prompt. The turn is then closed by `user_turn_stop_timeout` (`on_user_turn_stopped` fires with `strategy=None`), which only flushes the transcript and emits events — it does **not** re-arm a timer or force a `✓`. Result: the user finishes, and the bot never responds.

We hit this repeatedly in production with `gemini-3.5-flash` (temperature 0, minimal thinking): across one interview, 17/42 inferences returned no marker and 10 of those were fully empty (0 tokens). Two turns stalled with zero bot response — one for ~2m44s, after which the candidate left the call.

## Solution (opt-in, default off)

- **New `UserTurnStopTimeoutFrame`** (`SystemFrame`), broadcast by `LLMUserAggregator` when a turn is finalized by the timeout (`strategy is None`), after the turn text is flushed so a re-prompt runs against the full context.
- **`UserTurnCompletionLLMServiceMixin` consumes it** and, when `UserTurnCompletionConfig.reprompt_on_turn_stop_timeout` is enabled and no `✓` was voiced this turn (and no `○`/`◐` re-prompt is already pending), re-prompts with the short incomplete prompt so the model commits to a `✓` response instead of the turn ending silently.
- **`_turn_reset` now also warns on an empty / marker-less completion.** Previously only the has-text-but-no-marker case logged a warning; a fully empty completion was swallowed with no signal, making the silent-turn failure mode invisible.

New config field:

```python
UserTurnCompletionConfig(
    # ...
    reprompt_on_turn_stop_timeout=True,  # default False
)
```

## Backward compatibility

`reprompt_on_turn_stop_timeout` defaults to `False`, so existing pipelines are unchanged. The new frame is a `SystemFrame` that unrelated processors ignore. The only unconditional change is the added warning log for empty completions.

## Test plan

- [x] `python -m py_compile` on the three modified modules
- [x] Ruff lint clean
- [ ] `pytest tests/ -k "turn_completion or user_turn"` in a dev env
- [ ] Manual: enable `reprompt_on_turn_stop_timeout`, drive a turn where the LLM returns an empty completion, confirm a single re-prompt fires on the turn-stop timeout and the bot responds

Made with [Cursor](https://cursor.com)