### PR TITLE
ci: create the GitHub Release from CHANGELOG.md after publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,3 +76,42 @@ jobs:
           verbose: true
           print-hash: true
           repository-url: https://test.pypi.org/legacy/
+
+  # Runs once the package is installable from PyPI, so the release notification
+  # never points at a version nobody can install yet. Notes come from the
+  # CHANGELOG.md section at the tag: the changelog is the single source of
+  # release notes, reformatted for GitHub by scripts/release-changelog.py. A tag
+  # whose version has no changelog section fails the run.
+  github-release:
+    name: 'Create GitHub Release'
+    runs-on: ubuntu-latest
+    needs: [publish-to-pypi]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.gitref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate release notes
+        env:
+          GITREF: ${{ github.event.inputs.gitref }}
+        run: |
+          python scripts/release-changelog.py --no-heading "${GITREF#v}" > release-notes.md
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITREF: ${{ github.event.inputs.gitref }}
+        run: |
+          if gh release view "$GITREF" >/dev/null 2>&1; then
+            gh release edit "$GITREF" --notes-file release-notes.md
+          else
+            gh release create "$GITREF" --title "$GITREF" --notes-file release-notes.md
+          fi

--- a/scripts/release-changelog.py
+++ b/scripts/release-changelog.py
@@ -6,6 +6,7 @@ Usage::
     python scripts/release-changelog.py VERSION
     python scripts/release-changelog.py 1.1.0
     python scripts/release-changelog.py --file path/to/CHANGELOG.md 1.1.0
+    python scripts/release-changelog.py --no-heading 1.1.0
 
 Extracts the requested ``## [VERSION]`` section (heading and ``### …``
 subheadings included) and prints it to stdout. The only transformation
@@ -13,6 +14,10 @@ applied is collapsing each entry paragraph onto a single line, so it is
 suitable for pasting into release notes that don't need 80-column wrapping.
 ``(PR [...])`` references stay on their own two-space-indented continuation
 line. The input file is never modified.
+
+``--no-heading`` drops the ``## [VERSION]`` line, leaving the body to start
+at the first ``### …`` subheading. GitHub Releases carry the version in the
+release title, so the heading would be redundant there.
 
 Every paragraph is unfilled. Indentation is preserved — each logical line
 (bullets, sub-bullets, and the ``(PR [...])`` continuation) keeps its
@@ -75,6 +80,11 @@ def extract_section(text: str, version: str) -> str:
     return text[m.start() : end]
 
 
+def strip_heading(section: str) -> str:
+    _, _, body = section.partition("\n")
+    return body.lstrip("\n")
+
+
 def main() -> None:
     summary = (__doc__ or "").splitlines()[0]
     parser = argparse.ArgumentParser(description=summary)
@@ -85,10 +95,17 @@ def main() -> None:
         default=DEFAULT_CHANGELOG,
         help=f"Path to the changelog (default: {DEFAULT_CHANGELOG}).",
     )
+    parser.add_argument(
+        "--no-heading",
+        action="store_true",
+        help="Omit the '## [VERSION]' heading line.",
+    )
     args = parser.parse_args()
 
     text = args.file.read_text()
     section = extract_section(text, args.version)
+    if args.no_heading:
+        section = strip_heading(section)
     sys.stdout.write(process(section))
 
 


### PR DESCRIPTION
## Summary

- The `publish` workflow now creates the GitHub Release itself, so releasing no longer means hand-formatting the changelog and filling in the release body through the UI.
- Notes come from the tag's `CHANGELOG.md` section, reformatted by `scripts/release-changelog.py` — the changelog stays the single source of release notes.
- The job is gated on `publish-to-pypi`, so the release notification never points at a version that isn't installable yet.
- A tag whose version has no changelog section fails the job rather than publishing empty notes. If a release already exists for the tag, its notes are edited in place.
- `scripts/release-changelog.py` gains `--no-heading`, which drops the `## [VERSION]` line so notes start at the first `###` subheading; GitHub carries the version in the release title.
- The new job takes `contents: write`. The PyPI jobs are untouched and keep their own `id-token: write`. No new dependencies — the script is stdlib-only, so the job is checkout + `setup-python` + `gh`.

## Release process

1. Merge the changelog PR and push the tag.
2. Dispatch `publish` with that tag as the `gitref`.

Step 2 now ends with the GitHub Release created.

## Testing

- `python scripts/release-changelog.py --no-heading 1.7.0` produces the release body for v1.7.0.
- `python scripts/release-changelog.py --no-heading 9.9.9` exits 1, which is what fails the job on a tag with no changelog section.
- The job itself can't be exercised without publishing a real release, so its first live run will be the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)