### PR TITLE
Add opt-in interim retranscription to SegmentedSTTService

### DIFF
--- a/changelog/5143.added.md
+++ b/changelog/5143.added.md
@@ -1,0 +1,1 @@
+- Added opt-in interim retranscriptions to `SegmentedSTTService`, with initial support in `WhisperSTTService` through a separately configurable interim model.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import io
+import math
 import time
 import warnings
 import wave
@@ -24,6 +25,7 @@ from pipecat.frames.frames import (
     EndFrame,
     ErrorFrame,
     Frame,
+    InterimTranscriptionFrame,
     InterruptionFrame,
     LLMContextAssistantTurnFrame,
     ServiceSwitcherRequestMetadataFrame,
@@ -44,6 +46,7 @@ from pipecat.services.stt_latency import DEFAULT_TTFS_P99
 from pipecat.services.websocket_service import WebsocketService
 from pipecat.transcriptions.language import Language
 from pipecat.utils.deprecation import deprecated
+from pipecat.utils.time import time_now_iso8601
 
 # Duration in seconds of silent audio sent for WebSocket keepalive (100ms).
 _KEEPALIVE_SILENCE_DURATION = 0.1
@@ -784,22 +787,44 @@ class SegmentedSTTService(STTService):
     :attr:`wants_wav_segments` to return ``False`` so they receive the
     unwrapped buffer instead. This is a subclass-level contract, not a
     user-configurable option: the format is dictated by what the model expects.
+
+    Subclasses can provide interim transcriptions by implementing :meth:`run_interim_stt`.
+    When ``interim_interval`` is set, the buffered segment is periodically re-transcribed
+    while the user is speaking. Each pass processes the complete segment buffered so far,
+    so the aggregate work grows quadratically with the utterance length.
     """
 
-    def __init__(self, *, sample_rate: int | None = None, **kwargs):
+    def __init__(
+        self,
+        *,
+        sample_rate: int | None = None,
+        interim_interval: float | None = None,
+        **kwargs,
+    ):
         """Initialize the segmented STT service.
 
         Args:
             sample_rate: The sample rate for audio input. If None, will be determined
                 from the start frame.
+            interim_interval: Seconds between interim transcriptions while the user is
+                speaking. None disables interim transcriptions. Requires the subclass to
+                implement :meth:`run_interim_stt`.
             **kwargs: Additional arguments passed to the parent STTService.
         """
+        if interim_interval is not None and (
+            not math.isfinite(interim_interval) or interim_interval <= 0
+        ):
+            raise ValueError("interim_interval must be a finite value greater than zero")
+
         super().__init__(sample_rate=sample_rate, **kwargs)
         self._content = None
         self._wave = None
         self._audio_buffer = bytearray()
         self._audio_buffer_size_1s = 0
         self._user_speaking = False
+
+        self._interim_interval = interim_interval
+        self._interim_task: asyncio.Task | None = None
 
     async def start(self, frame: StartFrame):
         """Start the segmented STT service and initialize audio buffer.
@@ -809,6 +834,29 @@ class SegmentedSTTService(STTService):
         """
         await super().start(frame)
         self._audio_buffer_size_1s = self.sample_rate * 2
+
+    async def stop(self, frame: EndFrame):
+        """Stop the service and any in-flight interim transcription.
+
+        Args:
+            frame: The end frame.
+        """
+        await self._cancel_interim_task()
+        await super().stop(frame)
+
+    async def cancel(self, frame: CancelFrame):
+        """Cancel the service and any in-flight interim transcription.
+
+        Args:
+            frame: The cancel frame.
+        """
+        await self._cancel_interim_task()
+        await super().cancel(frame)
+
+    async def cleanup(self):
+        """Release resources owned by the segmented STT service."""
+        await self._cancel_interim_task()
+        await super().cleanup()
 
     @property
     def wants_wav_segments(self) -> bool:
@@ -847,33 +895,91 @@ class SegmentedSTTService(STTService):
     async def _handle_user_started_speaking(self, frame: VADUserStartedSpeakingFrame):
         self._user_speaking = True
 
+        if self._interim_interval is not None and self._interim_task is None:
+            self._interim_task = self.create_task(self._interim_task_handler(), "interim_stt")
+
     async def _handle_user_stopped_speaking(self, frame: VADUserStoppedSpeakingFrame):
         self._user_speaking = False
+
+        await self._cancel_interim_task()
 
         # Report usage for the raw segment before transcription so tracing can
         # attach it to the STT span the resulting TranscriptionFrame closes.
         self._record_stt_audio_usage(self._audio_buffer)
         await self.emit_stt_usage_metrics()
 
-        if self.wants_wav_segments:
-            content = io.BytesIO()
-            wav = wave.open(content, "wb")
-            wav.setsampwidth(2)
-            wav.setnchannels(1)
-            wav.setframerate(self.sample_rate)
-            wav.writeframes(self._audio_buffer)
-            wav.close()
-            content.seek(0)
-            audio = content.read()
-        else:
-            # Local models read the buffer as raw 16-bit PCM; wrapping it in a
-            # WAV container would make them misread the 44-byte header as audio.
-            audio = bytes(self._audio_buffer)
+        audio = self._segment_audio(bytes(self._audio_buffer))
 
         # Start clean.
         self._audio_buffer.clear()
 
         await self.process_generator(self.run_stt(audio))
+
+    def _segment_audio(self, audio: bytes) -> bytes:
+        """Format a buffered segment per the :attr:`wants_wav_segments` contract."""
+        if not self.wants_wav_segments:
+            # Local models read the buffer as raw 16-bit PCM; wrapping it in a
+            # WAV container would make them misread the 44-byte header as audio.
+            return audio
+
+        content = io.BytesIO()
+        wav = wave.open(content, "wb")
+        wav.setsampwidth(2)
+        wav.setnchannels(1)
+        wav.setframerate(self.sample_rate)
+        wav.writeframes(audio)
+        wav.close()
+        content.seek(0)
+        return content.read()
+
+    async def _cancel_interim_task(self):
+        """Stop the interim transcription task if running."""
+        if self._interim_task:
+            await self.cancel_task(self._interim_task)
+            self._interim_task = None
+
+    async def _interim_task_handler(self):
+        """Periodically re-transcribe the buffered audio while the user speaks."""
+        interval = self._interim_interval
+        if interval is None:
+            return
+
+        last_text = ""
+        while True:
+            await asyncio.sleep(interval)
+
+            audio = bytes(self._audio_buffer)
+            if not audio:
+                continue
+
+            try:
+                text = await self.run_interim_stt(self._segment_audio(audio))
+            except NotImplementedError:
+                logger.warning(
+                    f"{self}: interim_interval is set but run_interim_stt is not implemented"
+                )
+                return
+            except Exception as e:
+                logger.warning(f"{self}: interim transcription failed: {e}")
+                continue
+
+            if text and text != last_text:
+                last_text = text
+                language = self._settings.language if is_given(self._settings.language) else None
+                await self.push_frame(
+                    InterimTranscriptionFrame(text, self._user_id, time_now_iso8601(), language)
+                )
+
+    async def run_interim_stt(self, audio: bytes) -> str | None:
+        """Transcribe buffered audio for an interim result.
+
+        Args:
+            audio: Audio formatted according to :attr:`wants_wav_segments`.
+
+        Returns:
+            The interim transcription, or None if nothing was transcribed.
+        """
+        raise NotImplementedError("Subclasses must implement run_interim_stt")
 
     async def process_audio_frame(self, frame: AudioRawFrame, direction: FrameDirection):
         """Process audio frames by buffering them for segmented transcription.

--- a/src/pipecat/services/whisper/stt.py
+++ b/src/pipecat/services/whisper/stt.py
@@ -27,6 +27,8 @@ from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
 
+_MIN_INTERIM_AUDIO_SECONDS = 0.5
+
 try:
     from faster_whisper import WhisperModel
 except ModuleNotFoundError as e:
@@ -213,6 +215,22 @@ class WhisperSTTService(SegmentedSTTService):
 
     This service uses Faster Whisper to perform speech-to-text transcription on audio
     segments. It supports multiple languages and various model sizes.
+
+    Supports opt-in interim transcriptions: pass ``interim_interval`` to
+    periodically re-transcribe the buffered segment with a separate interim
+    model (``interim_model``, default ``tiny``) while the user speaks.
+    Whisper has no incremental decoding mode, so each pass re-transcribes the
+    whole segment buffered so far; keep the interim model small.
+
+    Example::
+
+        stt = WhisperSTTService(
+            interim_interval=0.25,
+            interim_model=Model.TINY,
+            settings=WhisperSTTService.Settings(
+                model=Model.DISTIL_MEDIUM_EN,
+            ),
+        )
     """
 
     Settings = WhisperSTTSettings
@@ -227,6 +245,7 @@ class WhisperSTTService(SegmentedSTTService):
         self,
         *,
         model: str | Model | None = None,
+        interim_model: str | Model = Model.TINY,
         device: str = "auto",
         compute_type: str = "default",
         no_speech_prob: float | None = None,
@@ -243,6 +262,9 @@ class WhisperSTTService(SegmentedSTTService):
                     Use ``settings=WhisperSTTService.Settings(model=...)`` instead.
                     Will be removed in 2.0.0.
 
+            interim_model: The init-only Whisper model used for interim
+                transcriptions. Should be small enough to transcribe the buffered
+                segment within ``interim_interval``.
             device: The device to run inference on ('cpu', 'cuda', or 'auto').
                 Defaults to ``"auto"``.
             compute_type: The compute type for inference ('default', 'int8',
@@ -297,8 +319,15 @@ class WhisperSTTService(SegmentedSTTService):
         self._compute_type = compute_type
 
         self._model: WhisperModel | None = None
+        self._interim_model: WhisperModel | None = None
 
         self._load()
+        if self._interim_interval is not None:
+            self._interim_model = WhisperModel(
+                interim_model.value if isinstance(interim_model, Model) else interim_model,
+                device=self._device,
+                compute_type=self._compute_type,
+            )
 
     def can_generate_metrics(self) -> bool:
         """Indicates whether this service can generate metrics.
@@ -340,6 +369,44 @@ class WhisperSTTService(SegmentedSTTService):
         """Handle a transcription result with tracing."""
         pass
 
+    async def run_interim_stt(self, audio: bytes) -> str | None:
+        """Transcribe the audio buffered so far with the interim model.
+
+        Args:
+            audio: Raw audio bytes in 16-bit PCM format.
+
+        Returns:
+            The partial transcription, or None if nothing was transcribed.
+        """
+        if not self._interim_model:
+            return None
+
+        min_audio_bytes = int(self.sample_rate * _MIN_INTERIM_AUDIO_SECONDS * 2)
+        if len(audio) < min_audio_bytes:
+            return None
+
+        return await self._transcribe(self._interim_model, audio)
+
+    async def _transcribe(self, model: WhisperModel, audio: bytes) -> str | None:
+        """Transcribe raw PCM audio with the provided Whisper model."""
+
+        def transcribe() -> str | None:
+            # Divide by 32768 because we have signed 16-bit data.
+            audio_float = np.frombuffer(audio, dtype=np.int16).astype(np.float32) / 32768.0
+            language = assert_given(self._settings.language)
+            no_speech_prob_threshold = assert_given(self._settings.no_speech_prob)
+            segments, _ = model.transcribe(audio_float, language=language)
+            text = ""
+            for segment in segments:
+                if (
+                    no_speech_prob_threshold is not None
+                    and segment.no_speech_prob < no_speech_prob_threshold
+                ):
+                    text += f"{segment.text} "
+            return text or None
+
+        return await asyncio.to_thread(transcribe)
+
     async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
         """Transcribe audio data using Whisper.
 
@@ -359,23 +426,8 @@ class WhisperSTTService(SegmentedSTTService):
             return
 
         await self.start_processing_metrics()
-
-        # Divide by 32768 because we have signed 16-bit data.
-        audio_float = np.frombuffer(audio, dtype=np.int16).astype(np.float32) / 32768.0
-
         language = assert_given(self._settings.language)
-        segments, _ = await asyncio.to_thread(
-            self._model.transcribe, audio_float, language=language
-        )
-        text: str = ""
-        no_speech_prob_threshold = assert_given(self._settings.no_speech_prob)
-        for segment in segments:
-            if (
-                no_speech_prob_threshold is not None
-                and segment.no_speech_prob < no_speech_prob_threshold
-            ):
-                text += f"{segment.text} "
-
+        text = await self._transcribe(self._model, audio)
         await self.stop_processing_metrics()
 
         if text:
@@ -440,6 +492,9 @@ class WhisperSTTServiceMLX(WhisperSTTService):
                 parameters, ``settings`` values take precedence.
             **kwargs: Additional arguments passed to SegmentedSTTService.
         """
+        if kwargs.get("interim_interval") is not None:
+            raise ValueError("WhisperSTTServiceMLX does not support interim transcriptions")
+
         # --- 1. Hardcoded defaults ---
         default_settings = self.Settings(
             model=MLXModel.TINY.value,

--- a/tests/test_segmented_stt.py
+++ b/tests/test_segmented_stt.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 import io
 import wave
 from collections.abc import AsyncGenerator
@@ -13,11 +14,15 @@ import pytest
 from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
+    InterimTranscriptionFrame,
+    TranscriptionFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.services.stt_service import SegmentedSTTService
-from pipecat.tests.utils import run_test
+from pipecat.tests.utils import SleepFrame, run_test
+from pipecat.utils.asyncio.task_manager import TaskManager
+from pipecat.utils.time import time_now_iso8601
 
 SAMPLE_RATE = 16000
 # Distinct, non-zero 16-bit samples so a misread WAV header would be obvious.
@@ -124,3 +129,188 @@ async def test_segment_emits_usage_for_raw_buffer_duration():
     ]
     assert len(usage_data) == 1
     assert usage_data[0].value.audio_seconds == pytest.approx(len(PCM) / (SAMPLE_RATE * 2))
+
+
+def _make_interim_service(
+    wants_wav: bool = False,
+    *,
+    interim_interval: float = 0.05,
+    interim_failures: int = 0,
+    **kwargs,
+) -> SegmentedSTTService:
+    """Build a SegmentedSTTService with interim transcriptions enabled.
+
+    Defined as a factory (not a module-level class) so this concrete subclass
+    isn't picked up by the service-discovery scan in test_service_init.py.
+    The interim stub returns text that changes as the buffer grows, so dedup
+    behavior can be asserted; the final stub returns a fixed transcript.
+    """
+
+    class _InterimSegmentedSTTService(SegmentedSTTService):
+        def __init__(self):
+            super().__init__(sample_rate=SAMPLE_RATE, interim_interval=interim_interval, **kwargs)
+            self.interim_audio: list[bytes] = []
+            self._interim_failures_remaining = interim_failures
+
+        async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+            yield TranscriptionFrame("final transcript", "", time_now_iso8601(), None)
+
+        async def run_interim_stt(self, audio: bytes) -> str | None:
+            self.interim_audio.append(audio)
+            if self._interim_failures_remaining:
+                self._interim_failures_remaining -= 1
+                raise RuntimeError("transient interim failure")
+            await asyncio.sleep(0.01)
+            return f"partial after {len(audio)} bytes"
+
+    _InterimSegmentedSTTService.wants_wav_segments = property(lambda self: wants_wav)
+
+    return _InterimSegmentedSTTService()
+
+
+@pytest.mark.asyncio
+async def test_interims_while_speaking_then_finalized_transcription():
+    service = _make_interim_service()
+
+    down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.15),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    interims = [f for f in down if isinstance(f, InterimTranscriptionFrame)]
+    finals = [f for f in down if isinstance(f, TranscriptionFrame)]
+
+    assert len(interims) >= 1
+    assert len(finals) == 1
+    assert finals[0].text == "final transcript"
+    assert finals[0].finalized
+
+    # Interims must precede the final transcription.
+    assert down.index(interims[-1]) < down.index(finals[0])
+
+
+@pytest.mark.asyncio
+async def test_identical_consecutive_interims_are_deduplicated():
+    service = _make_interim_service()
+
+    # A single audio frame: the buffer stops growing, so every interim pass
+    # after the first returns identical text and must not be re-pushed.
+    down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.2),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    interims = [f.text for f in down if isinstance(f, InterimTranscriptionFrame)]
+    assert len(service.interim_audio) >= 2
+    assert interims == [f"partial after {len(PCM)} bytes"]
+
+
+@pytest.mark.asyncio
+async def test_no_interims_after_user_stops_speaking():
+    service = _make_interim_service()
+
+    down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.12),
+            VADUserStoppedSpeakingFrame(),
+            # Audio keeps arriving after the turn (e.g. background noise); the
+            # interim task must be gone and push nothing for it.
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.15),
+        ],
+    )
+
+    finals = [f for f in down if isinstance(f, TranscriptionFrame)]
+    assert len(finals) == 1
+
+    assert [f for f in down if isinstance(f, InterimTranscriptionFrame)]
+    after_final = down[down.index(finals[0]) + 1 :]
+    assert not [f for f in after_final if isinstance(f, InterimTranscriptionFrame)]
+
+
+@pytest.mark.asyncio
+async def test_interim_audio_follows_wav_segment_contract():
+    service = _make_interim_service(wants_wav=True)
+
+    await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.12),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    assert service.interim_audio
+    # run_interim_stt receives segments in the same format as run_stt.
+    with wave.open(io.BytesIO(service.interim_audio[0]), "rb") as wav:
+        assert wav.getframerate() == SAMPLE_RATE
+        assert wav.readframes(wav.getnframes()) == PCM
+
+
+@pytest.mark.asyncio
+async def test_interims_disabled_by_default():
+    # run_stt-only subclass: run_interim_stt stays unimplemented and must
+    # never be called when interim_interval isn't set.
+    service = _make_capturing_service(wants_wav=False)
+
+    down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    assert not [f for f in down if isinstance(f, InterimTranscriptionFrame)]
+
+
+@pytest.mark.parametrize("interim_interval", [0.0, -0.1, float("nan"), float("inf")])
+def test_interim_interval_must_be_finite_and_positive(interim_interval: float):
+    with pytest.raises(ValueError, match="finite value greater than zero"):
+        _make_interim_service(interim_interval=interim_interval)
+
+
+@pytest.mark.asyncio
+async def test_transient_interim_failure_does_not_stop_later_interims():
+    service = _make_interim_service(interim_failures=1)
+
+    down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.15),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    assert len(service.interim_audio) >= 2
+    assert [f for f in down if isinstance(f, InterimTranscriptionFrame)]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_interim_task():
+    service = _make_interim_service(task_manager=TaskManager())
+    task = service.create_task(service._interim_task_handler(), "interim_stt")
+    service._interim_task = task
+
+    await service.cleanup()
+
+    assert service._interim_task is None
+    assert task.cancelled()

--- a/tests/test_whisper_stt.py
+++ b/tests/test_whisper_stt.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import pytest
+
+from pipecat.frames.frames import (
+    InputAudioRawFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.services.whisper import stt as whisper_stt
+from pipecat.services.whisper.stt import Model, WhisperSTTService, WhisperSTTServiceMLX
+from pipecat.tests.utils import SleepFrame, run_test
+
+SAMPLE_RATE = 16000
+# 16-bit mono PCM: 2 bytes per sample.
+ONE_SECOND_PCM = b"\x01\x02" * SAMPLE_RATE
+
+
+def _make_service(monkeypatch, **kwargs) -> tuple[WhisperSTTService, list]:
+    """Build a WhisperSTTService with stubbed model instances."""
+
+    models = []
+
+    class _Segment:
+        no_speech_prob = 0.0
+
+        def __init__(self, text: str):
+            self.text = text
+
+    class _FakeWhisperModel:
+        def __init__(self, model_name, **kwargs):
+            self.model_name = model_name
+            self.transcribe_calls = 0
+            models.append(self)
+
+        def transcribe(self, audio, *, language):
+            self.transcribe_calls += 1
+            text = (
+                "final transcript"
+                if self.model_name == Model.DISTIL_MEDIUM_EN.value
+                else "interim transcript"
+            )
+            return iter([_Segment(text)]), None
+
+    monkeypatch.setattr(whisper_stt, "WhisperModel", _FakeWhisperModel)
+    return WhisperSTTService(sample_rate=SAMPLE_RATE, **kwargs), models
+
+
+@pytest.mark.asyncio
+async def test_interims_use_interim_model_and_final_uses_final_model(monkeypatch):
+    service, models = _make_service(monkeypatch, interim_interval=0.2, interim_model=Model.BASE)
+
+    interim = await service.run_interim_stt(ONE_SECOND_PCM)
+    finals = [frame async for frame in service.run_stt(ONE_SECOND_PCM)]
+
+    assert len(models) == 2
+    assert models[1].model_name == Model.BASE.value
+    assert interim == "interim transcript "
+    assert len(finals) == 1
+    assert isinstance(finals[0], TranscriptionFrame)
+    assert finals[0].text == "final transcript "
+
+
+@pytest.mark.asyncio
+async def test_no_interim_model_loaded_when_disabled(monkeypatch):
+    service, models = _make_service(monkeypatch)
+
+    assert service._interim_model is None
+    assert len(models) == 1
+
+
+@pytest.mark.asyncio
+async def test_short_audio_skips_interim_transcription(monkeypatch):
+    service, models = _make_service(monkeypatch, interim_interval=0.2)
+    short_audio = b"\x01\x02" * (SAMPLE_RATE // 2 - 1)
+
+    await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=short_audio, sample_rate=SAMPLE_RATE, num_channels=1),
+            SleepFrame(sleep=0.25),
+            VADUserStoppedSpeakingFrame(),
+        ],
+    )
+
+    assert models[1].transcribe_calls == 0
+
+
+def test_mlx_rejects_interim_transcriptions():
+    with pytest.raises(ValueError, match="does not support interim transcriptions"):
+        WhisperSTTServiceMLX(interim_interval=0.2)


### PR DESCRIPTION
Fixes #5142.

Adds an opt-in interim-retranscription capability to `SegmentedSTTService`, implementing the shape @markbackman suggested when closing #5010: a shared capability any segmented service can adopt, rather than a Whisper-specific "streaming" service. This is periodic retranscription of the VAD-gated buffer & not streaming or incremental decoding.

## How it works

- `SegmentedSTTService` gains an `interim_interval: float | None = None` constructor parameter (following the `keepalive_timeout` pattern on `STTService`) and a `run_interim_stt(audio) -> str | None` subclass hook.
- While VAD reports the user speaking, the base class periodically snapshots the buffered segment, formats it per the existing `wants_wav_segments` contract (identical to what `run_stt` receives), and pushes changed results as deduplicated `InterimTranscriptionFrame`s.
- The interim task starts on `VADUserStartedSpeakingFrame` and is cancelled before final transcription on `VADUserStoppedSpeakingFrame`, and during `stop()`, `cancel()`, and `cleanup()` so interims can never trail the final transcript.
- With `interim_interval=None` (the default) there is no interim task, no extra model, and no behavior change for existing services. Final transcription, processing metrics, and STT TTFB tracking (which keys on `TranscriptionFrame` only) are unaffected either way.
- Transient interim inference failures are logged and retried on the next interval. A non-finite or non-positive `interim_interval` raises `ValueError` at construction.

## First implementation: `WhisperSTTService`

```python
stt = WhisperSTTService(
    interim_interval=0.25,
    interim_model=Model.TINY,
    settings=WhisperSTTService.Settings(model=Model.DISTIL_MEDIUM_EN),
)
```

- An init-only `interim_model` parameter (default `tiny`, alongside the existing init-only `device`/`compute_type`) names a separate Faster Whisper model, loaded only when interims are enabled.
- Interim passes skip inference until 0.5 s of audio is buffered, since Whisper mostly hallucinates on shorter segments.
- Interim and final passes share a `_transcribe()` helper, which also consumes Faster Whisper's lazy segment iterator inside the worker thread instead of on the event loop.
- Each pass retranscribes the complete buffered segment, so aggregate work grows roughly quadratically with utterance duration for a fixed interval — hence opt-in, with the interval and interim model independently configurable. A LocalAgreement-style prefix-commit strategy is a possible follow-up optimization.

## Out of scope

`WhisperSTTServiceMLX` explicitly rejects `interim_interval` for now (it bypasses Faster Whisper model loading). MLX Whisper, Moonshine, and other segmented implementations can adopt the shared hook in follow-up changes.

## Testing

- New tests in `tests/test_segmented_stt.py` and `tests/test_whisper_stt.py` cover interim→final ordering, deduplication, VAD and lifecycle cancellation, WAV/raw-PCM contracts, disabled-by-default behavior, recovery after transient failures, interval validation, Whisper final/interim model routing, the minimum-audio guard, and MLX rejection (18 tests).

### Live demo

It compares the original behavior with the modified implementation, where interim models are passed to Whisper as options, allowing interim transcriptions to be displayed before finalization.

https://www.loom.com/share/b9112374c6424fc3a132ea1bf4951952
