### PR TITLE
fix(tts): don't leak _processing_text when a filter strips the text to empty

### DIFF
--- a/changelog/5174.fixed.md
+++ b/changelog/5174.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TTSService` leaving frame processing permanently paused when a text filter strips the text to empty and `pause_frame_processing` is enabled.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1158,11 +1158,6 @@ class TTSService(AIService):
             if not text.strip():
                 return
 
-        # This is just a flag that indicates if we sent something to the TTS
-        # service. It will be cleared if we sent text because of a TTSSpeakFrame
-        # or when we received an LLMFullResponseEndFrame
-        self._processing_text = True
-
         # Accumulate text for a single debug log at flush time when streaming tokens.
         if self._is_streaming_tokens:
             self._streamed_text += text
@@ -1188,6 +1183,14 @@ class TTSService(AIService):
         elif not text.strip():
             await self.stop_processing_metrics()
             return
+
+        # This is just a flag that indicates if we sent something to the TTS
+        # service. It will be cleared if we sent text because of a TTSSpeakFrame
+        # or when we received an LLMFullResponseEndFrame. Set only after the
+        # whitespace/filter gates above, otherwise a filter that strips the text
+        # to empty would leave the flag latched and, with pause_frame_processing
+        # enabled, pause frame processing waiting for audio that never comes.
+        self._processing_text = True
 
         # To support use cases that may want to know the text before it's spoken, we
         # push the AggregatedTextFrame version before transforming and sending to TTS.

--- a/tests/test_tts_frame_ordering.py
+++ b/tests/test_tts_frame_ordering.py
@@ -63,6 +63,7 @@ from pipecat.services.tts_service import TextAggregationMode, TTSService
 from pipecat.tests.utils import SleepFrame, run_test
 from pipecat.utils.string import TextPartForConcatenation, concatenate_aggregated_text
 from pipecat.utils.text.base_text_aggregator import AggregationType
+from pipecat.utils.text.base_text_filter import BaseTextFilter
 
 # ---------------------------------------------------------------------------
 # Test-only frame
@@ -1625,6 +1626,51 @@ async def test_no_deadlock_on_zero_audio_context_completion():
     assert any(f.label == "after_completion" for f in foo_frames), (
         "FooFrame after zero-audio context completion was not received — "
         "pipeline deadlocked (missing resume-on-zero-audio guard)"
+    )
+
+
+class _StripEverythingFilter(BaseTextFilter):
+    """Text filter that strips all text, like a filter removing leaked reasoning tokens."""
+
+    async def filter(self, text: str) -> str:
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_filter_stripped_text_does_not_pause_frame_processing():
+    """A text filter that strips the whole utterance must not pause frame processing.
+
+    _push_tts_frames used to set _processing_text=True before running the text
+    filters. If a filter stripped the text to empty, the early return left the
+    flag latched, and LLMFullResponseEndFrame paused frame processing waiting
+    for TTS audio that would never come — permanently muting the bot.
+
+    The mock never delivers audio, so if the pause is (wrongly) engaged there
+    is no BotStoppedSpeakingFrame to release it and FooFrame never arrives.
+    """
+    tts = MockWebSocketPauseTTSServiceNoAudio(text_filters=[_StripEverythingFilter()])
+
+    frames_to_send = [
+        LLMFullResponseStartFrame(),
+        TextFrame(text="Leaked reasoning tokens."),
+        LLMFullResponseEndFrame(),
+        SleepFrame(sleep=0.1),
+        FooFrame(label="after_stripped_response"),
+    ]
+
+    frames_received = await asyncio.wait_for(
+        run_test(tts, frames_to_send=frames_to_send),
+        timeout=3.0,
+    )
+
+    assert not tts._processing_text, (
+        "_processing_text leaked True after a filter stripped the text to empty"
+    )
+
+    down = frames_received[0]
+    foo_frames = [f for f in down if isinstance(f, FooFrame)]
+    assert any(f.label == "after_stripped_response" for f in foo_frames), (
+        "FooFrame was not received — frame processing paused on filter-stripped text"
     )
 
 


### PR DESCRIPTION
## What breaks

With `pause_frame_processing=True`, if a text filter strips an entire utterance to empty (e.g. a filter removing leaked reasoning tokens), the bot goes permanently mute. We hit this on a production voice agent: one filtered utterance and the rest of the call was silence.

## Where the flag leaks

In `src/pipecat/services/tts_service.py`, `_push_tts_frames` set `self._processing_text = True` before running the text-filter loop. The post-filter empty-text early return (`elif not text.strip(): await self.stop_processing_metrics(); return`) returned without clearing it. `LLMFullResponseEndFrame` then calls `_maybe_pause_frame_processing()`, which sees the stale flag and pauses frame processing waiting for TTS audio that will never come — no `run_tts` was called, so no `BotStoppedSpeakingFrame` ever releases the pause. The pause watchdog eventually force-resumes after its timeout, but that's a stall mitigation, not correct behavior.

## Fix

Move the `self._processing_text = True` assignment below the post-filter whitespace gates, so the flag is only set when text will actually be sent to TTS. Nothing between the old and new position reads the flag.

Includes a regression test (`test_filter_stripped_text_does_not_pause_frame_processing`) that fails on main and passes with the fix.