### PR TITLE
Fixed handle_patch_request to handle RFC 8840 end-of-candidates markers.

### DIFF
--- a/changelog/5126.fixed.md
+++ b/changelog/5126.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SmallWebRTCTransport` PATCH `/api/offer` requests crashing with an `AssertionError` when the browser sends an RFC 8840 end-of-candidates marker (an empty candidate string) for a media line, as Firefox does on every connection. The marker is now forwarded to aiortc as `None` instead of being parsed as a regular candidate.

--- a/src/pipecat/transports/smallwebrtc/request_handler.py
+++ b/src/pipecat/transports/smallwebrtc/request_handler.py
@@ -248,9 +248,15 @@ class SmallWebRTCRequestHandler:
             raise HTTPException(status_code=404, detail="Peer connection not found")
 
         for c in request.candidates:
-            candidate = candidate_from_sdp(c.candidate)
-            candidate.sdpMid = c.sdp_mid
-            candidate.sdpMLineIndex = c.sdp_mline_index
+            if c.candidate:
+                candidate = candidate_from_sdp(c.candidate)
+                candidate.sdpMid = c.sdp_mid
+                candidate.sdpMLineIndex = c.sdp_mline_index
+            else:
+                # An empty candidate string is an RFC 8840 end-of-candidates marker
+                # (e.g. sent by Firefox per media line). aiortc signals this by
+                # passing `None` rather than a candidate with an empty SDP.
+                candidate = None
             await peer_connection.add_ice_candidate(candidate)
 
     async def close(self):


### PR DESCRIPTION
## Summary

- Fixed `SmallWebRTCTransport` PATCH `/api/offer` requests crashing with an `AssertionError` when the browser sends an RFC 8840 end-of-candidates marker (an empty candidate string) for a media line, as Firefox does on every connection. The marker is now forwarded to aiortc as `None` instead of being parsed as a regular candidate.

