### PR TITLE
chore: remove unused imports

### DIFF
--- a/examples/function-calling/function-calling-baseten.py
+++ b/examples/function-calling/function-calling-baseten.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.evals.transport import EvalTransportParams
-from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext

--- a/examples/function-calling/function-calling-crusoe.py
+++ b/examples/function-calling/function-calling-crusoe.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.evals.transport import EvalTransportParams
-from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -91,13 +91,11 @@ from pipecat.turns.user_idle_controller import UserIdleController
 from pipecat.turns.user_mute import BaseUserMuteStrategy
 from pipecat.turns.user_start import (
     BaseUserTurnStartStrategy,
-    ExternalUserTurnStartStrategy,
     TranscriptionUserTurnStartStrategy,
     UserTurnStartedParams,
 )
 from pipecat.turns.user_stop import (
     BaseUserTurnStopStrategy,
-    ExternalUserTurnStopStrategy,
     UserTurnStoppedParams,
 )
 from pipecat.turns.user_turn_completion_mixin import UserTurnCompletionConfig

--- a/src/pipecat/runner/types.py
+++ b/src/pipecat/runner/types.py
@@ -13,7 +13,7 @@ information to bot functions.
 import argparse
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import WebSocket
 from pydantic import BaseModel, ConfigDict, Field

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -26,7 +26,6 @@ from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
     LLMContextAssistantTurnFrame,
-    ServiceSwitcherRequestMetadataFrame,
     StartFrame,
     STTMetadataFrame,
     STTMuteFrame,

--- a/src/pipecat/workers/runner.py
+++ b/src/pipecat/workers/runner.py
@@ -66,7 +66,6 @@ from pipecat.registry.types import WorkerReadyData, WorkerRegistryEntry
 from pipecat.utils.asyncio.task_manager import (
     BaseTaskManager,
     TaskManager,
-    TaskManagerParams,
 )
 from pipecat.utils.base_object import BaseObject
 from pipecat.utils.startup import run_setup_hook

--- a/tests/test_app_resources.py
+++ b/tests/test_app_resources.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import asyncio
 import unittest
 from dataclasses import dataclass, field
 from types import SimpleNamespace

--- a/tests/test_deprecation_markers.py
+++ b/tests/test_deprecation_markers.py
@@ -17,7 +17,6 @@ assertions over its validators, plus runtime checks that the converted shims
 still emit ``DeprecationWarning`` without warning at import time.
 """
 
-import asyncio
 import json
 import subprocess
 import sys

--- a/tests/test_flows_context_strategies.py
+++ b/tests/test_flows_context_strategies.py
@@ -16,9 +16,8 @@ focusing on:
 
 import unittest
 import warnings
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
-from pipecat.flows.exceptions import FlowError
 from pipecat.flows.manager import FlowManager
 from pipecat.flows.types import ContextStrategy, ContextStrategyConfig, NodeConfig
 from pipecat.frames.frames import (

--- a/tests/test_flows_direct_functions.py
+++ b/tests/test_flows_direct_functions.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import unittest
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 
 from pipecat.flows.exceptions import InvalidFunctionError
 from pipecat.flows.manager import FlowManager

--- a/tests/test_flows_manager.py
+++ b/tests/test_flows_manager.py
@@ -38,7 +38,6 @@ from pipecat.frames.frames import (
 )
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
-from pipecat.services.settings import LLMSettings
 from tests.flows_test_helpers import (
     assert_tts_speak_frames_queued,
     get_advertised_tool_handlers,


### PR DESCRIPTION
- Removed unused imports following the process from #3492.

## Summary

- Removed imports that are no longer referenced across `src/`, `examples/`, and `tests/`
- Cleanup only — no behavior changes

The removals in `llm_response_universal.py`, `stt_service.py`, and `workers/runner.py` were incidental re-exports: none appear in an `__all__`, and nothing in the repo imports them from those modules. Canonical paths (`pipecat.turns.user_start`, `pipecat.turns.user_stop`, `pipecat.utils.asyncio.task_manager`, `pipecat.frames.frames`) are unchanged.

## Testing

- `uv run ruff check` / `uv run ruff format --check` pass
- `uv run pytest tests/test_app_resources.py tests/test_deprecation_markers.py tests/test_flows_context_strategies.py tests/test_flows_direct_functions.py tests/test_flows_manager.py` — 97 passed