### PR TITLE
fix(metrics): count cached input tokens in total_tokens for Anthropic and Bedrock

### DIFF
--- a/changelog/5163.fixed.md
+++ b/changelog/5163.fixed.md
@@ -1,8 +1,1 @@
-- Fixed `total_tokens` dropping cached input tokens on the Anthropic and AWS Bedrock LLM
-  services. Both compute the total locally from an input count that is already net of the
-  prompt cache, so cache reads and cache writes were left out entirely, while the OpenAI
-  and Google services report a total that includes them. Cached tokens are now counted on
-  all four, so `total_tokens` is comparable across services. The per-field breakdown is
-  unchanged; read `prompt_tokens` for the net input figure.
-- Fixed the AWS Bedrock usage guard discarding a usage report that carried only prompt
-  cache activity.
+- Fixed `total_tokens` omitting cached input tokens on the Anthropic and AWS Bedrock LLM services. Both report their input count net of the prompt cache, so cache reads and cache writes were left out of the total — a large undercount for a voice agent, where the cached prefix comes to dominate the input within a few turns. `total_tokens` is now the gross figure on both, matching what the OpenAI and Google services already reported, and on Bedrock a usage report carrying only cache activity is no longer skipped. The per-field breakdown is unchanged; read `prompt_tokens` for the net input figure.

--- a/changelog/5163.fixed.md
+++ b/changelog/5163.fixed.md
@@ -1,0 +1,8 @@
+- Fixed `total_tokens` dropping cached input tokens on the Anthropic and AWS Bedrock LLM
+  services. Both compute the total locally from an input count that is already net of the
+  prompt cache, so cache reads and cache writes were left out entirely, while the OpenAI
+  and Google services report a total that includes them. Cached tokens are now counted on
+  all four, so `total_tokens` is comparable across services. The per-field breakdown is
+  unchanged; read `prompt_tokens` for the net input figure.
+- Fixed the AWS Bedrock usage guard discarding a usage report that carried only prompt
+  cache activity.

--- a/src/pipecat/metrics/metrics.py
+++ b/src/pipecat/metrics/metrics.py
@@ -74,10 +74,20 @@ class ProcessingMetricsData(MetricsData):
 class LLMTokenUsage(BaseModel):
     """Token usage statistics for LLM operations.
 
+    Services differ in whether their input count is reported net or gross of the
+    prompt cache. OpenAI and Google count cache reads inside ``prompt_tokens``;
+    Anthropic and Bedrock report them alongside it. ``total_tokens`` is normalized
+    to the gross figure either way, so summing it across services is meaningful,
+    but it means ``total_tokens`` is not always ``prompt_tokens +
+    completion_tokens``. For a breakdown, read the cache fields rather than
+    subtracting.
+
     Parameters:
-        prompt_tokens: Number of tokens in the input prompt.
+        prompt_tokens: Number of tokens in the input prompt. Net of the cache on
+            services that report cache reads separately.
         completion_tokens: Number of tokens in the generated completion.
-        total_tokens: Total number of tokens used (prompt + completion).
+        total_tokens: Total number of tokens used, including any cached input
+            tokens.
         cache_read_input_tokens: Number of tokens read from cache, if applicable.
         cache_creation_input_tokens: Number of tokens used to create cache entries, if applicable.
         reasoning_tokens: Number of completion tokens used for reasoning, if applicable.

--- a/src/pipecat/metrics/metrics.py
+++ b/src/pipecat/metrics/metrics.py
@@ -75,11 +75,9 @@ class LLMTokenUsage(BaseModel):
     """Token usage statistics for LLM operations.
 
     Services differ in whether their input count is reported net or gross of the
-    prompt cache. OpenAI and Google count cache reads inside ``prompt_tokens``;
-    Anthropic and Bedrock report them alongside it. ``total_tokens`` is normalized
-    to the gross figure either way, so summing it across services is meaningful,
-    but it means ``total_tokens`` is not always ``prompt_tokens +
-    completion_tokens``. For a breakdown, read the cache fields rather than
+    prompt cache. ``total_tokens`` is the gross figure either way, so it stays
+    comparable across services, and it is therefore not always ``prompt_tokens +
+    completion_tokens``. Read the cache fields for the breakdown rather than
     subtracting.
 
     Parameters:

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -591,6 +591,16 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
                 completion_tokens=completion_tokens,
                 cache_creation_input_tokens=cache_creation_input_tokens,
                 cache_read_input_tokens=cache_read_input_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
+                # Anthropic reports input_tokens net of the cache, so the cached
+                # tokens have to be added back to get a total comparable with the
+                # services that take their total straight from the provider. This
+                # is the same sum _process_context already uses for the caching
+                # threshold check.
+                total_tokens=(
+                    prompt_tokens
+                    + cache_creation_input_tokens
+                    + cache_read_input_tokens
+                    + completion_tokens
+                ),
             )
             await self.start_llm_usage_metrics(tokens)

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -592,10 +592,8 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
                 cache_creation_input_tokens=cache_creation_input_tokens,
                 cache_read_input_tokens=cache_read_input_tokens,
                 # Anthropic reports input_tokens net of the cache, so the cached
-                # tokens have to be added back to get a total comparable with the
-                # services that take their total straight from the provider. This
-                # is the same sum _process_context already uses for the caching
-                # threshold check.
+                # tokens are added back to keep the total comparable with services
+                # whose provider supplies it already gross.
                 total_tokens=(
                     prompt_tokens
                     + cache_creation_input_tokens

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -663,9 +663,10 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
             tokens = LLMTokenUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
-                # Bedrock reports inputTokens net of the cache, the same as the
-                # Anthropic API it fronts, so the cached tokens have to be added
-                # back for the total to mean what it means elsewhere.
+                # Bedrock reports inputTokens net of the cache, so the cached
+                # tokens are added back. The provider's own totalTokens is unused
+                # because an interrupted turn reports an estimated completion
+                # count, which the total has to agree with.
                 total_tokens=(
                     prompt_tokens
                     + cache_creation_input_tokens

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -654,11 +654,24 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
         cache_read_input_tokens: int,
         cache_creation_input_tokens: int,
     ):
-        if prompt_tokens or completion_tokens:
+        if (
+            prompt_tokens
+            or completion_tokens
+            or cache_read_input_tokens
+            or cache_creation_input_tokens
+        ):
             tokens = LLMTokenUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
+                # Bedrock reports inputTokens net of the cache, the same as the
+                # Anthropic API it fronts, so the cached tokens have to be added
+                # back for the total to mean what it means elsewhere.
+                total_tokens=(
+                    prompt_tokens
+                    + cache_creation_input_tokens
+                    + cache_read_input_tokens
+                    + completion_tokens
+                ),
                 cache_read_input_tokens=cache_read_input_tokens,
                 cache_creation_input_tokens=cache_creation_input_tokens,
             )

--- a/tests/test_llm_token_usage_totals.py
+++ b/tests/test_llm_token_usage_totals.py
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests that ``LLMTokenUsage.total_tokens`` means the same thing across services.
+
+Services report their input count differently: OpenAI and Google count cache reads
+inside ``prompt_tokens`` and hand back a total that already includes them, while
+Anthropic and Bedrock report cache reads alongside an input count that excludes
+them. Computing ``prompt_tokens + completion_tokens`` on the second group therefore
+drops every cached token, and a consumer summing ``total_tokens`` over a session
+gets a number that is quietly too low without anything raising.
+
+The gap is not marginal for a voice agent, where the system prompt and the
+conversation history are re-read from cache on every turn, so cache reads come to
+dominate the input count within a few turns.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.services.anthropic.llm import AnthropicLLMService
+from pipecat.services.aws.llm import AWSBedrockLLMService
+
+
+def _anthropic_service() -> AnthropicLLMService:
+    service = AnthropicLLMService(api_key="test-key")
+    service.start_llm_usage_metrics = AsyncMock()
+    return service
+
+
+def _bedrock_service() -> AWSBedrockLLMService:
+    service = AWSBedrockLLMService(
+        aws_access_key="test-key",
+        aws_secret_key="test-secret",
+        aws_region="us-east-1",
+        settings=AWSBedrockLLMService.Settings(model="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    )
+    service.start_llm_usage_metrics = AsyncMock()
+    return service
+
+
+def _reported(service) -> object:
+    """The single LLMTokenUsage handed to start_llm_usage_metrics."""
+    service.start_llm_usage_metrics.assert_called_once()
+    return service.start_llm_usage_metrics.call_args.args[0]
+
+
+class TestAnthropicTotals:
+    @pytest.mark.asyncio
+    async def test_cached_reads_are_counted_in_the_total(self):
+        """The turn billed 2100 input tokens; only 100 of them were uncached."""
+        service = _anthropic_service()
+        await service._report_usage_metrics(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=2000,
+        )
+        usage = _reported(service)
+        assert usage.total_tokens == 2150
+
+    @pytest.mark.asyncio
+    async def test_cache_creation_is_counted_in_the_total(self):
+        """Writing the cache is billed too, and at a premium."""
+        service = _anthropic_service()
+        await service._report_usage_metrics(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_input_tokens=1500,
+            cache_read_input_tokens=0,
+        )
+        assert _reported(service).total_tokens == 1650
+
+    @pytest.mark.asyncio
+    async def test_the_components_are_still_reported_separately(self):
+        """The total is normalized, so the breakdown has to stay available."""
+        service = _anthropic_service()
+        await service._report_usage_metrics(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_input_tokens=300,
+            cache_read_input_tokens=2000,
+        )
+        usage = _reported(service)
+        assert usage.prompt_tokens == 100
+        assert usage.cache_read_input_tokens == 2000
+        assert usage.cache_creation_input_tokens == 300
+        assert usage.total_tokens == 2450
+
+    @pytest.mark.asyncio
+    async def test_an_uncached_turn_is_unaffected(self):
+        """No cache in play means the old arithmetic was already right."""
+        service = _anthropic_service()
+        await service._report_usage_metrics(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+        assert _reported(service).total_tokens == 150
+
+
+class TestBedrockTotals:
+    @pytest.mark.asyncio
+    async def test_cached_reads_are_counted_in_the_total(self):
+        """Bedrock fronts the same Anthropic models and reports inputTokens the same way."""
+        service = _bedrock_service()
+        await service._report_usage_metrics(
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_read_input_tokens=2000,
+            cache_creation_input_tokens=300,
+        )
+        assert _reported(service).total_tokens == 2450
+
+    @pytest.mark.asyncio
+    async def test_a_cache_only_report_is_not_dropped(self):
+        """The guard skipped reporting unless input or output was non-zero, so a
+        report carrying only cache activity vanished instead of being counted."""
+        service = _bedrock_service()
+        await service._report_usage_metrics(
+            prompt_tokens=0,
+            completion_tokens=0,
+            cache_read_input_tokens=2000,
+            cache_creation_input_tokens=0,
+        )
+        assert _reported(service).total_tokens == 2000
+
+    @pytest.mark.asyncio
+    async def test_an_empty_report_is_still_skipped(self):
+        """Widening the guard must not start emitting all-zero usage."""
+        service = _bedrock_service()
+        await service._report_usage_metrics(
+            prompt_tokens=0,
+            completion_tokens=0,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+        service.start_llm_usage_metrics.assert_not_called()

--- a/tests/test_llm_token_usage_totals.py
+++ b/tests/test_llm_token_usage_totals.py
@@ -4,18 +4,12 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Tests that ``LLMTokenUsage.total_tokens`` means the same thing across services.
+"""Tests that ``LLMTokenUsage.total_tokens`` counts cached input tokens.
 
-Services report their input count differently: OpenAI and Google count cache reads
-inside ``prompt_tokens`` and hand back a total that already includes them, while
-Anthropic and Bedrock report cache reads alongside an input count that excludes
-them. Computing ``prompt_tokens + completion_tokens`` on the second group therefore
-drops every cached token, and a consumer summing ``total_tokens`` over a session
-gets a number that is quietly too low without anything raising.
-
-The gap is not marginal for a voice agent, where the system prompt and the
-conversation history are re-read from cache on every turn, so cache reads come to
-dominate the input count within a few turns.
+Anthropic and Bedrock report cache reads and cache writes alongside an input count
+that excludes them, so their totals are summed from all four component counts. On
+services whose provider supplies the total, cached tokens are already inside it, so
+``total_tokens`` carries the same meaning everywhere.
 """
 
 from unittest.mock import AsyncMock
@@ -50,9 +44,11 @@ def _reported(service) -> object:
 
 
 class TestAnthropicTotals:
+    """Anthropic totals cover the cache reads and writes reported beside the input count."""
+
     @pytest.mark.asyncio
     async def test_cached_reads_are_counted_in_the_total(self):
-        """The turn billed 2100 input tokens; only 100 of them were uncached."""
+        """A turn billed for 2100 input tokens, only 100 of them uncached."""
         service = _anthropic_service()
         await service._report_usage_metrics(
             prompt_tokens=100,
@@ -76,8 +72,8 @@ class TestAnthropicTotals:
         assert _reported(service).total_tokens == 1650
 
     @pytest.mark.asyncio
-    async def test_the_components_are_still_reported_separately(self):
-        """The total is normalized, so the breakdown has to stay available."""
+    async def test_the_components_are_reported_separately(self):
+        """The total is the gross figure, so the breakdown stays available beside it."""
         service = _anthropic_service()
         await service._report_usage_metrics(
             prompt_tokens=100,
@@ -92,8 +88,8 @@ class TestAnthropicTotals:
         assert usage.total_tokens == 2450
 
     @pytest.mark.asyncio
-    async def test_an_uncached_turn_is_unaffected(self):
-        """No cache in play means the old arithmetic was already right."""
+    async def test_an_uncached_turn_counts_input_plus_output(self):
+        """With no cache activity the total is just the input and output counts."""
         service = _anthropic_service()
         await service._report_usage_metrics(
             prompt_tokens=100,
@@ -105,9 +101,11 @@ class TestAnthropicTotals:
 
 
 class TestBedrockTotals:
+    """Bedrock reports inputTokens net of the cache, so its totals are summed the same way."""
+
     @pytest.mark.asyncio
     async def test_cached_reads_are_counted_in_the_total(self):
-        """Bedrock fronts the same Anthropic models and reports inputTokens the same way."""
+        """A turn carrying both cache reads and cache writes."""
         service = _bedrock_service()
         await service._report_usage_metrics(
             prompt_tokens=100,
@@ -119,8 +117,7 @@ class TestBedrockTotals:
 
     @pytest.mark.asyncio
     async def test_a_cache_only_report_is_not_dropped(self):
-        """The guard skipped reporting unless input or output was non-zero, so a
-        report carrying only cache activity vanished instead of being counted."""
+        """Cache activity alone is enough to report usage."""
         service = _bedrock_service()
         await service._report_usage_metrics(
             prompt_tokens=0,
@@ -131,8 +128,8 @@ class TestBedrockTotals:
         assert _reported(service).total_tokens == 2000
 
     @pytest.mark.asyncio
-    async def test_an_empty_report_is_still_skipped(self):
-        """Widening the guard must not start emitting all-zero usage."""
+    async def test_an_empty_report_is_skipped(self):
+        """An all-zero report produces no usage metrics."""
         service = _bedrock_service()
         await service._report_usage_metrics(
             prompt_tokens=0,


### PR DESCRIPTION
## The problem

`total_tokens` does not mean the same thing depending on which LLM service produced it.

| Service | `total_tokens` source | Counts cache reads? |
| --- | --- | --- |
| OpenAI | `chunk.usage.total_tokens` | yes, `prompt_tokens` includes `prompt_tokens_details.cached_tokens` |
| Google | `usage_metadata.total_token_count` | yes, includes `cached_content_token_count` |
| Anthropic | `prompt_tokens + completion_tokens` | **no** |
| AWS Bedrock | `prompt_tokens + completion_tokens` | **no** |

The two services that take the total from the provider get a gross figure. The two that
compute it locally add up an input count that is already net of the cache, so every cached
token disappears from the total. Nothing raises; the number is just low.

For a voice agent that is not a rounding error. The system prompt and the conversation
history are re-read from cache on every turn, which is the whole point of
`LLMEnablePromptCachingFrame`, so `cache_read_input_tokens` comes to dominate the input
count within a few turns. A turn billed for 2100 input tokens with 2000 of them cached was
reported as 150 total instead of 2150.

The Anthropic service already had the correct sum a few lines above the bug.
`_process_context` computes

```python
total_input_tokens = prompt_tokens + cache_creation_input_tokens + cache_read_input_tokens
```

for its caching threshold check, on the same values, and then `_report_usage_metrics` left
both cache terms out.

## The change

- Anthropic and Bedrock now include `cache_creation_input_tokens` and
  `cache_read_input_tokens` in `total_tokens`, matching what the provider-supplied totals
  already mean.
- The Bedrock guard was `if prompt_tokens or completion_tokens:`, so a report carrying only
  cache activity was dropped rather than counted. It now checks all four, which is what the
  Anthropic service already did.
- `LLMTokenUsage` documents the contract: `total_tokens` is gross, the component fields
  carry the breakdown, and it is therefore not always `prompt_tokens + completion_tokens`.

The component fields are untouched, so anyone who wants the net input figure still reads
`prompt_tokens`. The OTel span attributes already emit the components separately and are
unaffected.

## Tests

`tests/test_llm_token_usage_totals.py`, seven tests, five of which fail on `main`:

```
FAILED TestAnthropicTotals::test_cached_reads_are_counted_in_the_total
FAILED TestAnthropicTotals::test_cache_creation_is_counted_in_the_total
FAILED TestAnthropicTotals::test_the_components_are_still_reported_separately
FAILED TestBedrockTotals::test_cached_reads_are_counted_in_the_total
FAILED TestBedrockTotals::test_a_cache_only_report_is_not_dropped
```

The other two are guards: an uncached turn is unchanged, and an all-zero report is still
skipped.

Full suite: 3187 passed. The 5 unrelated failures (`test_deprecation_markers`,
`test_openai_responses_http`, `test_runner_utils`) reproduce on an unmodified checkout.

## One thing I did not do

I left the OpenAI and Google services alone. Their totals come from the provider and are
already gross, so they are consistent with this after the change, but I have not
independently verified every field on `gemini_live`, `openai/realtime` and `xai/realtime`,
which build `LLMTokenUsage` from their own event shapes. Happy to follow up on those
separately if you would like the audit.

I will add the changelog fragment once this has a PR number.
