### PR TITLE
Add numerals support to Deepgram Flux STT

### DIFF
--- a/changelog/5099.added.md
+++ b/changelog/5099.added.md
@@ -1,0 +1,1 @@
+- Added `numerals` setting to `DeepgramFluxSTTSettings` to convert spoken numbers to numeral form in transcripts (e.g. "twenty three" → "23"). Enable with `numerals=True` in the settings; configured at connection time per Deepgram's Flux API.

--- a/src/pipecat/services/deepgram/flux/base.py
+++ b/src/pipecat/services/deepgram/flux/base.py
@@ -123,6 +123,9 @@ class DeepgramFluxSTTSettings(STTSettings):
             confidence (default 5000).
         keyterm: Keyterms to boost recognition accuracy for specialized terminology.
         min_confidence: Minimum confidence required to create a TranscriptionFrame.
+        numerals: Convert spoken numbers to numeral form (e.g. "twenty three" -> "23").
+            On Flux this is configured at connection time only and cannot be
+            changed mid-stream via ``Configure``.
         language_hints: Languages to bias transcription toward. Only honored by the
             ``flux-general-multi`` model. An empty list clears any active hints;
             ``None``/``NOT_GIVEN`` means no hints (auto-detect). Can be updated
@@ -134,6 +137,7 @@ class DeepgramFluxSTTSettings(STTSettings):
     eot_timeout_ms: int | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     keyterm: list | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     min_confidence: float | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    numerals: bool | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
     language_hints: list[Language] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
@@ -276,6 +280,11 @@ class DeepgramFluxSTTBase(STTService):
 
         if self._settings.eot_timeout_ms is not None:
             params.append(f"eot_timeout_ms={self._settings.eot_timeout_ms}")
+
+        # Flux numerals are set via query parameter at connect-time only.
+        numerals = assert_given(self._settings.numerals)
+        if numerals is not None:
+            params.append(f"numerals={str(numerals).lower()}")
 
         if self._mip_opt_out is not None:
             params.append(f"mip_opt_out={str(self._mip_opt_out).lower()}")

--- a/src/pipecat/services/deepgram/flux/base.py
+++ b/src/pipecat/services/deepgram/flux/base.py
@@ -123,9 +123,9 @@ class DeepgramFluxSTTSettings(STTSettings):
             confidence (default 5000).
         keyterm: Keyterms to boost recognition accuracy for specialized terminology.
         min_confidence: Minimum confidence required to create a TranscriptionFrame.
-        numerals: Convert spoken numbers to numeral form (e.g. "twenty three" -> "23").
-            On Flux this is configured at connection time only and cannot be
-            changed mid-stream via ``Configure``.
+        numerals: Convert spoken numbers to numeral form (e.g. "twenty three" → "23").
+            Connection-time only: Flux does not support toggling numerals
+            mid-stream, so updates via ``STTUpdateSettingsFrame`` are ignored.
         language_hints: Languages to bias transcription toward. Only honored by the
             ``flux-general-multi`` model. An empty list clears any active hints;
             ``None``/``NOT_GIVEN`` means no hints (auto-detect). Can be updated
@@ -281,10 +281,8 @@ class DeepgramFluxSTTBase(STTService):
         if self._settings.eot_timeout_ms is not None:
             params.append(f"eot_timeout_ms={self._settings.eot_timeout_ms}")
 
-        # Flux numerals are set via query parameter at connect-time only.
-        numerals = assert_given(self._settings.numerals)
-        if numerals is not None:
-            params.append(f"numerals={str(numerals).lower()}")
+        if self._settings.numerals is not None:
+            params.append(f"numerals={str(self._settings.numerals).lower()}")
 
         if self._mip_opt_out is not None:
             params.append(f"mip_opt_out={str(self._mip_opt_out).lower()}")

--- a/src/pipecat/services/deepgram/flux/sagemaker/stt.py
+++ b/src/pipecat/services/deepgram/flux/sagemaker/stt.py
@@ -123,6 +123,7 @@ class DeepgramFluxSageMakerSTTService(DeepgramFluxSTTBase):
             keyterm=[],
             min_confidence=None,
             language_hints=None,
+            numerals=None,
         )
 
         # Apply settings delta

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -93,8 +93,6 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
                 (default False).
             tag: List of tags to label requests for identification during usage reporting.
             min_confidence: Optional. Minimum confidence required confidence to create a TranscriptionFrame
-            numerals: Optional. Converts spoken numbers to numeral form in transcripts.
-                For Flux, this is set at connection time and cannot be toggled mid-stream.
         """
 
         eager_eot_threshold: float | None = None
@@ -104,7 +102,6 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
         mip_opt_out: bool | None = None
         tag: list = []
         min_confidence: float | None = None  # New parameter
-        numerals: bool | None = None
 
     def __init__(
         self,
@@ -220,8 +217,6 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
                 if params.tag and tag is None:
                     tag = params.tag
                 default_settings.min_confidence = params.min_confidence
-                if params.numerals is not None:
-                    default_settings.numerals = params.numerals
                 if params.mip_opt_out is not None:
                     mip_opt_out = params.mip_opt_out
 

--- a/src/pipecat/services/deepgram/flux/stt.py
+++ b/src/pipecat/services/deepgram/flux/stt.py
@@ -93,6 +93,8 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
                 (default False).
             tag: List of tags to label requests for identification during usage reporting.
             min_confidence: Optional. Minimum confidence required confidence to create a TranscriptionFrame
+            numerals: Optional. Converts spoken numbers to numeral form in transcripts.
+                For Flux, this is set at connection time and cannot be toggled mid-stream.
         """
 
         eager_eot_threshold: float | None = None
@@ -102,6 +104,7 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
         mip_opt_out: bool | None = None
         tag: list = []
         min_confidence: float | None = None  # New parameter
+        numerals: bool | None = None
 
     def __init__(
         self,
@@ -197,6 +200,7 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
             eot_timeout_ms=None,
             keyterm=[],
             min_confidence=None,
+            numerals=None,
             language_hints=None,
         )
 
@@ -216,6 +220,8 @@ class DeepgramFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
                 if params.tag and tag is None:
                     tag = params.tag
                 default_settings.min_confidence = params.min_confidence
+                if params.numerals is not None:
+                    default_settings.numerals = params.numerals
                 if params.mip_opt_out is not None:
                     mip_opt_out = params.mip_opt_out
 


### PR DESCRIPTION
## Summary

- Added `numerals` setting to `DeepgramFluxSTTSettings` to enable Deepgram's numeral conversion feature on Flux models
- When enabled, spoken numbers are converted to numeral form in transcripts (e.g. "twenty three" → "23")
- Configured as a connection-time query parameter per Deepgram's Flux API (not toggleable mid-stream)

## Testing

```python
stt = DeepgramFluxSTTService(
    api_key="your-api-key",
    settings=DeepgramFluxSTTService.Settings(
        model="flux-general-en",
        numerals=True,
    ),
)
```


Made with [Cursor](https://cursor.com)