### PR TITLE
perf(vad): only dispatch to the executor when a full analysis frame is buffered

### DIFF
--- a/changelog/5179.performance.md
+++ b/changelog/5179.performance.md
@@ -1,0 +1,4 @@
+- `VADAnalyzer.analyze_audio` now buffers audio on the caller's thread and only hands off to
+  its executor once a full analysis frame is available. With `SileroVADAnalyzer` at 16 kHz on
+  a 10 ms transport, 11 of every 16 calls previously paid a thread round trip to do nothing
+  but append bytes.

--- a/src/pipecat/audio/vad/vad_analyzer.py
+++ b/src/pipecat/audio/vad/vad_analyzer.py
@@ -194,9 +194,18 @@ class VADAnalyzer(ABC):
         state = await loop.run_in_executor(self._executor, self._run_analyzer)
         return state
 
-    def _run_analyzer(self) -> VADState:
-        """Analyze the buffered audio and return current VAD state."""
+    def _run_analyzer(self, buffer: bytes = b"") -> VADState:
+        """Analyze the buffered audio and return current VAD state.
+
+        Args:
+            buffer: Additional audio to buffer before analyzing. Subclasses that
+                override :meth:`analyze_audio` may pass the incoming chunk here.
+        """
+        self._vad_buffer += buffer
+
         num_required_bytes = self._vad_frames_num_bytes
+        if len(self._vad_buffer) < num_required_bytes:
+            return self._vad_state
 
         while len(self._vad_buffer) >= num_required_bytes:
             audio_frames = self._vad_buffer[:num_required_bytes]

--- a/src/pipecat/audio/vad/vad_analyzer.py
+++ b/src/pipecat/audio/vad/vad_analyzer.py
@@ -182,17 +182,21 @@ class VADAnalyzer(ABC):
         Returns:
             Current VAD state after processing the buffer.
         """
-        loop = asyncio.get_running_loop()
-        state = await loop.run_in_executor(self._executor, self._run_analyzer, buffer)
-        return state
-
-    def _run_analyzer(self, buffer: bytes) -> VADState:
-        """Analyze audio buffer and return current VAD state."""
         self._vad_buffer += buffer
 
-        num_required_bytes = self._vad_frames_num_bytes
-        if len(self._vad_buffer) < num_required_bytes:
+        # Transports deliver audio in chunks smaller than one analysis frame
+        # (10 ms is 320 bytes at 16 kHz, while Silero needs 1024), so most calls
+        # only buffer. Hand off to the model thread once a full frame is ready.
+        if len(self._vad_buffer) < self._vad_frames_num_bytes:
             return self._vad_state
+
+        loop = asyncio.get_running_loop()
+        state = await loop.run_in_executor(self._executor, self._run_analyzer)
+        return state
+
+    def _run_analyzer(self) -> VADState:
+        """Analyze the buffered audio and return current VAD state."""
+        num_required_bytes = self._vad_frames_num_bytes
 
         while len(self._vad_buffer) >= num_required_bytes:
             audio_frames = self._vad_buffer[:num_required_bytes]


### PR DESCRIPTION
`VADAnalyzer.analyze_audio` hands every incoming chunk to its single-worker
`ThreadPoolExecutor`, including chunks too small for the model to run on. `_run_analyzer`
appends to `self._vad_buffer` and returns the previous state unchanged whenever fewer than
`num_frames_required()` samples are buffered. On a WebRTC transport most of those hand-offs
do a byte append and nothing else, and each one costs a thread round trip.

This buffers on the caller's thread and dispatches only once a complete analysis frame is
available. The model still runs off the event loop, and `analyze_audio` returns the same
sequence of `VADState` values.

### Call frequency

`VADController._handle_vad` calls `analyze_audio` once per `InputAudioRawFrame`. With
`SileroVADAnalyzer` at 16 kHz (512 samples required):

| transport chunk | analyses | calls that only buffer |
| --- | --- | --- |
| 10 ms (WebRTC / LiveKit) | 5 per 16 calls | 11/16 = 68.75% |
| 20 ms (`daily/transport.py:638`, `local/audio.py:80`) | 5 per 8 calls | 3/8 = 37.5% |

`AICVADAnalyzer` uses a 10 ms window, which already matches the transport chunk. There this
skips nothing and costs one length comparison per call.

### Measurements

32 vCPU AWS instance, CPython 3.12.13, under an exclusive host CPU lock.

- One `loop.run_in_executor` round trip: **57.9 µs** (median of 7 × 3000 iterations). The
  same callable invoked inline costs 0.05 µs.
- 1000 × 10 ms frames (10 s of audio) through `analyze_audio` with a deterministic
  512-sample analyzer, this branch and `main` interleaved on identical fixtures inside one
  process pair: **133.1 ms → 88.6 ms** of caller-side time. That is **44.5 ms per 10 s of
  audio per stream**, or about **13.4 ms per 3 s utterance**. Analyses run either way: 312.
- Executor round trips over those 1000 frames: **1000 → 312**.

The unit is caller-side time on the task that pumps audio frames. It is not VAD detection
latency: transitions still report on the same frame as before.

### On #3218

This addresses the first of the three costs @daniel1014 measured in
https://github.com/pipecat-ai/pipecat/issues/3218#issuecomment-4683595532. It should not
close that issue. I could not reproduce #3218's headline symptom, 100-280 ms/s of
accumulating frame age, on current `main`, so I make no claim to have fixed it.

I left out two larger nearby wins to keep this reviewable on its own. One is the per-block
`pyloudnorm` meter construction in `calculate_audio_volume`, cost 2 in the same profile,
which is #5124 in `audio/utils.py` and does not overlap this diff. The other is coalescing
input frames before the pipeline, which changes transport behaviour rather than VAD.

### Thread ownership

The append to `self._vad_buffer` now happens on the caller's thread instead of only on the
executor thread. That holds for the documented usage: the comment above `self._executor`
notes that one analyzer handles one audio stream, and `VADController` awaits each call. But
two overlapping un-awaited `analyze_audio` calls on one instance would now interleave, where
the single-worker executor previously serialised them. I can add an explicit guard if you
would rather not rely on that invariant.

### Checks

`uv run pytest tests/` gives 3660 passed / 33 skipped on this branch and on the merge base
(all extras except `gstreamer` and `local`). `ruff check` and `ruff format --check` are
clean.

### Optimization record

https://dashboard.weco.ai/share/h0N3o3wj2G0aYADy43D6hNYwV4VqEecI records the search behind this change. Weco is an optimization-search tool,
and that link records experiments run against a frozen evaluator. It is not a claim about
authorship: I wrote and reviewed this diff by hand.