### PR TITLE
Fix TTS word-timestamp matching desyncing when a provider adds terminal punctuation absent from the source text.

### DIFF
--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -15,6 +15,7 @@ from enum import Enum, auto
 
 from pipecat.utils.text.transforms._alnum_utils import (
     advance_by_alnums,
+    fold_case_and_accents,
     normalize,
     strip_trailing_punctuation,
 )
@@ -327,6 +328,44 @@ class TextSegmentMap:
         self._last_overflow: str | None = None
 
     @staticmethod
+    def _literal_hop(candidates: list[tuple[str, int]], remaining_word: str) -> "_Hop | None":
+        """Try PLACED/CROSSES of *remaining_word* against *candidates*, literally.
+
+        Shared by the raw and case/accent-folded passes in :meth:`_classify_hop`
+        -- both compare the same way, just on different (length-preserving)
+        transforms of the text, so the offsets this returns are valid for
+        whichever text produced *candidates* and *remaining_word*.
+
+        Tries an as-is match first, then retries with the word's own trailing
+        punctuation removed (some TTS providers add terminal punctuation the
+        original text doesn't have, e.g. reading a list item -- ``"my
+        account"`` -- as its own sentence, ``"account."``). The segment's own
+        punctuation is untouched either way and is still picked up verbatim by
+        the next word.
+
+        Returns:
+            A ``PLACED`` or ``CROSSES`` hop, or ``None`` if nothing matched.
+        """
+        trimmed_word = strip_trailing_punctuation(remaining_word)
+        words = (
+            (remaining_word,)
+            if trimmed_word == remaining_word
+            else (
+                remaining_word,
+                trimmed_word,
+            )
+        )
+        for word in words:
+            if not word:
+                continue
+            for candidate, offset in candidates:
+                if candidate.startswith(word):
+                    return _Hop(_HopKind.PLACED, seg_chars=offset + len(word))
+                if candidate and word.startswith(candidate):
+                    return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
+        return None
+
+    @staticmethod
     def _classify_hop(segment_remaining: str, remaining_word: str) -> _Hop:
         """Decide where *remaining_word* goes against this segment's remaining raw text.
 
@@ -334,23 +373,25 @@ class TextSegmentMap:
         word is checked with four matching strategies, in order:
 
         1. Literal, as-is: for providers whose word tokens carry their own
-           surrounding whitespace (e.g. Inworld's ``" world"``).
-        2. Literal, with the segment's leading whitespace stripped: the common
-           case where the word omits the separating space.
-        3. Same as 1 and 2, but with the word's own trailing punctuation
-           removed: some TTS providers add terminal punctuation the original
-           text doesn't have (e.g. reading a list item -- ``"my account"`` --
-           as its own sentence, ``"account."``). The segment's actual
-           punctuation is untouched by this and is still picked up verbatim by
-           the next word.
-        4. Markup-stripped on both sides: for a provider that wraps the word
+           surrounding whitespace (e.g. Inworld's ``" world"``), optionally with
+           the segment's leading whitespace stripped, and with the word's own
+           trailing punctuation removed (see :meth:`_literal_hop`).
+        2. Same as 1, with both sides case- and accent-folded: for a provider
+           that lowercases a word or strips its diacritics in word-timestamp
+           events (e.g. ``"SQL"`` -> ``"sql"``, ``"café"`` -> ``"cafe"``).
+           Folding is a length-preserving, per-character transform (unlike
+           :func:`normalize`, it never drops or merges characters), so an
+           offset found against the folded text applies unchanged to the
+           original -- it can't match across a word/punctuation boundary that
+           wasn't already a candidate in strategy 1.
+        3. Markup-stripped on both sides: for a provider that wraps the word
            token in tags absent from ``tts_text`` (or vice versa). Recomputed
            fresh each call -- no persisted tag state.
 
-        Strategies 1-3 yield :attr:`_HopKind.PLACED` (word fits inside this
+        Strategies 1 and 2 yield :attr:`_HopKind.PLACED` (word fits inside this
         segment) or :attr:`_HopKind.CROSSES` (the segment's remaining text is
         only a prefix of the word, which spills into the next segment). Strategy
-        4 only yields ``PLACED``.
+        3 only yields ``PLACED``.
 
         If none match, the outcome is structural:
 
@@ -368,28 +409,22 @@ class TextSegmentMap:
         stripped = segment_remaining.lstrip()
         lead_ws = len(segment_remaining) - len(stripped)
 
-        # Strategies 1 and 2: literal match, as-is then whitespace-stripped.
+        # Strategy 1: literal match, as-is then whitespace-stripped.
         candidates = [(segment_remaining, 0)]
         if lead_ws:
             candidates.append((stripped, lead_ws))
-        for candidate, offset in candidates:
-            if candidate.startswith(remaining_word):
-                return _Hop(_HopKind.PLACED, seg_chars=offset + len(remaining_word))
-            if candidate and remaining_word.startswith(candidate):
-                return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
+        hop = TextSegmentMap._literal_hop(candidates, remaining_word)
+        if hop is not None:
+            return hop
 
-        # Strategy 3: same candidates, with the word's own trailing punctuation
-        # removed. The trimmed word is a prefix of remaining_word, so word_chars
-        # computed against it is still a valid split point for remaining_word.
-        trimmed_word = strip_trailing_punctuation(remaining_word)
-        if trimmed_word and trimmed_word != remaining_word:
-            for candidate, offset in candidates:
-                if candidate.startswith(trimmed_word):
-                    return _Hop(_HopKind.PLACED, seg_chars=offset + len(trimmed_word))
-                if candidate and trimmed_word.startswith(candidate):
-                    return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
+        # Strategy 2: same candidates, case/accent-folded.
+        folded_word = fold_case_and_accents(remaining_word)
+        folded_candidates = [(fold_case_and_accents(c), offset) for c, offset in candidates]
+        hop = TextSegmentMap._literal_hop(folded_candidates, folded_word)
+        if hop is not None:
+            return hop
 
-        # Strategy 4: markup-stripped match.
+        # Strategy 3: markup-stripped match.
         clean_word = strip_markup(remaining_word)
         if clean_word and strip_markup(stripped).startswith(clean_word):
             raw_len = _raw_len_for_clean_chars(stripped, len(clean_word))

--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -13,7 +13,11 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum, auto
 
-from pipecat.utils.text.transforms._alnum_utils import advance_by_alnums, normalize
+from pipecat.utils.text.transforms._alnum_utils import (
+    advance_by_alnums,
+    normalize,
+    strip_trailing_punctuation,
+)
 
 
 def _iter_clean_chars(text: str) -> Iterator[tuple[int, str]]:
@@ -327,20 +331,26 @@ class TextSegmentMap:
         """Decide where *remaining_word* goes against this segment's remaining raw text.
 
         Purely positional/textual -- no tag-name parsing or cross-call state. The
-        word is checked with three matching strategies, in order:
+        word is checked with four matching strategies, in order:
 
         1. Literal, as-is: for providers whose word tokens carry their own
            surrounding whitespace (e.g. Inworld's ``" world"``).
         2. Literal, with the segment's leading whitespace stripped: the common
            case where the word omits the separating space.
-        3. Markup-stripped on both sides: for a provider that wraps the word
+        3. Same as 1 and 2, but with the word's own trailing punctuation
+           removed: some TTS providers add terminal punctuation the original
+           text doesn't have (e.g. reading a list item -- ``"my account"`` --
+           as its own sentence, ``"account."``). The segment's actual
+           punctuation is untouched by this and is still picked up verbatim by
+           the next word.
+        4. Markup-stripped on both sides: for a provider that wraps the word
            token in tags absent from ``tts_text`` (or vice versa). Recomputed
            fresh each call -- no persisted tag state.
 
-        Strategies 1 and 2 yield :attr:`_HopKind.PLACED` (word fits inside this
+        Strategies 1-3 yield :attr:`_HopKind.PLACED` (word fits inside this
         segment) or :attr:`_HopKind.CROSSES` (the segment's remaining text is
         only a prefix of the word, which spills into the next segment). Strategy
-        3 only yields ``PLACED``.
+        4 only yields ``PLACED``.
 
         If none match, the outcome is structural:
 
@@ -368,7 +378,18 @@ class TextSegmentMap:
             if candidate and remaining_word.startswith(candidate):
                 return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
 
-        # Strategy 3: markup-stripped match.
+        # Strategy 3: same candidates, with the word's own trailing punctuation
+        # removed. The trimmed word is a prefix of remaining_word, so word_chars
+        # computed against it is still a valid split point for remaining_word.
+        trimmed_word = strip_trailing_punctuation(remaining_word)
+        if trimmed_word and trimmed_word != remaining_word:
+            for candidate, offset in candidates:
+                if candidate.startswith(trimmed_word):
+                    return _Hop(_HopKind.PLACED, seg_chars=offset + len(trimmed_word))
+                if candidate and trimmed_word.startswith(candidate):
+                    return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
+
+        # Strategy 4: markup-stripped match.
         clean_word = strip_markup(remaining_word)
         if clean_word and strip_markup(stripped).startswith(clean_word):
             raw_len = _raw_len_for_clean_chars(stripped, len(clean_word))

--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -201,11 +201,15 @@ class TextSegmentMap:
     Callers drive the map word-by-word: :meth:`word_belongs_current_segment`
     asks whether a raw word-timestamp token plausibly continues the remaining
     TTS text, and :meth:`advance_word` consumes it. Both match the token against
-    the segment's remaining raw text directly -- literally, or (as a stateless
-    fallback) with markup stripped from both sides -- so a token that is a
-    fragment of a still-open SSML tag (e.g. an attribute-only word from a
-    multi-attribute tag some TTS providers split across several word-timestamp
-    events) needs no special tag parsing.
+    the segment's remaining raw text directly -- literally, then (as stateless
+    fallbacks, recomputed fresh each call) with the word's own trailing
+    punctuation stripped, with both sides case/accent-folded, or with markup
+    stripped from both sides -- so a token that adds punctuation or changes
+    case/diacritics the source text doesn't have, or is a fragment of a still-
+    open SSML tag (e.g. an attribute-only word from a multi-attribute tag some
+    TTS providers split across several word-timestamp events), needs no special
+    handling from the caller. See :meth:`_classify_hop` for the full ordered
+    list of fallbacks.
 
     Example::
 
@@ -328,7 +332,11 @@ class TextSegmentMap:
         self._last_overflow: str | None = None
 
     @staticmethod
-    def _literal_hop(candidates: list[tuple[str, int]], remaining_word: str) -> "_Hop | None":
+    def _literal_hop(
+        candidates: list[tuple[str, int]],
+        remaining_word: str,
+        require_word_boundary: bool = False,
+    ) -> "_Hop | None":
         """Try PLACED/CROSSES of *remaining_word* against *candidates*, literally.
 
         Shared by the raw and case/accent-folded passes in :meth:`_classify_hop`
@@ -342,6 +350,21 @@ class TextSegmentMap:
         account"`` -- as its own sentence, ``"account."``). The segment's own
         punctuation is untouched either way and is still picked up verbatim by
         the next word.
+
+        Args:
+            candidates: ``(text, offset)`` pairs to match *remaining_word*
+                against, tried in order.
+            remaining_word: The word (or its trailing-punctuation-stripped
+                variant) to match.
+            require_word_boundary: When True, a ``PLACED`` match is only
+                accepted if it ends at a word boundary in the candidate (the
+                candidate is fully consumed, or the next character is not
+                alphanumeric) -- rejecting a short word that only happens to
+                be a prefix of a longer one (e.g. ``"account"`` inside
+                ``"Accountant"``). Used by the case/accent-folded pass, where
+                folding can otherwise turn a same-case mismatch into a
+                spurious mid-word prefix match; the raw pass leaves this off
+                to preserve its existing case-sensitive matching.
 
         Returns:
             A ``PLACED`` or ``CROSSES`` hop, or ``None`` if nothing matched.
@@ -360,8 +383,14 @@ class TextSegmentMap:
                 continue
             for candidate, offset in candidates:
                 if candidate.startswith(word):
-                    return _Hop(_HopKind.PLACED, seg_chars=offset + len(word))
-                if candidate and word.startswith(candidate):
+                    lands_mid_word = (
+                        require_word_boundary
+                        and len(word) < len(candidate)
+                        and candidate[len(word)].isalnum()
+                    )
+                    if not lands_mid_word:
+                        return _Hop(_HopKind.PLACED, seg_chars=offset + len(word))
+                elif candidate and word.startswith(candidate):
                     return _Hop(_HopKind.CROSSES, word_chars=len(candidate))
         return None
 
@@ -370,7 +399,7 @@ class TextSegmentMap:
         """Decide where *remaining_word* goes against this segment's remaining raw text.
 
         Purely positional/textual -- no tag-name parsing or cross-call state. The
-        word is checked with four matching strategies, in order:
+        word is checked with three matching strategies, in order:
 
         1. Literal, as-is: for providers whose word tokens carry their own
            surrounding whitespace (e.g. Inworld's ``" world"``), optionally with
@@ -382,8 +411,11 @@ class TextSegmentMap:
            Folding is a length-preserving, per-character transform (unlike
            :func:`normalize`, it never drops or merges characters), so an
            offset found against the folded text applies unchanged to the
-           original -- it can't match across a word/punctuation boundary that
-           wasn't already a candidate in strategy 1.
+           original. Folding erases case, which could otherwise turn a short
+           word into a spurious mid-word prefix match against a longer one
+           (e.g. folded ``"account"`` against ``"Accountant"``); a
+           ``PLACED`` match is only accepted here if it lands on a word
+           boundary (see :meth:`_literal_hop`'s ``require_word_boundary``).
         3. Markup-stripped on both sides: for a provider that wraps the word
            token in tags absent from ``tts_text`` (or vice versa). Recomputed
            fresh each call -- no persisted tag state.
@@ -417,10 +449,14 @@ class TextSegmentMap:
         if hop is not None:
             return hop
 
-        # Strategy 2: same candidates, case/accent-folded.
+        # Strategy 2: same candidates, case/accent-folded. require_word_boundary
+        # guards against folding turning a short word into a false mid-word
+        # prefix match against a longer one that only differs in case.
         folded_word = fold_case_and_accents(remaining_word)
         folded_candidates = [(fold_case_and_accents(c), offset) for c, offset in candidates]
-        hop = TextSegmentMap._literal_hop(folded_candidates, folded_word)
+        hop = TextSegmentMap._literal_hop(
+            folded_candidates, folded_word, require_word_boundary=True
+        )
         if hop is not None:
             return hop
 

--- a/src/pipecat/utils/text/transforms/_alnum_utils.py
+++ b/src/pipecat/utils/text/transforms/_alnum_utils.py
@@ -25,6 +25,41 @@ def strip_trailing_punctuation(text: str) -> str:
     return text[:i]
 
 
+def _fold_accented_char(char: str) -> str:
+    """Lowercase *char*, reduced to its base letter if it carries a combining accent.
+
+    NFD decomposes an accented character into a base letter plus a combining
+    mark (e.g. ``é`` -> ``e`` + ``◌́``, category ``Mn``); dropping the mark
+    keeps only the base letter. Always returns exactly one character, so
+    callers can rely on a 1:1 length mapping with the input.
+    """
+    nfd = unicodedata.normalize("NFD", char)
+    if len(nfd) >= 2 and unicodedata.category(nfd[1]) == "Mn":
+        return nfd[0].lower()
+    return char.lower()
+
+
+def fold_case_and_accents(text: str) -> str:
+    """Lowercase letters and strip accents, preserving every other character 1:1.
+
+    Unlike :func:`normalize`, this never removes or merges characters --
+    punctuation, spaces, and markup are passed through unchanged, and each
+    output character corresponds to exactly the same-index input character. A
+    raw offset computed against the folded text therefore applies unchanged to
+    the original, so callers can use it as a drop-in transform before a
+    position-based literal comparison, without the risk of a fully-normalized
+    (whitespace/punctuation-stripped) comparison matching across a boundary
+    that wasn't already a candidate in the untransformed comparison.
+
+    Args:
+        text: Input text to fold.
+
+    Returns:
+        *text* with letters case- and accent-folded; same length as *text*.
+    """
+    return "".join(_fold_accented_char(ch) if ch.isalpha() else ch for ch in text)
+
+
 def normalize(text: str) -> str:
     """Strip XML/HTML tags then keep only lowercase alphanumeric characters.
 
@@ -47,31 +82,11 @@ def normalize(text: str) -> str:
         # Keep only letters and numbers.
         if not char.isalnum():
             continue
-        # NFD decomposes accented characters into:
-        #   é -> e + ◌́
-        #   ã -> a + ◌̃
-        #
-        # Non-accented characters usually stay unchanged.
-        nfd = unicodedata.normalize("NFD", char)
-        # Unicode category "Mn" means:
-        #   Mark, Nonspacing
-        #
-        # These are combining accent marks that modify
-        # the previous character but are not standalone.
-        #
-        # Example:
-        #   "é" becomes:
-        #       nfd[0] = "e"
-        #       nfd[1] = "◌́"  (category = "Mn")
-        #
-        # If the second character is a combining accent,
-        # keep only the base letter.
-        if len(nfd) >= 2 and unicodedata.category(nfd[1]) == "Mn":
-            # Accented letter: keep the base character only (drops the combining mark).
-            result.append(nfd[0].lower())
+        if char.isalpha():
+            result.append(_fold_accented_char(char))
         else:
-            # Regular ASCII, numbers, CJK, Hangul, etc.
-            # are kept unchanged (except lowercase conversion).
+            # Regular numbers, CJK, Hangul, etc. are kept unchanged (except
+            # lowercase conversion, a no-op for characters with no case).
             result.append(char.lower())
     return "".join(result)
 

--- a/src/pipecat/utils/text/transforms/_alnum_utils.py
+++ b/src/pipecat/utils/text/transforms/_alnum_utils.py
@@ -10,6 +10,21 @@ import re
 import unicodedata
 
 
+def strip_trailing_punctuation(text: str) -> str:
+    """Remove punctuation only at the very end of *text*.
+
+    Args:
+        text: Input text to trim.
+
+    Returns:
+        *text* with any trailing run of Unicode punctuation characters removed.
+    """
+    i = len(text)
+    while i > 0 and unicodedata.category(text[i - 1]).startswith("P"):
+        i -= 1
+    return text[:i]
+
+
 def normalize(text: str) -> str:
     """Strip XML/HTML tags then keep only lowercase alphanumeric characters.
 

--- a/src/pipecat/utils/text/transforms/_alnum_utils.py
+++ b/src/pipecat/utils/text/transforms/_alnum_utils.py
@@ -83,10 +83,12 @@ def normalize(text: str) -> str:
         if not char.isalnum():
             continue
         if char.isalpha():
+            # Letters, including CJK and Hangul (both alphabetic per
+            # str.isalpha()): fold accents, a no-op for scripts that have none.
             result.append(_fold_accented_char(char))
         else:
-            # Regular numbers, CJK, Hangul, etc. are kept unchanged (except
-            # lowercase conversion, a no-op for characters with no case).
+            # Digits and other alnum-but-not-alphabetic characters: no case or
+            # accent to fold, so keep as-is (lowercase conversion is a no-op).
             result.append(char.lower())
     return "".join(result)
 

--- a/tests/test_text_segment_map.py
+++ b/tests/test_text_segment_map.py
@@ -382,5 +382,35 @@ class TestClassifyHopLiteralMatchHandlesStrayAngleBracket(unittest.TestCase):
         self.assertEqual(hop.seg_chars, len("<3"))
 
 
+class TestClassifyHopCaseFoldRequiresWordBoundary(unittest.TestCase):
+    """The case/accent-folded fallback strategy must not PLACE a word mid-word.
+
+    Folding erases case before the prefix (startswith) match, so a short word
+    that is only a case-insensitive prefix of a longer word (e.g. "account" vs
+    "Accountant") must not be accepted -- that would silently corrupt the
+    cursor by landing inside the longer word instead of at a real boundary.
+    """
+
+    def test_short_word_not_placed_inside_longer_word_via_case_fold(self):
+        hop = TextSegmentMap._classify_hop(" Accountant", "account")
+        self.assertNotEqual(
+            hop.kind, _HopKind.PLACED, "must not match 'account' mid-word inside 'Accountant'"
+        )
+
+        smap = TextSegmentMap("Please talk to the Accountant", "Please talk to the Accountant")
+        for word in ("Please", "talk", "to", "the"):
+            smap.advance_word(word)
+        self.assertFalse(smap.word_belongs_current_segment("account"))
+
+    def test_whole_word_case_fold_still_matches_at_boundary(self):
+        smap = TextSegmentMap("Please open the SQL database", "Please open the SQL database")
+        for word in ("Please", "open", "the"):
+            smap.advance_word(word)
+
+        self.assertTrue(smap.word_belongs_current_segment("sql"))
+        smap.advance_word("sql")
+        self.assertTrue(smap.word_belongs_current_segment("database"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_word_completion_tracker.py
+++ b/tests/test_word_completion_tracker.py
@@ -2375,5 +2375,59 @@ class TestWordCompletionTrackerAddedTerminalPunctuation(unittest.TestCase):
             tracker.add_word_and_check_complete(word)
 
 
+class TestWordCompletionTrackerCaseFolding(unittest.TestCase):
+    """Some TTS providers lowercase a word in word-timestamp events.
+
+    e.g. an acronym like "SQL" in the source text may be reported back as
+    "sql". Without tolerating this, the tracker desyncs the same way it did
+    for added terminal punctuation.
+    """
+
+    SENTENCE = "Please open the SQL database now."
+    TTS_WORDS = ["Please", "open", "the", "sql", "database", "now."]
+
+    def test_all_words_recognised_despite_case_difference(self):
+        tracker = WordCompletionTracker(self.SENTENCE)
+        for word in self.TTS_WORDS:
+            self.assertTrue(
+                tracker.word_belongs_here(word),
+                f"word {word!r} should be recognised despite the case difference",
+            )
+            tracker.add_word_and_check_complete(word)
+
+    def test_completes_after_last_word(self):
+        tracker = WordCompletionTracker(self.SENTENCE)
+        for word in self.TTS_WORDS[:-1]:
+            self.assertFalse(tracker.add_word_and_check_complete(word))
+        self.assertTrue(tracker.add_word_and_check_complete(self.TTS_WORDS[-1]))
+
+
+class TestWordCompletionTrackerAccentFolding(unittest.TestCase):
+    """Some TTS providers strip diacritics from a word in word-timestamp events.
+
+    e.g. "café" in the source text may be reported back as "cafe". Without
+    tolerating this, the tracker desyncs the same way it did for added
+    terminal punctuation.
+    """
+
+    SENTENCE = "Bienvenue au café parisien."
+    TTS_WORDS = ["Bienvenue", "au", "cafe", "parisien."]
+
+    def test_all_words_recognised_despite_accent_difference(self):
+        tracker = WordCompletionTracker(self.SENTENCE)
+        for word in self.TTS_WORDS:
+            self.assertTrue(
+                tracker.word_belongs_here(word),
+                f"word {word!r} should be recognised despite the accent difference",
+            )
+            tracker.add_word_and_check_complete(word)
+
+    def test_completes_after_last_word(self):
+        tracker = WordCompletionTracker(self.SENTENCE)
+        for word in self.TTS_WORDS[:-1]:
+            self.assertFalse(tracker.add_word_and_check_complete(word))
+        self.assertTrue(tracker.add_word_and_check_complete(self.TTS_WORDS[-1]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_word_completion_tracker.py
+++ b/tests/test_word_completion_tracker.py
@@ -2274,5 +2274,106 @@ class TestWordCompletionTrackerSpaceBeforePunctuation(unittest.TestCase):
         self.assertEqual(tracker.get_accumulated_user_facing_text(), "Comment ça va ? Bien")
 
 
+class TestWordCompletionTrackerAddedTerminalPunctuation(unittest.TestCase):
+    """Some TTS providers append terminal punctuation absent from the source text.
+
+    e.g. reading a multi-line list of options, a provider may speak each line as
+    its own sentence and report a word-timestamp word like "account." even though
+    the source text has "account" followed by a newline, not a period. Without
+    tolerating this, the tracker permanently desyncs on the first such word and
+    every later word is rejected too.
+    """
+
+    SENTENCE = (
+        "To better assist you, please choose one of the following options:\n\n"
+        "        A. I need help with my account\n"
+        "        B. I have a question about billing\n"
+        "        C. I need technical support\n\n"
+        "        Which option fits your needs best?"
+    )
+
+    # Words as Cartesia (and similar providers) report them: a period appended
+    # to the last word of each list line, which the source text does not have.
+    TTS_WORDS = [
+        "To",
+        "better",
+        "assist",
+        "you,",
+        "please",
+        "choose",
+        "one",
+        "of",
+        "the",
+        "following",
+        "options:",
+        "A.",
+        "I",
+        "need",
+        "help",
+        "with",
+        "my",
+        "account.",
+        "B.",
+        "I",
+        "have",
+        "a",
+        "question",
+        "about",
+        "billing.",
+        "C.",
+        "I",
+        "need",
+        "technical",
+        "support.",
+        "Which",
+        "option",
+        "fits",
+        "your",
+        "needs",
+        "best?",
+    ]
+
+    def test_all_words_recognised_despite_added_period(self):
+        """No word should be rejected just because the TTS added a period."""
+        tracker = WordCompletionTracker(
+            self.SENTENCE, llm_text=self.SENTENCE, user_facing_text=self.SENTENCE
+        )
+        for word in self.TTS_WORDS:
+            self.assertTrue(
+                tracker.word_belongs_here(word),
+                f"word {word!r} should be recognised despite the added period",
+            )
+            tracker.add_word_and_check_complete(word)
+
+    def test_completes_after_last_word(self):
+        """The tracker must reach completion once the final word arrives."""
+        tracker = WordCompletionTracker(
+            self.SENTENCE, llm_text=self.SENTENCE, user_facing_text=self.SENTENCE
+        )
+        for word in self.TTS_WORDS[:-1]:
+            self.assertFalse(tracker.add_word_and_check_complete(word))
+        self.assertTrue(tracker.add_word_and_check_complete(self.TTS_WORDS[-1]))
+
+    def test_no_force_complete_desync(self):
+        """Once desynced, every later word used to fail too -- verify recovery.
+
+        The bug produced a permanent desync: the first mismatched word forced
+        the segment map's cursor to stall, so every subsequent word was also
+        rejected as not belonging. Asserting on the middle-of-list words (not
+        just the last) guards against a fix that only patches the first hop.
+        """
+        tracker = WordCompletionTracker(
+            self.SENTENCE, llm_text=self.SENTENCE, user_facing_text=self.SENTENCE
+        )
+        for word in self.TTS_WORDS[:17]:  # up to "my", just before "account."
+            tracker.add_word_and_check_complete(word)
+        for word in self.TTS_WORDS[17:]:  # "account." onward
+            self.assertTrue(
+                tracker.word_belongs_here(word),
+                f"word {word!r} incorrectly rejected after the 'account.' hop",
+            )
+            tracker.add_word_and_check_complete(word)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
  
  - Fixes a permanent word-timestamp desync in `TextSegmentMap` / `WordCompletionTracker`.
  - **Root cause**: the recent segment-map refactor replaced the old alnum-count-based word matching with strict literal text matching. When a TTS provider adds terminal punctuation the source text doesn't have (e.g. Cartesia appending a period while reading a multi-line option list — `"my account"` spoken as `"account."`), the word no longer matches literally, `word_belongs_here` returns `False`, and the slot desyncs permanently: since the cursor never advances, every subsequent word fails the same way for the rest of the turn, falling back to passthrough emission and losing RTVI progress tracking.
  - `_classify_hop` now retries with the incoming word's trailing punctuation stripped before giving up, tolerating this class of provider-added punctuation while leaving the segment's own text untouched.
  - Extracted the trailing-punctuation trim into `_alnum_utils.strip_trailing_punctuation`, shared with the existing helper in
  `word_completion_tracker.py`.

  No changelog entry — this hasn't been released yet.
  
  ## Test plan

  - [x] Added `TestWordCompletionTrackerAddedTerminalPunctuation`, reproducing the exact sentence/word sequence from the reported issue (via `examples/voice/voice-assemblyai.py`), asserting no word is rejected and the tracker completes.
  - [x] `uv run pytest tests/test_word_completion_tracker.py tests/test_text_segment_map.py tests/test_aggregated_frame_sequencer.py` — all pass.
  - [x] `uv run pytest tests/` — 3547 passed (5 pre-existing Krisp-SDK test failures, order-dependent and unrelated to this change — pass in isolation both with and without this diff).