### PR TITLE
Remove <Pause> from Twilio and Telnyx TeXML

### DIFF
--- a/changelog/5135.changed.md
+++ b/changelog/5135.changed.md
@@ -1,0 +1,1 @@
+- The TeXML served by the development runner for Twilio and Telnyx no longer includes a trailing `<Pause length="40"/>`. `<Connect><Stream>` holds the call for the duration of the WebSocket session, so the call now hangs up as soon as the stream ends instead of lingering for another 40 seconds.

--- a/src/pipecat/cli/templates/_readme_blocks/setup_telnyx.jinja2
+++ b/src/pipecat/cli/templates/_readme_blocks/setup_telnyx.jinja2
@@ -25,7 +25,6 @@ A TeXML Bin contains the XML that tells Telnyx how to handle incoming calls.
       <Connect>
         <Stream url="wss://your-url.ngrok.io/ws" bidirectionalMode="rtp"></Stream>
       </Connect>
-      <Pause length="40"/>
     </Response>
     ```
 
@@ -39,7 +38,6 @@ A TeXML Bin contains the XML that tells Telnyx how to handle incoming calls.
       <Connect>
         <Stream url="wss://api.pipecat.daily.co/ws/telnyx?serviceHost=AGENT_NAME.ORGANIZATION_NAME" bidirectionalMode="rtp"></Stream>
       </Connect>
-      <Pause length="40"/>
     </Response>
     ```
 

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -1343,14 +1343,12 @@ def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
   <Connect>
     <Stream url="wss://{args.proxy}/ws"></Stream>
   </Connect>
-  <Pause length="40"/>
 </Response>""",
             "telnyx": f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
     <Stream url="wss://{args.proxy}/ws" bidirectionalMode="rtp"></Stream>
   </Connect>
-  <Pause length="40"/>
 </Response>""",
             "plivo": f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>


### PR DESCRIPTION
## Summary

- Removed the trailing `<Pause length="40"/>` from the Twilio and Telnyx TeXML served by the development runner. `<Connect><Stream>` already holds the call for the life of the WebSocket session, so the pause only kept the call open for another 40 seconds after the bot hung up.
- Updated the Telnyx setup instructions in the `pipecat init` README template to match.

## Testing

- Start a bot with `-t twilio` or `-t telnyx` and place a call; the call should end as soon as the bot disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)