### PR TITLE
Emit whole 16-bit samples from XAIHttpTTSService

### DIFF
--- a/changelog/5090.fixed.md
+++ b/changelog/5090.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `XAIHttpTTSService` could intermittently crash the audio playback task and leave the bot mute for the rest of the session (`buffer size must be a multiple of element size`). xAI's `/v1/tts` endpoint chops its PCM stream at arbitrary byte boundaries, so a chunk could end mid-sample; the service now emits only whole 16-bit samples.

--- a/src/pipecat/services/xai/tts.py
+++ b/src/pipecat/services/xai/tts.py
@@ -277,7 +277,6 @@ class XAIHttpTTSService(TTSService):
             "Content-Type": "application/json",
         }
 
-        measuring_ttfb = True
         try:
             async with self._session.post(
                 self._base_url, json=payload, headers=headers
@@ -291,18 +290,14 @@ class XAIHttpTTSService(TTSService):
 
                 await self.start_tts_usage_metrics(text)
 
-                async for chunk in response.content.iter_chunked(self.chunk_size):
-                    if not chunk:
-                        continue
-                    if measuring_ttfb:
-                        await self.stop_ttfb_metrics()
-                        measuring_ttfb = False
-                    yield TTSAudioRawFrame(
-                        chunk,
-                        self.sample_rate,
-                        1,
-                        context_id=context_id,
-                    )
+                # xAI chops the stream at arbitrary byte boundaries, so let the
+                # iterator helper keep emitted frames sample-aligned.
+                async for frame in self._stream_audio_frames_from_iterator(
+                    response.content.iter_chunked(self.chunk_size),
+                    context_id=context_id,
+                ):
+                    await self.stop_ttfb_metrics()
+                    yield frame
         except Exception as e:
             yield ErrorFrame(error=f"Unknown error occurred: {e}")
 

--- a/tests/test_xai_tts.py
+++ b/tests/test_xai_tts.py
@@ -44,6 +44,7 @@ async def test_run_xai_tts_success(aiohttp_client):
     """xAI TTS should send the documented request body and emit PCM frames."""
 
     request_bodies = []
+    pcm_audio = b"\x00\x01\x02\x03" * 1024
 
     async def handler(request):
         request_bodies.append(await request.json())
@@ -54,9 +55,10 @@ async def test_run_xai_tts_success(aiohttp_client):
             headers={"Content-Type": "audio/pcm"},
         )
         await response.prepare(request)
-        await response.write(b"\x00\x01\x02\x03" * 1024)
+        # Split mid-sample to check that emitted frames stay sample-aligned.
+        await response.write(pcm_audio[:2047])
         await asyncio.sleep(0.01)
-        await response.write(b"\x04\x05\x06\x07" * 1024)
+        await response.write(pcm_audio[2047:])
         await response.write_eof()
         return response
 
@@ -88,6 +90,8 @@ async def test_run_xai_tts_success(aiohttp_client):
     assert audio_frames
     assert all(frame.sample_rate == 24000 for frame in audio_frames)
     assert all(frame.num_channels == 1 for frame in audio_frames)
+    assert all(len(frame.audio) % 2 == 0 for frame in audio_frames)
+    assert b"".join(frame.audio for frame in audio_frames) == pcm_audio
 
     assert len(request_bodies) == 1
     assert request_bodies[0] == {


### PR DESCRIPTION
## Summary

xAI's `/v1/tts` endpoint chops its raw PCM stream at arbitrary **byte** boundaries, so a chunk can end mid-sample. `XAIHttpTTSService` passed those chunks straight into `TTSAudioRawFrame`s, producing odd-length frames that crash sample-wise consumers downstream — most visibly the TTFA metrics scan (`np.frombuffer(..., dtype=np.int16)` raises `buffer size must be a multiple of element size`), which killed `_audio_context_task_handler` and left the bot mute for the rest of the session.

Same issue as #4952, on the HTTP path instead of the WebSocket one.

## Fix

Stream the response through `TTSService._stream_audio_frames_from_iterator` (already used by `RimeHttpTTSService` and Piper), which holds back a dangling byte so every emitted frame contains whole 16-bit samples.

## Testing

- `tests/test_xai_tts.py`: the mock server now splits its response mid-sample; the test asserts all emitted frames are even-length and reassemble byte-for-byte into the original PCM.
- Live smoke test against `api.x.ai/v1/tts`: 44 audio frames, all sample-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)