### PR TITLE
refactor(llm): report token usage once per completion in the base loop

### DIFF
--- a/changelog/5190.changed.md
+++ b/changelog/5190.changed.md
@@ -1,0 +1,1 @@
+- OpenAI-compatible LLM services now report token usage once per completion. Providers that repeat a cumulative usage snapshot on every streamed chunk previously produced a token-usage `MetricsFrame` for each one, over-counting a single turn for anything aggregating those frames. `SambaNovaLLMService` also now reports the cache-read and reasoning token counts its provider sends.

--- a/src/pipecat/services/baseten/llm.py
+++ b/src/pipecat/services/baseten/llm.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from pipecat.metrics.metrics import LLMTokenUsage
-from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
 
@@ -73,40 +71,6 @@ class BasetenLLMService(OpenAILLMService):
             default_settings.apply_update(settings)
 
         super().__init__(api_key=api_key, base_url=base_url, settings=default_settings, **kwargs)
-
-        # Baseten repeats a cumulative usage snapshot on every streamed chunk, so
-        # the latest one holds the totals for the whole completion.
-        self._token_usage: LLMTokenUsage | None = None
-
-    async def _process_context(self, context: LLMContext):
-        """Process a context through the LLM, reporting usage once per completion.
-
-        Args:
-            context: The context to process, containing messages and other
-                information needed for the LLM interaction.
-        """
-        self._token_usage = None
-
-        try:
-            await super()._process_context(context)
-        finally:
-            # Only the base implementation emits the metrics; report through it
-            # even if the response is interrupted or cancelled mid-stream.
-            if self._token_usage:
-                await super().start_llm_usage_metrics(self._token_usage)
-                self._token_usage = None
-
-    async def start_llm_usage_metrics(self, tokens: LLMTokenUsage):
-        """Hold the latest usage snapshot rather than reporting it.
-
-        The inherited streaming loop calls this for every chunk carrying usage.
-        Holding the snapshot here suppresses that per-chunk reporting, leaving
-        :meth:`_process_context` to report the final one when the completion ends.
-
-        Args:
-            tokens: Cumulative token usage for the completion so far.
-        """
-        self._token_usage = tokens
 
     def create_client(self, api_key=None, base_url=None, **kwargs):
         """Create OpenAI-compatible client for Baseten API endpoint.

--- a/src/pipecat/services/novita/llm.py
+++ b/src/pipecat/services/novita/llm.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from pipecat.metrics.metrics import LLMTokenUsage
-from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
 
@@ -63,40 +61,6 @@ class NovitaLLMService(OpenAILLMService):
             settings=default_settings,
             **kwargs,
         )
-
-        # Novita repeats a cumulative usage snapshot on every streamed chunk, so
-        # the latest one holds the totals for the whole completion.
-        self._token_usage: LLMTokenUsage | None = None
-
-    async def _process_context(self, context: LLMContext):
-        """Process a context through the LLM, reporting usage once per completion.
-
-        Args:
-            context: The context to process, containing messages and other
-                information needed for the LLM interaction.
-        """
-        self._token_usage = None
-
-        try:
-            await super()._process_context(context)
-        finally:
-            # Only the base implementation emits the metrics; report through it
-            # even if the response is interrupted or cancelled mid-stream.
-            if self._token_usage:
-                await super().start_llm_usage_metrics(self._token_usage)
-                self._token_usage = None
-
-    async def start_llm_usage_metrics(self, tokens: LLMTokenUsage):
-        """Hold the latest usage snapshot rather than reporting it.
-
-        The inherited streaming loop calls this for every chunk carrying usage.
-        Holding the snapshot here suppresses that per-chunk reporting, leaving
-        :meth:`_process_context` to report the final one when the completion ends.
-
-        Args:
-            tokens: Cumulative token usage for the completion so far.
-        """
-        self._token_usage = tokens
 
     def create_client(self, api_key=None, base_url=None, **kwargs):
         """Create OpenAI-compatible client for Novita AI API endpoint.

--- a/src/pipecat/services/nvidia/llm.py
+++ b/src/pipecat/services/nvidia/llm.py
@@ -27,7 +27,6 @@ from pipecat.frames.frames import (
     LLMThoughtStartFrame,
     LLMThoughtTextFrame,
 )
-from pipecat.metrics.metrics import LLMTokenUsage
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
@@ -55,8 +54,6 @@ class NvidiaLLMService(OpenAILLMService):
     This service extends OpenAILLMService to work with NVIDIA's NIM API while
     maintaining compatibility with the OpenAI-style interface. It handles:
 
-    - Incremental token usage reporting (NIM sends per-chunk counts instead
-      of a final summary)
     - Detection and filtering of leading ``<think>``/``</think>`` content for
       models that emit reasoning inline before visible output (e.g.
       DeepSeek-R1, some nemotron models)
@@ -120,18 +117,12 @@ class NvidiaLLMService(OpenAILLMService):
                 "Set base_url to your local NIM endpoint for local deployments."
             )
 
-        # NVIDIA repeats a cumulative usage snapshot on every streamed chunk, so
-        # the latest one holds the totals for the whole completion.
-        self._token_usage: LLMTokenUsage | None = None
-
     def _reset_response_state(self):
         """Reset per-response state at the start of each LLM call.
 
-        Resets the held token usage, leading-think-tag detection state, and
-        reasoning-content field tracking.
+        Resets leading-think-tag detection state and reasoning-content field
+        tracking.
         """
-        self._token_usage = None
-
         self._think_tag_state = _ThinkTagState.DETECTING
         self._think_tag_buffer = ""
 
@@ -336,40 +327,16 @@ class NvidiaLLMService(OpenAILLMService):
             )
 
     async def _process_context(self, context: LLMContext):
-        """Process a context through the LLM and accumulate token usage metrics.
+        """Process a context through the LLM.
 
-        Delegates to the base OpenAI streaming loop while adding
-        NVIDIA-specific behavior:
-
-        - ``reasoning_content`` and leading ``<think>`` content are
-          intercepted via the ``get_chat_completions`` stream wrapper and
-          emitted as
-          ``LLMThought*Frame`` objects.
-        - Token usage is reported once per completion rather than per chunk.
+        Delegates to the base OpenAI streaming loop, resetting the per-response
+        state it needs to emit ``LLMThought*Frame`` objects for
+        ``reasoning_content`` and leading ``<think>`` content, which the
+        ``get_chat_completions`` stream wrapper intercepts.
 
         Args:
             context: The context to process, containing messages and other
                 information needed for the LLM interaction.
         """
         self._reset_response_state()
-
-        try:
-            await super()._process_context(context)
-        finally:
-            # Only the base implementation emits the metrics; report through it
-            # even if the response is interrupted or cancelled mid-stream.
-            if self._token_usage:
-                await super().start_llm_usage_metrics(self._token_usage)
-                self._token_usage = None
-
-    async def start_llm_usage_metrics(self, tokens: LLMTokenUsage):
-        """Hold the latest usage snapshot rather than reporting it.
-
-        The inherited streaming loop calls this for every chunk carrying usage.
-        Holding the snapshot here suppresses that per-chunk reporting, leaving
-        :meth:`_process_context` to report the final one when the completion ends.
-
-        Args:
-            tokens: Cumulative token usage for the completion so far.
-        """
-        self._token_usage = tokens
+        await super()._process_context(context)

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -444,77 +444,88 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                 elif hasattr(stream, "aclose"):
                     await stream.aclose()
 
-        async with _closing(chunk_stream) as chunk_iter:
-            async for chunk in chunk_iter:
-                if chunk.usage:
-                    cached_tokens = (
-                        chunk.usage.prompt_tokens_details.cached_tokens
-                        if chunk.usage.prompt_tokens_details
-                        else None
-                    )
-                    reasoning_tokens = (
-                        chunk.usage.completion_tokens_details.reasoning_tokens
-                        if chunk.usage.completion_tokens_details
-                        else None
-                    )
-                    tokens = LLMTokenUsage(
-                        prompt_tokens=chunk.usage.prompt_tokens,
-                        completion_tokens=chunk.usage.completion_tokens,
-                        total_tokens=chunk.usage.total_tokens,
-                        cache_read_input_tokens=cached_tokens,
-                        reasoning_tokens=reasoning_tokens,
-                    )
-                    await self.start_llm_usage_metrics(tokens)
+        # Providers differ in how often they send usage: some once at the end,
+        # others a cumulative snapshot on every chunk. Holding the latest and
+        # reporting it after the stream keeps that to one report per completion.
+        token_usage: LLMTokenUsage | None = None
 
-                if chunk.model and self.get_full_model_name() != chunk.model:
-                    self.set_full_model_name(chunk.model)
+        try:
+            async with _closing(chunk_stream) as chunk_iter:
+                async for chunk in chunk_iter:
+                    if chunk.usage:
+                        cached_tokens = (
+                            chunk.usage.prompt_tokens_details.cached_tokens
+                            if chunk.usage.prompt_tokens_details
+                            else None
+                        )
+                        reasoning_tokens = (
+                            chunk.usage.completion_tokens_details.reasoning_tokens
+                            if chunk.usage.completion_tokens_details
+                            else None
+                        )
+                        token_usage = LLMTokenUsage(
+                            prompt_tokens=chunk.usage.prompt_tokens,
+                            completion_tokens=chunk.usage.completion_tokens,
+                            total_tokens=chunk.usage.total_tokens,
+                            cache_read_input_tokens=cached_tokens,
+                            reasoning_tokens=reasoning_tokens,
+                        )
 
-                if chunk.choices is None or len(chunk.choices) == 0:
-                    continue
+                    if chunk.model and self.get_full_model_name() != chunk.model:
+                        self.set_full_model_name(chunk.model)
 
-                await self.stop_ttfb_metrics()
+                    if chunk.choices is None or len(chunk.choices) == 0:
+                        continue
 
-                if not chunk.choices[0].delta:
-                    continue
+                    await self.stop_ttfb_metrics()
 
-                if chunk.choices[0].delta.tool_calls:
-                    # We're streaming the LLM response to enable the fastest response times.
-                    # For text, we just yield each chunk as we receive it and count on consumers
-                    # to do whatever coalescing they need (eg. to pass full sentences to TTS)
-                    #
-                    # If the LLM is a function call, we'll do some coalescing here.
-                    # If the response contains a function name, we'll yield a frame to tell consumers
-                    # that they can start preparing to call the function with that name.
-                    # We accumulate all the arguments for the rest of the streamed response, then when
-                    # the response is done, we package up all the arguments and the function name and
-                    # yield a frame containing the function name and the arguments.
+                    if not chunk.choices[0].delta:
+                        continue
 
-                    tool_call = chunk.choices[0].delta.tool_calls[0]
-                    if tool_call.index != func_idx:
-                        functions_list.append(function_name)
-                        arguments_list.append(arguments or "{}")
-                        tool_id_list.append(tool_call_id)
-                        function_name = ""
-                        arguments = ""
-                        tool_call_id = ""
-                        func_idx += 1
-                    if tool_call.function and tool_call.function.name:
-                        function_name += tool_call.function.name
-                        tool_call_id = tool_call.id
-                    if tool_call.function and tool_call.function.arguments:
-                        # Keep iterating through the response to collect all the argument fragments
-                        arguments += tool_call.function.arguments
-                elif chunk.choices[0].delta.content:
-                    await self._push_llm_text(chunk.choices[0].delta.content)
+                    if chunk.choices[0].delta.tool_calls:
+                        # We're streaming the LLM response to enable the fastest response times.
+                        # For text, we just yield each chunk as we receive it and count on consumers
+                        # to do whatever coalescing they need (eg. to pass full sentences to TTS)
+                        #
+                        # If the LLM is a function call, we'll do some coalescing here.
+                        # If the response contains a function name, we'll yield a frame to tell consumers
+                        # that they can start preparing to call the function with that name.
+                        # We accumulate all the arguments for the rest of the streamed response, then when
+                        # the response is done, we package up all the arguments and the function name and
+                        # yield a frame containing the function name and the arguments.
 
-                # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
-                # we need to get LLMTextFrame for the transcript
-                elif (
-                    hasattr(chunk.choices[0].delta, "audio")
-                    and chunk.choices[0].delta.audio
-                    and chunk.choices[0].delta.audio.get("transcript")
-                ):
-                    await self.push_frame(LLMTextFrame(chunk.choices[0].delta.audio["transcript"]))
+                        tool_call = chunk.choices[0].delta.tool_calls[0]
+                        if tool_call.index != func_idx:
+                            functions_list.append(function_name)
+                            arguments_list.append(arguments or "{}")
+                            tool_id_list.append(tool_call_id)
+                            function_name = ""
+                            arguments = ""
+                            tool_call_id = ""
+                            func_idx += 1
+                        if tool_call.function and tool_call.function.name:
+                            function_name += tool_call.function.name
+                            tool_call_id = tool_call.id
+                        if tool_call.function and tool_call.function.arguments:
+                            # Keep iterating through the response to collect all the argument fragments
+                            arguments += tool_call.function.arguments
+                    elif chunk.choices[0].delta.content:
+                        await self._push_llm_text(chunk.choices[0].delta.content)
+
+                    # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
+                    # we need to get LLMTextFrame for the transcript
+                    elif (
+                        hasattr(chunk.choices[0].delta, "audio")
+                        and chunk.choices[0].delta.audio
+                        and chunk.choices[0].delta.audio.get("transcript")
+                    ):
+                        await self.push_frame(
+                            LLMTextFrame(chunk.choices[0].delta.audio["transcript"])
+                        )
+        finally:
+            # Report even if the response is interrupted or cancelled mid-stream.
+            if token_usage:
+                await self.start_llm_usage_metrics(token_usage)
 
         # if we got a function name and arguments, check to see if it's a function with
         # a registered handler. If so, run the registered callback, save the result to

--- a/src/pipecat/services/perplexity/llm.py
+++ b/src/pipecat/services/perplexity/llm.py
@@ -7,16 +7,13 @@
 """Perplexity LLM service implementation.
 
 This module provides a service for interacting with Perplexity's API using
-an OpenAI-compatible interface. It handles Perplexity's unique token usage
-reporting patterns while maintaining compatibility with the Pipecat framework.
+an OpenAI-compatible interface.
 """
 
 from dataclasses import dataclass
 
 from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
 from pipecat.adapters.services.perplexity_adapter import PerplexityLLMAdapter
-from pipecat.metrics.metrics import LLMTokenUsage
-from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
 
@@ -32,9 +29,7 @@ class PerplexityLLMService(OpenAILLMService):
     """A service for interacting with Perplexity's API.
 
     This service extends OpenAILLMService to work with Perplexity's API while maintaining
-    compatibility with the OpenAI-style interface. It specifically handles the difference
-    in token usage reporting between Perplexity (a cumulative snapshot on every streamed
-    chunk) and OpenAI (a final summary).
+    compatibility with the OpenAI-style interface.
     """
 
     adapter_class = PerplexityLLMAdapter
@@ -84,9 +79,6 @@ class PerplexityLLMService(OpenAILLMService):
             default_settings.apply_update(settings)
 
         super().__init__(api_key=api_key, base_url=base_url, settings=default_settings, **kwargs)
-        # Perplexity repeats a cumulative usage snapshot on every streamed chunk,
-        # so the latest one holds the totals for the whole completion.
-        self._token_usage: LLMTokenUsage | None = None
 
     def build_chat_completion_params(self, params_from_context: OpenAILLMInvocationParams) -> dict:
         """Build parameters for Perplexity chat completion request.
@@ -120,33 +112,3 @@ class PerplexityLLMService(OpenAILLMService):
             params["max_tokens"] = self._settings.max_tokens
 
         return params
-
-    async def _process_context(self, context: LLMContext):
-        """Process a context through the LLM, reporting usage once per completion.
-
-        Args:
-            context: The context to process, containing messages and other
-                information needed for the LLM interaction.
-        """
-        self._token_usage = None
-
-        try:
-            await super()._process_context(context)
-        finally:
-            # Only the base implementation emits the metrics; report through it
-            # even if the response is interrupted or cancelled mid-stream.
-            if self._token_usage:
-                await super().start_llm_usage_metrics(self._token_usage)
-                self._token_usage = None
-
-    async def start_llm_usage_metrics(self, tokens: LLMTokenUsage):
-        """Hold the latest usage snapshot rather than reporting it.
-
-        The inherited streaming loop calls this for every chunk carrying usage.
-        Holding the snapshot here suppresses that per-chunk reporting, leaving
-        :meth:`_process_context` to report the final one when the completion ends.
-
-        Args:
-            tokens: Cumulative token usage for the completion so far.
-        """
-        self._token_usage = tokens

--- a/src/pipecat/services/sambanova/llm.py
+++ b/src/pipecat/services/sambanova/llm.py
@@ -158,62 +158,85 @@ class SambaNovaLLMService(OpenAILLMService):  # type: ignore
 
         chunk_stream = await self.get_chat_completions(context)
 
-        # Use context manager to ensure stream is closed on cancellation/exception.
-        # Without this, CancelledError during iteration leaves the underlying socket open.
-        async with chunk_stream:
-            async for chunk in chunk_stream:
-                if chunk.usage:
-                    tokens = LLMTokenUsage(
-                        prompt_tokens=chunk.usage.prompt_tokens,
-                        completion_tokens=chunk.usage.completion_tokens,
-                        total_tokens=chunk.usage.total_tokens,
-                    )
-                    await self.start_llm_usage_metrics(tokens)
+        # Providers differ in how often they send usage: some once at the end,
+        # others a cumulative snapshot on every chunk. Holding the latest and
+        # reporting it after the stream keeps that to one report per completion.
+        token_usage: LLMTokenUsage | None = None
 
-                if chunk.choices is None or len(chunk.choices) == 0:
-                    continue
+        try:
+            # Use context manager to ensure stream is closed on cancellation/exception.
+            # Without this, CancelledError during iteration leaves the underlying socket open.
+            async with chunk_stream:
+                async for chunk in chunk_stream:
+                    if chunk.usage:
+                        cached_tokens = (
+                            chunk.usage.prompt_tokens_details.cached_tokens
+                            if getattr(chunk.usage, "prompt_tokens_details", None)
+                            else None
+                        )
+                        reasoning_tokens = (
+                            chunk.usage.completion_tokens_details.reasoning_tokens
+                            if getattr(chunk.usage, "completion_tokens_details", None)
+                            else None
+                        )
+                        token_usage = LLMTokenUsage(
+                            prompt_tokens=chunk.usage.prompt_tokens,
+                            completion_tokens=chunk.usage.completion_tokens,
+                            total_tokens=chunk.usage.total_tokens,
+                            cache_read_input_tokens=cached_tokens,
+                            reasoning_tokens=reasoning_tokens,
+                        )
 
-                await self.stop_ttfb_metrics()
+                    if chunk.choices is None or len(chunk.choices) == 0:
+                        continue
 
-                if not chunk.choices[0].delta:
-                    continue
+                    await self.stop_ttfb_metrics()
 
-                if chunk.choices[0].delta.tool_calls:
-                    # We're streaming the LLM response to enable the fastest response times.
-                    # For text, we just yield each chunk as we receive it and count on consumers
-                    # to do whatever coalescing they need (eg. to pass full sentences to TTS)
-                    #
-                    # If the LLM is a function call, we'll do some coalescing here.
-                    # If the response contains a function name, we'll yield a frame to tell consumers
-                    # that they can start preparing to call the function with that name.
-                    # We accumulate all the arguments for the rest of the streamed response, then when
-                    # the response is done, we package up all the arguments and the function name and
-                    # yield a frame containing the function name and the arguments.
+                    if not chunk.choices[0].delta:
+                        continue
 
-                    tool_call = chunk.choices[0].delta.tool_calls[0]
-                    if tool_call.index != func_idx:
-                        functions_list.append(function_name)
-                        arguments_list.append(arguments)
-                        tool_id_list.append(tool_call_id)
-                        function_name = ""
-                        arguments = ""
-                        tool_call_id = ""
-                        func_idx += 1
-                    if tool_call.function and tool_call.function.name:
-                        function_name += tool_call.function.name
-                        tool_call_id = tool_call.id  # type: ignore
-                    if tool_call.function and tool_call.function.arguments:
-                        # Keep iterating through the response to collect all the argument fragments
-                        arguments += tool_call.function.arguments
-                elif chunk.choices[0].delta.content:
-                    await self.push_frame(LLMTextFrame(chunk.choices[0].delta.content))
+                    if chunk.choices[0].delta.tool_calls:
+                        # We're streaming the LLM response to enable the fastest response times.
+                        # For text, we just yield each chunk as we receive it and count on consumers
+                        # to do whatever coalescing they need (eg. to pass full sentences to TTS)
+                        #
+                        # If the LLM is a function call, we'll do some coalescing here.
+                        # If the response contains a function name, we'll yield a frame to tell consumers
+                        # that they can start preparing to call the function with that name.
+                        # We accumulate all the arguments for the rest of the streamed response, then when
+                        # the response is done, we package up all the arguments and the function name and
+                        # yield a frame containing the function name and the arguments.
 
-                # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
-                # we need to get LLMTextFrame for the transcript
-                elif hasattr(chunk.choices[0].delta, "audio") and chunk.choices[0].delta.audio.get(
-                    "transcript"
-                ):
-                    await self.push_frame(LLMTextFrame(chunk.choices[0].delta.audio["transcript"]))
+                        tool_call = chunk.choices[0].delta.tool_calls[0]
+                        if tool_call.index != func_idx:
+                            functions_list.append(function_name)
+                            arguments_list.append(arguments)
+                            tool_id_list.append(tool_call_id)
+                            function_name = ""
+                            arguments = ""
+                            tool_call_id = ""
+                            func_idx += 1
+                        if tool_call.function and tool_call.function.name:
+                            function_name += tool_call.function.name
+                            tool_call_id = tool_call.id  # type: ignore
+                        if tool_call.function and tool_call.function.arguments:
+                            # Keep iterating through the response to collect all the argument fragments
+                            arguments += tool_call.function.arguments
+                    elif chunk.choices[0].delta.content:
+                        await self.push_frame(LLMTextFrame(chunk.choices[0].delta.content))
+
+                    # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
+                    # we need to get LLMTextFrame for the transcript
+                    elif hasattr(chunk.choices[0].delta, "audio") and chunk.choices[
+                        0
+                    ].delta.audio.get("transcript"):
+                        await self.push_frame(
+                            LLMTextFrame(chunk.choices[0].delta.audio["transcript"])
+                        )
+        finally:
+            # Report even if the response is interrupted or cancelled mid-stream.
+            if token_usage:
+                await self.start_llm_usage_metrics(token_usage)
 
         # if we got a function name and arguments, check to see if it's a function with
         # a registered handler. If so, run the registered callback, save the result to

--- a/src/pipecat/services/xai/llm.py
+++ b/src/pipecat/services/xai/llm.py
@@ -7,16 +7,13 @@
 """Grok LLM service implementation using OpenAI-compatible interface.
 
 This module provides a service for interacting with Grok's API through an
-OpenAI-compatible interface, including specialized token usage tracking
-and context aggregation functionality.
+OpenAI-compatible interface.
 """
 
 from dataclasses import dataclass
 
 from loguru import logger
 
-from pipecat.metrics.metrics import LLMTokenUsage
-from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import (
     OpenAILLMService,
@@ -35,8 +32,6 @@ class GrokLLMService(OpenAILLMService):
 
     This service extends OpenAILLMService to connect to Grok's API endpoint while
     maintaining full compatibility with OpenAI's interface and functionality.
-    Includes specialized token usage tracking that accumulates metrics during
-    processing and reports final totals.
     """
 
     Settings = GrokLLMSettings
@@ -83,9 +78,6 @@ class GrokLLMService(OpenAILLMService):
             default_settings.apply_update(settings)
 
         super().__init__(api_key=api_key, base_url=base_url, settings=default_settings, **kwargs)
-        # Grok repeats a cumulative usage snapshot on every streamed chunk, so
-        # the latest one holds the totals for the whole completion.
-        self._token_usage: LLMTokenUsage | None = None
 
     def create_client(self, api_key=None, base_url=None, **kwargs):
         """Create OpenAI-compatible client for Grok API endpoint.
@@ -100,33 +92,3 @@ class GrokLLMService(OpenAILLMService):
         """
         logger.debug(f"Creating Grok client with api {base_url}")
         return super().create_client(api_key, base_url, **kwargs)
-
-    async def _process_context(self, context: LLMContext):
-        """Process a context through the LLM, reporting usage once per completion.
-
-        Args:
-            context: The context to process, containing messages and other
-                information needed for the LLM interaction.
-        """
-        self._token_usage = None
-
-        try:
-            await super()._process_context(context)
-        finally:
-            # Only the base implementation emits the metrics; report through it
-            # even if the response is interrupted or cancelled mid-stream.
-            if self._token_usage:
-                await super().start_llm_usage_metrics(self._token_usage)
-                self._token_usage = None
-
-    async def start_llm_usage_metrics(self, tokens: LLMTokenUsage):
-        """Hold the latest usage snapshot rather than reporting it.
-
-        The inherited streaming loop calls this for every chunk carrying usage.
-        Holding the snapshot here suppresses that per-chunk reporting, leaving
-        :meth:`_process_context` to report the final one when the completion ends.
-
-        Args:
-            tokens: Cumulative token usage for the completion so far.
-        """
-        self._token_usage = tokens

--- a/tests/test_novita_llm.py
+++ b/tests/test_novita_llm.py
@@ -7,29 +7,12 @@
 """Unit tests for Novita LLM service."""
 
 import asyncio
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.services.novita.llm import NovitaLLMService
-
-
-def _usage_chunk(prompt_tokens: int, completion_tokens: int, reasoning_tokens: int = 0):
-    """Build a stream chunk carrying a cumulative usage snapshot."""
-    return SimpleNamespace(
-        usage=SimpleNamespace(
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            total_tokens=prompt_tokens + completion_tokens,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
-            completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
-        ),
-        model=None,
-        choices=[],
-    )
 
 
 @pytest.mark.asyncio
@@ -83,90 +66,3 @@ async def test_novita_llm_stream_closed_on_cancellation():
             await service._process_context(context)
 
         assert stream_closed, "Stream should be closed even when CancelledError occurs"
-
-
-class TestCumulativeTokenUsage:
-    """Novita repeats a cumulative usage snapshot on every streamed chunk."""
-
-    @staticmethod
-    def _service(chunks):
-        """A service whose stream yields the given chunks."""
-        with patch.object(NovitaLLMService, "create_client"):
-            service = NovitaLLMService(
-                api_key="test-key", settings=NovitaLLMService.Settings(model="test-model")
-            )
-        service._client = AsyncMock()
-
-        async def stream():
-            for chunk in chunks:
-                yield chunk
-
-        service.get_chat_completions = AsyncMock(return_value=stream())
-        service.start_ttfb_metrics = AsyncMock()
-        service.stop_ttfb_metrics = AsyncMock()
-        return service
-
-    @pytest.mark.asyncio
-    async def test_the_snapshots_are_reported_once_as_a_final_total(self):
-        """Three snapshots for one completion produce one report of the last."""
-        service = self._service(
-            [_usage_chunk(20, 5), _usage_chunk(20, 12), _usage_chunk(20, 30, reasoning_tokens=8)]
-        )
-
-        with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
-            await service._process_context(LLMContext(messages=[{"role": "user", "content": "Hi"}]))
-
-        reported.assert_called_once()
-        usage = reported.call_args.args[0]
-        assert usage.prompt_tokens == 20
-        assert usage.completion_tokens == 30
-        assert usage.total_tokens == 50
-        assert usage.reasoning_tokens == 8
-
-    @pytest.mark.asyncio
-    async def test_usage_is_reported_when_the_response_is_interrupted(self):
-        """A completion cancelled mid-stream still reports what it consumed."""
-        service = self._service([])
-
-        async def interrupted_stream():
-            yield _usage_chunk(20, 5)
-            yield _usage_chunk(20, 12)
-            raise asyncio.CancelledError()
-
-        service.get_chat_completions = AsyncMock(return_value=interrupted_stream())
-
-        with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
-            with pytest.raises(asyncio.CancelledError):
-                await service._process_context(
-                    LLMContext(messages=[{"role": "user", "content": "Hi"}])
-                )
-
-        reported.assert_called_once()
-        assert reported.call_args.args[0].completion_tokens == 12
-
-    @pytest.mark.asyncio
-    async def test_a_completion_without_usage_reports_nothing(self):
-        """Streams that carry no usage snapshot produce no metrics."""
-        service = self._service([SimpleNamespace(usage=None, model=None, choices=[])])
-
-        with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
-            await service._process_context(LLMContext(messages=[{"role": "user", "content": "Hi"}]))
-
-        reported.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_a_later_completion_does_not_inherit_earlier_usage(self):
-        """Each completion starts from a clean slate."""
-        service = self._service([_usage_chunk(20, 30)])
-        context = LLMContext(messages=[{"role": "user", "content": "Hi"}])
-
-        with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
-            await service._process_context(context)
-
-            async def empty_stream():
-                yield SimpleNamespace(usage=None, model=None, choices=[])
-
-            service.get_chat_completions = AsyncMock(return_value=empty_stream())
-            await service._process_context(context)
-
-        reported.assert_called_once()

--- a/tests/test_openai_compatible_token_usage.py
+++ b/tests/test_openai_compatible_token_usage.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Tests for OpenAI-compatible services that report cumulative token usage.
+"""Tests that OpenAI-compatible services report token usage once per completion.
 
-Baseten, Grok, Perplexity and NVIDIA all repeat a cumulative usage snapshot on
-every streamed chunk rather than sending one summary at the end. Each service
-holds the latest snapshot and reports it once when the completion finishes, so
-a single turn produces a single usage metric.
+Providers differ in how often they send usage: some once at the end, others a
+cumulative snapshot on every streamed chunk. The base streaming loop holds the
+latest snapshot and reports it when the completion finishes, so a single turn
+produces a single usage metric either way.
 """
 
 import asyncio
@@ -21,15 +21,23 @@ import pytest
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.services.baseten.llm import BasetenLLMService
+from pipecat.services.novita.llm import NovitaLLMService
 from pipecat.services.nvidia.llm import NvidiaLLMService
+from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.services.perplexity.llm import PerplexityLLMService
+from pipecat.services.sambanova.llm import SambaNovaLLMService
 from pipecat.services.xai.llm import GrokLLMService
 
+# SambaNova keeps its own copy of the streaming loop, so it is covered here
+# alongside the services that inherit the base one.
 SERVICES = [
+    pytest.param(OpenAILLMService, {"api_key": "test-key"}, id="openai"),
     pytest.param(BasetenLLMService, {"api_key": "test-key"}, id="baseten"),
     pytest.param(GrokLLMService, {"api_key": "test-key"}, id="grok"),
+    pytest.param(NovitaLLMService, {"api_key": "test-key"}, id="novita"),
     pytest.param(PerplexityLLMService, {"api_key": "test-key"}, id="perplexity"),
     pytest.param(NvidiaLLMService, {"api_key": "test-key"}, id="nvidia"),
+    pytest.param(SambaNovaLLMService, {"api_key": "test-key"}, id="sambanova"),
 ]
 
 
@@ -48,17 +56,43 @@ def _usage_chunk(prompt_tokens: int, completion_tokens: int, reasoning_tokens: i
     )
 
 
-def _service(service_class, init_kwargs, chunks):
+class _FakeStream:
+    """Stands in for the provider's chat completion stream.
+
+    Satisfies the base streaming loop, which iterates and then closes the
+    stream, as well as SambaNova's copy, which enters it as an async context
+    manager.
+    """
+
+    def __init__(self, chunks, raise_at_end=None):
+        self._chunks = list(chunks)
+        self._raise_at_end = raise_at_end
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self._chunks:
+            yield chunk
+        if self._raise_at_end:
+            raise self._raise_at_end
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def close(self):
+        pass
+
+
+def _service(service_class, init_kwargs, chunks, raise_at_end=None):
     """A service whose stream yields the given chunks."""
     with patch.object(service_class, "create_client"):
         service = service_class(settings=service_class.Settings(model="test-model"), **init_kwargs)
     service._client = AsyncMock()
-
-    async def stream():
-        for chunk in chunks:
-            yield chunk
-
-    service.get_chat_completions = AsyncMock(return_value=stream())
+    service.get_chat_completions = AsyncMock(return_value=_FakeStream(chunks, raise_at_end))
     service.start_ttfb_metrics = AsyncMock()
     service.stop_ttfb_metrics = AsyncMock()
     return service
@@ -92,14 +126,12 @@ async def test_the_snapshots_are_reported_once_as_a_final_total(service_class, i
 @pytest.mark.asyncio
 async def test_usage_is_reported_when_the_response_is_interrupted(service_class, init_kwargs):
     """A completion cancelled mid-stream still reports the latest snapshot once."""
-    service = _service(service_class, init_kwargs, [])
-
-    async def interrupted_stream():
-        yield _usage_chunk(20, 5)
-        yield _usage_chunk(20, 12)
-        raise asyncio.CancelledError()
-
-    service.get_chat_completions = AsyncMock(return_value=interrupted_stream())
+    service = _service(
+        service_class,
+        init_kwargs,
+        [_usage_chunk(20, 5), _usage_chunk(20, 12)],
+        raise_at_end=asyncio.CancelledError(),
+    )
 
     with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
         with pytest.raises(asyncio.CancelledError):
@@ -148,10 +180,9 @@ async def test_a_later_completion_does_not_inherit_earlier_usage(service_class, 
     with patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()) as reported:
         await service._process_context(_context())
 
-        async def empty_stream():
-            yield SimpleNamespace(usage=None, model=None, choices=[])
-
-        service.get_chat_completions = AsyncMock(return_value=empty_stream())
+        service.get_chat_completions = AsyncMock(
+            return_value=_FakeStream([SimpleNamespace(usage=None, model=None, choices=[])])
+        )
         await service._process_context(_context())
 
     reported.assert_called_once()


### PR DESCRIPTION
## Summary

- OpenAI-compatible LLM services now report token usage once per completion, handled in `BaseOpenAILLMService._process_context` rather than per service. Providers differ in how often they send usage — some once at the end, others a cumulative snapshot on every streamed chunk — and the base loop already requests `stream_options: {"include_usage": True}` for all of them. Holding the latest snapshot and reporting it when the completion ends is a no-op for the first kind and collapses the per-chunk `MetricsFrame` storm for the second.
- Drops the per-service overrides in `BasetenLLMService`, `GrokLLMService`, `NovitaLLMService`, `NvidiaLLMService` and `PerplexityLLMService`. Net 227 insertions against 447 deletions.
- The snapshot lives in a local, not instance state, so `start_llm_usage_metrics` means only "report" — no subclass overrides it to intercept, and each completion is independent by construction rather than by remembering to reset.
- `SambaNovaLLMService` keeps its own copy of the streaming loop for tool call indexing, so it carries the same handling directly. It now also reports the cache-read and reasoning token counts its provider sends.

## Behavior changes worth a look

- **Usage is reported after the stream ends** rather than the instant the usage chunk arrives. It still lands before `LLMFullResponseEndFrame`, and before `run_function_calls`. This is the part with the widest blast radius — it applies to every OpenAI-compatible provider.
- A provider that sent *incremental* usage needing summation rather than a cumulative snapshot would report only its last delta. No current service behaves that way; each one this replaces tracked a running maximum, which is cumulative semantics.

## Testing

- `uv run pytest tests/test_openai_compatible_token_usage.py`
- Parametrized across seven services — stock OpenAI, Baseten, Grok, Novita, NVIDIA, Perplexity and SambaNova — covering repeated snapshots collapsing to one report, an interrupted completion still reporting, cache-read and reasoning counts surviving, no usage producing no metrics, and one completion not inheriting the previous one's usage.
- Verified the suite exercises the base change: with the base loop reverted and the service overrides removed, all seven services fail.
- Full suite green (3803 passed, 29 skipped).
