### PR TITLE
Strip unused imports on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,11 @@
 repos:
   - repo: local
     hooks:
+      # F401 (unused imports) is selected here rather than in pyproject.toml so
+      # imports are only stripped at commit time, not mid-development.
       - id: ruff
         name: ruff
-        entry: uv run ruff check --fix
+        entry: uv run ruff check --fix --extend-select F401
         language: system
         types: [python]
       - id: ruff-format


### PR DESCRIPTION
The ruff pre-commit hook now selects F401 and fixes it, so unused imports never reach a commit.

Keeping F401 out of the `pyproject.toml` lint config means an editor-triggered or manual `ruff check --fix` leaves imports alone — an import you haven't wired up yet, or one whose only use you just deleted, survives until you commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)