### PR TITLE
Emit STTMetadataFrame from DailyTransport when transcription is enabled

### DIFF
--- a/changelog/5088.added.md
+++ b/changelog/5088.added.md
@@ -1,0 +1,1 @@
+- `DailyTransport` now broadcasts an `STTMetadataFrame` with Deepgram's TTFS P99 latency when `transcription_enabled=True` and transcription starts successfully, matching standalone STT services. Downstream consumers like `LLMUserAggregator` and the user-turn-stop strategies now use the correct STT latency instead of falling back to defaults.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -44,12 +44,14 @@ from pipecat.frames.frames import (
     OutputTransportMessageUrgentFrame,
     SpriteFrame,
     StartFrame,
+    STTMetadataFrame,
     TranscriptionFrame,
     UserAudioRawFrame,
     UserImageRawFrame,
     UserImageRequestFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
+from pipecat.services.stt_latency import DEEPGRAM_TTFS_P99
 from pipecat.transcriptions.language import Language
 from pipecat.transports.base_input import BaseInputTransport
 from pipecat.transports.base_output import BaseOutputTransport
@@ -1984,6 +1986,12 @@ class DailyInputTransport(BaseInputTransport):
         """
         await self.push_frame(frame)
 
+    async def push_stt_metadata_frame(self):
+        """Broadcast STT metadata for Daily's built-in transcription (Deepgram)."""
+        await self.broadcast_frame(
+            STTMetadataFrame, service_name=self.name, ttfs_p99_latency=DEEPGRAM_TTFS_P99
+        )
+
     async def push_app_message(self, message: Any, sender: str):
         """Push an application message as an urgent transport frame.
 
@@ -2848,6 +2856,7 @@ class DailyTransport(BaseTransport):
 
     async def _on_joined(self, data):
         """Handle room joined events."""
+        transcription_started = False
         if self._params.transcription_enabled:
             # We report an error because we are starting transcription
             # internally and if it fails we need to know.
@@ -2855,11 +2864,15 @@ class DailyTransport(BaseTransport):
             error = await self.start_transcription(settings)
             if error:
                 await self._on_error(f"Unable to start transcription: {error}")
+            else:
+                transcription_started = True
         await self._call_event_handler("on_joined", data)
         # Also call on_connected for compatibility with other transports
         await self._call_event_handler("on_connected", data)
         if self._input:
             await self._input.push_frame(BotConnectedFrame())
+            if transcription_started:
+                await self._input.push_stt_metadata_frame()
 
     async def _on_left(self):
         """Handle room left events."""

--- a/tests/test_daily_transport.py
+++ b/tests/test_daily_transport.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2024–2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the Daily transport."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.frames.frames import BotConnectedFrame, STTMetadataFrame
+from pipecat.services.stt_latency import DEEPGRAM_TTFS_P99
+from pipecat.transports.daily.transport import DailyParams, DailyTransport
+
+
+def _make_transport(**params_kwargs) -> DailyTransport:
+    with (
+        patch("pipecat.transports.daily.transport.Daily"),
+        patch("pipecat.transports.daily.transport.CallClient"),
+    ):
+        return DailyTransport(
+            "https://mock.daily.co/mock", None, "bot", params=DailyParams(**params_kwargs)
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_joined_pushes_stt_metadata_when_transcription_starts():
+    transport = _make_transport(transcription_enabled=True)
+    transport.start_transcription = AsyncMock(return_value=None)
+    transport._input = AsyncMock()
+
+    await transport._on_joined({})
+
+    transport._input.push_stt_metadata_frame.assert_awaited_once()
+    # BotConnectedFrame is pushed before the STT metadata frame.
+    call_names = [name for (name, _, _) in transport._input.mock_calls]
+    assert call_names.index("push_frame") < call_names.index("push_stt_metadata_frame")
+    (frame,) = transport._input.push_frame.await_args.args
+    assert isinstance(frame, BotConnectedFrame)
+
+
+@pytest.mark.asyncio
+async def test_on_joined_skips_stt_metadata_when_transcription_fails():
+    transport = _make_transport(transcription_enabled=True)
+    transport.start_transcription = AsyncMock(return_value="some error")
+    transport._on_error = AsyncMock()
+    transport._input = AsyncMock()
+
+    await transport._on_joined({})
+
+    transport._on_error.assert_awaited_once()
+    transport._input.push_stt_metadata_frame.assert_not_awaited()
+    transport._input.push_frame.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_joined_skips_stt_metadata_when_transcription_disabled():
+    transport = _make_transport()
+    transport._input = AsyncMock()
+
+    await transport._on_joined({})
+
+    transport._input.push_stt_metadata_frame.assert_not_awaited()
+    transport._input.push_frame.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_push_stt_metadata_frame_contents():
+    transport = _make_transport(transcription_enabled=True)
+    input_transport = transport.input()
+    input_transport.broadcast_frame = AsyncMock()
+
+    await input_transport.push_stt_metadata_frame()
+
+    input_transport.broadcast_frame.assert_awaited_once_with(
+        STTMetadataFrame,
+        service_name=input_transport.name,
+        ttfs_p99_latency=DEEPGRAM_TTFS_P99,
+    )


### PR DESCRIPTION
## Summary

- `DailyTransport` now broadcasts an `STTMetadataFrame` with Deepgram's TTFS P99 latency (`DEEPGRAM_TTFS_P99`) when `transcription_enabled=True`, matching what standalone STT services emit at startup
- Downstream consumers (`LLMUserAggregator`, `SpeechTimeout`/`TurnAnalyzer` user-turn-stop strategies) now use the correct STT latency instead of falling back to defaults
- The frame is emitted from `_on_joined` right after `BotConnectedFrame`, only if transcription starts successfully — `StartFrame` is guaranteed to already be downstream, and the metadata frame always precedes the first transcription frame

## Testing

- `uv run pytest tests/test_daily_transport.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)