### PR TITLE
BaseOutputTransport: resolve media sender via type(self).MediaSender

### DIFF
--- a/changelog/5166.added.md
+++ b/changelog/5166.added.md
@@ -1,0 +1,1 @@
+- `BaseOutputTransport` now resolves its media sender via `type(self).MediaSender`, allowing transport subclasses to provide a custom `MediaSender` implementation by shadowing the inner class. ([#5166](https://github.com/pipecat-ai/pipecat/issues/5166))

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -171,8 +171,9 @@ class BaseOutputTransport(FrameProcessor):
         for destination in self._params.video_out_destinations:
             await self.register_video_destination(destination)
 
-        # Start default media sender.
-        self._media_senders[None] = BaseOutputTransport.MediaSender(
+        # Start default media sender. Resolve via type(self) so transport
+        # subclasses can provide a custom MediaSender implementation.
+        self._media_senders[None] = type(self).MediaSender(
             self,
             destination=None,
             sample_rate=self.sample_rate,
@@ -189,7 +190,7 @@ class BaseOutputTransport(FrameProcessor):
 
         # Start media senders.
         for destination in destinations:
-            self._media_senders[destination] = BaseOutputTransport.MediaSender(
+            self._media_senders[destination] = type(self).MediaSender(
                 self,
                 destination=destination,
                 sample_rate=self.sample_rate,

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -261,3 +261,52 @@ class TestBaseOutputTransportAudioBuffering(unittest.IsolatedAsyncioTestCase):
             self.assertIn(BotStoppedSpeakingFrame, pushed_types)
         finally:
             await transport.cancel(CancelFrame())
+
+
+class TestBaseOutputTransportCustomMediaSender(unittest.IsolatedAsyncioTestCase):
+    """The media sender class is resolved via ``type(self).MediaSender``, so a
+    transport subclass can provide its own sender implementation by shadowing
+    the inner class.
+    """
+
+    class _CustomOutputTransport(BaseOutputTransport):
+        class MediaSender(BaseOutputTransport.MediaSender):
+            pass
+
+    async def _make_transport(self, cls, **params_kwargs) -> BaseOutputTransport:
+        params = TransportParams(audio_out_enabled=True, **params_kwargs)
+        transport = cls(params)
+        transport.push_frame = AsyncMock()
+        transport.write_audio_frame = AsyncMock(return_value=True)
+
+        task_manager = TaskManager()
+        task_manager.setup(TaskManagerParams(loop=asyncio.get_event_loop()))
+        await transport.setup(
+            FrameProcessorSetup(
+                clock=SystemClock(),
+                task_manager=task_manager,
+                pipeline_worker=SimpleNamespace(app_resources=None),  # type: ignore[arg-type]
+            )
+        )
+        start_frame = StartFrame(audio_out_sample_rate=16000)
+        await transport.process_frame(start_frame, FrameDirection.DOWNSTREAM)
+        await transport.set_transport_ready(start_frame)
+        return transport
+
+    async def test_default_sender_is_base_media_sender(self):
+        transport = await self._make_transport(BaseOutputTransport)
+        try:
+            self.assertIs(type(transport._media_senders[None]), BaseOutputTransport.MediaSender)
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_subclass_media_sender_is_used_for_default_and_destinations(self):
+        transport = await self._make_transport(
+            self._CustomOutputTransport, audio_out_destinations=["screenAudio"]
+        )
+        try:
+            custom_cls = self._CustomOutputTransport.MediaSender
+            self.assertIs(type(transport._media_senders[None]), custom_cls)
+            self.assertIs(type(transport._media_senders["screenAudio"]), custom_cls)
+        finally:
+            await transport.cancel(CancelFrame())


### PR DESCRIPTION
## What

Resolve the media sender class from the transport's type at both construction sites in `set_transport_ready()` (`base_output.py`), instead of hardcoding `BaseOutputTransport.MediaSender`:

```python
self._media_senders[destination] = type(self).MediaSender(...)
```

This lets a transport subclass provide its own sender implementation by shadowing the inner class — the same extension pattern the class already uses for destinations (`register_audio_destination`), per-destination mixers, and delivery (`write_audio_frame`). It completes the per-destination sender model introduced in #1697: the sender becomes a per-transport extension point.

## Compatibility

Fully backward compatible. `type(self).MediaSender` resolves to `BaseOutputTransport.MediaSender` unless a subclass deliberately shadows the inner class; no behavior change for any existing transport.

```python
class MyOutputTransport(FastAPIWebsocketOutputTransport):
    class MediaSender(FastAPIWebsocketOutputTransport.MediaSender):
        async def _bot_started_speaking(self):
            await super()._bot_started_speaking()
            ...  # transport-specific behavior
```

## Use case

Telephony platform (FastAPI websocket transport, multiple carriers) where transport-specific behavior genuinely lives in the sender layer: per-carrier audio pacing interacting with the sender's clock task, clearing buffered audio on programmatic (non-VAD) interruption without the bot-stopped-speaking lifecycle (same need as #3872), and observability on bot speech start/stop from inside the audio task loop. Today the only way to express these is post-construction mutation of `_media_senders`, which #3872's workaround shows is already happening in the wild.

## Tests

Added `TestBaseOutputTransportCustomMediaSender` covering:

- default transports still get `BaseOutputTransport.MediaSender`
- a subclass-shadowed `MediaSender` is used for both the default sender and per-destination senders

Closes #5166