### PR TITLE
feat(livekit): receive inbound SIP DTMF as InputDTMFFrame

### DIFF
--- a/changelog/5097.added.md
+++ b/changelog/5097.added.md
@@ -1,0 +1,1 @@
+- Added inbound SIP DTMF support on the LiveKit transport via `on_dtmf_event` and `InputDTMFFrame`, so `DTMFAggregator` works with LiveKit SIP/PSTN calls.

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -20,6 +20,7 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel
 
+from pipecat.audio.dtmf.types import KeypadEntry
 from pipecat.audio.utils import create_stream_resampler
 from pipecat.frames.frames import (
     AudioRawFrame,
@@ -29,6 +30,7 @@ from pipecat.frames.frames import (
     EndFrame,
     Frame,
     ImageRawFrame,
+    InputDTMFFrame,
     InterruptionFrame,
     OutputAudioRawFrame,
     OutputDTMFFrame,
@@ -114,6 +116,7 @@ class LiveKitCallbacks(BaseModel):
         on_audio_track_unsubscribed: Called when an audio track is unsubscribed.
         on_data_received: Called when data is received from a participant.
         on_first_participant_joined: Called when the first participant joins.
+        on_dtmf_event: Called when a SIP DTMF tone is received.
     """
 
     on_connected: Callable[[], Awaitable[None]]
@@ -127,6 +130,7 @@ class LiveKitCallbacks(BaseModel):
     on_video_track_unsubscribed: Callable[[str], Awaitable[None]]
     on_data_received: Callable[[bytes, str], Awaitable[None]]
     on_first_participant_joined: Callable[[str], Awaitable[None]]
+    on_dtmf_event: Callable[[Any], Awaitable[None]]
 
 
 class LiveKitTransportClient:
@@ -224,6 +228,7 @@ class LiveKitTransportClient:
         self.room.on("data_received")(self._on_data_received_wrapper)
         self.room.on("connected")(self._on_connected_wrapper)
         self.room.on("disconnected")(self._on_disconnected_wrapper)
+        self.room.on("sip_dtmf_received")(self._on_sip_dtmf_received_wrapper)
 
     async def cleanup(self):
         """Cleanup client resources."""
@@ -482,6 +487,13 @@ class LiveKitTransportClient:
             self._async_on_disconnected(), f"{self}::_async_on_disconnected"
         )
 
+    def _on_sip_dtmf_received_wrapper(self, dtmf: rtc.SipDTMF):
+        """Wrapper for inbound SIP DTMF events."""
+        self._task_manager.create_task(
+            self._async_on_sip_dtmf_received(dtmf),
+            f"{self}::_async_on_sip_dtmf_received",
+        )
+
     # Async methods for event handling
     async def _async_on_participant_connected(self, participant: rtc.RemoteParticipant):
         """Handle participant connected events."""
@@ -609,6 +621,19 @@ class LiveKitTransportClient:
         self._connected = False
         logger.info(f"Disconnected from {self._room_name}. Reason: {reason}")
         await self._callbacks.on_disconnected()
+
+    async def _async_on_sip_dtmf_received(self, dtmf: rtc.SipDTMF):
+        """Handle inbound SIP DTMF events from LiveKit telephony."""
+        participant = getattr(dtmf, "participant", None)
+        participant_id = getattr(participant, "sid", None) if participant else None
+        data = {
+            "tone": dtmf.digit,
+            "digit": dtmf.digit,
+            "code": dtmf.code,
+            "participant_id": participant_id,
+        }
+        logger.debug(f"{self} SIP DTMF event: {data}")
+        await self._callbacks.on_dtmf_event(data)
 
     async def _process_audio_stream(self, audio_stream: rtc.AudioStream, participant_id: str):
         """Process incoming audio stream from a participant."""
@@ -1028,6 +1053,10 @@ class LiveKitTransport(BaseTransport):
       Args: (participant_id: str)
     - on_data_received: Called when data is received from a participant.
       Args: (data: bytes, participant_id: str)
+    - on_dtmf_event: Called when a SIP DTMF tone is received from a participant.
+      Args: (data: dict) with keys ``tone``/``digit``, ``code``, and
+      ``participant_id``. Also pushes an ``InputDTMFFrame`` so
+      ``DTMFAggregator`` works on LiveKit SIP calls.
 
     Example::
 
@@ -1073,6 +1102,7 @@ class LiveKitTransport(BaseTransport):
             on_video_track_unsubscribed=self._on_video_track_unsubscribed,
             on_data_received=self._on_data_received,
             on_first_participant_joined=self._on_first_participant_joined,
+            on_dtmf_event=self._on_dtmf_event,
         )
         self._params = params or LiveKitParams()
 
@@ -1095,6 +1125,7 @@ class LiveKitTransport(BaseTransport):
         self._register_event_handler("on_participant_left")
         self._register_event_handler("on_call_state_updated")
         self._register_event_handler("on_before_disconnect", sync=True)
+        self._register_event_handler("on_dtmf_event")
 
     def input(self) -> LiveKitInputTransport:
         """Get the input transport for receiving media and events.
@@ -1239,6 +1270,27 @@ class LiveKitTransport(BaseTransport):
         if self._input:
             await self._input.push_app_message(data.decode(), participant_id)
         await self._call_event_handler("on_data_received", data, participant_id)
+
+    async def _on_dtmf_event(self, data: Any):
+        """Handle inbound SIP DTMF events.
+
+        Mirrors Daily transport behavior: expose ``on_dtmf_event`` to user code
+        and push ``InputDTMFFrame`` so ``DTMFAggregator`` can consume digits.
+        """
+        logger.debug(f"{self} DTMF event: {data}")
+        await self._call_event_handler("on_dtmf_event", data)
+
+        tone = data.get("tone") if isinstance(data, dict) else None
+        if tone is None or self._input is None:
+            return
+
+        try:
+            button = KeypadEntry(tone)
+        except ValueError:
+            logger.warning(f"{self} Ignoring unsupported DTMF tone: {tone!r}")
+            return
+
+        await self._input.push_frame(InputDTMFFrame(button=button))
 
     async def send_message(self, message: str, participant_id: str | None = None):
         """Send a message to participants in the room.

--- a/tests/test_livekit_transport.py
+++ b/tests/test_livekit_transport.py
@@ -54,6 +54,7 @@ class TestLiveKitVideoStreamMemoryLeak(unittest.IsolatedAsyncioTestCase):
             on_video_track_unsubscribed=AsyncMock(),
             on_data_received=AsyncMock(),
             on_first_participant_joined=AsyncMock(),
+            on_dtmf_event=AsyncMock(),
         )
         client = LiveKitTransportClient(
             url="wss://test.livekit.cloud",
@@ -154,6 +155,7 @@ class TestLiveKitAudioStreamLeakOnUnsubscribe(unittest.IsolatedAsyncioTestCase):
             on_video_track_unsubscribed=AsyncMock(),
             on_data_received=AsyncMock(),
             on_first_participant_joined=AsyncMock(),
+            on_dtmf_event=AsyncMock(),
         )
         client = LiveKitTransportClient(
             url="wss://test.livekit.cloud",
@@ -276,6 +278,108 @@ class TestLiveKitAudioStreamLeakOnUnsubscribe(unittest.IsolatedAsyncioTestCase):
         await client._async_on_track_unsubscribed(track, pub, participant)
         mock_stream.aclose.assert_awaited_once()
         self.assertNotIn(participant.sid, client._video_streams)
+
+
+@unittest.skipUnless(LIVEKIT_AVAILABLE, "livekit package not installed")
+class TestLiveKitSipDtmfInput(unittest.IsolatedAsyncioTestCase):
+    """Inbound SIP DTMF should surface as InputDTMFFrame (#4436)."""
+
+    def _create_client(self) -> LiveKitTransportClient:
+        params = LiveKitParams()
+        callbacks = LiveKitCallbacks(
+            on_connected=AsyncMock(),
+            on_disconnected=AsyncMock(),
+            on_before_disconnect=AsyncMock(),
+            on_participant_connected=AsyncMock(),
+            on_participant_disconnected=AsyncMock(),
+            on_audio_track_subscribed=AsyncMock(),
+            on_audio_track_unsubscribed=AsyncMock(),
+            on_video_track_subscribed=AsyncMock(),
+            on_video_track_unsubscribed=AsyncMock(),
+            on_data_received=AsyncMock(),
+            on_first_participant_joined=AsyncMock(),
+            on_dtmf_event=AsyncMock(),
+        )
+        client = LiveKitTransportClient(
+            url="wss://test.livekit.cloud",
+            token="test-token",
+            room_name="test-room",
+            params=params,
+            callbacks=callbacks,
+            transport_name="test-transport",
+        )
+        client._task_manager = MagicMock()
+        return client
+
+    async def test_sip_dtmf_forwards_digit_to_callback(self):
+        """Room sip_dtmf_received events are normalized and forwarded."""
+        client = self._create_client()
+        participant = MagicMock()
+        participant.sid = "sip-participant-1"
+        dtmf = MagicMock()
+        dtmf.digit = "5"
+        dtmf.code = 5
+        dtmf.participant = participant
+
+        await client._async_on_sip_dtmf_received(dtmf)
+
+        client._callbacks.on_dtmf_event.assert_awaited_once_with(
+            {
+                "tone": "5",
+                "digit": "5",
+                "code": 5,
+                "participant_id": "sip-participant-1",
+            }
+        )
+
+    async def test_transport_dtmf_event_pushes_input_frame(self):
+        """Transport pushes InputDTMFFrame so DTMFAggregator can consume digits."""
+        from pipecat.audio.dtmf.types import KeypadEntry
+        from pipecat.frames.frames import InputDTMFFrame
+        from pipecat.transports.livekit.transport import LiveKitTransport
+
+        transport = LiveKitTransport(
+            url="wss://test.livekit.cloud",
+            token="test-token",
+            room_name="test-room",
+        )
+        transport._input = MagicMock()
+        transport._input.push_frame = AsyncMock()
+        transport._call_event_handler = AsyncMock()
+
+        data = {
+            "tone": "1",
+            "digit": "1",
+            "code": 1,
+            "participant_id": "sip-participant-1",
+        }
+        await transport._on_dtmf_event(data)
+
+        transport._call_event_handler.assert_awaited_once_with("on_dtmf_event", data)
+        transport._input.push_frame.assert_awaited_once()
+        frame = transport._input.push_frame.await_args.args[0]
+        self.assertIsInstance(frame, InputDTMFFrame)
+        self.assertEqual(frame.button, KeypadEntry.ONE)
+
+    async def test_transport_ignores_unsupported_dtmf_tone(self):
+        """Unsupported tones are logged and do not push a frame."""
+        from pipecat.transports.livekit.transport import LiveKitTransport
+
+        transport = LiveKitTransport(
+            url="wss://test.livekit.cloud",
+            token="test-token",
+            room_name="test-room",
+        )
+        transport._input = MagicMock()
+        transport._input.push_frame = AsyncMock()
+        transport._call_event_handler = AsyncMock()
+
+        await transport._on_dtmf_event(
+            {"tone": "A", "digit": "A", "code": 12, "participant_id": "p1"}
+        )
+
+        transport._call_event_handler.assert_awaited_once()
+        transport._input.push_frame.assert_not_awaited()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Wire LiveKit room `sip_dtmf_received` into the transport as `on_dtmf_event`, mirroring Daily.
- Push `InputDTMFFrame` for each digit so `DTMFAggregator` works on inbound SIP/PSTN calls.
- Add unit coverage for digit forwarding, frame push, and unsupported tone handling.

Fixes #4436

## Test plan
- [x] `pytest tests/test_livekit_transport.py` (10 passed)
- [ ] Manual: inbound SIP call into a LiveKit room with Pipecat LiveKit transport + `DTMFAggregator`; press keypad digits and confirm digits aggregate / handler fires