### PR TITLE
fix(turns): apply user idle timeout updates to a running timer

### DIFF
--- a/changelog/5173.fixed.md
+++ b/changelog/5173.fixed.md
@@ -1,1 +1,1 @@
-- Fixed `UserIdleController` ignoring `UserIdleTimeoutUpdateFrame` until the next re-arm: a running idle timer now restarts with the new duration, and enabling a positive timeout while everything is already idle arms the timer immediately.
+- Fixed `UserIdleController` ignoring `UserIdleTimeoutUpdateFrame` until the next re-arm: a running idle timer now restarts with the new duration, and enabling a positive timeout while waiting for the user to speak arms the timer immediately.

--- a/changelog/5173.fixed.md
+++ b/changelog/5173.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `UserIdleController` ignoring `UserIdleTimeoutUpdateFrame` until the next re-arm: a running idle timer now restarts with the new duration, and enabling a positive timeout while everything is already idle arms the timer immediately.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2130,7 +2130,9 @@ class UserIdleTimeoutUpdateFrame(SystemFrame):
     """Frame for updating the user idle timeout at runtime.
 
     Setting timeout to 0 disables idle detection. Setting a positive value
-    enables it.
+    enables it. Updates apply immediately: a running idle timer restarts with
+    the new duration, and if the bot is waiting for the user to speak the
+    timer is armed right away.
 
     Parameters:
         timeout: The new idle timeout in seconds. 0 disables idle detection.

--- a/src/pipecat/turns/user_idle_controller.py
+++ b/src/pipecat/turns/user_idle_controller.py
@@ -62,6 +62,7 @@ class UserIdleController(BaseObject):
 
         self._user_idle_timeout = user_idle_timeout
 
+        self._bot_speaking: bool = False
         self._user_turn_in_progress: bool = False
         self._function_calls_in_progress: int = 0
         self._idle_timer_task: asyncio.Task | None = None
@@ -80,12 +81,19 @@ class UserIdleController(BaseObject):
             frame: The frame to be processed.
         """
         if isinstance(frame, UserIdleTimeoutUpdateFrame):
+            was_running = self._idle_timer_task is not None
             self._user_idle_timeout = frame.timeout
             if self._user_idle_timeout <= 0:
                 await self._cancel_idle_timer()
+            elif was_running or self._can_start_idle_timer():
+                # Restart a running timer so the new duration applies now, and
+                # arm a fresh one if the update arrives while everything is
+                # already idle (e.g. the timeout was previously disabled).
+                await self._start_idle_timer()
             return
 
         if isinstance(frame, BotStoppedSpeakingFrame):
+            self._bot_speaking = False
             # Only start the timer if the user isn't mid-turn and no function
             # calls are pending.
             #
@@ -103,6 +111,7 @@ class UserIdleController(BaseObject):
             if not self._user_turn_in_progress and self._function_calls_in_progress == 0:
                 await self._start_idle_timer()
         elif isinstance(frame, BotStartedSpeakingFrame):
+            self._bot_speaking = True
             await self._cancel_idle_timer()
         elif isinstance(frame, UserStartedSpeakingFrame):
             self._user_turn_in_progress = True
@@ -114,6 +123,14 @@ class UserIdleController(BaseObject):
             await self._cancel_idle_timer()
         elif isinstance(frame, (FunctionCallResultFrame, FunctionCallCancelFrame)):
             self._function_calls_in_progress = max(0, self._function_calls_in_progress - 1)
+
+    def _can_start_idle_timer(self) -> bool:
+        """Whether current state allows arming the idle timer."""
+        return (
+            not self._bot_speaking
+            and not self._user_turn_in_progress
+            and self._function_calls_in_progress == 0
+        )
 
     async def _start_idle_timer(self):
         """Start (or restart) the idle timer."""

--- a/src/pipecat/turns/user_idle_controller.py
+++ b/src/pipecat/turns/user_idle_controller.py
@@ -35,6 +35,10 @@ class UserIdleController(BaseObject):
     triggers during interruptions (where BotStoppedSpeakingFrame arrives while
     the user is still speaking).
 
+    A UserIdleTimeoutUpdateFrame applies immediately: it restarts a running
+    timer with the new duration and, while waiting for the user to speak, arms
+    the timer even if idle detection was previously disabled.
+
     Event handlers available:
 
     - on_user_turn_idle: Emitted when the user has been idle for the timeout period.
@@ -62,7 +66,7 @@ class UserIdleController(BaseObject):
 
         self._user_idle_timeout = user_idle_timeout
 
-        self._bot_speaking: bool = False
+        self._waiting_for_user: bool = False
         self._user_turn_in_progress: bool = False
         self._function_calls_in_progress: int = 0
         self._idle_timer_task: asyncio.Task | None = None
@@ -81,19 +85,17 @@ class UserIdleController(BaseObject):
             frame: The frame to be processed.
         """
         if isinstance(frame, UserIdleTimeoutUpdateFrame):
-            was_running = self._idle_timer_task is not None
             self._user_idle_timeout = frame.timeout
             if self._user_idle_timeout <= 0:
                 await self._cancel_idle_timer()
-            elif was_running or self._can_start_idle_timer():
-                # Restart a running timer so the new duration applies now, and
-                # arm a fresh one if the update arrives while everything is
-                # already idle (e.g. the timeout was previously disabled).
+            elif self._waiting_for_user:
+                # Apply the new timeout now: restart a running timer with the
+                # new duration, or arm one if idle detection was previously
+                # disabled.
                 await self._start_idle_timer()
             return
 
         if isinstance(frame, BotStoppedSpeakingFrame):
-            self._bot_speaking = False
             # Only start the timer if the user isn't mid-turn and no function
             # calls are pending.
             #
@@ -109,28 +111,26 @@ class UserIdleController(BaseObject):
             # on_function_calls_started event handler, so the counter guard
             # prevents the timer from starting while a function call is in progress.
             if not self._user_turn_in_progress and self._function_calls_in_progress == 0:
+                # Track the waiting-for-user window even when the timeout is
+                # currently <= 0 (no timer), so a later timeout update can arm
+                # the timer without waiting for the next bot turn.
+                self._waiting_for_user = True
                 await self._start_idle_timer()
         elif isinstance(frame, BotStartedSpeakingFrame):
-            self._bot_speaking = True
+            self._waiting_for_user = False
             await self._cancel_idle_timer()
         elif isinstance(frame, UserStartedSpeakingFrame):
+            self._waiting_for_user = False
             self._user_turn_in_progress = True
             await self._cancel_idle_timer()
         elif isinstance(frame, UserStoppedSpeakingFrame):
             self._user_turn_in_progress = False
         elif isinstance(frame, FunctionCallsStartedFrame):
+            self._waiting_for_user = False
             self._function_calls_in_progress += len(frame.function_calls)
             await self._cancel_idle_timer()
         elif isinstance(frame, (FunctionCallResultFrame, FunctionCallCancelFrame)):
             self._function_calls_in_progress = max(0, self._function_calls_in_progress - 1)
-
-    def _can_start_idle_timer(self) -> bool:
-        """Whether current state allows arming the idle timer."""
-        return (
-            not self._bot_speaking
-            and not self._user_turn_in_progress
-            and self._function_calls_in_progress == 0
-        )
 
     async def _start_idle_timer(self):
         """Start (or restart) the idle timer."""

--- a/tests/test_user_idle_controller.py
+++ b/tests/test_user_idle_controller.py
@@ -318,6 +318,75 @@ class TestUserIdleController(unittest.IsolatedAsyncioTestCase):
 
         await controller.cleanup()
 
+    async def test_update_applies_to_running_timer(self):
+        """Test that a timeout update restarts a running timer with the new duration."""
+        controller = UserIdleController(user_idle_timeout=10)
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        # Timer starts with the long timeout
+        await controller.process_frame(BotStoppedSpeakingFrame())
+        # Retune to a short timeout while the timer is running
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertTrue(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_enable_via_frame_arms_while_idle(self):
+        """Test that enabling via frame arms the timer when everything is already idle."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        # Bot finished speaking while idle detection was disabled
+        await controller.process_frame(BotStartedSpeakingFrame())
+        await controller.process_frame(BotStoppedSpeakingFrame())
+
+        # Enable idle detection — no further speaking events will re-arm
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertTrue(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_update_while_bot_speaking_does_not_arm(self):
+        """Test that a timeout update while the bot is speaking does not arm the timer."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        await controller.process_frame(BotStartedSpeakingFrame())
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertFalse(idle_triggered)
+
+        await controller.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_user_idle_controller.py
+++ b/tests/test_user_idle_controller.py
@@ -15,6 +15,7 @@ from pipecat.frames.frames import (
     FunctionCallsStartedFrame,
     UserIdleTimeoutUpdateFrame,
     UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
 )
 from pipecat.turns.user_idle_controller import UserIdleController
 from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
@@ -379,6 +380,97 @@ class TestUserIdleController(unittest.IsolatedAsyncioTestCase):
             idle_triggered = True
 
         await controller.process_frame(BotStartedSpeakingFrame())
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertFalse(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_update_before_first_bot_turn_does_not_arm(self):
+        """Test that a timeout update before the bot has spoken does not arm the timer."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertFalse(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_update_while_user_turn_in_progress_does_not_arm(self):
+        """Test that a timeout update during a user turn does not arm the timer."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        await controller.process_frame(BotStartedSpeakingFrame())
+        await controller.process_frame(UserStartedSpeakingFrame())
+        await controller.process_frame(BotStoppedSpeakingFrame())
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertFalse(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_update_while_awaiting_bot_response_does_not_arm(self):
+        """Test that a timeout update between a user turn and the bot's response does not arm."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        # User finished a turn; the bot's response is still in flight.
+        await controller.process_frame(UserStartedSpeakingFrame())
+        await controller.process_frame(UserStoppedSpeakingFrame())
+        await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertFalse(idle_triggered)
+
+        await controller.cleanup()
+
+    async def test_update_while_function_call_in_progress_does_not_arm(self):
+        """Test that a timeout update during a function call does not arm the timer."""
+        controller = UserIdleController()
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        await controller.process_frame(BotStartedSpeakingFrame())
+        await controller.process_frame(BotStoppedSpeakingFrame())
+        await controller.process_frame(
+            FunctionCallsStartedFrame(function_calls=[unittest.mock.Mock()])
+        )
         await controller.process_frame(UserIdleTimeoutUpdateFrame(timeout=USER_IDLE_TIMEOUT))
 
         await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)


### PR DESCRIPTION
## Symptom

Pushing a `UserIdleTimeoutUpdateFrame` mid-call has no visible effect until the next time the timer is re-armed (i.e. the next `BotStoppedSpeakingFrame`). Observed on a production voice agent that tunes idle timeouts per conversation node.

## Cause

`UserIdleController.process_frame` only stores the new value:

- a timer that is already running keeps sleeping on the old duration, so the new timeout applies only on the next re-arm;
- if idle detection was previously disabled (timeout <= 0), or the timer isn't running because everything is already idle, setting a positive timeout never starts a timer at all.

## Fix

On a timeout update: restart a currently running timer with the new duration, and arm a fresh timer when the controller is in a state where one should be armed (bot not speaking, no user turn in progress, no function calls pending). Adds a `_bot_speaking` flag so the arming conditions can be checked outside the `BotStoppedSpeakingFrame` handler.

## Tests

Added to `tests/test_user_idle_controller.py`:

- update from 10s to 0.2s while the timer is running fires at the new duration;
- enabling via frame while everything is already idle arms and fires;
- enabling via frame while the bot is speaking does not arm.