### PR TITLE
Isolate the test suite from a local .env file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Shared pytest configuration for the Pipecat test suite."""
+
+import dotenv
+
+
+def pytest_configure(config):
+    """Keep a developer's ``.env`` out of the test session.
+
+    Modules that call ``load_dotenv()`` at import scope would otherwise pull the
+    repository's ``.env`` into ``os.environ`` while pytest collects the suite,
+    before any test runs. Tests would then see whichever variables that
+    developer happens to have set, and behave differently than they do in CI.
+
+    Collection imports test modules after this hook, so a module binding the
+    name with ``from dotenv import load_dotenv`` picks up the stub.
+    """
+    dotenv.load_dotenv = lambda *args, **kwargs: False

--- a/tests/test_krisp_ip_user_turn_start_strategy.py
+++ b/tests/test_krisp_ip_user_turn_start_strategy.py
@@ -288,8 +288,11 @@ class TestKrispVivaIPUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(strategy._sdk_acquired)
 
     def test_init_raises_if_no_model_path(self):
-        with self.assertRaises(ValueError):
-            KrispVivaIPUserTurnStartStrategy(api_key="test-key")
+        # Cleared, since the constructor falls back to KRISP_VIVA_IP_MODEL_PATH
+        # and an ambient value would satisfy it.
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                KrispVivaIPUserTurnStartStrategy(api_key="test-key")
 
     def test_init_raises_if_wrong_extension(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
pytest imports every test module while collecting, so a module calling `load_dotenv()` at import scope loads the repository's `.env` into `os.environ` before the first test runs. Tests then see whichever variables a developer happens to have configured, and diverge from CI, which has no `.env`.

`tests/conftest.py` stubs `load_dotenv` for the session. `pytest_configure` runs before test modules are collected, so a module binding the name with `from dotenv import load_dotenv` picks up the stub.

### The failure that surfaced this

`KrispVivaIPUserTurnStartStrategy` falls back to `KRISP_VIVA_IP_MODEL_PATH` when no model path is passed, so `test_init_raises_if_no_model_path` fails for anyone whose `.env` names a Krisp model. It reproduces only on a full-suite run — collecting that file alone imports nothing that loads dotenv, which is why the test passes when you run it by itself and fails under `uv run pytest`. Two modules currently trigger it: `pipecat.runner.run` and `pipecat.services.speechmatics.stt`.

That test now also clears the environment around the construction, so it holds regardless of what else the session imports.

### Effect on local runs

A local suite now reports the same counts as CI. On a machine with a populated `.env` that means some tests move from passed to skipped — the ones ambient credentials and model paths were silently enabling. That is the intended trade: a local run that agrees with CI.

No changelog entry; test-only change.
