### PR TITLE
fix(turns): warn when turn analyzer gets transcripts without STTMetadataFrame

### DIFF
--- a/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
@@ -77,6 +77,8 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._stop_secs: float = 0.0  # VAD stop_secs from VADUserStoppedSpeakingFrame
 
         self._stop_secs_warned: bool = False
+        self._stt_metadata_seen: bool = False
+        self._no_stt_metadata_warned: bool = False
 
         self._text = ""
         self._turn_complete = False
@@ -155,6 +157,7 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
             await self._start(frame)
         elif isinstance(frame, STTMetadataFrame):
             self._stt_timeout = frame.ttfs_p99_latency
+            self._stt_metadata_seen = True
             self._stop_secs_warned = False
         elif isinstance(frame, VADUserStartedSpeakingFrame):
             await self._handle_vad_user_started_speaking(frame)
@@ -255,6 +258,19 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
+        if not self._stt_metadata_seen and not self._no_stt_metadata_warned:
+            self._no_stt_metadata_warned = True
+            logger.warning(
+                f"{self}: receiving transcripts but no STTMetadataFrame has been "
+                f"seen. Without it the STT p99 grace window is 0s, so turn-end "
+                f"timing can be unreliable and the bot may respond before the "
+                f"user finishes. This usually means transcription is coming from "
+                f"the transport (for example Daily transcription_enabled=True) "
+                f"instead of a Pipecat STT service in the pipeline. Add a Pipecat "
+                f"STT service (for example DeepgramSTTService) to the pipeline so "
+                f"this strategy receives STTMetadataFrame and finalized transcripts."
+            )
+
         # We don't really care about the content.
         self._text = frame.text
         if frame.finalized:

--- a/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/turn_analyzer_user_turn_stop_strategy.py
@@ -258,7 +258,11 @@ class TurnAnalyzerUserTurnStopStrategy(BaseUserTurnStopStrategy):
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
         """Handle user transcription."""
-        if not self._stt_metadata_seen and not self._no_stt_metadata_warned:
+        if (
+            self._wait_for_transcript
+            and not self._stt_metadata_seen
+            and not self._no_stt_metadata_warned
+        ):
             self._no_stt_metadata_warned = True
             logger.warning(
                 f"{self}: receiving transcripts but no STTMetadataFrame has been "

--- a/tests/test_user_turn_stop_strategy.py
+++ b/tests/test_user_turn_stop_strategy.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pipecat.frames.frames import (
     InterimTranscriptionFrame,
@@ -22,6 +22,7 @@ from pipecat.turns.user_stop import (
     ExternalUserTurnCompletionStopStrategy,
     ExternalUserTurnStopStrategy,
     SpeechTimeoutUserTurnStopStrategy,
+    TurnAnalyzerUserTurnStopStrategy,
 )
 from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
 
@@ -796,6 +797,55 @@ class TestSpeechTimeoutStopSecsWarnings(unittest.IsolatedAsyncioTestCase):
         await strategy.process_frame(VADUserStartedSpeakingFrame())
         await strategy.process_frame(VADUserStoppedSpeakingFrame(stop_secs=0.2))
 
+        mock_logger.warning.assert_not_called()
+
+
+class TestTurnAnalyzerMissingSTTMetadataWarning(unittest.IsolatedAsyncioTestCase):
+    """Tests for the one-time missing STTMetadataFrame warning."""
+
+    async def asyncSetUp(self) -> None:
+        self.task_manager = TaskManager()
+        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+
+    async def _create_strategy(self, wait_for_transcript=True):
+        strategy = TurnAnalyzerUserTurnStopStrategy(
+            turn_analyzer=MagicMock(), wait_for_transcript=wait_for_transcript
+        )
+        await strategy.setup(self.task_manager)
+        return strategy
+
+    @patch("pipecat.turns.user_stop.turn_analyzer_user_turn_stop_strategy.logger")
+    async def test_warns_once_when_no_stt_metadata(self, mock_logger):
+        strategy = await self._create_strategy(wait_for_transcript=True)
+
+        # First transcript without any prior STTMetadataFrame triggers the warning.
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        self.assertEqual(mock_logger.warning.call_count, 1)
+        self.assertIn("no STTMetadataFrame", mock_logger.warning.call_args[0][0])
+
+        # A second transcript does not warn again.
+        await strategy.process_frame(
+            TranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        self.assertEqual(mock_logger.warning.call_count, 1)
+
+    @patch("pipecat.turns.user_stop.turn_analyzer_user_turn_stop_strategy.logger")
+    async def test_no_warning_when_wait_for_transcript_false(self, mock_logger):
+        strategy = await self._create_strategy(wait_for_transcript=False)
+
+        # In realtime speech-to-speech mode transcripts don't gate turn-end
+        # timing, so a missing STTMetadataFrame is expected: no warning.
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
+        mock_logger.warning.assert_not_called()
+
+    @patch("pipecat.turns.user_stop.turn_analyzer_user_turn_stop_strategy.logger")
+    async def test_no_warning_when_stt_metadata_seen(self, mock_logger):
+        strategy = await self._create_strategy(wait_for_transcript=True)
+
+        await strategy.process_frame(
+            STTMetadataFrame(service_name="test", ttfs_p99_latency=STT_TIMEOUT)
+        )
+        await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="cat", timestamp=""))
         mock_logger.warning.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

`TurnAnalyzerUserTurnStopStrategy` sets its STT grace-window timeout from an `STTMetadataFrame` (which carries `ttfs_p99_latency`). A Pipecat STT service in the pipeline broadcasts that frame; transport-level transcription (for example Daily's `transcription_enabled=True`) does not. When the frame never arrives, `_stt_timeout` stays `0.0`, the grace window collapses to zero, and turn-end timing gets brittle: the bot can respond before the user is done. Today this happens silently.

## Fix

Log-only change, no behavior change. Adds a one-time `logger.warning` when the strategy receives transcripts but has never seen an `STTMetadataFrame`, following the existing `_stop_secs_warned` pattern in the same file. The warning points users at the fix: add a Pipecat STT service (for example `DeepgramSTTService`) to the pipeline so the strategy gets `STTMetadataFrame` and finalized transcripts.

The warning only fires when `wait_for_transcript=True`. In realtime speech-to-speech mode (`wait_for_transcript=False`), transcripts do not gate turn-end timing, so a missing `STTMetadataFrame` is expected and does not warrant a warning.

## Testing

`tests/test_user_turn_stop_strategy.py`: 29 passed, including 3 new tests covering the warning path (warns once when no metadata is seen, no warning in realtime mode, no warning when an `STTMetadataFrame` arrived first).
