### PR TITLE
Fix flaky heartbeat monitor timeout test

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -440,13 +440,11 @@ class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
                 cancel_on_idle_timeout=False,
             )
 
-            try:
-                await asyncio.wait_for(
-                    worker.run(WorkerParams(task_manager=TaskManager())),
-                    timeout=0.6,
-                )
-            except TimeoutError:
-                pass
+            @worker.event_handler("on_heartbeat_timeout")
+            async def on_heartbeat_timeout(worker: PipelineWorker):
+                await worker.cancel()
+
+            await worker.run(WorkerParams(task_manager=TaskManager()))
 
             log_text = log_output.getvalue()
             assert f"more than {custom_monitor_secs} seconds" in log_text


### PR DESCRIPTION
tl;dr
Found this flaky test in making another change. Instead of a timeout, this now uses the `on_heartbeat_timeout` event handler.

## Summary

`test_heartbeat_monitor_respects_custom_timeout` raced pipeline startup against a fixed wall-clock budget:

```python
await asyncio.wait_for(worker.run(...), timeout=0.6)
assert f"more than {custom_monitor_secs} seconds" in log_text   # 0.3s
```

The heartbeat monitor only starts once `StartFrame` reaches the sink (`_maybe_start_heartbeat_tasks()` in `_sink_push_frame`), so startup has to fit inside that 0.6s alongside the 0.3s monitor window. On a loaded runner it doesn't. From a failed Coverage job:

```
49.006  Starting. Waiting for StartFrame#201 to reach the end of the pipeline...
49.415  StartFrame#201 reached the end of the pipeline    ← 409ms of the 600ms budget
49.601  got cancelled from outside
```

That left the monitor ~186ms of its 0.3s window, so it never warned and the assertion saw an empty log. asyncio's own diagnostic in the same run: `Executing <Task ...HeartbeatBlocker#0::__input_frame_task_handler...> took 0.401 seconds`.

The `coverage` workflow is where this shows up, because it re-runs the whole suite under `coverage run` (`pyproject.toml:256`) and the tracing overhead widens startup.

The test now ends by cancelling the worker from an `on_heartbeat_timeout` handler, which is the pattern the two sibling tests already use (`test_heartbeat_timeout_event_handler`, `test_heartbeat_timeout_fires_repeatedly`). The warning is logged immediately before the event fires (`worker.py:1236-1239`), so it's in the buffer by the time the handler runs. No wall-clock budget remains.

## Test plan

- `uv run pytest tests/test_pipeline.py` — 31 passed.
- `uv run pytest tests/test_pipeline.py -k heartbeat` five consecutive times — 5 passed each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)