### PR TITLE
fix(tts): report accumulated TTS usage when a turn is interrupted

### DIFF
--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -1000,6 +1000,13 @@ class TTSService(AIService):
             await filter.handle_interruption()
 
         self._llm_response_started = False
+        # Report before dropping the accumulator. When streaming tokens the
+        # per-token usage calls short-circuit and the flush is the only thing
+        # that emits the metric, so an interrupted turn would otherwise report
+        # nothing at all for text the service has already been sent and billed
+        # for. Barge-in is the normal case in a voice agent, not an edge case.
+        if self._streamed_text:
+            await super().start_tts_usage_metrics(self._streamed_text)
         self._streamed_text = ""
         self._text_aggregation_metrics_started = False
         self._aggregated_frame_sequencer.clear()  # discard all pending slots on interruption

--- a/tests/test_tts_usage_on_interruption.py
+++ b/tests/test_tts_usage_on_interruption.py
@@ -1,0 +1,106 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests that an interrupted turn still reports the TTS characters it was billed for.
+
+In ``TextAggregationMode.TOKEN`` the per-token ``start_tts_usage_metrics`` calls
+short-circuit and the text is accumulated instead, then reported once when the turn
+flushes. An interrupted turn never reaches that flush, so clearing the accumulator in
+``_handle_interruption`` dropped the whole turn's character count even though the text
+had already been sent to the service and billed for.
+
+Barge-in is the normal case in a voice agent rather than an edge case, and
+``TextAggregationMode.TOKEN`` is the default for Deepgram Flux, so this ran on every
+interrupted turn and nothing raised.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pipecat.frames.frames import InterruptionFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.ai_service import AIService
+from pipecat.services.tts_service import TextAggregationMode, TTSService
+
+
+class _StubTTSService(TTSService):
+    """Minimal concrete TTSService; the transport is irrelevant to usage accounting."""
+
+    async def run_tts(self, text: str):  # pragma: no cover - never driven here
+        return
+        yield
+
+
+def _service(mode: TextAggregationMode) -> _StubTTSService:
+    service = _StubTTSService(text_aggregation_mode=mode)
+    # _handle_interruption also cycles word timestamps and the audio context
+    # task. Neither exists outside a running pipeline, and the audio context
+    # task needs a TaskManager, so both are stubbed. Usage accounting is
+    # independent of both.
+    service.reset_word_timestamps = AsyncMock()
+    service._stop_audio_context_task = AsyncMock()
+    service._create_audio_context_task = MagicMock()
+    service.push_frame = AsyncMock()
+    return service
+
+
+async def _interrupt(service) -> None:
+    await service._handle_interruption(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+
+def _reported_text(recorder: AsyncMock) -> list:
+    return [call.args[0] for call in recorder.await_args_list]
+
+
+class TestInterruptedTurnReportsUsage:
+    @pytest.mark.asyncio
+    async def test_accumulated_characters_are_reported(self):
+        """The service was sent this text and billed for it before the barge-in."""
+        service = _service(TextAggregationMode.TOKEN)
+        service._streamed_text = "The nearest office is on Market Street and it opens at"
+        with patch.object(AIService, "start_tts_usage_metrics", new_callable=AsyncMock) as recorder:
+            await _interrupt(service)
+        assert _reported_text(recorder) == [
+            "The nearest office is on Market Street and it opens at"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_accumulator_is_still_cleared(self):
+        """Reporting must not leave the text behind to be counted twice next turn."""
+        service = _service(TextAggregationMode.TOKEN)
+        service._streamed_text = "some spoken text"
+        with patch.object(AIService, "start_tts_usage_metrics", new_callable=AsyncMock):
+            await _interrupt(service)
+        assert service._streamed_text == ""
+
+    @pytest.mark.asyncio
+    async def test_a_turn_interrupted_twice_is_counted_once(self):
+        """The second interruption has nothing left to report."""
+        service = _service(TextAggregationMode.TOKEN)
+        service._streamed_text = "some spoken text"
+        with patch.object(AIService, "start_tts_usage_metrics", new_callable=AsyncMock) as recorder:
+            await _interrupt(service)
+            await _interrupt(service)
+        assert _reported_text(recorder) == ["some spoken text"]
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_reported_when_no_text_was_sent(self):
+        """An interruption before any token must not emit a zero-character metric."""
+        service = _service(TextAggregationMode.TOKEN)
+        service._streamed_text = ""
+        with patch.object(AIService, "start_tts_usage_metrics", new_callable=AsyncMock) as recorder:
+            await _interrupt(service)
+        recorder.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sentence_mode_is_unaffected(self):
+        """Sentence aggregation reports per sentence as it goes and never accumulates."""
+        service = _service(TextAggregationMode.SENTENCE)
+        assert service._streamed_text == ""
+        with patch.object(AIService, "start_tts_usage_metrics", new_callable=AsyncMock) as recorder:
+            await _interrupt(service)
+        recorder.assert_not_awaited()


### PR DESCRIPTION
## The problem

An interrupted turn contributes nothing to TTS character usage, for text that was already
sent to the service and billed for.

In `TextAggregationMode.TOKEN`, `TTSService.start_tts_usage_metrics` short-circuits:

```python
if self._is_streaming_tokens:
    return
await super().start_tts_usage_metrics(text)
```

The text is accumulated into `_streamed_text` instead, and reported once when the turn
flushes. `_handle_interruption` then cleared that accumulator without reporting it, so a
turn that was interrupted never reported at all.

This is not an edge case. Barge-in is the normal way a voice conversation goes, and
`TextAggregationMode.TOKEN` is the default for `DeepgramFluxTTSService`. Sentence
aggregation is unaffected, since it reports per sentence as it goes and never accumulates.

## How it got there

The accumulator started out as a debug-log buffer, which is what the comment at its
assignment still says:

```python
# Accumulate text for a single debug log at flush time when streaming tokens.
if self._is_streaming_tokens:
    self._streamed_text += text
```

While that was all it was, dropping it on interruption was correct. It later became the
source for the usage metric as well, and the interruption path was not updated with it.

## The change

Report before dropping:

```python
if self._streamed_text:
    await super().start_tts_usage_metrics(self._streamed_text)
self._streamed_text = ""
```

`super()` deliberately, to bypass the token-mode short-circuit, matching what the flush
path at the end of the turn already does.

## Tests

`tests/test_tts_usage_on_interruption.py`, five tests, two of which fail on `main`:

```
FAILED TestInterruptedTurnReportsUsage::test_accumulated_characters_are_reported
FAILED TestInterruptedTurnReportsUsage::test_a_turn_interrupted_twice_is_counted_once
```

The other three are guards: the accumulator is still cleared so nothing is double counted
on the next turn, an interruption before any token emits nothing rather than a
zero-character metric, and sentence mode is untouched.

Full suite: 3282 passed. The 7 unrelated failures (`test_bridge_processor`,
`test_deprecation_markers`, `test_openai_responses_http`, `test_runner_utils`,
`test_service_switcher`) all reproduce with this diff reverted on the same checkout.

## One thing I noticed and did not change

`_streamed_text` accumulates at the top of `_push_tts_frames`, before the text filters run
a few lines below it. So both the existing flush-time report and this one count pre-filter
characters, which can differ from what is actually sent to the provider if a filter
rewrites the text. I matched the existing behaviour rather than change it here, since that
is a separate decision about what the metric is supposed to mean. Happy to follow up if
you want the filtered text counted instead.
