### PR TITLE
fix(inworld): providerData typo; RT Tool call fixes

### DIFF
--- a/changelog/5116.changed.md
+++ b/changelog/5116.changed.md
@@ -1,0 +1,1 @@
+- `InworldRealtimeLLMService` now sends `providerData.auto_tool_response=false`, leaving Pipecat responsible for requesting continuation after submitting a tool result.

--- a/changelog/5116.fixed.2.md
+++ b/changelog/5116.fixed.2.md
@@ -1,0 +1,1 @@
+- Fixed `InworldRealtimeLLMService` resending a server-VAD user transcript after a fast tool result context update, which duplicated user turns and responses.

--- a/changelog/5116.fixed.md
+++ b/changelog/5116.fixed.md
@@ -1,0 +1,1 @@
+- `InworldRealtimeLLMService` now serializes Inworld extensions under `providerData` instead of `provider_data`, allowing the server to apply them.

--- a/src/pipecat/services/inworld/realtime/events.py
+++ b/src/pipecat/services/inworld/realtime/events.py
@@ -192,7 +192,7 @@ class SessionProperties(BaseModel):
     """
 
     # Needed to support ToolSchema in tools field.
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
     type: str | None = "realtime"
     model: str | None = None
@@ -204,7 +204,7 @@ class SessionProperties(BaseModel):
     # tools (the validator below normalizes that to a ToolsSchema); a list of
     # provider-native InworldTool objects passes through.
     tools: ToolsSchema | list[FunctionSchema | DirectFunction] | list[InworldTool] | None = None
-    provider_data: dict[str, Any] | None = None
+    provider_data: dict[str, Any] | None = Field(default=None, alias="providerData")
 
     @field_validator("tools", mode="before")
     @classmethod

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -595,17 +595,24 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
             messages = self._context.get_messages()
             current_count = len(messages)
             if current_count > self._last_context_message_count:
+                new_messages = messages[self._last_context_message_count :]
                 last_msg = messages[-1]
                 self._last_context_message_count = current_count
 
                 # When server-side VAD handled this turn, the server already
-                # has the user's audio and auto-created a response.  Skip
-                # sending a duplicate text item + response.create.
-                if self._server_vad_handled_turn:
+                # has the user's audio and auto-created a response. Skip the
+                # corresponding context message, but do not consume this marker
+                # for assistant/tool updates that can arrive before the deferred
+                # realtime transcript.
+                server_user_message_added = any(
+                    isinstance(message, Mapping) and message.get("role") == "user"
+                    for message in new_messages
+                )
+                if self._server_vad_handled_turn and server_user_message_added:
                     self._server_vad_handled_turn = False
                     return
 
-                if last_msg.get("role") == "user":
+                if isinstance(last_msg, Mapping) and last_msg.get("role") == "user":
                     content = last_msg.get("content", "")
                     if isinstance(content, list):
                         content = " ".join(
@@ -636,7 +643,10 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
         Args:
             event: The client event to send.
         """
-        await self._ws_send(event.model_dump(exclude_none=True))
+        message = event.model_dump(exclude_none=True, by_alias=True)
+        if isinstance(event, events.SessionUpdateEvent):
+            logger.debug(f"{self} sending session.update: {json.dumps(message)}")
+        await self._ws_send(message)
 
     async def _connect(self):
         """Establish WebSocket connection to Inworld."""
@@ -741,7 +751,12 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
         if settings.tools and isinstance(settings.tools, ToolsSchema):
             settings.tools = adapter.from_standard_tools(settings.tools)
 
-        settings.provider_data = {"metadata": {"sdk": "pipecat-realtime"}}
+        provider_data = dict(settings.provider_data or {})
+        metadata = dict(provider_data.get("metadata") or {})
+        metadata["sdk"] = "pipecat-realtime"
+        provider_data["metadata"] = metadata
+        provider_data["auto_tool_response"] = False # Set to false because Pipecat creates a tool response from client
+        settings.provider_data = provider_data
 
         await self.send_client_event(events.SessionUpdateEvent(session=settings))
 

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -755,7 +755,9 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
         metadata = dict(provider_data.get("metadata") or {})
         metadata["sdk"] = "pipecat-realtime"
         provider_data["metadata"] = metadata
-        provider_data["auto_tool_response"] = False # Set to false because Pipecat creates a tool response from client
+        provider_data["auto_tool_response"] = (
+            False  # Set to false because Pipecat creates a tool response from client
+        )
         settings.provider_data = provider_data
 
         await self.send_client_event(events.SessionUpdateEvent(session=settings))

--- a/tests/test_inworld_realtime_context.py
+++ b/tests/test_inworld_realtime_context.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Inworld Realtime context synchronization."""
+
+import unittest
+from unittest.mock import AsyncMock
+
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.services.inworld.realtime.llm import InworldRealtimeLLMService
+
+
+class TestInworldRealtimeContext(unittest.IsolatedAsyncioTestCase):
+    async def test_tool_update_does_not_consume_server_vad_user_turn(self):
+        context = LLMContext([{"role": "developer", "content": "Be helpful."}])
+        service = InworldRealtimeLLMService(api_key="test")
+        service._context = context
+        service._last_context_message_count = len(context.get_messages())
+        service._server_vad_handled_turn = True
+        service._process_completed_function_calls = AsyncMock()
+        service.send_client_event = AsyncMock()
+
+        context.add_messages(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": '{"temp": 22}'},
+            ]
+        )
+        await service._handle_context(context)
+
+        self.assertTrue(service._server_vad_handled_turn)
+        service.send_client_event.assert_not_awaited()
+
+        context.add_message({"role": "user", "content": "What is the weather?"})
+        await service._handle_context(context)
+
+        self.assertFalse(service._server_vad_handled_turn)
+        service.send_client_event.assert_not_awaited()
+        self.assertEqual(service._last_context_message_count, len(context.get_messages()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_realtime_service_tool_sync.py
+++ b/tests/test_realtime_service_tool_sync.py
@@ -206,6 +206,31 @@ class TestInworldRealtimeServiceToolSync(
             settings=mod.InworldRealtimeLLMService.Settings(session_properties=sp),
         )
 
+    async def test_session_update_serializes_provider_data(self):
+        mod = pytest.importorskip("pipecat.services.inworld.realtime.llm")
+        events = pytest.importorskip("pipecat.services.inworld.realtime.events")
+        provider_data = {"stt": {"voice_profile": True}}
+        sp = events.SessionProperties(provider_data=provider_data)
+        service = mod.InworldRealtimeLLMService(
+            api_key="test-key",
+            settings=mod.InworldRealtimeLLMService.Settings(session_properties=sp),
+        )
+        service._ws_send = AsyncMock()
+
+        await service._send_session_update()
+
+        message = service._ws_send.await_args.args[0]
+        self.assertNotIn("provider_data", message["session"])
+        self.assertEqual(
+            message["session"]["providerData"],
+            {
+                "stt": {"voice_profile": True},
+                "metadata": {"sdk": "pipecat-realtime"},
+                "auto_tool_response": False,
+            },
+        )
+        self.assertEqual(service._settings.session_properties.provider_data, provider_data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Correct providerData name. Disable auto tool handling on server by default. Fix a race condition

**Summary:**

1. Correct providerData name. 
2. Disable auto tool handling on server by default. Pipecat issues tool call continuation (the response.create after tool call output submission) automatically, so we should disable it.
3. Fix a race condition, where might cause a user tool call to be duplicated.

**Note:**

Please do not merge until Inworld prod release completes. (We will message via Slack)

**Update:**
It is safe to merge now as of Jul. 27, 2026.