### PR TITLE
Add prose-review skill

### DIFF
--- a/.agents/skills/prose-review
+++ b/.agents/skills/prose-review
@@ -1,0 +1,1 @@
+../../.claude/skills/prose-review

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,7 @@
         "./.claude/skills/docstring",
         "./.claude/skills/pr-description",
         "./.claude/skills/pr-submit",
+        "./.claude/skills/prose-review",
         "./.claude/skills/update-docs"
       ]
     }

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -46,10 +46,7 @@ Create changelog files for the important commits in this PR. The PR number is pr
 
    Ask yourself: "If I'm a developer building on Pipecat, what would I notice changed?" Start there.
 
-8. Once the entries are written, run `/prose-review changelog/` and fix anything it
-   flags. Contrasting old and new *user-visible* behavior is expected here; what it
-   catches is development-process detail — internal refactoring described from the
-   inside, rejected approaches, verification narrative.
+8. Once the entries are written, run `/prose-review changelog/` and fix anything it flags.
 
 ## Example
 

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -46,6 +46,11 @@ Create changelog files for the important commits in this PR. The PR number is pr
 
    Ask yourself: "If I'm a developer building on Pipecat, what would I notice changed?" Start there.
 
+8. Once the entries are written, run `/prose-review changelog/` and fix anything it
+   flags. Contrasting old and new *user-visible* behavior is expected here; what it
+   catches is development-process detail — internal refactoring described from the
+   inside, rejected approaches, verification narrative.
+
 ## Example
 
 For PR #3519 with a new feature and a bug fix:

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -233,6 +233,8 @@ async def bot(runner_args: RunnerArguments):
    - Pattern consistency
 4. Generate actionable recommendations
 5. Apply Pipecat standards
+6. Run `/prose-review branch` over the comments and docstrings written above, and fix
+   anything it flags
 
 ---
 

--- a/.claude/skills/docstring/SKILL.md
+++ b/.claude/skills/docstring/SKILL.md
@@ -243,7 +243,8 @@ When documenting deprecated code:
 
 ## Checklist
 
-Before finishing, verify:
+Before finishing, run `/prose-review <path>` over the documented file and fix
+anything it flags, then verify:
 
 - [ ] Module has a docstring at the top (after copyright header and imports)
 - [ ] All public classes have docstrings

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -119,13 +119,9 @@ Note: Use "Fixes #X" format (not "Closes" or "Resolves") for consistency. Each i
 
 ## Checklist
 
-Before updating the PR, read the description against the "Writing for Future
-Readers" standard in `AGENTS.md` — the same one `/prose-review` applies to code
-prose. A description is release notes: what changed and why it matters to users.
-Cut development-process detail — approaches tried and abandoned, review
-back-and-forth, verification narrative, refactoring described from the inside.
-Then verify:
+Before updating the PR:
 
+- [ ] Description documents the change for users, not the development process — the standard `/prose-review` applies, in `AGENTS.md` under "Writing for Future Readers"
 - [ ] Verified existing description needs updating (not already complete)
 - [ ] Summary accurately reflects the changes
 - [ ] Breaking changes are clearly documented (if any)

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -119,7 +119,12 @@ Note: Use "Fixes #X" format (not "Closes" or "Resolves") for consistency. Each i
 
 ## Checklist
 
-Before updating the PR:
+Before updating the PR, read the description against the "Writing for Future
+Readers" standard in `AGENTS.md` — the same one `/prose-review` applies to code
+prose. A description is release notes: what changed and why it matters to users.
+Cut development-process detail — approaches tried and abandoned, review
+back-and-forth, verification narrative, refactoring described from the inside.
+Then verify:
 
 - [ ] Verified existing description needs updating (not already complete)
 - [ ] Summary accurately reflects the changes

--- a/.claude/skills/pr-submit/SKILL.md
+++ b/.claude/skills/pr-submit/SKILL.md
@@ -17,12 +17,20 @@ Submit the current changes as a GitHub pull request.
    - Create a new branch based on the current branch
    - Commit the changes using multiple commits if the changes are unrelated
 
-3. Push the branch and create the PR:
+3. Run `/prose-review branch` and fix anything it flags. Do this before pushing,
+   while corrections are still cheap.
+
+4. Push the branch and create the PR:
    - Push with `-u` flag to set upstream tracking
    - Create the PR using `gh pr create`
 
-4. After the PR is created:
+5. After the PR is created:
    - Run `/changelog <pr_number>` to generate changelog files, then commit and push them
    - Run `/pr-description <pr_number>` to update the PR description
 
-5. Return the PR URL to the user.
+   Both skills review their own prose — no separate pass is needed here.
+
+6. Return the PR URL to the user.
+
+Commit messages are prose too — `/prose-review` reads diffs and so won't see them.
+Read the messages in `git log main..HEAD` against the same standard before pushing.

--- a/.claude/skills/prose-review/SKILL.md
+++ b/.claude/skills/prose-review/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: prose-review
+description: Check that added comments, docstrings, and changelog entries document the code rather than narrate the change that produced it
+argument-hint: "[staged|branch|<path>] (default: branch)"
+---
+
+Review the prose this work adds — comments, docstrings, changelog entries — against
+the "Writing for Future Readers" section of `AGENTS.md`, which is the authority.
+This skill is the operational check.
+
+The reader you are writing for has never seen this change. They open the file
+months from now and see only the code as it stands. Detail that feels important
+while making a change — what the code used to do, why an alternative was
+rejected, that the fix was verified — is invisible context to them, and often
+actively misleading.
+
+## Scope
+
+| Argument | Diff to review |
+| --- | --- |
+| `staged` | `git diff --cached -U0` |
+| `branch` (default) | `git diff $(git merge-base main HEAD) -U0` |
+| `<path>` | `git diff $(git merge-base main HEAD) -U0 -- <path>` |
+
+The `branch` and `<path>` scopes diff against the merge base, so they cover
+committed *and* uncommitted work — prose written moments ago still needs review.
+
+Review **added lines only** (`^\+`): comments, docstrings, and any
+`changelog/*.md` content. Untouched prose is out of scope. Read the surrounding
+code for each hit — the judgment depends on what the code already shows.
+
+## The Test
+
+For each added line, ask: **does this describe the code as it now stands, or does
+it narrate the change that produced it?**
+
+Rewrite or delete anything that:
+
+- Describes what the code used to do, or contrasts old behavior with new
+- Argues the change is correct, or records that it was tested or verified
+- Names an alternative that was considered and rejected
+- Only restates what the adjacent code already shows
+- Uses shorthand that made sense mid-task but won't to someone reading cold
+
+Rationale survives only when its absence would puzzle a future reader — a
+constraint or non-obvious decision the code itself cannot express. Keep those,
+and prefer stating the constraint over recounting the discovery.
+
+## Calibration
+
+Do not pattern-match on words like "previously", "instead of", "no longer", or
+"used to". They appear constantly in correct prose. Judge the sentence's subject:
+the code, or the change.
+
+Legitimate — all describe current behavior:
+
+```python
+# This queue is the queue used to push frames to the pipeline.
+# ...discarded rather than flushed, since it's no longer wanted.
+# ...at arg-parse time so users get a clear message instead of a downstream crash.
+```
+
+Violations, and their fixes:
+
+```python
+# We used to buffer here, but that broke interruptions, so now we flush.
+# → Flush immediately; buffering here delays interruption handling.
+
+# Changed from a list to a deque for O(1) pops.
+# → delete; the code shows the deque
+
+# Note: verified this against the Deepgram sandbox.
+# → delete
+
+# Tried a lock here first, but it deadlocked with the task manager.
+# → Reentrant by design: the task manager may re-enter during cancellation.
+```
+
+```python
+"""Replay buffered word events, replacing the old single-slot matcher."""
+# → """Replay buffered word events now that a new slot may match them."""
+```
+
+## Changelog Exception
+
+Changelog entries and PR descriptions are release notes for users, so contrasting
+old and new *user-visible behavior* belongs there — `/changelog` models this
+deliberately. What does not belong is development-process detail: rejected
+approaches, review back-and-forth, verification narrative, or refactoring
+described from the inside.
+
+## Remediation
+
+Fix the prose directly, then land the correction at the cheapest point:
+
+| Situation | Fix |
+| --- | --- |
+| Nothing committed yet | Just edit the files |
+| Committed, not pushed, one commit | Edit, then `git commit --amend --no-edit` |
+| Committed, not pushed, several commits | Edit, commit the fixes, then `/squash-commits` |
+| Commit message wording, not pushed | `git commit --amend -m` for the tip; `/squash-commits` across the branch (interactive rebase is unavailable) |
+| Pushed, no PR yet | Fix as above, then force-push with `--force-with-lease` |
+| Changelog file, any time | Edit and commit normally — no history rewrite |
+| PR description, any time | `gh pr edit <pr_number> --body` |
+| PR already under review | Follow-up commit; do not rewrite pushed history |
+
+## Report
+
+List each violation as `file:line`, the offending text, and what it became. If
+the prose is clean, say so explicitly — callers rely on knowing the check ran.


### PR DESCRIPTION
## Summary

- Adds a `prose-review` skill that checks added comments, docstrings, and changelog entries against the "Writing for Future Readers" section of `AGENTS.md`
- The skills that produce prose now call it on their own output: `docstring` and `cleanup` over the code they touch, `changelog` over its entries, and `pr-submit` over the branch before pushing
- `pr-description` checks its description against the same standard, since a PR description isn't a diff

The skill takes a scope — `staged`, `branch` (default), or a path — and reviews added lines only, diffing against the merge base so prose that hasn't been committed yet is still covered.

It judges whether a sentence's subject is the code or the change, rather than pattern-matching vocabulary: words like "previously", "instead of", and "no longer" appear throughout correct prose in this repo, so a lexical check would flag mostly innocent comments. The calibration section pairs real legitimate examples from `src/pipecat` against violations and their fixes.

Ships as part of the `pipecat-dev` plugin, so it is listed in `marketplace.json` and linked from `.agents/skills/`.

## Testing

```
/prose-review branch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)