### PR TITLE
Add HecttorFilter audio filter for real-time speech enhancement

### DIFF
--- a/changelog/5087.added.md
+++ b/changelog/5087.added.md
@@ -1,0 +1,1 @@
+- Added `HecttorFilter`, an input audio filter using the Hecttor SDK's ASR-optimized speech enhancer to remove background noise before audio reaches an STT service. Configure the enhancement model and blend weight, and enable it on any transport via `audio_in_filter`. The `hecttor_sdk` package is installed manually; see `examples/voice/voice-hecttor.py` for usage.

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -60,6 +60,8 @@ autodoc_default_options = {
 
 # Mock imports for optional dependencies
 autodoc_mock_imports = [
+    # Hecttor - not publicly available, installed manually
+    "hecttor_sdk",
     # Krisp - has build issues on some platforms
     "krisp_audio",
     # System-specific GUI libraries

--- a/examples/voice/voice-hecttor.py
+++ b/examples/voice/voice-hecttor.py
@@ -1,0 +1,161 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Voice bot with Hecttor speech enhancement on incoming audio.
+
+This example demonstrates a conversational bot with:
+- Hecttor ASR-optimized denoising on incoming audio
+- Voice activity detection (VAD) with Silero
+- Deepgram STT, OpenAI LLM, and Cartesia TTS
+
+The Hecttor filter enhances incoming speech by removing background noise before
+it reaches the STT service, improving transcription accuracy in noisy environments.
+
+Required environment variables:
+- HECTTOR_API_KEY: Hecttor API key
+- DEEPGRAM_API_KEY: Deepgram API key for STT
+- OPENAI_API_KEY: OpenAI API key for LLM
+- CARTESIA_API_KEY: Cartesia API key for TTS
+
+Note: The hecttor_sdk package is not available on PyPI. Contact Hecttor
+(https://hecttor.ai) for SDK access and an API key, then install the wheel:
+    pip install hecttor_sdk-<version>-<platform>.whl
+"""
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.filters.hecttor_filter import HecttorFilter
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+# The Hecttor filter uses the ASR-optimized enhancer, which improves
+# transcription accuracy by removing background noise before audio reaches STT.
+hecttor_filter = HecttorFilter(model_name="coda-vi-1.0")
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        audio_in_filter=hecttor_filter,
+    ),
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        audio_in_filter=hecttor_filter,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        audio_in_filter=hecttor_filter,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        audio_in_filter=hecttor_filter,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+
+    tts = CartesiaTTSService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaTTSService.Settings(
+            voice="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+        ),
+    )
+
+    llm = OpenAILLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAILLMService.Settings(
+            system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
+        ),
+    )
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input
+            stt,  # STT
+            user_aggregator,  # User responses
+            llm,  # LLM
+            tts,  # TTS
+            transport.output(),  # Transport bot output
+            assistant_aggregator,  # Assistant spoken responses
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+        # Kick off the conversation.
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
+        await worker.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/hecttor/test_hecttor_filter_audiofile.py
+++ b/scripts/hecttor/test_hecttor_filter_audiofile.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Standalone script to test the Hecttor filter with real audio files.
+
+This script processes an audio file through the Hecttor ASR speech enhancer and
+saves the output, allowing you to compare the original and enhanced audio.
+
+Usage:
+    python test_hecttor_filter_audiofile.py input.wav output.wav
+    python test_hecttor_filter_audiofile.py input.wav output.wav --model crest-2.0
+    python test_hecttor_filter_audiofile.py input.wav output.wav --enhancer-weight 0.8
+
+Requirements:
+    uv add soundfile numpy
+    Install the hecttor_sdk wheel manually (contact Hecttor for SDK access)
+    Set the HECTTOR_API_KEY environment variable
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    import numpy as np
+    import soundfile as sf
+except ImportError as e:
+    print(f"Error: Missing required dependencies: {e}")
+    print("Install with: uv add soundfile numpy")
+    sys.exit(1)
+
+# Add src directory to Python path for development environment
+script_dir = Path(__file__).parent
+project_root = script_dir.parent.parent
+src_dir = project_root / "src"
+if src_dir.exists() and str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+try:
+    from pipecat.audio.filters.hecttor_filter import SUPPORTED_MODELS, HecttorFilter
+except ImportError as e:
+    print(f"Error: Could not import the Hecttor filter: {e}")
+    print("Contact Hecttor (https://hecttor.ai) for SDK access and an API key.")
+    sys.exit(1)
+
+
+def read_audio_file(input_path: str) -> tuple[np.ndarray, int]:
+    """Read an audio file and convert it to int16 mono.
+
+    Args:
+        input_path: Path to the input audio file.
+
+    Returns:
+        Tuple of (audio_data, sample_rate) where audio_data is int16 mono.
+    """
+    info = sf.info(input_path)
+    print(f"Input format: {info.subtype}, {info.channels} channel(s), {info.samplerate} Hz")
+
+    if info.subtype in ("PCM_16", "PCM_S16"):
+        audio_data, sample_rate = sf.read(input_path, dtype="int16")
+    elif info.subtype in ("FLOAT", "DOUBLE"):
+        audio_data, sample_rate = sf.read(input_path, dtype="float32")
+        audio_data = (audio_data * 32767).astype(np.int16)
+    else:
+        print(f"Error: Unsupported audio format: {info.subtype}")
+        print("Supported formats: PCM_16, PCM_S16, FLOAT, DOUBLE")
+        sys.exit(1)
+
+    # Convert stereo to mono if needed, widening to int32 to avoid overflow.
+    if audio_data.ndim > 1:
+        print(f"Converting from {audio_data.shape[1]} channels to mono")
+        audio_data = audio_data.astype(np.int32).mean(axis=1).astype(np.int16)
+
+    duration = len(audio_data) / sample_rate
+    print(f"Loaded {len(audio_data)} samples, {sample_rate} Hz, {duration:.2f} seconds")
+
+    return audio_data, sample_rate
+
+
+def audio_stats(audio_data: np.ndarray) -> dict:
+    """Calculate statistics for audio data.
+
+    Args:
+        audio_data: Audio data as a numpy array.
+
+    Returns:
+        Dictionary with audio statistics.
+    """
+    rms = np.sqrt(np.mean(audio_data.astype(np.float32) ** 2))
+    return {
+        "min": int(audio_data.min()),
+        "max": int(audio_data.max()),
+        "rms": float(rms),
+        "samples": len(audio_data),
+    }
+
+
+async def process_audio_file(
+    input_path: str,
+    output_path: str,
+    model_name: str,
+    chunk_size_ms: int,
+    enhancer_weight: float | None,
+) -> None:
+    """Process an audio file through the Hecttor filter.
+
+    Args:
+        input_path: Path to the input audio file.
+        output_path: Path to save the enhanced audio.
+        model_name: Hecttor ASR enhancement model to use.
+        chunk_size_ms: Chunk size in milliseconds (16 or 20).
+        enhancer_weight: Blend factor between original and enhanced audio.
+    """
+    audio_data, sample_rate = read_audio_file(input_path)
+
+    print(f"\nInitializing Hecttor filter:")
+    print(f"  - Model: {model_name}")
+    print(f"  - Chunk size: {chunk_size_ms}ms")
+    print(f"  - Enhancer weight: {enhancer_weight if enhancer_weight is not None else 'default'}")
+    print(f"  - Sample rate: {sample_rate}Hz")
+
+    filter_obj = HecttorFilter(
+        model_name=model_name,
+        chunk_size_ms=chunk_size_ms,
+        enhancer_weight=enhancer_weight,
+    )
+
+    start_time = time.time()
+    await filter_obj.start(sample_rate)
+    print(f"\nFilter started in {(time.time() - start_time) * 1000:.2f}ms")
+
+    try:
+        # Feed audio in chunks matching the filter's configured chunk size.
+        chunk_size = int(sample_rate * chunk_size_ms / 1000)
+        print(f"Processing in chunks of {chunk_size} samples ({chunk_size_ms}ms)...")
+
+        enhanced_chunks = []
+        process_start = time.time()
+
+        for i in range(0, len(audio_data), chunk_size):
+            chunk = audio_data[i : i + chunk_size]
+
+            # Skip the incomplete final chunk.
+            if len(chunk) < chunk_size:
+                print(f"Skipping incomplete final chunk: {len(chunk)} samples")
+                break
+
+            enhanced_bytes = await filter_obj.filter(chunk.tobytes())
+            if enhanced_bytes:
+                enhanced_chunks.append(np.frombuffer(enhanced_bytes, dtype=np.int16))
+
+        process_duration = time.time() - process_start
+
+        if not enhanced_chunks:
+            print("Error: The filter produced no output audio.")
+            sys.exit(1)
+
+        enhanced_audio = np.concatenate(enhanced_chunks)
+    finally:
+        await filter_obj.stop()
+
+    sf.write(output_path, enhanced_audio, sample_rate)
+
+    audio_duration = len(audio_data) / sample_rate
+    realtime_factor = audio_duration / process_duration if process_duration > 0 else float("inf")
+
+    print(f"\nProcessed {audio_duration:.2f}s of audio in {process_duration:.2f}s")
+    print(f"Realtime factor: {realtime_factor:.1f}x")
+
+    original_stats = audio_stats(audio_data)
+    enhanced_stats = audio_stats(enhanced_audio)
+
+    print("\nAudio statistics:")
+    print(f"  {'':<10} {'original':>12} {'enhanced':>12}")
+    for key in ("samples", "min", "max", "rms"):
+        original_value = original_stats[key]
+        enhanced_value = enhanced_stats[key]
+        if key == "rms":
+            print(f"  {key:<10} {original_value:>12.1f} {enhanced_value:>12.1f}")
+        else:
+            print(f"  {key:<10} {original_value:>12} {enhanced_value:>12}")
+
+    # The filter buffers audio internally, so the output is expected to be
+    # slightly shorter than the input.
+    dropped = len(audio_data) - len(enhanced_audio)
+    if dropped > 0:
+        print(f"\nNote: output is {dropped} samples shorter (filter warm-up and buffering).")
+
+    print(f"\nSaved enhanced audio to: {output_path}")
+
+
+def main():
+    """Parse arguments and run the Hecttor filter over an audio file."""
+    parser = argparse.ArgumentParser(
+        description="Test the Hecttor filter with real audio files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("input", help="Input audio file (WAV, FLAC, OGG)")
+    parser.add_argument("output", help="Output audio file (WAV, FLAC, OGG)")
+    parser.add_argument(
+        "--model",
+        default="coda-vi-1.0",
+        choices=SUPPORTED_MODELS,
+        help="ASR enhancement model to use (default: coda-vi-1.0)",
+    )
+    parser.add_argument(
+        "--chunk-size-ms",
+        type=int,
+        default=20,
+        choices=(16, 20),
+        help="Chunk size in milliseconds (default: 20)",
+    )
+    parser.add_argument(
+        "--enhancer-weight",
+        type=float,
+        default=None,
+        help="Blend factor 0.0-1.0 between original and enhanced audio (default: model default)",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.input):
+        print(f"Error: Input file not found: {args.input}")
+        sys.exit(1)
+
+    if not os.getenv("HECTTOR_API_KEY"):
+        print("Error: HECTTOR_API_KEY environment variable not set")
+        print("Contact Hecttor (https://hecttor.ai) for SDK access and an API key.")
+        sys.exit(1)
+
+    asyncio.run(
+        process_audio_file(
+            args.input,
+            args.output,
+            args.model,
+            args.chunk_size_ms,
+            args.enhancer_weight,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipecat/audio/filters/hecttor_filter.py
+++ b/src/pipecat/audio/filters/hecttor_filter.py
@@ -1,0 +1,232 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Hecttor audio denoising filter for Pipecat.
+
+This module provides an audio filter implementation using the Hecttor SDK
+to enhance speech audio in real time. It uses the ASR-optimized enhancer,
+which is tuned to improve intelligibility for speech recognition pipelines.
+"""
+
+import os
+
+import numpy as np
+from loguru import logger
+
+from pipecat.audio.filters.base_audio_filter import BaseAudioFilter
+from pipecat.frames.frames import FilterControlFrame, FilterEnableFrame
+
+try:
+    from hecttor_sdk import ASRSpeechEnhancer, ASRSpeechEnhancerConfig, ModelConfig
+except ModuleNotFoundError as e:
+    logger.error(f"Exception: {e}")
+    logger.error(
+        "In order to use HecttorFilter, you need to install the hecttor_sdk package. "
+        "Contact Hecttor (https://hecttor.ai) for SDK access and an API key."
+    )
+    raise ImportError(f"Missing module: {e}") from e
+
+
+#: ASR-optimized models exposed by the Hecttor SDK.
+SUPPORTED_MODELS = ("crest-1.0", "crest-2.0", "mist-1.0", "coda-1.0", "coda-vi-1.0")
+
+#: Models that only support a 20 ms chunk size.
+_MODELS_REQUIRING_20MS = ("crest-2.0", "coda-1.0", "coda-vi-1.0")
+
+
+class HecttorFilter(BaseAudioFilter):
+    """Audio filter using the Hecttor SDK for speech enhancement.
+
+    Provides real-time audio denoising for audio streams using Hecttor's
+    neural network-based processing. Uses the ASR-optimized enhancer, which
+    removes background noise to improve transcription accuracy before audio
+    reaches an STT service.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model_name: str = "coda-vi-1.0",
+        chunk_size_ms: int = 20,
+        enhancer_weight: float | None = None,
+    ) -> None:
+        """Initialize the Hecttor audio filter.
+
+        Args:
+            api_key: Hecttor API key. If None, uses the HECTTOR_API_KEY
+                environment variable.
+            model_name: ASR enhancement model to use. One of
+                ``"crest-1.0"``, ``"crest-2.0"``, ``"mist-1.0"``,
+                ``"coda-1.0"``, or ``"coda-vi-1.0"``.
+            chunk_size_ms: Chunk size in milliseconds. Either 16 or 20.
+                ``"crest-2.0"``, ``"coda-1.0"``, and ``"coda-vi-1.0"``
+                require 20.
+            enhancer_weight: Blend factor between original and enhanced
+                audio in the range [0.0, 1.0]. 1.0 = fully enhanced,
+                0.0 = original audio. If None, the model's default weight
+                is used.
+
+        Raises:
+            ValueError: If api_key is not provided and HECTTOR_API_KEY is not
+                set, if model_name is unsupported, chunk_size_ms is not 16 or
+                20 (or is unsupported by the chosen model), or enhancer_weight
+                is out of range.
+        """
+        super().__init__()
+
+        self._api_key = api_key or os.getenv("HECTTOR_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "Hecttor API key must be provided via api_key parameter "
+                "or HECTTOR_API_KEY environment variable."
+            )
+
+        if model_name not in SUPPORTED_MODELS:
+            raise ValueError(
+                f"Invalid model_name '{model_name}'. Must be one of {SUPPORTED_MODELS}."
+            )
+
+        if chunk_size_ms not in (16, 20):
+            raise ValueError(f"chunk_size_ms must be 16 or 20, got {chunk_size_ms}.")
+
+        if model_name in _MODELS_REQUIRING_20MS and chunk_size_ms != 20:
+            raise ValueError(
+                f"Model '{model_name}' requires chunk_size_ms=20, got {chunk_size_ms}."
+            )
+
+        if enhancer_weight is not None and not 0.0 <= enhancer_weight <= 1.0:
+            raise ValueError(f"enhancer_weight must be between 0.0 and 1.0, got {enhancer_weight}.")
+
+        self._model_name = model_name
+        self._chunk_size_ms = chunk_size_ms
+        self._enhancer_weight = enhancer_weight
+
+        self._enhancer = None
+        self._samples_per_chunk = 0
+        self._audio_buffer = bytearray()
+        self._filtering = True
+        self._first_chunk = True
+
+    async def start(self, sample_rate: int):
+        """Initialize the Hecttor enhancer with the transport's sample rate.
+
+        Args:
+            sample_rate: The sample rate of the input transport in Hz.
+
+        Raises:
+            RuntimeError: If Hecttor initialization fails.
+        """
+        try:
+            self._enhancer = ASRSpeechEnhancer()
+            config = ASRSpeechEnhancerConfig(
+                api_key=self._api_key,
+                model_config=ModelConfig(
+                    model_name=self._model_name,
+                    enhancer_weight=self._enhancer_weight,
+                ),
+                chunk_size_ms=self._chunk_size_ms,
+                sample_rate=sample_rate,
+            )
+            success, message = self._enhancer.initialize(config)
+
+            if not success:
+                self._enhancer = None
+                raise RuntimeError(f"Hecttor initialization failed: {message}")
+
+            self._samples_per_chunk = self._enhancer.get_chunk_size_samples()
+            self._audio_buffer.clear()
+            self._first_chunk = True
+
+            logger.debug(
+                f"Hecttor filter started: model={self._model_name}, "
+                f"sample_rate={sample_rate}, "
+                f"chunk_size={self._samples_per_chunk} samples "
+                f"({self._chunk_size_ms}ms)"
+            )
+        except Exception as e:
+            self._enhancer = None
+            logger.error(f"Failed to start Hecttor filter: {e}", exc_info=True)
+            raise RuntimeError(f"Failed to start Hecttor filter: {e}") from e
+
+    async def stop(self):
+        """Clean up the Hecttor enhancer when stopping."""
+        try:
+            if self._enhancer is not None:
+                self._enhancer.reset_caches()
+            self._enhancer = None
+            self._audio_buffer.clear()
+            self._first_chunk = True
+        except Exception as e:
+            logger.error(f"Error stopping Hecttor filter: {e}", exc_info=True)
+            raise RuntimeError(f"Failed to stop Hecttor filter: {e}") from e
+
+    async def process_frame(self, frame: FilterControlFrame):
+        """Process control frames to enable/disable filtering.
+
+        Args:
+            frame: The control frame containing filter commands.
+        """
+        if isinstance(frame, FilterEnableFrame):
+            self._filtering = frame.enable
+
+    async def filter(self, audio: bytes) -> bytes:
+        """Apply Hecttor speech enhancement to audio data.
+
+        Args:
+            audio: Raw PCM int16 audio data as bytes.
+
+        Returns:
+            Enhanced audio data as bytes, or empty bytes while buffering.
+        """
+        if not self._filtering:
+            return audio
+
+        if self._enhancer is None:
+            return audio
+
+        try:
+            self._audio_buffer.extend(audio)
+
+            bytes_per_sample = 2  # int16
+            total_samples = len(self._audio_buffer) // bytes_per_sample
+            num_complete_chunks = total_samples // self._samples_per_chunk
+
+            if num_complete_chunks == 0:
+                return b""
+
+            bytes_per_chunk = self._samples_per_chunk * bytes_per_sample
+            total_bytes = num_complete_chunks * bytes_per_chunk
+            audio_to_process = bytes(self._audio_buffer[:total_bytes])
+            self._audio_buffer = self._audio_buffer[total_bytes:]
+
+            output_chunks = []
+            for i in range(num_complete_chunks):
+                start = i * bytes_per_chunk
+                chunk_bytes = audio_to_process[start : start + bytes_per_chunk]
+
+                samples_int16 = np.frombuffer(chunk_bytes, dtype=np.int16)
+                samples_float32 = samples_int16.astype(np.float32) / 32768.0
+
+                enhanced, message = self._enhancer.process_chunk(samples_float32)
+
+                if enhanced is None:
+                    if self._first_chunk:
+                        logger.debug("Hecttor filter: initial buffering (first chunk)")
+                        self._first_chunk = False
+                    continue
+
+                enhanced_int16 = (np.clip(enhanced, -1.0, 1.0) * 32767).astype(np.int16)
+                output_chunks.append(enhanced_int16.tobytes())
+
+            if not output_chunks:
+                return b""
+
+            return b"".join(output_chunks)
+
+        except Exception as e:
+            logger.error(f"Error during Hecttor filtering: {e}", exc_info=True)
+            return audio

--- a/tests/test_hecttor_filter.py
+++ b/tests/test_hecttor_filter.py
@@ -1,0 +1,249 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+# Mock hecttor_sdk before any pipecat imports so these tests run without the
+# SDK installed. The package is not distributed on PyPI.
+mock_hecttor_sdk = MagicMock()
+sys.modules["hecttor_sdk"] = mock_hecttor_sdk
+
+from pipecat.audio.filters.hecttor_filter import SUPPORTED_MODELS, HecttorFilter
+from pipecat.frames.frames import FilterEnableFrame
+
+API_KEY = "test-api-key"
+SAMPLE_RATE = 16000
+SAMPLES_PER_CHUNK = 320  # 20ms at 16kHz
+BYTES_PER_CHUNK = SAMPLES_PER_CHUNK * 2
+
+
+class TestHecttorFilter(unittest.IsolatedAsyncioTestCase):
+    """Test suite for the HecttorFilter audio filter."""
+
+    def setUp(self):
+        """Set up a mock enhancer that echoes back the audio it is given."""
+        self.mock_enhancer = MagicMock()
+        self.mock_enhancer.initialize.return_value = (True, "ok")
+        self.mock_enhancer.get_chunk_size_samples.return_value = SAMPLES_PER_CHUNK
+        self.mock_enhancer.process_chunk.side_effect = lambda chunk: (chunk, "ok")
+
+        self.enhancer_patcher = patch(
+            "pipecat.audio.filters.hecttor_filter.ASRSpeechEnhancer",
+            return_value=self.mock_enhancer,
+        )
+        self.enhancer_patcher.start()
+        self.addCleanup(self.enhancer_patcher.stop)
+
+        for name in ("ASRSpeechEnhancerConfig", "ModelConfig"):
+            patcher = patch(f"pipecat.audio.filters.hecttor_filter.{name}")
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    async def _started_filter(self, **kwargs) -> HecttorFilter:
+        """Build a filter with the API key set and start it."""
+        kwargs.setdefault("api_key", API_KEY)
+        audio_filter = HecttorFilter(**kwargs)
+        await audio_filter.start(SAMPLE_RATE)
+        return audio_filter
+
+    @staticmethod
+    def _audio(num_samples: int, value: int = 1000) -> bytes:
+        """Build int16 PCM audio of a constant value."""
+        return np.full(num_samples, value, dtype=np.int16).tobytes()
+
+    # Initialization
+
+    def test_api_key_from_argument(self):
+        audio_filter = HecttorFilter(api_key=API_KEY)
+        self.assertEqual(audio_filter._api_key, API_KEY)
+
+    def test_api_key_from_environment(self):
+        with patch.dict("os.environ", {"HECTTOR_API_KEY": "env-key"}):
+            audio_filter = HecttorFilter()
+        self.assertEqual(audio_filter._api_key, "env-key")
+
+    def test_missing_api_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ValueError):
+                HecttorFilter()
+
+    def test_invalid_model_raises(self):
+        with self.assertRaises(ValueError):
+            HecttorFilter(api_key=API_KEY, model_name="not-a-model")
+
+    def test_supported_models_accepted(self):
+        for model_name in SUPPORTED_MODELS:
+            # Models restricted to 20ms are covered by the chunk size tests.
+            HecttorFilter(api_key=API_KEY, model_name=model_name, chunk_size_ms=20)
+
+    def test_invalid_chunk_size_raises(self):
+        with self.assertRaises(ValueError):
+            HecttorFilter(api_key=API_KEY, chunk_size_ms=10)
+
+    def test_model_requiring_20ms_rejects_16ms(self):
+        with self.assertRaises(ValueError):
+            HecttorFilter(api_key=API_KEY, model_name="coda-vi-1.0", chunk_size_ms=16)
+
+    def test_model_allowing_16ms_is_accepted(self):
+        audio_filter = HecttorFilter(api_key=API_KEY, model_name="crest-1.0", chunk_size_ms=16)
+        self.assertEqual(audio_filter._chunk_size_ms, 16)
+
+    def test_enhancer_weight_out_of_range_raises(self):
+        for weight in (-0.1, 1.1):
+            with self.assertRaises(ValueError):
+                HecttorFilter(api_key=API_KEY, enhancer_weight=weight)
+
+    def test_enhancer_weight_bounds_accepted(self):
+        for weight in (0.0, 0.5, 1.0):
+            HecttorFilter(api_key=API_KEY, enhancer_weight=weight)
+
+    # Lifecycle
+
+    async def test_start_initializes_enhancer(self):
+        audio_filter = await self._started_filter()
+        self.mock_enhancer.initialize.assert_called_once()
+        self.assertEqual(audio_filter._samples_per_chunk, SAMPLES_PER_CHUNK)
+
+    async def test_start_failure_raises_and_clears_enhancer(self):
+        self.mock_enhancer.initialize.return_value = (False, "bad key")
+        audio_filter = HecttorFilter(api_key=API_KEY)
+        with self.assertRaises(RuntimeError):
+            await audio_filter.start(SAMPLE_RATE)
+        self.assertIsNone(audio_filter._enhancer)
+
+    async def test_stop_resets_enhancer(self):
+        audio_filter = await self._started_filter()
+        await audio_filter.stop()
+        self.mock_enhancer.reset_caches.assert_called_once()
+        self.assertIsNone(audio_filter._enhancer)
+
+    async def test_stop_without_start(self):
+        audio_filter = HecttorFilter(api_key=API_KEY)
+        await audio_filter.stop()
+        self.assertIsNone(audio_filter._enhancer)
+
+    async def test_stop_clears_buffer(self):
+        audio_filter = await self._started_filter()
+        await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2))
+        self.assertGreater(len(audio_filter._audio_buffer), 0)
+        await audio_filter.stop()
+        self.assertEqual(len(audio_filter._audio_buffer), 0)
+
+    # Control frames
+
+    async def test_process_frame_toggles_filtering(self):
+        audio_filter = await self._started_filter()
+
+        await audio_filter.process_frame(FilterEnableFrame(False))
+        self.assertFalse(audio_filter._filtering)
+
+        await audio_filter.process_frame(FilterEnableFrame(True))
+        self.assertTrue(audio_filter._filtering)
+
+    # Filtering
+
+    async def test_filter_passthrough_when_disabled(self):
+        audio_filter = await self._started_filter()
+        await audio_filter.process_frame(FilterEnableFrame(False))
+
+        audio = self._audio(SAMPLES_PER_CHUNK)
+        self.assertEqual(await audio_filter.filter(audio), audio)
+        self.mock_enhancer.process_chunk.assert_not_called()
+
+    async def test_filter_passthrough_before_start(self):
+        audio_filter = HecttorFilter(api_key=API_KEY)
+        audio = self._audio(SAMPLES_PER_CHUNK)
+        self.assertEqual(await audio_filter.filter(audio), audio)
+
+    async def test_filter_buffers_partial_chunk(self):
+        audio_filter = await self._started_filter()
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2))
+        self.assertEqual(result, b"")
+        self.mock_enhancer.process_chunk.assert_not_called()
+
+    async def test_filter_emits_once_chunk_is_complete(self):
+        audio_filter = await self._started_filter()
+
+        self.assertEqual(await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2)), b"")
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2))
+
+        self.assertEqual(len(result), BYTES_PER_CHUNK)
+        self.mock_enhancer.process_chunk.assert_called_once()
+
+    async def test_filter_processes_multiple_chunks(self):
+        audio_filter = await self._started_filter()
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK * 3))
+
+        self.assertEqual(len(result), BYTES_PER_CHUNK * 3)
+        self.assertEqual(self.mock_enhancer.process_chunk.call_count, 3)
+
+    async def test_filter_retains_remainder_in_buffer(self):
+        audio_filter = await self._started_filter()
+        remainder = 100
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK + remainder))
+
+        self.assertEqual(len(result), BYTES_PER_CHUNK)
+        self.assertEqual(len(audio_filter._audio_buffer), remainder * 2)
+
+    async def test_filter_converts_to_float32_for_the_sdk(self):
+        audio_filter = await self._started_filter()
+        await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK, value=16384))
+
+        chunk = self.mock_enhancer.process_chunk.call_args[0][0]
+        self.assertEqual(chunk.dtype, np.float32)
+        self.assertEqual(len(chunk), SAMPLES_PER_CHUNK)
+        np.testing.assert_allclose(chunk, 0.5, atol=1e-4)
+
+    async def test_filter_roundtrips_audio(self):
+        audio_filter = await self._started_filter()
+        value = 1000
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK, value=value))
+
+        samples = np.frombuffer(result, dtype=np.int16)
+        # int16 -> float32 -> int16 conversion is lossy by up to one LSB.
+        np.testing.assert_allclose(samples, value, atol=2)
+
+    async def test_filter_skips_warmup_chunks(self):
+        audio_filter = await self._started_filter()
+        self.mock_enhancer.process_chunk.side_effect = lambda chunk: (None, "warming up")
+
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK))
+        self.assertEqual(result, b"")
+
+    async def test_filter_clips_out_of_range_output(self):
+        audio_filter = await self._started_filter()
+        self.mock_enhancer.process_chunk.side_effect = lambda chunk: (
+            np.full(len(chunk), 2.0, dtype=np.float32),
+            "ok",
+        )
+
+        result = await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK))
+        samples = np.frombuffer(result, dtype=np.int16)
+        np.testing.assert_array_equal(samples, 32767)
+
+    async def test_filter_returns_original_audio_on_error(self):
+        audio_filter = await self._started_filter()
+        self.mock_enhancer.process_chunk.side_effect = RuntimeError("boom")
+
+        audio = self._audio(SAMPLES_PER_CHUNK)
+        self.assertEqual(await audio_filter.filter(audio), audio)
+
+    async def test_filter_across_start_stop_cycles(self):
+        audio_filter = await self._started_filter()
+        await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2))
+        await audio_filter.stop()
+
+        await audio_filter.start(SAMPLE_RATE)
+        # The buffer was cleared, so a half chunk is still not enough to emit.
+        self.assertEqual(await audio_filter.filter(self._audio(SAMPLES_PER_CHUNK // 2)), b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds `HecttorFilter`, an input audio filter backed by the [Hecttor](https://hecttor.ai) SDK's ASR-optimized speech enhancer. It removes background noise before audio reaches the STT service, improving transcription accuracy in noisy environments.

The `hecttor_sdk` package is not published to PyPI, so this follows the same manual-install pattern already used by the Krisp VIVA filter:

- **No `pyproject.toml` extra.** An empty `hecttor = []` extra would make `pipecat-ai[hecttor]` silently install nothing, so it's omitted — matching how `krisp` is handled today.
- **`hecttor_sdk` added to `autodoc_mock_imports`** so the Sphinx build works without the SDK present.
- Users contact Hecttor for SDK access and an API key.

## Changes

| File | Purpose |
| --- | --- |
| `src/pipecat/audio/filters/hecttor_filter.py` | The filter — a `BaseAudioFilter` subclass |
| `tests/test_hecttor_filter.py` | Unit tests, with `hecttor_sdk` mocked |
| `examples/voice/voice-hecttor.py` | Voice bot example (Deepgram STT, OpenAI LLM, Cartesia TTS) |
| `scripts/hecttor/test_hecttor_filter_audiofile.py` | Runs the filter over a pre-recorded audio file, mirroring `scripts/krisp/` |
| `docs/api/conf.py` | Mock `hecttor_sdk` for docs builds |
| `changelog/5087.added.md` | Changelog fragment |

## Configuration

```python
from pipecat.audio.filters.hecttor_filter import HecttorFilter

transport = DailyTransport(
    room_url, token, "Respond bot",
    DailyParams(
        audio_in_enabled=True,
        audio_in_filter=HecttorFilter(),
        audio_out_enabled=True,
    ),
)
```

| Parameter | Default | Notes |
| --- | --- | --- |
| `api_key` | `None` | Falls back to `HECTTOR_API_KEY` |
| `model_name` | `"coda-vi-1.0"` | One of `crest-1.0`, `crest-2.0`, `mist-1.0`, `coda-1.0`, `coda-vi-1.0` |
| `chunk_size_ms` | `20` | `16` or `20`; `crest-2.0`, `coda-1.0` and `coda-vi-1.0` require `20` |
| `enhancer_weight` | `None` | Blend factor `[0.0, 1.0]` between original and enhanced audio |

`FilterEnableFrame` toggles filtering at runtime, consistent with the other audio filters.

## Verification

- **Unit tests:** `tests/test_hecttor_filter.py` adds 28 tests covering parameter validation, the start/stop lifecycle, runtime enable/disable via `FilterEnableFrame`, chunk buffering and remainder handling, int16↔float32 conversion, warm-up chunks (the SDK returns `None` until its internal buffer fills), output clipping, and error passthrough. `hecttor_sdk` is mocked in `sys.modules`, following the approach in `tests/test_krisp_viva_filter.py`, so the suite runs without the SDK installed.
- Ran together with the other filter suites (`test_krisp_viva_filter`, `test_rnnoise_filter`, `test_aic_filter`, `test_filters`): **77 passed, 47 skipped**, confirming the module mock does not leak.
- `ruff check` and `ruff format --check` pass on all added files.
- The filter can also be exercised against real audio with `scripts/hecttor/test_hecttor_filter_audiofile.py in.wav out.wav`, which reports the realtime factor and before/after audio statistics.

## Notes

- Docs companion PR: see the linked PR in pipecat-ai/docs.
