### PR TITLE
smallwebrtc: ignore end-of-candidates ICE markers in patch requests

### DIFF
--- a/changelog/5074.fixed.md
+++ b/changelog/5074.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `SmallWebRTCRequestHandler.handle_patch_request` crashing with an
+  `AssertionError` on the standard trickle-ICE end-of-candidates marker (an
+  empty `candidate` string, which browsers send for every media line). The
+  marker is now ignored and the remaining candidates in the batch are added.

--- a/src/pipecat/transports/smallwebrtc/request_handler.py
+++ b/src/pipecat/transports/smallwebrtc/request_handler.py
@@ -241,13 +241,30 @@ class SmallWebRTCRequestHandler:
             raise
 
     async def handle_patch_request(self, request: SmallWebRTCPatchRequest):
-        """Handle a SmallWebRTC patch candidate request."""
+        """Handle a SmallWebRTC patch candidate request.
+
+        Empty ``candidate`` strings (RFC 8838 end-of-candidates markers) are
+        ignored; the remaining candidates are added to the peer connection.
+
+        Args:
+            request: The patch request containing the peer connection ID and
+                the ICE candidates to add.
+
+        Raises:
+            HTTPException: If no peer connection matches the request's ``pc_id``.
+        """
         peer_connection = self._pcs_map.get(request.pc_id)
 
         if not peer_connection:
             raise HTTPException(status_code=404, detail="Peer connection not found")
 
         for c in request.candidates:
+            if not c.candidate:
+                # Per RFC 8838, an empty candidate string signals the peer is
+                # done gathering candidates for this media line; there is no
+                # candidate to add.
+                logger.trace(f"Ignoring end-of-candidates marker for mid: {c.sdp_mid}")
+                continue
             candidate = candidate_from_sdp(c.candidate)
             candidate.sdpMid = c.sdp_mid
             candidate.sdpMLineIndex = c.sdp_mline_index

--- a/tests/test_smallwebrtc_request_handler.py
+++ b/tests/test_smallwebrtc_request_handler.py
@@ -1,0 +1,85 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for `SmallWebRTCRequestHandler.handle_patch_request`.
+
+Covers trickle-ICE candidate patch handling:
+
+1. **End-of-candidates markers are skipped** — per RFC 8838, a peer signals
+   "done gathering for this media line" with a patch whose ``candidate``
+   string is empty. Browsers send one per media line on every connection.
+   The marker must not be parsed as SDP (aiortc's ``candidate_from_sdp``
+   asserts on it) and must not abort the rest of the batch.
+
+2. **Real candidates are applied** — non-empty candidates in the same batch
+   reach ``add_ice_candidate`` with ``sdpMid``/``sdpMLineIndex`` set.
+
+3. **Unknown ``pc_id`` raises a 404** ``HTTPException``.
+"""
+
+import unittest
+from unittest.mock import AsyncMock
+
+import pytest
+
+# The `webrtc` extra and the runner's HTTP dependencies are optional; skip the
+# whole module when they are unavailable, matching the default CI unit test
+# environment which does not install extras.
+pytest.importorskip("aiortc")
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException  # noqa: E402
+
+from pipecat.transports.smallwebrtc.request_handler import (  # noqa: E402
+    IceCandidate,
+    SmallWebRTCPatchRequest,
+    SmallWebRTCRequestHandler,
+)
+
+HOST_CANDIDATE = "candidate:840965716 1 udp 2122260223 192.168.1.7 54321 typ host"
+
+
+class TestHandlePatchRequest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.handler = SmallWebRTCRequestHandler()
+        self.connection = AsyncMock()
+        self.handler._pcs_map["pc-1"] = self.connection
+
+    async def test_end_of_candidates_markers_are_skipped(self):
+        request = SmallWebRTCPatchRequest(
+            pc_id="pc-1",
+            candidates=[
+                IceCandidate(candidate="", sdp_mid="0", sdp_mline_index=0),
+                IceCandidate(candidate=HOST_CANDIDATE, sdp_mid="0", sdp_mline_index=0),
+                IceCandidate(candidate="", sdp_mid="1", sdp_mline_index=1),
+            ],
+        )
+
+        await self.handler.handle_patch_request(request)
+
+        self.assertEqual(self.connection.add_ice_candidate.await_count, 1)
+        (candidate,) = self.connection.add_ice_candidate.await_args.args
+        self.assertEqual(candidate.port, 54321)
+        self.assertEqual(candidate.sdpMid, "0")
+        self.assertEqual(candidate.sdpMLineIndex, 0)
+
+    async def test_marker_only_batch_is_a_no_op(self):
+        request = SmallWebRTCPatchRequest(
+            pc_id="pc-1",
+            candidates=[IceCandidate(candidate="", sdp_mid="0", sdp_mline_index=0)],
+        )
+
+        await self.handler.handle_patch_request(request)
+
+        self.connection.add_ice_candidate.assert_not_awaited()
+
+    async def test_unknown_pc_id_raises_404(self):
+        request = SmallWebRTCPatchRequest(pc_id="missing", candidates=[])
+
+        with self.assertRaises(HTTPException) as ctx:
+            await self.handler.handle_patch_request(request)
+
+        self.assertEqual(ctx.exception.status_code, 404)


### PR DESCRIPTION
Fixes #5054

Per RFC 8838 (Trickle ICE), browsers signal "done gathering candidates for this media line" by sending one final candidate patch whose `candidate` field is an empty string — spec-compliant behavior that occurs on every media line of every connection. `SmallWebRTCRequestHandler.handle_patch_request` passed that empty string straight to aiortc's `candidate_from_sdp`, which asserts (`assert len(bits) >= 8`). As a result:

- every `SmallWebRTCTransport` session hit an unhandled `AssertionError` in the PATCH `/api/offer` route — surfacing client-side as an opaque `NetworkError` / `Failed to fetch`, and
- real candidates queued after the marker in the same batch were dropped, since the loop aborted on the first exception.

This PR skips empty-candidate entries, as suggested by @Lluc24 in the issue: the marker carries no candidate to add, and the peer connection already infers per-line gathering completion. Real candidates in the same batch are still applied.

Also adds unit tests for `handle_patch_request`: markers are skipped without aborting the batch, real candidates still reach `add_ice_candidate` with `sdpMid`/`sdpMLineIndex` set, and an unknown `pc_id` still raises a 404.
