### PR TITLE
claude review

### DIFF
--- a/changelog/3415.added.md
+++ b/changelog/3415.added.md
@@ -1,0 +1,6 @@
+- Added support for clients sending files and images to the bot via the new RTVI `send-file` message, incorporating them into the LLM context.
+  - New frames: `FileRawFrame`, `InputFileRawFrame`, and `UserFileRawFrame` (parallel to the image frame hierarchy), carrying a file payload as bytes, a URL, or an upload ID.
+  - New `LLMContext` methods: `create_file_message()`, `create_file_url_message()`, and `add_file_frame_message()`, producing universal `file` (base64 data URL) and `file_url` content items translated per adapter (Anthropic, AWS Bedrock, Gemini, OpenAI Chat, OpenAI Responses). Unsupported MIME types or source combinations log a warning and are skipped.
+  - `RTVIProcessor` takes a new `uploads_folder` parameter for resolving `pipecat:<id>` file references produced by the upload endpoint.
+  - The development runner gains a `POST /files` upload endpoint (50 MB cap), enabled with the new `-u/--uploads-folder` flag; `--uploads-folder-max-files` (default 10) trims the oldest uploads.
+  - `LLMContext.maybe_remove_invalid_message()` removes a file message from context when OpenAI rejects it, preventing the context from getting permanently stuck.

--- a/changelog/3415.changed.2.md
+++ b/changelog/3415.changed.2.md
@@ -1,0 +1,1 @@
+- The minimum `aiohttp` version is now 3.14.0 (required by `google-genai` >= 2.8.0). Applications pinning `aiohttp<3.14` will need to update their pin.

--- a/changelog/3415.changed.md
+++ b/changelog/3415.changed.md
@@ -1,0 +1,1 @@
+- The RTVI protocol version is now 2.2.0, adding the `send-file` client message. Clients gate `sendFile()` on the bot advertising 2.2.0+.

--- a/changelog/3415.deprecated.md
+++ b/changelog/3415.deprecated.md
@@ -1,0 +1,1 @@
+- The development runner's `-f/--folder` flag is renamed to `--downloads-folder`; `--folder` remains as a deprecated alias.

--- a/src/pipecat/adapters/services/anthropic_adapter.py
+++ b/src/pipecat/adapters/services/anthropic_adapter.py
@@ -143,7 +143,9 @@ class AnthropicLLMAdapter(BaseLLMAdapter[AnthropicLLMInvocationParams]):
                     if item.get("type") == "thinking" and item.get("signature"):
                         item["signature"] = "..."
                     if item.get("type") == "document":
-                        item["source"]["data"] = "..."
+                        source = item.get("source")
+                        if isinstance(source, dict) and "data" in source:
+                            source["data"] = "..."
             messages_for_logging.append(msg)
         return messages_for_logging
 

--- a/src/pipecat/processors/aggregators/llm_context.py
+++ b/src/pipecat/processors/aggregators/llm_context.py
@@ -21,9 +21,8 @@ import io
 import wave
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, TypeAlias, TypeGuard, TypeVar, cast, get_args, overload
+from typing import Any, TypeAlias, TypeGuard, TypeVar, cast, overload
 
-import aiohttp
 from loguru import logger
 from openai._types import NOT_GIVEN as OPEN_AI_NOT_GIVEN
 from openai._types import NotGiven as OpenAINotGiven
@@ -200,7 +199,7 @@ class LLMContext:
         Args:
             role: The role of this message (defaults to "user").
             type: The type of the file (e.g., "bytes" or "url").
-            format: File format (MIME type) or "url" if the file is a URL.
+            format: MIME type of the file (e.g., "application/pdf").
             file: Base64 data URL (``data:<mime>;base64,...``) or plain URL string.
             name: Optional name of the file.
             text: Optional text to include with the file.
@@ -539,7 +538,7 @@ class LLMContext:
 
         Args:
             type: File source type ('bytes' or 'url').
-            format: MIME type of the file (e.g., 'application/pdf') or "url".
+            format: MIME type of the file (e.g., 'application/pdf').
             file: Base64 data URL (``data:<mime>;base64,...``) or plain URL string.
                 URL fetching for providers that require bytes is handled by the
                 provider adapter during message conversion.
@@ -584,9 +583,11 @@ class LLMContext:
         ):
             for i in range(len(self._messages) - 1, -1, -1):
                 message = self._messages[i]
-                content = getattr(message, "content", [])
+                if isinstance(message, LLMSpecificMessage):
+                    continue
+                content = message.get("content")
                 if isinstance(content, list) and any(
-                    item.get("type") == "file" for item in content
+                    isinstance(item, dict) and item.get("type") == "file" for item in content
                 ):
                     logger.warning(
                         "Removing message with file content from context due to invalid response."

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1884,7 +1884,6 @@ class LLMAssistantAggregator(LLMContextAggregator):
             text=frame.text,
             file=frame.file,
             name=frame.filename,
-            #            options=frame.custom_options,
         )
 
         await self.push_aggregation()

--- a/src/pipecat/processors/frameworks/rtvi/models.py
+++ b/src/pipecat/processors/frameworks/rtvi/models.py
@@ -30,7 +30,7 @@ from pipecat.frames.frames import (
 from pipecat.utils.deprecation import deprecated
 
 # -- Constants --
-PROTOCOL_VERSION = "2.1.0"
+PROTOCOL_VERSION = "2.2.0"
 
 # -- Version compatibility --
 # Any 1.x client is deprecated but still supported with the old bot-output format.

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -13,6 +13,7 @@ import re
 from collections.abc import Mapping
 from typing import Any, Optional
 
+import aiofiles
 import aiohttp
 from loguru import logger
 from pydantic import BaseModel, ValidationError
@@ -81,8 +82,9 @@ class RTVIProcessor(FrameProcessor):
                     downstream. For client-ready audio gating, set
                     ``audio_in_stream_on_start=False`` on the transport params.
             uploads_folder: Path to folder where client uploads (e.g. POST /files) are
-                stored; required for send-file with /files/ URLs. Use
-                runner_uploads_folder() when using the development runner.
+                stored; required for send-file messages that reference an uploaded
+                file ID (``pipecat:<id>``). Use runner_uploads_folder() when using
+                the development runner.
 
             **kwargs: Additional arguments passed to parent class.
         """
@@ -517,7 +519,11 @@ class RTVIProcessor(FrameProcessor):
 
         match file.source:
             case RTVI.FileBytes() as fs:
-                source = f"data:{file.format};base64,{fs.bytes}"
+                # `bytes` is raw base64, but tolerate clients that send a full data URL.
+                if fs.bytes.startswith("data:"):
+                    source = fs.bytes
+                else:
+                    source = f"data:{file.format};base64,{fs.bytes}"
             case RTVI.FileUrl() as fs:
                 if not fs.public:
                     if not fs.url.startswith(("http://", "https://")):
@@ -570,10 +576,16 @@ class RTVIProcessor(FrameProcessor):
                 # read bytes from file system, encode to base64, then delete the file
                 type = "bytes"
                 file_path = os.path.join(self._folder, suffix)
-                with open(file_path, "rb") as f:
-                    raw_bytes = f.read()
-                    encoded_file = base64.b64encode(raw_bytes).decode("utf-8")
-                    source = f"data:{file.format};base64,{encoded_file}"
+                try:
+                    async with aiofiles.open(file_path, "rb") as f:
+                        raw_bytes = await f.read()
+                except OSError as e:
+                    # Uploads are short-lived: the file may have been consumed or trimmed.
+                    logger.warning(f"Failed to read uploaded file {file_path}: {e}")
+                    await self._send_error_response(message_id, "File not found")
+                    return
+                encoded_file = base64.b64encode(raw_bytes).decode("utf-8")
+                source = f"data:{file.format};base64,{encoded_file}"
                 try:
                     os.remove(file_path)
                 except OSError as e:

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -1432,6 +1432,9 @@ def _setup_telephony_routes(app: FastAPI, args: argparse.Namespace, ws_used_toke
         await _handle_telephony_ws(websocket, path_token=token)
 
 
+_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+
+
 def _setup_file_uploads_route(app: FastAPI, args: argparse.Namespace):
     @app.post("/files")
     async def upload_file(file: UploadFile = File(...)):
@@ -1447,7 +1450,9 @@ def _setup_file_uploads_route(app: FastAPI, args: argparse.Namespace):
         safe_name = uuid.uuid4().hex
         file_path = folder / safe_name
         try:
-            contents = await file.read()
+            contents = await file.read(_MAX_UPLOAD_BYTES + 1)
+            if len(contents) > _MAX_UPLOAD_BYTES:
+                raise HTTPException(413, f"File exceeds {_MAX_UPLOAD_BYTES} byte limit")
             file_path.write_bytes(contents)
             logger.debug(f"Uploaded file to {file_path}")
         except OSError as e:
@@ -1457,6 +1462,7 @@ def _setup_file_uploads_route(app: FastAPI, args: argparse.Namespace):
         # Use original filename only for format/mime in response
         original_name = Path(file.filename or "").name
         media_type, _ = mimetypes.guess_type(original_name, strict=False)
+        media_type = media_type or file.content_type or "application/octet-stream"
         # Return the file as a URL that can be used in the client, matching the format of RTVIFile
         return {
             "name": original_name,

--- a/tests/test_llm_context.py
+++ b/tests/test_llm_context.py
@@ -431,5 +431,51 @@ class TestCreateFileMessage(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(messages[0]["content"][0]["file"]["filename"], "test.pdf")
 
 
+class TestMaybeRemoveInvalidMessage(unittest.IsolatedAsyncioTestCase):
+    """Tests for LLMContext.maybe_remove_invalid_message."""
+
+    def _file_error(self) -> Exception:
+        e = Exception("invalid file")
+        e.type = "invalid_request_error"
+        e.param = "file_id"
+        return e
+
+    async def _context_with_file_message(self) -> LLMContext:
+        context = LLMContext()
+        context.add_message({"role": "user", "content": "hello"})
+        await context.add_file_frame_message(
+            type="bytes", format="application/pdf", file="data:application/pdf;base64,abc123"
+        )
+        return context
+
+    async def test_removes_most_recent_file_message(self):
+        context = await self._context_with_file_message()
+        context.maybe_remove_invalid_message(self._file_error())
+
+        messages = context.get_messages()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["content"], "hello")
+
+    async def test_ignores_unrelated_exception(self):
+        context = await self._context_with_file_message()
+        context.maybe_remove_invalid_message(Exception("boom"))
+
+        self.assertEqual(len(context.get_messages()), 2)
+
+    async def test_skips_llm_specific_and_string_content_messages(self):
+        context = LLMContext(
+            messages=[
+                LLMSpecificMessage(
+                    llm="openai",
+                    message={"role": "user", "content": [{"type": "file", "file": {}}]},
+                ),
+                {"role": "user", "content": "plain text"},
+            ]
+        )
+        context.maybe_remove_invalid_message(self._file_error())
+
+        self.assertEqual(len(context.get_messages()), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rtvi_processor.py
+++ b/tests/test_rtvi_processor.py
@@ -490,6 +490,45 @@ class TestRTVISendFile(unittest.IsolatedAsyncioTestCase):
         self.processor._send_error_response.assert_called_once()
         self.assertEqual(len(self._pushed_frames()), 0)
 
+    async def test_file_id_missing_file_sends_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.processor._folder = tmpdir
+            data = self._make_send_file_data(
+                RTVI.FileId(id=f"pipecat:{uuid.uuid4().hex}"), fmt="application/pdf"
+            )
+            await self.processor._handle_send_file(data, "msg-1")
+
+        self.processor._send_error_response.assert_called_once()
+        error_msg = self.processor._send_error_response.call_args[0][1]
+        self.assertIn("not found", error_msg)
+        self.assertEqual(len(self._pushed_frames()), 0)
+
+    # -- FileBytes carrying a full data URL -----------------------------------
+
+    async def test_file_bytes_data_url_not_double_wrapped(self):
+        raw = b"%PDF-1.4 fake content"
+        b64 = base64.b64encode(raw).decode()
+        data_url = f"data:application/pdf;base64,{b64}"
+        data = self._make_send_file_data(RTVI.FileBytes(bytes=data_url), fmt="application/pdf")
+        await self.processor._handle_send_file(data, "msg-1")
+
+        frames = self._pushed_frames()
+        self.assertEqual(len(frames), 1)
+        self.assertIsInstance(frames[0], UserFileRawFrame)
+        self.assertEqual(frames[0].file, data_url)
+
+    async def test_file_bytes_image_data_url_decodes_to_raw_bytes(self):
+        raw = b"\x89PNG\r\n\x1a\n fake png"
+        b64 = base64.b64encode(raw).decode()
+        data_url = f"data:image/png;base64,{b64}"
+        data = self._make_send_file_data(RTVI.FileBytes(bytes=data_url), fmt="image/png")
+        await self.processor._handle_send_file(data, "msg-1")
+
+        frames = self._pushed_frames()
+        self.assertEqual(len(frames), 1)
+        self.assertIsInstance(frames[0], UserImageRawFrame)
+        self.assertEqual(frames[0].image, raw)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  - rtvi/models.py: PROTOCOL_VERSION 2.1.0 → 2.2.0 (verified the negotiation code only compares majors, so this is safe, and BotReady now advertises what the client gate needs).
  - llm_context.py: fixed maybe_remove_invalid_message to use .get("content") on dict messages and skip LLMSpecificMessage (it previously could never match anything); removed unused aiohttp/get_args imports; fixed the two misleading format docstrings.
  - rtvi/processor.py: FileBytes now tolerates a full data URL in bytes (no more double-wrapping); the FileId path reads via aiofiles and returns a clean "File not found" error instead of leaking the filesystem path; uploads_folder docstring corrected.
  - runner/run.py: POST /files now caps uploads at 50 MB (413 above it) and falls back to file.content_type / application/octet-stream when the MIME type can't be guessed (was returning format: null).
  - anthropic_adapter.py: document log-redaction only touches source.data when it exists.
  - Removed the commented-out options=frame.custom_options line in the aggregator.
  - New tests: 3 for maybe_remove_invalid_message, 3 for the data-URL and missing-file RTVI paths. Added towncrier changelog entries (3415.added/changed/changed.2/deprecated) — verified they render.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.