### PR TITLE
Keyterm boosting support for Cartesia STT services

### DIFF
--- a/changelog/5168.added.md
+++ b/changelog/5168.added.md
@@ -1,1 +1,10 @@
-- Added `keyterm` boosting support to `CartesiaSTTService` and `CartesiaTurnsSTTService`, matching the `keyterm`/`keywords` boosting already available on Deepgram and ElevenLabs STT services.
+- Added `keyterm` to `CartesiaSTTService.Settings` and `CartesiaTurnsSTTService.Settings`, biasing transcription toward domain-specific words and phrases such as product names and jargon.
+
+    ```python
+    stt = CartesiaTurnsSTTService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaTurnsSTTService.Settings(keyterm=["Pipecat", "Ink 2"]),
+    )
+    ```
+
+    Cartesia binds keyterms to a connection, so updating them with an `STTUpdateSettingsFrame` reconnects to apply them. Lists longer than Cartesia's limit of 100 keyterms or 1200 total characters are truncated with a warning. `CartesiaSTTService` sends keyterms only for ink-2 models, the only family Cartesia supports them on.

--- a/changelog/5168.added.md
+++ b/changelog/5168.added.md
@@ -1,0 +1,1 @@
+- Added `keyterm` boosting support to `CartesiaSTTService` and `CartesiaTurnsSTTService`, matching the `keyterm`/`keywords` boosting already available on Deepgram and ElevenLabs STT services.

--- a/changelog/5168.changed.md
+++ b/changelog/5168.changed.md
@@ -1,0 +1,4 @@
+- `CartesiaSTTService` now connects with `Cartesia-Version: 2026-03-01`, the
+  version that supports `keyterm` and returns structured JSON errors. This
+  brings it in line with `CartesiaTTSService` and `CartesiaTurnsSTTService`,
+  which already use that version.

--- a/examples/voice/voice-cartesia.py
+++ b/examples/voice/voice-cartesia.py
@@ -56,7 +56,12 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info(f"Starting bot")
 
-    stt = CartesiaSTTService(api_key=os.environ["CARTESIA_API_KEY"])
+    stt = CartesiaSTTService(
+        api_key=os.environ["CARTESIA_API_KEY"],
+        settings=CartesiaSTTService.Settings(
+            model="ink-2",
+        ),
+    )
 
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -414,7 +414,7 @@ class CartesiaSTTService(WebsocketSTTService):
             # only emits with quote_via=quote.
             query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
             ws_url = f"wss://{self._base_url}/stt/websocket?{query}"
-            headers = {"Cartesia-Version": "2025-04-16", "X-API-Key": self._api_key}
+            headers = {"Cartesia-Version": "2026-03-01", "X-API-Key": self._api_key}
 
             self._websocket = await self._websocket_connect(ws_url, additional_headers=headers)
             await self._call_event_handler("on_connected")

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -38,20 +38,60 @@ from pipecat.utils.deprecation import deprecated
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
 
+# Cartesia caps a connection at 100 keyterms totaling 1200 characters.
+_MAX_KEYTERMS = 100
+_MAX_KEYTERM_CHARS = 1200
+
+# Keyterms are only honored by the ink-2 model family.
+_KEYTERM_MODEL_PREFIX = "ink-2"
+
+
+def _prepare_keyterms(keyterms: list[str] | None | _NotGiven) -> list[str]:
+    """Normalize keyterms to the limits Cartesia accepts on a connection.
+
+    Drops blank entries and truncates to :data:`_MAX_KEYTERMS` terms totaling
+    :data:`_MAX_KEYTERM_CHARS` characters, warning about whatever is dropped.
+    Clamping rather than forwarding an oversized list keeps a bad keyterm
+    list from failing the connection outright mid-call.
+
+    Args:
+        keyterms: Keyterms from settings, which may be unset or ``None``.
+
+    Returns:
+        The keyterms to send, in the order given.
+    """
+    if not is_given(keyterms) or not keyterms:
+        return []
+
+    terms = [stripped for term in keyterms if (stripped := term.strip())]
+
+    prepared: list[str] = []
+    total_chars = 0
+    for term in terms:
+        if len(prepared) >= _MAX_KEYTERMS or total_chars + len(term) > _MAX_KEYTERM_CHARS:
+            break
+        prepared.append(term)
+        total_chars += len(term)
+
+    if len(prepared) < len(terms):
+        logger.warning(
+            f"Cartesia accepts at most {_MAX_KEYTERMS} keyterms totaling "
+            f"{_MAX_KEYTERM_CHARS} characters; dropping {len(terms) - len(prepared)} keyterm(s)"
+        )
+
+    return prepared
+
 
 @dataclass
 class CartesiaSTTSettings(STTSettings):
     """Settings for CartesiaSTTService.
 
-    ``model`` and ``language`` are inherited from ``STTSettings`` /
-    ``ServiceSettings``.
-
     Parameters:
-        keyterm: List of key terms or phrases to bias transcription towards.
-            Sent as repeated ``keyterm`` query parameters on the WebSocket
-            connection URL. Cartesia applies keyterms only at connection
-            time and does not support changing them mid-stream; updating
-            this setting at runtime triggers a reconnect. See
+        keyterm: Key terms or phrases to bias transcription towards, sent as
+            repeated ``keyterm`` query parameters on the connection URL. Only
+            honored by ink-2 models; keyterms set for any other model are
+            ignored with a warning. Cartesia binds keyterms to a connection,
+            so updating this setting at runtime triggers a reconnect. See
             https://docs.cartesia.ai/use-the-api/stt/keyterms.
     """
 
@@ -361,10 +401,19 @@ class CartesiaSTTService(WebsocketSTTService):
                 ("encoding", self._encoding),
                 ("sample_rate", str(self.sample_rate)),
             ]
-            keyterm = self._settings.keyterm
-            if is_given(keyterm) and keyterm is not None:
-                params.extend(("keyterm", term) for term in keyterm)
-            ws_url = f"wss://{self._base_url}/stt/websocket?{urllib.parse.urlencode(params)}"
+            keyterms = _prepare_keyterms(self._settings.keyterm)
+            if keyterms:
+                if str(self._settings.model).startswith(_KEYTERM_MODEL_PREFIX):
+                    params.extend(("keyterm", term) for term in keyterms)
+                else:
+                    logger.warning(
+                        f"keyterms are only supported on {_KEYTERM_MODEL_PREFIX} models; "
+                        f"ignoring keyterms for model {self._settings.model!r}"
+                    )
+            # Cartesia expects spaces inside a keyterm as %20, which urlencode
+            # only emits with quote_via=quote.
+            query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+            ws_url = f"wss://{self._base_url}/stt/websocket?{query}"
             headers = {"Cartesia-Version": "2025-04-16", "X-API-Key": self._api_key}
 
             self._websocket = await self._websocket_connect(ws_url, additional_headers=headers)

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -51,8 +51,7 @@ def _prepare_keyterms(keyterms: list[str] | None | _NotGiven) -> list[str]:
 
     Drops blank entries and truncates to :data:`_MAX_KEYTERMS` terms totaling
     :data:`_MAX_KEYTERM_CHARS` characters, warning about whatever is dropped.
-    Clamping rather than forwarding an oversized list keeps a bad keyterm
-    list from failing the connection outright mid-call.
+    Truncating keeps an oversized list from failing the connection mid-call.
 
     Args:
         keyterms: Keyterms from settings, which may be unset or ``None``.

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -13,7 +13,7 @@ the Cartesia Live transcription API for real-time speech recognition.
 import json
 import urllib.parse
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from loguru import logger
@@ -30,7 +30,7 @@ from pipecat.frames.frames import (
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.services.settings import STTSettings
+from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven, is_given
 from pipecat.services.stt_latency import CARTESIA_TTFS_P99
 from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
@@ -41,9 +41,21 @@ from pipecat.utils.tracing.service_decorators import traced_stt
 
 @dataclass
 class CartesiaSTTSettings(STTSettings):
-    """Settings for CartesiaSTTService."""
+    """Settings for CartesiaSTTService.
 
-    pass
+    ``model`` and ``language`` are inherited from ``STTSettings`` /
+    ``ServiceSettings``.
+
+    Parameters:
+        keyterm: List of key terms or phrases to bias transcription towards.
+            Sent as repeated ``keyterm`` query parameters on the WebSocket
+            connection URL. Cartesia applies keyterms only at connection
+            time and does not support changing them mid-stream; updating
+            this setting at runtime triggers a reconnect. See
+            https://docs.cartesia.ai/use-the-api/stt/keyterms.
+    """
+
+    keyterm: list[str] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 @deprecated(
@@ -186,6 +198,7 @@ class CartesiaSTTService(WebsocketSTTService):
         default_settings = self.Settings(
             model="ink-whisper",
             language=Language.EN.value,
+            keyterm=None,
         )
 
         # 2. Apply live_options overrides — only if settings not provided
@@ -342,12 +355,15 @@ class CartesiaSTTService(WebsocketSTTService):
                 return
             logger.debug("Connecting to Cartesia STT")
 
-            params = {
-                "model": self._settings.model,
-                "language": self._settings.language,
-                "encoding": self._encoding,
-                "sample_rate": str(self.sample_rate),
-            }
+            params = [
+                ("model", self._settings.model),
+                ("language", self._settings.language),
+                ("encoding", self._encoding),
+                ("sample_rate", str(self.sample_rate)),
+            ]
+            keyterm = self._settings.keyterm
+            if is_given(keyterm) and keyterm is not None:
+                params.extend(("keyterm", term) for term in keyterm)
             ws_url = f"wss://{self._base_url}/stt/websocket?{urllib.parse.urlencode(params)}"
             headers = {"Cartesia-Version": "2025-04-16", "X-API-Key": self._api_key}
 

--- a/src/pipecat/services/cartesia/turns/stt.py
+++ b/src/pipecat/services/cartesia/turns/stt.py
@@ -11,7 +11,7 @@ import json
 import time
 import urllib.parse
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from loguru import logger
@@ -29,7 +29,7 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
-from pipecat.services.settings import STTSettings
+from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven, is_given
 from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
@@ -41,11 +41,20 @@ from pipecat.utils.tracing.service_decorators import traced_stt
 class CartesiaTurnsSTTSettings(STTSettings):
     """Settings for CartesiaTurnsSTTService.
 
-    The ink-2 model family is English-only and does not support runtime model or language switching,
-    so no fields are added beyond the inherited :class:`STTSettings`.
+    ``model`` and ``language`` are inherited from ``STTSettings`` /
+    ``ServiceSettings``. The ink-2 model family is English-only and does not
+    support runtime model or language switching.
+
+    Parameters:
+        keyterm: List of key terms or phrases to bias transcription towards.
+            Sent as repeated ``keyterm`` query parameters on the WebSocket
+            connection URL. Cartesia applies keyterms only at connection
+            time; like ``model`` and ``language``, changing this at runtime
+            has no effect and is reported as unhandled. See
+            https://docs.cartesia.ai/use-the-api/stt/keyterms.
     """
 
-    pass
+    keyterm: list[str] | None | _NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class CartesiaTurnsSTTService(WebsocketSTTService):
@@ -112,8 +121,8 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
             extra_headers: Optional additional HTTP headers to send with the
                 WebSocket handshake.
             settings: Runtime-updatable settings. The ink-2 family does not
-                support runtime model or language switching; attempts to update
-                either field will be reported as unhandled.
+                support runtime model, language, or keyterm switching; attempts
+                to update any of these fields will be reported as unhandled.
             **kwargs: Additional arguments passed to the parent
                 :class:`WebsocketSTTService`.
         """
@@ -121,6 +130,7 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
         default_settings = self.Settings(
             model="ink-2",
             language=None,
+            keyterm=None,
         )
 
         if settings is not None:
@@ -253,11 +263,14 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
     def _websocket_url(self) -> str:
         # Pipecat pipes 16-bit signed little-endian PCM through the pipeline,
         # so the wire encoding is fixed.
-        params = {
-            "model": self._settings.model,
-            "encoding": "pcm_s16le",
-            "sample_rate": str(self.sample_rate),
-        }
+        params = [
+            ("model", self._settings.model),
+            ("encoding", "pcm_s16le"),
+            ("sample_rate", str(self.sample_rate)),
+        ]
+        keyterm = self._settings.keyterm
+        if is_given(keyterm) and keyterm is not None:
+            params.extend(("keyterm", term) for term in keyterm)
         return f"{self._url}?{urllib.parse.urlencode(params)}"
 
     async def _connect_websocket(self):

--- a/src/pipecat/services/cartesia/turns/stt.py
+++ b/src/pipecat/services/cartesia/turns/stt.py
@@ -29,7 +29,8 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
-from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven, is_given
+from pipecat.services.cartesia.stt import _prepare_keyterms
+from pipecat.services.settings import NOT_GIVEN, STTSettings, _NotGiven
 from pipecat.services.stt_service import WebsocketSTTService
 from pipecat.transcriptions.language import Language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
@@ -41,16 +42,14 @@ from pipecat.utils.tracing.service_decorators import traced_stt
 class CartesiaTurnsSTTSettings(STTSettings):
     """Settings for CartesiaTurnsSTTService.
 
-    ``model`` and ``language`` are inherited from ``STTSettings`` /
-    ``ServiceSettings``. The ink-2 model family is English-only and does not
-    support runtime model or language switching.
+    The ink-2 model family is English-only and does not support runtime model
+    or language switching.
 
     Parameters:
-        keyterm: List of key terms or phrases to bias transcription towards.
-            Sent as repeated ``keyterm`` query parameters on the WebSocket
-            connection URL. Cartesia applies keyterms only at connection
-            time; like ``model`` and ``language``, changing this at runtime
-            has no effect and is reported as unhandled. See
+        keyterm: Key terms or phrases to bias transcription towards, sent as
+            repeated ``keyterm`` query parameters on the connection URL.
+            Cartesia binds keyterms to a connection, so updating this setting
+            at runtime triggers a reconnect. See
             https://docs.cartesia.ai/use-the-api/stt/keyterms.
     """
 
@@ -121,8 +120,8 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
             extra_headers: Optional additional HTTP headers to send with the
                 WebSocket handshake.
             settings: Runtime-updatable settings. The ink-2 family does not
-                support runtime model, language, or keyterm switching; attempts
-                to update any of these fields will be reported as unhandled.
+                support runtime model or language switching; attempts to update
+                either field will be reported as unhandled.
             **kwargs: Additional arguments passed to the parent
                 :class:`WebsocketSTTService`.
         """
@@ -229,8 +228,9 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
         """Apply a settings delta.
 
-        Ink-2 does not support runtime model or language switching, so any
-        changed fields are reported as unhandled.
+        Keyterms are bound to a connection, so a changed ``keyterm`` list is
+        applied by reconnecting. Ink-2 does not support runtime model or
+        language switching, so those changes are reported as unhandled.
 
         Args:
             delta: A :class:`STTSettings` (or
@@ -240,7 +240,12 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
             Dict mapping changed field names to their previous values.
         """
         changed = await super()._update_settings(delta)
-        self._warn_unhandled_updated_settings(changed.keys())
+
+        self._warn_unhandled_updated_settings(changed.keys() - {"keyterm"})
+
+        if "keyterm" in changed:
+            await self._request_reconnect()
+
         return changed
 
     # ------------------------------------------------------------------
@@ -268,10 +273,10 @@ class CartesiaTurnsSTTService(WebsocketSTTService):
             ("encoding", "pcm_s16le"),
             ("sample_rate", str(self.sample_rate)),
         ]
-        keyterm = self._settings.keyterm
-        if is_given(keyterm) and keyterm is not None:
-            params.extend(("keyterm", term) for term in keyterm)
-        return f"{self._url}?{urllib.parse.urlencode(params)}"
+        params.extend(("keyterm", term) for term in _prepare_keyterms(self._settings.keyterm))
+        # Cartesia expects spaces inside a keyterm as %20, which urlencode only
+        # emits with quote_via=quote.
+        return f"{self._url}?{urllib.parse.urlencode(params, quote_via=urllib.parse.quote)}"
 
     async def _connect_websocket(self):
         """Connect to the v2 WebSocket and wait for the server's ``connected`` frame."""

--- a/tests/test_cartesia_stt.py
+++ b/tests/test_cartesia_stt.py
@@ -36,25 +36,35 @@ async def test_cartesia_connect_failure_clears_stale_websocket(monkeypatch):
     assert service._websocket is None
 
 
-@pytest.mark.asyncio
-async def test_cartesia_connect_websocket_url_includes_keyterm(monkeypatch):
+def _capture_connect_url(monkeypatch) -> dict:
+    """Stub out the websocket connect and capture the URL it's called with."""
     captured = {}
 
-    async def fake_websocket_connect(url, *, additional_headers):
+    async def fake_websocket_connect(url, **kwargs):
         captured["url"] = url
-        captured["headers"] = additional_headers
+        captured["headers"] = kwargs.get("additional_headers")
         return _FakeWebsocket()
 
-    monkeypatch.setattr("pipecat.services.cartesia.stt.websocket_connect", fake_websocket_connect)
-
-    service = CartesiaSTTService(
-        api_key="test-key",
-        sample_rate=16000,
-        settings=CartesiaSTTService.Settings(keyterm=["Cartesia", "Ink Whisper"]),
+    monkeypatch.setattr(
+        "pipecat.services.websocket_service.websocket_connect", fake_websocket_connect
     )
-    # sample_rate is normally set from StartFrame; poke it directly since this
-    # test calls _connect_websocket() without running a full pipeline.
+    return captured
+
+
+def _connected_service(**kwargs) -> CartesiaSTTService:
+    service = CartesiaSTTService(api_key="test-key", sample_rate=16000, **kwargs)
+    # sample_rate is normally set from StartFrame, which these tests skip.
     service._sample_rate = 16000
+    return service
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_includes_keyterm(monkeypatch):
+    captured = _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(model="ink-2", keyterm=["Cartesia", "Ink 2"]),
+    )
 
     await service._connect_websocket()
 
@@ -63,29 +73,97 @@ async def test_cartesia_connect_websocket_url_includes_keyterm(monkeypatch):
     assert parsed.scheme == "wss"
     assert parsed.netloc == "api.cartesia.ai"
     assert parsed.path == "/stt/websocket"
-    assert query["model"] == ["ink-whisper"]
+    assert query["model"] == ["ink-2"]
     assert query["sample_rate"] == ["16000"]
-    assert query["keyterm"] == ["Cartesia", "Ink Whisper"]
+    assert query["keyterm"] == ["Cartesia", "Ink 2"]
     assert captured["headers"]["X-API-Key"] == "test-key"
 
 
 @pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_encodes_keyterm_spaces_as_percent_20(monkeypatch):
+    captured = _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(model="ink-2", keyterm=["Ink 2"]),
+    )
+
+    await service._connect_websocket()
+
+    assert "keyterm=Ink%202" in captured["url"]
+
+
+@pytest.mark.asyncio
 async def test_cartesia_connect_websocket_url_omits_keyterm_when_not_set(monkeypatch):
-    captured = {}
+    captured = _capture_connect_url(monkeypatch)
 
-    async def fake_websocket_connect(url, *, additional_headers):
-        captured["url"] = url
-        return _FakeWebsocket()
-
-    monkeypatch.setattr("pipecat.services.cartesia.stt.websocket_connect", fake_websocket_connect)
-
-    service = CartesiaSTTService(api_key="test-key", sample_rate=16000)
-    service._sample_rate = 16000
+    service = _connected_service()
 
     await service._connect_websocket()
 
     query = parse_qs(urlparse(captured["url"]).query)
     assert "keyterm" not in query
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_omits_keyterm_for_non_ink_2_model(monkeypatch):
+    captured = _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(keyterm=["Cartesia"]),
+    )
+
+    await service._connect_websocket()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["model"] == ["ink-whisper"]
+    assert "keyterm" not in query
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_clamps_keyterms_to_limits(monkeypatch):
+    captured = _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(
+            model="ink-2",
+            keyterm=[f"term{i}" for i in range(150)],
+        ),
+    )
+
+    await service._connect_websocket()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["keyterm"] == [f"term{i}" for i in range(100)]
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_clamps_keyterms_to_character_budget(monkeypatch):
+    captured = _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(model="ink-2", keyterm=["a" * 700, "b" * 700, "c"]),
+    )
+
+    await service._connect_websocket()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["keyterm"] == ["a" * 700]
+
+
+@pytest.mark.asyncio
+async def test_cartesia_update_keyterm_reconnects(monkeypatch):
+    _capture_connect_url(monkeypatch)
+
+    service = _connected_service(
+        settings=CartesiaSTTService.Settings(model="ink-2", keyterm=["Cartesia"]),
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_request_reconnect", reconnect)
+
+    await service._update_settings(CartesiaSTTService.Settings(keyterm=["Ink 2"]))
+
+    assert service._settings.keyterm == ["Ink 2"]
+    reconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cartesia_stt.py
+++ b/tests/test_cartesia_stt.py
@@ -5,6 +5,7 @@
 #
 
 from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from websockets.protocol import State
@@ -33,6 +34,58 @@ async def test_cartesia_connect_failure_clears_stale_websocket(monkeypatch):
     await service._connect_websocket()
 
     assert service._websocket is None
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_includes_keyterm(monkeypatch):
+    captured = {}
+
+    async def fake_websocket_connect(url, *, additional_headers):
+        captured["url"] = url
+        captured["headers"] = additional_headers
+        return _FakeWebsocket()
+
+    monkeypatch.setattr("pipecat.services.cartesia.stt.websocket_connect", fake_websocket_connect)
+
+    service = CartesiaSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        settings=CartesiaSTTService.Settings(keyterm=["Cartesia", "Ink Whisper"]),
+    )
+    # sample_rate is normally set from StartFrame; poke it directly since this
+    # test calls _connect_websocket() without running a full pipeline.
+    service._sample_rate = 16000
+
+    await service._connect_websocket()
+
+    parsed = urlparse(captured["url"])
+    query = parse_qs(parsed.query)
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "api.cartesia.ai"
+    assert parsed.path == "/stt/websocket"
+    assert query["model"] == ["ink-whisper"]
+    assert query["sample_rate"] == ["16000"]
+    assert query["keyterm"] == ["Cartesia", "Ink Whisper"]
+    assert captured["headers"]["X-API-Key"] == "test-key"
+
+
+@pytest.mark.asyncio
+async def test_cartesia_connect_websocket_url_omits_keyterm_when_not_set(monkeypatch):
+    captured = {}
+
+    async def fake_websocket_connect(url, *, additional_headers):
+        captured["url"] = url
+        return _FakeWebsocket()
+
+    monkeypatch.setattr("pipecat.services.cartesia.stt.websocket_connect", fake_websocket_connect)
+
+    service = CartesiaSTTService(api_key="test-key", sample_rate=16000)
+    service._sample_rate = 16000
+
+    await service._connect_websocket()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert "keyterm" not in query
 
 
 @pytest.mark.asyncio

--- a/tests/test_cartesia_turns_stt.py
+++ b/tests/test_cartesia_turns_stt.py
@@ -4,20 +4,23 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
+
+import pytest
 
 from pipecat.services.cartesia.turns.stt import CartesiaTurnsSTTService
 
 
-def test_cartesia_turns_websocket_url_includes_keyterm():
-    service = CartesiaTurnsSTTService(
-        api_key="test-key",
-        sample_rate=16000,
-        settings=CartesiaTurnsSTTService.Settings(keyterm=["Cartesia", "Ink 2"]),
-    )
-    # sample_rate is normally set from StartFrame; poke it directly since this
-    # test calls _websocket_url() without running a full pipeline.
+def _service(**kwargs) -> CartesiaTurnsSTTService:
+    service = CartesiaTurnsSTTService(api_key="test-key", sample_rate=16000, **kwargs)
+    # sample_rate is normally set from StartFrame, which these tests skip.
     service._sample_rate = 16000
+    return service
+
+
+def test_cartesia_turns_websocket_url_includes_keyterm():
+    service = _service(settings=CartesiaTurnsSTTService.Settings(keyterm=["Cartesia", "Ink 2"]))
 
     parsed = urlparse(service._websocket_url())
     query = parse_qs(parsed.query)
@@ -30,10 +33,48 @@ def test_cartesia_turns_websocket_url_includes_keyterm():
     assert query["keyterm"] == ["Cartesia", "Ink 2"]
 
 
+def test_cartesia_turns_websocket_url_encodes_keyterm_spaces_as_percent_20():
+    service = _service(settings=CartesiaTurnsSTTService.Settings(keyterm=["Ink 2"]))
+
+    assert "keyterm=Ink%202" in service._websocket_url()
+
+
 def test_cartesia_turns_websocket_url_omits_keyterm_when_not_set():
-    service = CartesiaTurnsSTTService(api_key="test-key", sample_rate=16000)
-    service._sample_rate = 16000
+    service = _service()
 
     query = parse_qs(urlparse(service._websocket_url()).query)
 
     assert "keyterm" not in query
+
+
+def test_cartesia_turns_websocket_url_clamps_keyterms_to_limits():
+    service = _service(
+        settings=CartesiaTurnsSTTService.Settings(keyterm=[f"term{i}" for i in range(150)])
+    )
+
+    query = parse_qs(urlparse(service._websocket_url()).query)
+
+    assert query["keyterm"] == [f"term{i}" for i in range(100)]
+
+
+@pytest.mark.asyncio
+async def test_cartesia_turns_update_keyterm_reconnects(monkeypatch):
+    service = _service(settings=CartesiaTurnsSTTService.Settings(keyterm=["Cartesia"]))
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_request_reconnect", reconnect)
+
+    await service._update_settings(CartesiaTurnsSTTService.Settings(keyterm=["Ink 2"]))
+
+    assert service._settings.keyterm == ["Ink 2"]
+    reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cartesia_turns_update_model_does_not_reconnect(monkeypatch):
+    service = _service()
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_request_reconnect", reconnect)
+
+    await service._update_settings(CartesiaTurnsSTTService.Settings(model="ink-3"))
+
+    reconnect.assert_not_awaited()

--- a/tests/test_cartesia_turns_stt.py
+++ b/tests/test_cartesia_turns_stt.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from urllib.parse import parse_qs, urlparse
+
+from pipecat.services.cartesia.turns.stt import CartesiaTurnsSTTService
+
+
+def test_cartesia_turns_websocket_url_includes_keyterm():
+    service = CartesiaTurnsSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        settings=CartesiaTurnsSTTService.Settings(keyterm=["Cartesia", "Ink 2"]),
+    )
+    # sample_rate is normally set from StartFrame; poke it directly since this
+    # test calls _websocket_url() without running a full pipeline.
+    service._sample_rate = 16000
+
+    parsed = urlparse(service._websocket_url())
+    query = parse_qs(parsed.query)
+
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "api.cartesia.ai"
+    assert parsed.path == "/stt/turns/websocket"
+    assert query["model"] == ["ink-2"]
+    assert query["sample_rate"] == ["16000"]
+    assert query["keyterm"] == ["Cartesia", "Ink 2"]
+
+
+def test_cartesia_turns_websocket_url_omits_keyterm_when_not_set():
+    service = CartesiaTurnsSTTService(api_key="test-key", sample_rate=16000)
+    service._sample_rate = 16000
+
+    query = parse_qs(urlparse(service._websocket_url()).query)
+
+    assert "keyterm" not in query


### PR DESCRIPTION
## Summary

Cartesia's STT WebSocket API supports biasing transcription toward specific words/phrases via a `keyterm` connection parameter (sent as repeated query params — see https://docs.cartesia.ai/use-the-api/stt/keyterms and 
https://docs.cartesia.ai/api-reference/stt/turns/websocket), but neither `CartesiaSTTService` nor `CartesiaTurnsSTTService` exposed it.

This adds a `keyterm` field to both settings dataclasses, following the same pattern already used for `DeepgramSTTSettings.keyterm`/`keywords` and `ElevenLabsRealtimeSTTSettings.keyterms`.

Both `_connect_websocket`/`_websocket_url` now append `keyterm` as repeated query params when set, matching the wire format Cartesia expects.

## Test plan

- [x] `uv run pytest tests/test_cartesia_stt.py tests/test_cartesia_turns_stt.py -v` — new tests cover: keyterm included/omitted from the connection URL, base params still present, and (for `CartesiaSTTService`) connect failure/no-op-when-open behavior is unaffected.
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] Manually verified against a live Cartesia STT connection with a small keyterm list, confirming correct transcription of the boosted terms.
