### PR TITLE
fix(aggregators): don't carry a closed turn's aggregation into the next user turn

### DIFF
--- a/changelog/5175.fixed.md
+++ b/changelog/5175.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `LLMUserAggregator` carrying a closed turn's buffered aggregation into the next user turn. A late final transcription that landed after its turn was committed used to be prepended to the next turn's user message; it is now dropped at turn start (transcriptions that themselves start a turn are kept, and realtime mode is unaffected).

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -693,6 +693,11 @@ class LLMUserAggregator(LLMContextAggregator):
 
         self._user_is_muted = False
         self._user_turn_start_timestamp = ""
+        # Aggregation length observed at the top of the current
+        # process_frame call. Lets _on_user_turn_started tell apart text
+        # appended by the frame that started the turn (which belongs to
+        # the new turn) from text left over from before it.
+        self._aggregation_len_before_frame = 0
         # One-shot guard: whether the first realtime LLM service metadata frame
         # has been handled this session — see _handle_llm_service_metadata.
         self._realtime_metadata_handled = False
@@ -771,6 +776,8 @@ class LLMUserAggregator(LLMContextAggregator):
             direction: The direction of frame flow in the pipeline.
         """
         await super().process_frame(frame, direction)
+
+        self._aggregation_len_before_frame = len(self._aggregation)
 
         if await self._maybe_mute_frame(frame):
             return
@@ -1197,6 +1204,23 @@ class LLMUserAggregator(LLMContextAggregator):
         params: UserTurnStartedParams,
     ):
         logger.debug(f"{self}: User started speaking (strategy: {strategy})")
+
+        # In cascade mode the previous turn pushed its aggregation when it
+        # stopped, so any text still buffered when a new turn starts is a
+        # late transcript from that closed turn and must not bleed into the
+        # new turn's user message. Only parts that predate the frame that
+        # started this turn are dropped: a transcription that itself starts
+        # the turn (TranscriptionUserTurnStartStrategy) is already in the
+        # buffer and is kept. Realtime mode keeps the buffer, since it is
+        # flushed on assistant response start rather than at turn stop.
+        if not self._realtime_service_mode:
+            stale = self._aggregation[: self._aggregation_len_before_frame]
+            if stale:
+                logger.debug(
+                    f"{self}: dropping stale aggregation from a previous turn: "
+                    f"{[p.text for p in stale]}"
+                )
+                del self._aggregation[: self._aggregation_len_before_frame]
 
         self._user_turn_start_timestamp = time_now_iso8601()
         self._full_user_turn_aggregation = None

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -461,6 +461,97 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stop_message.content, "Hello!")
         self.assertFalse(timeout)
 
+    async def test_stale_aggregation_not_carried_into_next_turn(self):
+        context = LLMContext()
+
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    start=[VADUserTurnStartStrategy()],
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+                user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+            ),
+        )
+
+        stop_messages = []
+
+        @user_aggregator.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(aggregator, strategy, message):
+            stop_messages.append(message)
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            # Turn 1: transcript lands in time and is committed on stop.
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Turn one.", user_id="", timestamp="now"),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.05),
+            # Late final from turn 1 arrives after the turn was committed.
+            TranscriptionFrame(text="Late straggler.", user_id="", timestamp="now"),
+            # Let the straggler (a data frame) drain before the VAD system
+            # frame, which would otherwise skip the queue and overtake it.
+            SleepFrame(),
+            # Turn 2: new speech must not inherit the stale straggler.
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Turn two.", user_id="", timestamp="now"),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.05),
+        ]
+        await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+        )
+
+        self.assertEqual(len(stop_messages), 2)
+        self.assertEqual(stop_messages[0].content, "Turn one.")
+        self.assertEqual(stop_messages[1].content, "Turn two.")
+        self.assertEqual(
+            [m["content"] for m in context.messages], ["Turn one.", "Turn two."]
+        )
+
+    async def test_transcription_that_starts_turn_is_kept(self):
+        context = LLMContext()
+
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    start=[TranscriptionUserTurnStartStrategy()],
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+                user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+            ),
+        )
+
+        stop_messages = []
+
+        @user_aggregator.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(aggregator, strategy, message):
+            stop_messages.append(message)
+
+        pipeline = Pipeline([user_aggregator])
+
+        # No VAD frames: the final transcription itself starts the turn and
+        # must survive the turn-start stale-aggregation cleanup.
+        frames_to_send = [
+            TranscriptionFrame(text="Hello there!", user_id="", timestamp="now"),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.05),
+        ]
+        await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+        )
+
+        self.assertEqual(len(stop_messages), 1)
+        self.assertEqual(stop_messages[0].content, "Hello there!")
+
     async def test_user_mute_strategies(self):
         context = LLMContext()
 

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -510,9 +510,7 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(stop_messages), 2)
         self.assertEqual(stop_messages[0].content, "Turn one.")
         self.assertEqual(stop_messages[1].content, "Turn two.")
-        self.assertEqual(
-            [m["content"] for m in context.messages], ["Turn one.", "Turn two."]
-        )
+        self.assertEqual([m["content"] for m in context.messages], ["Turn one.", "Turn two."])
 
     async def test_transcription_that_starts_turn_is_kept(self):
         context = LLMContext()


### PR DESCRIPTION
## Symptom

Observed on a production voice agent (cascade pipeline): the user message for a turn occasionally contained leftover text from the previous, already-committed turn, producing a garbled LLM user message and a confused response.

## Sequence

1. User turn N stops (e.g. via a stop strategy or the `user_turn_stop_timeout` watchdog). `_maybe_emit_user_turn_stopped` pushes the buffered aggregation and commits the user message to context.
2. A late final `TranscriptionFrame` from turn N arrives after the turn closed. `_handle_transcription` appends it to `_aggregation` unconditionally.
3. User turn N+1 starts (e.g. VAD start on new speech). `_on_user_turn_started` resets `_user_turn_start_timestamp` and `_full_user_turn_aggregation` but not `_aggregation`.
4. Turn N+1's transcripts are appended after the straggler, so the committed message for turn N+1 is `"<late text from turn N> <turn N+1 text>"`.

## Cause

`LLMUserAggregator._on_user_turn_started` never clears `_aggregation`, so text buffered between turn N's close and turn N+1's start bleeds into the new turn.

## Fix

At user turn start (cascade mode only), drop aggregation parts that were buffered before the frame that started the turn:

- A snapshot of `len(self._aggregation)` is taken at the top of `process_frame`, so a transcription that itself starts the turn (`TranscriptionUserTurnStartStrategy` — it is appended to the buffer before the turn controller runs on the same frame) is preserved. An unconditional clear would break transcription-started turns.
- Realtime mode is untouched: there the buffer legitimately survives turn boundaries and is flushed on assistant response start.

## Test

`test_stale_aggregation_not_carried_into_next_turn` reproduces the sequence above (turn 1 commits, straggler lands, turn 2 speaks) and asserts turn 2's message contains only turn 2's text; it fails on `main` with `"Late straggler. Turn two."`. `test_transcription_that_starts_turn_is_kept` guards the transcription-started-turn path against regression.