### PR TITLE
Default Baseten LLM to Kimi K2.6

### DIFF
--- a/changelog/5178.changed.md
+++ b/changelog/5178.changed.md
@@ -1,0 +1,1 @@
+- `BasetenLLMService` now defaults to `moonshotai/Kimi-K2.6`. Set `settings=BasetenLLMService.Settings(model=...)` to pin a different model.

--- a/src/pipecat/services/baseten/llm.py
+++ b/src/pipecat/services/baseten/llm.py
@@ -63,9 +63,9 @@ class BasetenLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # Initialize default_settings with hardcoded defaults.
-        # Kimi K2.5 streams visible content immediately, keeping time-to-first-word low.
+        # Kimi K2.6 streams visible content immediately, keeping time-to-first-word low.
         default_settings = self.Settings(
-            model="moonshotai/Kimi-K2.5",
+            model="moonshotai/Kimi-K2.6",
         )
 
         # Apply settings delta (canonical API, always wins)


### PR DESCRIPTION
## Summary

- `BasetenLLMService` now defaults to `moonshotai/Kimi-K2.6` instead of `moonshotai/Kimi-K2.5`
- Applications that pin a model via `settings=BasetenLLMService.Settings(model=...)` are unaffected