### PR TITLE
Replay RTVI mute state emitted before client-ready

### DIFF
--- a/changelog/5085.fixed.md
+++ b/changelog/5085.fixed.md
@@ -1,0 +1,7 @@
+- Fixed RTVI mute state emitted before the `client-ready` handshake being
+  silently dropped. A greeting-time mute (e.g. `MuteUntilFirstBotComplete`,
+  which reports the user muted from the first frame) engages before the client
+  subscribes to the transport, so `user-mute-started` never reached the client
+  and its mute UI stayed off while the bot was muted server-side.
+  `RTVIProcessor` now buffers pre-`client-ready` mute messages and replays them
+  once the client is ready.

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -82,6 +82,8 @@ class RTVIProcessor(FrameProcessor):
         self._bot_ready = False
         self._client_ready = False
         self._client_ready_id = ""
+        # Mute messages buffered before client-ready; replayed by set_client_ready().
+        self._pending_mute_messages: list[tuple[BaseModel, bool]] = []
         # Default to 0.0.0 to indicate unknown version.
         self._client_version = [0, 0, 0]
         self._llm_skip_tts: bool = False  # Keep in sync with llm_service.py's configuration.
@@ -129,6 +131,7 @@ class RTVIProcessor(FrameProcessor):
         """Mark the client as ready and trigger the ready event."""
         self._client_ready = True
         await self._call_event_handler("on_client_ready")
+        await self._flush_pending_mute_messages()
 
     async def set_bot_ready(self, about: Mapping[str, Any] | None = None):
         """Mark the bot as ready and send the bot-ready message.
@@ -169,11 +172,32 @@ class RTVIProcessor(FrameProcessor):
         await self._send_error_frame(ErrorFrame(error=error))
 
     async def push_transport_message(self, model: BaseModel, exclude_none: bool = True):
-        """Push a transport message frame."""
+        """Push a transport message frame.
+
+        Mute-state messages sent before the client-ready handshake are buffered
+        and replayed by :meth:`set_client_ready`. Mute is sticky state, so a
+        transition emitted before the client subscribes to the transport would
+        otherwise be dropped and leave the client's mute state desynced.
+
+        Args:
+            model: The message to send.
+            exclude_none: Whether to exclude None values from the model dump.
+        """
+        if not self._client_ready and isinstance(
+            model, (RTVI.UserMuteStartedMessage, RTVI.UserMuteStoppedMessage)
+        ):
+            self._pending_mute_messages.append((model, exclude_none))
+            return
         frame = OutputTransportMessageUrgentFrame(
             message=model.model_dump(exclude_none=exclude_none)
         )
         await self.push_frame(frame)
+
+    async def _flush_pending_mute_messages(self):
+        """Replay mute-state messages buffered before the client became ready."""
+        pending, self._pending_mute_messages = self._pending_mute_messages, []
+        for model, exclude_none in pending:
+            await self.push_transport_message(model, exclude_none)
 
     async def handle_message(self, message: RTVI.Message):
         """Handle an incoming RTVI message.

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -16,6 +16,7 @@ from pipecat.frames.frames import (
     InputAudioRawFrame,
     InputDTMFFrame,
     InputTransportStartAudioStreamingFrame,
+    OutputTransportMessageUrgentFrame,
 )
 from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
 
@@ -184,6 +185,47 @@ class TestRTVIFrameBasedAudio(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(pushed), 1)
         self.assertIsInstance(pushed[0], InputAudioRawFrame)
         self.assertEqual(pushed[0].sample_rate, 16000)
+
+
+class TestRTVIMuteBeforeClientReady(unittest.IsolatedAsyncioTestCase):
+    """Mute messages emitted before client-ready are buffered, then replayed."""
+
+    def setUp(self):
+        self.processor = RTVIProcessor()
+        self.processor.push_frame = AsyncMock()
+
+    async def asyncTearDown(self):
+        await self.processor.cleanup()
+
+    def _sent_message_types(self):
+        return [
+            c.args[0].message["type"]
+            for c in self.processor.push_frame.call_args_list
+            if isinstance(c.args[0], OutputTransportMessageUrgentFrame)
+        ]
+
+    async def test_mute_before_client_ready_is_buffered_not_sent(self):
+        await self.processor.push_transport_message(RTVI.UserMuteStartedMessage())
+        self.assertEqual(self._sent_message_types(), [])
+        self.assertEqual(len(self.processor._pending_mute_messages), 1)
+
+    async def test_client_ready_flushes_buffered_mute_in_order(self):
+        await self.processor.push_transport_message(RTVI.UserMuteStartedMessage())
+        await self.processor.push_transport_message(RTVI.UserMuteStoppedMessage())
+        await self.processor.set_client_ready()
+        self.assertEqual(self._sent_message_types(), ["user-mute-started", "user-mute-stopped"])
+        self.assertEqual(self.processor._pending_mute_messages, [])
+
+    async def test_mute_after_client_ready_is_sent_immediately(self):
+        await self.processor.set_client_ready()
+        await self.processor.push_transport_message(RTVI.UserMuteStartedMessage())
+        self.assertEqual(self._sent_message_types(), ["user-mute-started"])
+        self.assertEqual(self.processor._pending_mute_messages, [])
+
+    async def test_non_mute_message_before_client_ready_is_not_buffered(self):
+        await self.processor.push_transport_message(RTVI.ServerMessage(data={}))
+        self.assertEqual(self._sent_message_types(), ["server-message"])
+        self.assertEqual(self.processor._pending_mute_messages, [])
 
 
 class TestRTVIDTMF(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Fixes #5086

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`RTVIProcessor.push_transport_message()` has no `client-ready` gate, so a message sent before the client-ready handshake is handed to the transport while the data channel isn't subscribed yet, and is silently dropped.

This bites mute state. `MuteUntilFirstBotCompleteUserMuteStrategy` reports the user muted from the very first frame, so `user-mute-started` is pushed at pipeline start — before `client-ready` and before the data channel opens (a real-network round-trip away; loopback masks it). The mic is muted server-side, but the client never learns, so its mute UI never engages during the greeting. The later `user-mute-stopped` fires after `client-ready` and arrives fine — the asymmetry leaves the client permanently mute-off.

Unlike transient messages (transcripts, speaking events), mute is sticky state: a dropped transition desyncs the client until the next one. This buffers pre-`client-ready` mute messages and replays them, in order, from `set_client_ready()` (after the handshake, so `bot-ready` still precedes them). Only the two mute messages are gated; everything else is unchanged.

Different layer from #3738, which fixed intra-pipeline `StartFrame` vs `UserMuteStartedFrame` ordering — here the message is produced correctly but goes out over the transport before the client is subscribed.

Tests added in `tests/test_rtvi_processor.py` cover: buffered-before-ready, flushed-in-order on ready, sent-immediately after ready, and non-mute messages never buffered.