### PR TITLE
perf(audio): cache the VAD loudness meter instead of rebuilding it per frame

### DIFF
--- a/changelog/5124.performance.md
+++ b/changelog/5124.performance.md
@@ -1,0 +1,1 @@
+- Cached the per-stream loudness meter used by the VAD volume gate so `calculate_audio_volume` no longer rebuilds a `pyloudnorm.Meter` (and regenerates its K-weighting filter coefficients) on every audio frame. Output is unchanged.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -122,6 +122,65 @@ def normalize_value(value, min_value, max_value):
     return normalized_clamped
 
 
+# Loudness meters keyed by (sample_rate, block_size). Both values fully
+# determine the meter and its K-weighting filters, so a meter can be reused
+# across calls instead of being rebuilt on every audio frame.
+_loudness_meters: dict[tuple[int, float], pyln.Meter] = {}
+
+
+def _const_coefficients(coefficients):
+    """Return a zero-argument callable that always yields ``coefficients``.
+
+    Used to freeze a pyloudnorm ``IIRfilter``'s coefficient generation so the
+    K-weighting biquads are computed once instead of on every access.
+
+    Args:
+        coefficients: The precomputed ``(b, a)`` biquad coefficients to return.
+
+    Returns:
+        A callable taking no arguments that returns ``coefficients``.
+    """
+    return lambda: coefficients
+
+
+def _get_loudness_meter(sample_rate: int, block_size: float) -> pyln.Meter:
+    """Return a cached loudness meter for a given sample rate and block size.
+
+    ``calculate_audio_volume`` runs on every VAD frame (~31 times per second per
+    audio stream), and a fresh :class:`pyloudnorm.Meter` was previously built on
+    each call. A meter depends only on ``(sample_rate, block_size)``, so it is
+    built once and reused.
+
+    ``pyloudnorm``'s ``IIRfilter.a`` and ``.b`` are properties that regenerate
+    the biquad coefficients on every access, and ``apply_filter`` reads both, so
+    the K-weighting coefficients were being recomputed four times per call. The
+    coefficients depend only on the filter's fixed construction parameters, so
+    they are memoized on the cached meter. The value returned by
+    :meth:`pyloudnorm.Meter.integrated_loudness` is unchanged.
+
+    Args:
+        sample_rate: Sample rate of the audio in Hz.
+        block_size: Loudness gating block size in seconds.
+
+    Returns:
+        A cached, reusable loudness meter.
+    """
+    meter = _loudness_meters.get((sample_rate, block_size))
+    if meter is None:
+        meter = pyln.Meter(sample_rate, block_size=block_size)
+        # Freeze each K-weighting filter's coefficients. If a future pyloudnorm
+        # changes these internals, the plain cached meter is still correct.
+        try:
+            for filter_stage in meter._filters.values():
+                filter_stage.generate_coefficients = _const_coefficients(
+                    filter_stage.generate_coefficients()
+                )
+        except (AttributeError, TypeError):
+            pass
+        _loudness_meters[(sample_rate, block_size)] = meter
+    return meter
+
+
 def calculate_audio_volume(audio: bytes, sample_rate: int) -> float:
     """Calculate the loudness level of audio data using EBU R128 standard.
 
@@ -139,7 +198,7 @@ def calculate_audio_volume(audio: bytes, sample_rate: int) -> float:
     audio_float = audio_np.astype(np.float64)
 
     block_size = audio_np.size / sample_rate
-    meter = pyln.Meter(sample_rate, block_size=block_size)
+    meter = _get_loudness_meter(sample_rate, block_size)
     loudness = meter.integrated_loudness(audio_float)
 
     # Loudness goes from -20 to 80 (more or less), where -20 is quiet and 80 is

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,102 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for :func:`pipecat.audio.utils.calculate_audio_volume`.
+
+The loudness gate runs on every VAD frame, so its output must stay identical
+after the meter/coefficient caching in ``_get_loudness_meter``. These tests pin
+``calculate_audio_volume`` to an independent per-call pyloudnorm reference (a
+fresh ``Meter`` built on every call, i.e. the pre-caching behavior) across
+representative and edge-case frames at both supported sample rates.
+"""
+
+import unittest
+
+import numpy as np
+import pyloudnorm as pyln
+
+from pipecat.audio.utils import calculate_audio_volume, normalize_value
+
+# Silero VAD frame sizes: 512 samples at 16 kHz and 256 at 8 kHz, both 32 ms.
+RATES = {16000: 512, 8000: 256}
+
+
+def _reference_volume(audio: bytes, sample_rate: int) -> float:
+    """Compute the volume with a fresh pyloudnorm Meter per call.
+
+    This mirrors the implementation before meter caching was introduced and is
+    used as the ground truth the cached implementation must match exactly.
+    """
+    audio_np = np.frombuffer(audio, dtype=np.int16)
+    audio_float = audio_np.astype(np.float64)
+    block_size = audio_np.size / sample_rate
+    meter = pyln.Meter(sample_rate, block_size=block_size)
+    loudness = meter.integrated_loudness(audio_float)
+    return normalize_value(loudness, -20, 80)
+
+
+def _make_frames(sample_rate: int, num_samples: int) -> dict:
+    """Build representative and edge-case single-frame PCM buffers."""
+    rng = np.random.default_rng(1234)
+    t = np.arange(num_samples) / sample_rate
+
+    spike = np.zeros(num_samples, dtype=np.int16)
+    spike[num_samples // 2] = 30000
+
+    speech = 3000 * (
+        np.sin(2 * np.pi * 140 * t)
+        + 0.5 * np.sin(2 * np.pi * 310 * t)
+        + 0.25 * np.sin(2 * np.pi * 900 * t)
+    ) + rng.normal(0, 80, num_samples)
+
+    cases = {
+        "digital_silence": np.zeros(num_samples, dtype=np.int16),
+        "single_sample_spike": spike,
+        "full_scale_dc": np.full(num_samples, 32767, dtype=np.int16),
+        "full_scale_alternating": np.where(np.arange(num_samples) % 2 == 0, 32767, -32768).astype(
+            np.int16
+        ),
+        "near_silence": np.clip(3 * np.sin(2 * np.pi * 200 * t), -32768, 32767).astype(np.int16),
+        "quiet_level": np.clip(
+            20 * np.sin(2 * np.pi * 200 * t) + rng.normal(0, 5, num_samples), -32768, 32767
+        ).astype(np.int16),
+        "dc_offset": np.full(num_samples, 100, dtype=np.int16),
+        "speech_like": np.clip(speech, -32768, 32767).astype(np.int16),
+    }
+    return {name: samples.tobytes() for name, samples in cases.items()}
+
+
+class TestCalculateAudioVolume(unittest.TestCase):
+    """Verify the cached loudness gate is bit-identical to the reference."""
+
+    def test_matches_pyloudnorm_reference(self):
+        """calculate_audio_volume must equal a fresh-Meter computation exactly."""
+        for sample_rate, num_samples in RATES.items():
+            for name, audio in _make_frames(sample_rate, num_samples).items():
+                with self.subTest(sample_rate=sample_rate, case=name):
+                    self.assertEqual(
+                        calculate_audio_volume(audio, sample_rate),
+                        _reference_volume(audio, sample_rate),
+                    )
+
+    def test_repeated_calls_are_stable(self):
+        """The cached meter must not accumulate state across successive frames."""
+        for sample_rate, num_samples in RATES.items():
+            audio = _make_frames(sample_rate, num_samples)["speech_like"]
+            first = calculate_audio_volume(audio, sample_rate)
+            for _ in range(5):
+                self.assertEqual(calculate_audio_volume(audio, sample_rate), first)
+
+    def test_digital_silence_normalizes_to_zero(self):
+        """All-zero audio must normalize to 0.0 (the -inf loudness path)."""
+        for sample_rate, num_samples in RATES.items():
+            audio = np.zeros(num_samples, dtype=np.int16).tobytes()
+            with self.subTest(sample_rate=sample_rate):
+                self.assertEqual(calculate_audio_volume(audio, sample_rate), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`calculate_audio_volume()` (`src/pipecat/audio/utils.py`) is the loudness gate that
runs inside every VAD frame — `VADAnalyzer._get_smoothed_volume` → `_run_analyzer`.
It constructed a fresh `pyloudnorm.Meter` on every call, and `pyloudnorm`'s
`IIRfilter.a`/`.b` are properties that regenerate the K-weighting biquad
coefficients on every access (`apply_filter` reads both), so the coefficients
were rebuilt four times per call.

This caches the `Meter` per `(sample_rate, block_size)` and memoizes its filters'
coefficient generation. Both depend only on the sample rate and block size, so
`Meter.integrated_loudness()` returns exactly the same value.

## Measured cost on the real path

With Silero VAD defaults the gate runs **31.25 times per second per audio stream**
(512 samples @ 16 kHz / 256 @ 8 kHz = a 32 ms frame), for the whole duration of
every call, speech or silence.

Per-call CPU via `time.process_time_ns` at 16 kHz/512 (measured on a shared host,
so the absolute microseconds carry roughly ±8%; the before/after arms are
interleaved back-to-back so the ratio is stable):

| | CPU per call | per second of audio (per analyzer) |
|---|---|---|
| before | ~165 µs | ~5.6 ms |
| after | ~115 µs | ~3.6 ms |
| saved | ~49 µs | ~1.6 ms |

For context, this gate is ~51% of `_run_analyzer`'s per-frame CPU — slightly more
than the Silero model inference itself (~168 µs/frame). Output is **bit-identical**
to before: verified across digital-silence, single-sample-spike, full-scale,
DC-offset, quiet and speech frames at both 8 kHz and 16 kHz. A regression test
pinning `calculate_audio_volume` to a fresh-`Meter` pyloudnorm reference across
those cases is included (there was no existing test for this function).

## Where this does and doesn't matter

The gate runs in a per-analyzer worker thread, not on the event loop, so this is
**not** a single-turn latency win — for one call the saving is small (~1.6 ms of
CPU per second of audio). Where it helps is aggregate CPU and concurrency headroom
for a server carrying many simultaneous VAD sessions. The cached meter is only
read (its `integrated_loudness` return value), so sharing it across analyzers at
the same sample rate is safe.

## Faster options I looked at and deliberately left out

- Because `block_size == frame duration` here, the BS.1770 gating collapses to a
  single block, so a closed-form loudness reaches ~4–5× and is still bit-identical
  — but it needs `scipy` as a direct dependency (pipecat doesn't currently import
  it) and reimplements the loudness math, so I kept `pyloudnorm` as the source of
  truth instead.
- A fused-biquad variant reaches ~9× but is not bit-identical (differs at ~1e-13),
  so it isn't a safe drop-in.
- Caching only the `Meter` without freezing coefficients is ~1.14×; the coefficient
  regeneration is the larger share, which is why this memoizes it too.

Full record of the exploration behind this change — 10 approaches implemented and
measured on the real path, including the ones that don't help — from an external
run I recorded while investigating:
https://dashboard.weco.ai/share/Mojo93QQGjh5vJSB6hwhuo8EVPp_0zzc
