### PR TITLE
Add `safety_settings` to GoogleLLMService

### DIFF
--- a/changelog/5109.added.md
+++ b/changelog/5109.added.md
@@ -1,0 +1,19 @@
+- Added `safety_settings` to `GoogleLLMService.Settings` (and `GoogleVertexLLMService.Settings`), exposing Gemini's content safety filters. Previously these could only be set by smuggling them through `extra`.
+
+    ```python
+    from google.genai.types import HarmBlockThreshold, HarmCategory, SafetySetting
+
+    llm = GoogleLLMService(
+        api_key=os.getenv("GOOGLE_API_KEY"),
+        settings=GoogleLLMService.Settings(
+            safety_settings=[
+                SafetySetting(
+                    category=HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+                    threshold=HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+                ),
+            ],
+        ),
+    )
+    ```
+
+    Categories left unspecified keep the Gemini API defaults. The setting is runtime-updatable via `LLMUpdateSettingsFrame`, which also accepts plain dicts.

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -60,6 +60,7 @@ try:
         GenerateContentConfig,
         GenerateContentResponse,
         HttpOptions,
+        SafetySetting,
     )
 
     # Temporary hack to be able to process Nano Banana returned images.
@@ -107,22 +108,36 @@ class GoogleLLMSettings(LLMSettings):
 
     Parameters:
         thinking: Thinking configuration.
+        safety_settings: Content safety filters, as a list of
+            :class:`~google.genai.types.SafetySetting`. Each entry pairs a harm
+            category with the threshold at which content is blocked. Categories
+            left unspecified keep the Gemini API defaults.
     """
 
     thinking: Union["GoogleLLMService.ThinkingConfig", None, _NotGiven] = field(
         default_factory=lambda: NOT_GIVEN
     )
+    safety_settings: list[SafetySetting] | None | _NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
 
     @classmethod
     def from_mapping(cls, settings):
-        """Convert a plain dict to settings, coercing thinking dicts.
+        """Convert a plain dict to settings, coercing thinking and safety dicts.
 
-        For backward compatibility, a ``thinking`` value that is a plain dict
-        is converted to a :class:`GoogleLLMService.ThinkingConfig`.
+        For backward compatibility, a ``thinking`` value that is a plain dict is
+        converted to a :class:`GoogleLLMService.ThinkingConfig`, and any
+        ``safety_settings`` entry that is a plain dict is converted to a
+        :class:`~google.genai.types.SafetySetting`.
         """
         instance = super().from_mapping(settings)
         if is_given(instance.thinking) and isinstance(instance.thinking, dict):
             instance.thinking = GoogleLLMService.ThinkingConfig(**instance.thinking)
+        if is_given(instance.safety_settings) and instance.safety_settings:
+            instance.safety_settings = [
+                SafetySetting(**entry) if isinstance(entry, dict) else entry
+                for entry in instance.safety_settings
+            ]
         return instance
 
 
@@ -231,6 +246,7 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
             thinking=None,
+            safety_settings=None,
             extra={},
         )
 
@@ -361,6 +377,7 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
                 "top_p": self._settings.top_p,
                 "top_k": self._settings.top_k,
                 "max_output_tokens": self._settings.max_tokens,
+                "safety_settings": assert_given(self._settings.safety_settings),
                 "tools": tools,
                 "tool_config": tool_config,
             }.items()

--- a/src/pipecat/services/google/vertex/llm.py
+++ b/src/pipecat/services/google/vertex/llm.py
@@ -140,6 +140,7 @@ class GoogleVertexLLMService(GoogleLLMService):
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
             thinking=None,
+            safety_settings=None,
             extra={},
         )
 

--- a/tests/test_google_safety_settings.py
+++ b/tests/test_google_safety_settings.py
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for safety settings support in GoogleLLMService."""
+
+from google.genai.types import (
+    GenerateContentConfig,
+    HarmBlockThreshold,
+    HarmCategory,
+    SafetySetting,
+)
+
+from pipecat.services.google.llm import GoogleLLMService, GoogleLLMSettings
+from pipecat.services.settings import is_given
+
+
+def _safety_setting(
+    category: HarmCategory = HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    threshold: HarmBlockThreshold = HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+) -> SafetySetting:
+    return SafetySetting(category=category, threshold=threshold)
+
+
+def test_safety_settings_omitted_by_default():
+    """Generation params carry no safety_settings key unless configured."""
+    service = GoogleLLMService(api_key="test-key")
+
+    params = service._build_generation_params()
+
+    assert "safety_settings" not in params
+
+
+def test_safety_settings_passed_to_generation_params():
+    """Configured safety settings reach the generation params verbatim."""
+    safety = [_safety_setting()]
+    service = GoogleLLMService(
+        api_key="test-key",
+        settings=GoogleLLMService.Settings(safety_settings=safety),
+    )
+
+    params = service._build_generation_params()
+
+    assert params["safety_settings"] == safety
+
+
+def test_safety_settings_survive_config_construction():
+    """The generation params build a GenerateContentConfig the SDK accepts."""
+    service = GoogleLLMService(
+        api_key="test-key",
+        settings=GoogleLLMService.Settings(safety_settings=[_safety_setting()]),
+    )
+
+    config = GenerateContentConfig(**service._build_generation_params())
+
+    assert config.safety_settings is not None
+    assert config.safety_settings[0].category == HarmCategory.HARM_CATEGORY_HATE_SPEECH
+    assert config.safety_settings[0].threshold == HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+
+
+def test_safety_settings_updated_at_runtime():
+    """A settings delta replaces the safety settings on the live service."""
+    service = GoogleLLMService(
+        api_key="test-key",
+        settings=GoogleLLMService.Settings(safety_settings=[_safety_setting()]),
+    )
+    updated = [
+        _safety_setting(
+            category=HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+            threshold=HarmBlockThreshold.BLOCK_NONE,
+        )
+    ]
+
+    service._settings.apply_update(GoogleLLMService.Settings(safety_settings=updated))
+
+    assert service._build_generation_params()["safety_settings"] == updated
+
+
+def test_from_mapping_coerces_dict_entries():
+    """Plain dicts from a dict-based settings update become SafetySetting objects."""
+    settings = GoogleLLMSettings.from_mapping(
+        {
+            "safety_settings": [
+                {
+                    "category": "HARM_CATEGORY_HATE_SPEECH",
+                    "threshold": "BLOCK_LOW_AND_ABOVE",
+                }
+            ]
+        }
+    )
+
+    assert settings.safety_settings == [_safety_setting()]
+
+
+def test_from_mapping_leaves_safety_setting_objects_untouched():
+    """Already-typed entries pass through from_mapping unchanged."""
+    safety = [_safety_setting()]
+
+    settings = GoogleLLMSettings.from_mapping({"safety_settings": safety})
+
+    assert settings.safety_settings == safety
+
+
+def test_from_mapping_without_safety_settings_is_not_given():
+    """Omitting safety_settings leaves the delta field unset."""
+    settings = GoogleLLMSettings.from_mapping({"temperature": 0.5})
+
+    assert not is_given(settings.safety_settings)


### PR DESCRIPTION
## Summary

Closes #1393.

Exposes Gemini's content safety filters as a first-class `safety_settings` field on `GoogleLLMService.Settings` (and `GoogleVertexLLMService.Settings`). Previously only settable by smuggling them through `extra`.

```python
from google.genai.types import HarmBlockThreshold, HarmCategory, SafetySetting

settings = GoogleLLMService.Settings(
    safety_settings=[
        SafetySetting(
            category=HarmCategory.HARM_CATEGORY_HATE_SPEECH,
            threshold=HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
        ),
    ],
)
```

Mirrors the existing `thinking` field, so behavior is unchanged when unset. Runtime-updatable and accepts plain dicts. Tests in `tests/test_google_safety_settings.py`.

_Disclaimer: used Claude Code._
