### PR TITLE
fix(dtmf): mark flushed DTMF transcriptions as finalized

### DIFF
--- a/changelog/5172.fixed.md
+++ b/changelog/5172.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DTMFAggregator` emitting flushed `TranscriptionFrame`s with `finalized=False`, which stalled user-turn stop strategies waiting for a final transcription.

--- a/examples/features/features-dtmf-menu.py
+++ b/examples/features/features-dtmf-menu.py
@@ -12,6 +12,9 @@ that the LLM reacts to:
 
 - press 1 for business hours
 - press 2 for the office location
+- press 3 to request a callback: the caller enters their callback number and
+  presses ``#`` to finalize it (the aggregator's termination digit, which
+  flushes the sequence immediately instead of waiting for the idle timeout)
 
 DTMF arrives as ``InputDTMFFrame`` from the transport (e.g. a telephony provider,
 or the eval harness), so there's no STT in the pipeline. The bot speaks its
@@ -47,11 +50,18 @@ The caller interacts only with their phone keypad. Each keypress arrives as a \
 message like "DTMF: 1" (the digits they pressed, possibly ending in #).
 
 When the call starts, greet the caller and read this menu: press 1 for our \
-business hours, press 2 for our location.
+business hours, press 2 for our location, press 3 to request a callback.
 
 When the caller presses 1, tell them Acme Corp is open from 9 AM to 5 PM, Monday \
 through Friday. When they press 2, tell them Acme Corp is located at 123 Main \
-Street. For any other key, say that's not a valid option and read the menu again.
+Street. When they press 3, ask them to enter their callback number followed by \
+the pound key. For any other key, say that's not a valid option and read the \
+menu again.
+
+While collecting a callback number, the digits may arrive split across several \
+messages if the caller pauses; the number is complete only when a message ends \
+in #. Once you have the complete number, read it back digit by digit, tell the \
+caller someone will call them back, and read the menu again.
 
 Keep every response short. Your responses may be read aloud, so don't use emojis \
 or formatting."""

--- a/scripts/release-evals/scenarios/dtmf_menu.yaml
+++ b/scripts/release-evals/scenarios/dtmf_menu.yaml
@@ -29,3 +29,19 @@ turns:
         text_contains: "DTMF: 2"
       - event: response
         eval: "gives the office location (123 Main Street)"
+
+  # Press 3: request a callback.
+  - dtmf: "3"
+    expect:
+      - event: user_transcription
+        text_contains: "DTMF: 3"
+      - event: response
+        eval: "asks the caller to enter their callback number followed by the pound key"
+
+  # Enter the callback number, finalized with '#'.
+  - dtmf: "5551234567#"
+    expect:
+      - event: user_transcription
+        text_contains: "DTMF: 5551234567#"
+      - event: response
+        eval: "confirms the callback number 5551234567 and says someone will call back"

--- a/src/pipecat/processors/aggregators/dtmf_aggregator.py
+++ b/src/pipecat/processors/aggregators/dtmf_aggregator.py
@@ -141,8 +141,9 @@ class DTMFAggregator(FrameProcessor):
         sequence = self._aggregation
         transcription_text = f"{self._prefix}{sequence}"
 
+        # A DTMF flush is always a complete entry, so mark it finalized.
         transcription_frame = TranscriptionFrame(
-            text=transcription_text, user_id="", timestamp=time_now_iso8601()
+            text=transcription_text, user_id="", timestamp=time_now_iso8601(), finalized=True
         )
         await self.push_frame(transcription_frame)
 

--- a/tests/test_dtmf_aggregator.py
+++ b/tests/test_dtmf_aggregator.py
@@ -48,6 +48,7 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(len(transcription_frames), 1)
         self.assertEqual(transcription_frames[0].text, "DTMF: 123#")
+        self.assertTrue(transcription_frames[0].finalized)
 
     async def test_timeout_aggregation(self):
         """Test DTMF aggregation with timeout flush."""
@@ -82,6 +83,7 @@ class TestDTMFAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(transcription_frames), 2)
         self.assertEqual(transcription_frames[0].text, "DTMF: 12")
         self.assertEqual(transcription_frames[1].text, "DTMF: 3")
+        self.assertTrue(all(f.finalized for f in transcription_frames))
 
     async def test_multiple_aggregations(self):
         """Test multiple DTMF sequences with pound termination."""


### PR DESCRIPTION
## Problem

`DTMFAggregator._flush_aggregation` emits its `TranscriptionFrame` with the default `finalized=False`. Downstream user-turn stop strategies treat a non-finalized transcription as tentative and keep waiting for a final that never arrives, falling back to a timeout timer. On telephony that timer gets repeatedly reset by ambient line-noise VAD, so a DTMF entry can take many seconds to close the user turn. Observed on production voice agent calls.

A DTMF aggregation flush is by construction final; there is no interim DTMF.

## Fix

Emit the flushed frame with `finalized=True`, matching how STT services mark final transcriptions.

## Tests

Extended `tests/test_dtmf_aggregator.py` to assert `finalized` is set on both the termination-digit and timeout flush paths.