### PR TITLE
Voice completions from application-requested LLM runs

### DIFF
--- a/changelog/5146.fixed.md
+++ b/changelog/5146.fixed.md
@@ -1,0 +1,1 @@
+- Fixed responses to `LLMMessagesAppendFrame(..., run_llm=True)` being silently dropped when `filter_incomplete_user_turns` is enabled and the bot had already responded in the current user turn. The response was generated but never spoken, with nothing logged — most visibly breaking user-idle re-prompts, where an escalation ladder ended the session with an unspoken goodbye.

--- a/examples/turn-management/turn-management-filter-incomplete-turns-user-idle.py
+++ b/examples/turn-management/turn-management-filter-incomplete-turns-user-idle.py
@@ -1,0 +1,212 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Example 22: Filter Incomplete Turns with User Idle Re-Prompts
+
+Combines LLM-based turn completion detection with user idle detection.
+
+Turn completion detection suppresses bot responses when the user was cut off
+mid-thought. The LLM outputs one of three markers:
+- ✓ (complete): User finished their thought, respond normally
+- ○ (incomplete short): User was cut off, wait ~5s then prompt
+- ◐ (incomplete long): User needs time to think, wait ~10s then prompt
+
+Idle detection covers the other kind of silence: the user said nothing at all
+since the bot stopped speaking. After `user_idle_timeout` seconds the
+`on_user_turn_idle` event fires and the bot appends a developer message asking
+the LLM to check in, with `run_llm=True` to run inference right away. That
+response carries a marker like any other, and is spoken when it is ✓.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import LLMMessagesAppendFrame, LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    AssistantTurnStoppedMessage,
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+    UserTurnStoppedMessage,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.turns.user_turn_strategies import FilterIncompleteUserTurnStrategies
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+
+    llm = OpenAILLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        settings=OpenAILLMService.Settings(
+            system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
+        ),
+    )
+
+    tts = CartesiaTTSService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaTTSService.Settings(
+            voice="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+        ),
+    )
+
+    context = LLMContext()
+    # `FilterIncompleteUserTurnStrategies` pairs the default detector
+    # chain with `LLMTurnCompletionUserTurnStopStrategy`: detectors
+    # trigger LLM inference but the public `on_user_turn_stopped` event
+    # fires only when the LLM confirms ✓. The LLM marks each response
+    # with one of:
+    # ✓ = complete (respond normally)
+    # ○ = incomplete short (wait 5s, then prompt)
+    # ◐ = incomplete long (wait 10s, then prompt)
+    #
+    # `user_idle_timeout` is measured from the moment the bot stops speaking, so
+    # it should leave more room than the ○/◐ timeouts above: those cover a user
+    # who is mid-turn, this one a user who never started.
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(
+            vad_analyzer=SileroVADAnalyzer(),
+            user_idle_timeout=8.0,
+            user_turn_strategies=FilterIncompleteUserTurnStrategies(
+                # Optional: customize turn completion behavior
+                # config=UserTurnCompletionConfig(
+                #     incomplete_short_timeout=5.0,
+                #     incomplete_long_timeout=10.0,
+                #     incomplete_short_prompt="Custom prompt...",
+                #     incomplete_long_prompt="Custom prompt...",
+                #     instructions="Custom turn completion instructions...",
+                # ),
+            ),
+        ),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input
+            stt,
+            user_aggregator,  # User responses
+            llm,  # LLM
+            tts,  # TTS
+            transport.output(),  # Transport bot output
+            assistant_aggregator,  # Assistant spoken responses
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+        # Kick off the conversation.
+        context.add_message(
+            {
+                "role": "developer",
+                "content": "Please introduce yourself to the user, asking them a question that will require a complete response. To start, say 'Let me start with a fun one. If you could travel anywhere in the world right now, where would you go and why?'",
+            }
+        )
+        await worker.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await worker.cancel()
+
+    @user_aggregator.event_handler("on_user_turn_idle")
+    async def on_user_turn_idle(aggregator):
+        logger.info(f"User turn idle")
+        # The user aggregator consumes `LLMMessagesAppendFrame`, so push from it
+        # to reach the LLM service downstream.
+        await aggregator.push_frame(
+            LLMMessagesAppendFrame(
+                [
+                    {
+                        "role": "developer",
+                        "content": (
+                            "The user has been quiet. Politely and briefly ask if they're "
+                            "still there."
+                        ),
+                    }
+                ],
+                run_llm=True,
+            )
+        )
+
+    @user_aggregator.event_handler("on_user_turn_stopped")
+    async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
+        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
+        line = f"{timestamp}user: {message.content}"
+        logger.info(f"Transcript: {line}")
+
+    @assistant_aggregator.event_handler("on_assistant_turn_stopped")
+    async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+        timestamp = f"[{message.timestamp}] " if message.timestamp else ""
+        line = f"{timestamp}assistant: {message.content}"
+        logger.info(f"Transcript: {line}")
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -269,6 +269,14 @@ suite:
     scenarios: [filter_incomplete_turns]
 
   #
+  # Turn management: the user goes silent instead of trailing off. The bot's
+  # idle handler asks the LLM for a check-in, and that response has to be spoken
+  # even though no user speech preceded it.
+  #
+  - bot: turn-management/turn-management-filter-incomplete-turns-user-idle.py
+    scenarios: [filter_incomplete_turns_user_idle]
+
+  #
   # DTMF: the caller drives a keypad phone menu (IVR) with DTMF tones instead of
   # speech. The bot's DTMFAggregator turns each keypress into a transcription the
   # LLM responds to, so the harness can assert on the resulting transcription and

--- a/scripts/release-evals/scenarios/filter_incomplete_turns_user_idle.yaml
+++ b/scripts/release-evals/scenarios/filter_incomplete_turns_user_idle.yaml
@@ -1,0 +1,34 @@
+name: filter_incomplete_turns_user_idle
+
+# Audio modality. Covers filter_incomplete_user_turns combined with user idle
+# detection. The user completes a thought, so the bot voices a ✓ response; then
+# the user goes silent. Once the bot's idle timeout expires, its idle handler
+# appends a developer message with run_llm=True, and that response has to be
+# spoken like any other ✓ response.
+#
+# The final turn sends nothing: it only waits for speech the bot produces on its
+# own, with a budget covering the bot's 8s idle timeout plus inference and TTS.
+
+user: !include user_audio.yaml
+
+judge: !include judge_audio.yaml
+
+turns:
+  # Wait for the bot's on-connect greeting before speaking.
+  - expect:
+      - event: response
+        eval: "the bot opens the conversation in some way (a greeting, an introduction, or a question inviting the user to respond)"
+
+  # A complete thought: the bot marks the turn ✓ and answers. That is the one
+  # spoken completion for this user turn.
+  - user: "I'm planning a trip to Japan next spring."
+    expect:
+      - event: response
+        eval: "the response engages with the user's trip to Japan"
+
+  # The user stays silent. The bot's idle handler fires and asks the LLM for a
+  # check-in, which the bot must speak.
+  - expect:
+      - event: response
+        eval: "the bot checks in on the user, asking whether they are still there or still with the bot"
+        within_ms: 45000

--- a/src/pipecat/turns/user_turn_completion_mixin.py
+++ b/src/pipecat/turns/user_turn_completion_mixin.py
@@ -398,6 +398,12 @@ class UserTurnCompletionLLMServiceMixin(FrameProcessor):
         elif isinstance(frame, UserStartedSpeakingFrame):
             # A new user turn begins, so allow one fresh spoken completion.
             self._user_turn_completion_voiced = False
+        elif isinstance(frame, LLMMessagesAppendFrame) and frame.run_llm:
+            # An externally appended message that asks for a run (e.g. a user-idle
+            # check-in) is an explicit request for fresh speech, and it arrives
+            # precisely while the user is silent. Clear the voiced latch so the ✓
+            # guard in ``_push_turn_text`` does not drop its text.
+            self._user_turn_completion_voiced = False
         elif isinstance(frame, VADUserStartedSpeakingFrame):
             # The user resumed speaking within the same open turn. A new turn's
             # InterruptionFrame does not fire for a resume inside an already-open

--- a/tests/test_user_turn_completion_mixin.py
+++ b/tests/test_user_turn_completion_mixin.py
@@ -13,6 +13,7 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMarkerFrame,
+    LLMMessagesAppendFrame,
     LLMTextFrame,
     UserStartedSpeakingFrame,
     UserTurnInferenceCompletedFrame,
@@ -400,6 +401,125 @@ class TestUserUserTurnCompletionLLMServiceMixin(unittest.IsolatedAsyncioTestCase
 
         texts = [f.text for f in pushed_frames if isinstance(f, LLMTextFrame)]
         self.assertEqual(texts, ["One moment.", "Here are the openings."])
+        self.assertTrue(processor._user_turn_completion_voiced)
+
+    async def test_requested_run_resets_completion_latch(self):
+        """An appended message requesting a run lets its response voice a completion.
+
+        Re-prompts driven by the application (a user-idle check-in, a "didn't
+        catch that" nudge) fire while the user is silent, so no speech frame
+        clears the latch for them.
+        """
+        processor = MockProcessor()
+        processor._user_turn_completion_voiced = True
+
+        with unittest.mock.patch.object(FrameProcessor, "process_frame", AsyncMock()):
+            await processor.process_frame(
+                LLMMessagesAppendFrame(
+                    messages=[{"role": "developer", "content": "The user has been quiet."}],
+                    run_llm=True,
+                ),
+                FrameDirection.DOWNSTREAM,
+            )
+
+        self.assertFalse(processor._user_turn_completion_voiced)
+
+    async def test_append_without_run_keeps_completion_latch(self):
+        """Appending messages without requesting a run leaves the latch armed.
+
+        Nothing asked for fresh speech, so the turn keeps its one spoken
+        completion and a later duplicate inference is still dropped.
+        """
+        processor = MockProcessor()
+        processor._user_turn_completion_voiced = True
+
+        with unittest.mock.patch.object(FrameProcessor, "process_frame", AsyncMock()):
+            await processor.process_frame(
+                LLMMessagesAppendFrame(
+                    messages=[{"role": "developer", "content": "Background note."}],
+                ),
+                FrameDirection.DOWNSTREAM,
+            )
+
+        self.assertTrue(processor._user_turn_completion_voiced)
+
+    async def test_reprompt_speaks_after_voiced_completion(self):
+        """Regression test for #5145: silence after a re-prompt following a spoken ✓.
+
+        Sequence: the user's turn completes and the bot voices a ✓ reply, setting
+        the latch; the user stays silent, so an idle handler appends a developer
+        message with ``run_llm=True``; the resulting ✓ must be spoken. Without
+        resetting the latch on the requested run, that response is dropped and
+        the bot stays mute.
+        """
+        processor = MockProcessor()
+        processor.broadcast_frame = AsyncMock()
+
+        pushed_frames = []
+        with unittest.mock.patch.object(
+            FrameProcessor,
+            "push_frame",
+            AsyncMock(side_effect=lambda f, *args, **kwargs: pushed_frames.append(f)),
+        ):
+            # The user's turn completes and the bot answers, setting the latch.
+            await processor._push_turn_text(f"{USER_TURN_COMPLETE_MARKER} Japan is a great pick.")
+            await processor.push_frame(LLMFullResponseEndFrame())
+            self.assertTrue(processor._user_turn_completion_voiced)
+
+            # The user says nothing, so the idle handler asks for a check-in.
+            with unittest.mock.patch.object(FrameProcessor, "process_frame", AsyncMock()):
+                await processor.process_frame(
+                    LLMMessagesAppendFrame(
+                        messages=[{"role": "developer", "content": "The user has been quiet."}],
+                        run_llm=True,
+                    ),
+                    FrameDirection.DOWNSTREAM,
+                )
+
+            await processor._push_turn_text(f"{USER_TURN_COMPLETE_MARKER} Are you still there?")
+            await processor.push_frame(LLMFullResponseEndFrame())
+
+        texts = [f.text for f in pushed_frames if isinstance(f, LLMTextFrame)]
+        self.assertEqual(texts, ["Japan is a great pick.", "Are you still there?"])
+
+    async def test_requested_run_allows_only_one_extra_completion(self):
+        """A requested run grants exactly ONE extra spoken completion, then re-latches.
+
+        Clearing the latch on the requested run lets the re-prompt speak, but
+        that response's own ✓ re-arms the latch, so a later stray inference in
+        the same turn is still dropped. This guards against the reset
+        accidentally widening into an open-ended window.
+        """
+        processor = MockProcessor()
+        processor.broadcast_frame = AsyncMock()
+
+        pushed_frames = []
+        with unittest.mock.patch.object(
+            FrameProcessor,
+            "push_frame",
+            AsyncMock(side_effect=lambda f, *args, **kwargs: pushed_frames.append(f)),
+        ):
+            await processor._push_turn_text(f"{USER_TURN_COMPLETE_MARKER} Japan is a great pick.")
+            await processor.push_frame(LLMFullResponseEndFrame())
+
+            with unittest.mock.patch.object(FrameProcessor, "process_frame", AsyncMock()):
+                await processor.process_frame(
+                    LLMMessagesAppendFrame(
+                        messages=[{"role": "developer", "content": "The user has been quiet."}],
+                        run_llm=True,
+                    ),
+                    FrameDirection.DOWNSTREAM,
+                )
+
+            await processor._push_turn_text(f"{USER_TURN_COMPLETE_MARKER} Are you still there?")
+            await processor.push_frame(LLMFullResponseEndFrame())
+
+            # Stray acoustic-detector inference, same turn, no new run requested.
+            await processor._push_turn_text(f"{USER_TURN_COMPLETE_MARKER} Duplicate!")
+            await processor.push_frame(LLMFullResponseEndFrame())
+
+        texts = [f.text for f in pushed_frames if isinstance(f, LLMTextFrame)]
+        self.assertEqual(texts, ["Japan is a great pick.", "Are you still there?"])
         self.assertTrue(processor._user_turn_completion_voiced)
 
 


### PR DESCRIPTION
This issue was easily reproducible by just pushing an LLMMessagesAppendFrame with run_llm=True. I've added both an example + eval (turn-management-filter-incomplete-turns-user-idle.py) and unit tests to cover this, since it involves interaction between multiple processors.

## Summary

- Fixed responses to application-requested LLM runs being silently dropped when `filter_incomplete_user_turns` is enabled. The one-✓-per-turn latch in `UserTurnCompletionLLMServiceMixin` cleared only on user speech or a tool call (#5063), so a run requested while the user was silent had its text dropped by the guard at the top of `_push_turn_text`.
- This gagged the user-idle re-prompt pattern, which fires precisely when the user is silent. The failure was invisible: the guard returns before the marker-detection debug line and before buffering, so the no-marker fallback warning in `_turn_reset` never fired either. An idle escalation ladder ended the session with an unspoken goodbye.
- An `LLMMessagesAppendFrame` with `run_llm=True` is an explicit request for fresh speech, so it now clears the latch. The response's own ✓ re-arms it, keeping the reset to one extra completion rather than an unbounded window — same shape as the tool-call reset.
- Added an example composing turn completion filtering with user idle detection, plus a release-eval scenario and manifest entry.

Not covered: `LLMUserAggregator` consumes `LLMMessagesAppendFrame` without forwarding it, so the reset applies only when the frame is pushed downstream from the aggregator (what the idle handler and the example do). Queuing the same frame on the worker, upstream of the aggregator, still leaves the latch armed.

## Testing

- `uv run pytest tests/test_user_turn_completion_mixin.py` — four new tests cover the state change, the `run_llm=False` case (latch stays armed), the end-to-end regression, and the one-extra-completion bound. Three fail without the fix.
- End-to-end against a live bot:
  ```
  uv run python examples/turn-management/turn-management-filter-incomplete-turns-user-idle.py -t eval --port 7860
  uv run python -m pipecat.evals run scripts/release-evals/scenarios/filter_incomplete_turns_user_idle.yaml --bot-url ws://localhost:7860 -v
  ```
  Fails on unfixed main (`no matching 'response' event arrived within 45000ms`); passes with the fix, speaking "Just checking in. Are you still there?"

## Fixes

- Fixes #5145

🤖 Generated with [Claude Code](https://claude.com/claude-code)