### PR TITLE
Resample mixer sound files that don't match the output sample rate

### DIFF
--- a/changelog/5193.fixed.md
+++ b/changelog/5193.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SoundfileMixer` dropping sound files whose sample rate doesn't match the output transport; they are now resampled (and downmixed to mono) on load.

--- a/src/pipecat/audio/mixers/soundfile_mixer.py
+++ b/src/pipecat/audio/mixers/soundfile_mixer.py
@@ -19,6 +19,7 @@ import numpy as np
 from loguru import logger
 
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
+from pipecat.audio.utils import create_file_resampler
 from pipecat.frames.frames import MixerControlFrame, MixerEnableFrame, MixerUpdateSettingsFrame
 
 try:
@@ -36,8 +37,8 @@ class SoundfileMixer(BaseAudioMixer):
 
     This is an audio mixer that mixes incoming audio with audio from a
     file. It uses the soundfile library to load files so it supports multiple
-    formats. The audio files need to only have one channel (mono) and it needs
-    to match the sample rate of the output transport.
+    formats. Multi-channel files are downmixed to mono and files whose sample
+    rate doesn't match the output transport are resampled on load.
 
     Multiple files can be loaded, each with a different name. The
     `MixerUpdateSettingsFrame` has the following settings available: `sound`
@@ -84,7 +85,7 @@ class SoundfileMixer(BaseAudioMixer):
         """
         self._sample_rate = sample_rate
         for sound_name, file_name in self._sound_files.items():
-            await asyncio.to_thread(self._load_sound_file, sound_name, file_name)
+            await self._load_sound_file(sound_name, file_name)
 
     async def stop(self):
         """Clean up mixer resources.
@@ -151,20 +152,28 @@ class SoundfileMixer(BaseAudioMixer):
         """Update the looping behavior."""
         self._loop = loop
 
-    def _load_sound_file(self, sound_name: str, file_name: str):
+    async def _load_sound_file(self, sound_name: str, file_name: str):
         """Load an audio file into memory for mixing."""
         try:
             logger.debug(f"Loading mixer sound from {file_name}")
-            sound, sample_rate = sf.read(file_name, dtype="int16")
+            sound, sample_rate = await asyncio.to_thread(sf.read, file_name, dtype="int16")
+
+            if sound.ndim > 1:
+                sound = np.mean(sound, axis=1).astype(np.int16)
 
             if sample_rate == self._sample_rate:
                 audio = sound.tobytes()
                 # Convert from np to bytes again.
                 self._sounds[sound_name] = np.frombuffer(audio, dtype=np.int16)
             else:
-                logger.warning(
-                    f"Sound file {file_name} has incorrect sample rate {sample_rate} (should be {self._sample_rate})"
+                logger.debug(
+                    f"Resampling sound file {file_name} from {sample_rate} to {self._sample_rate}"
                 )
+                resampler = create_file_resampler()
+                resampled = await resampler.resample(
+                    sound.tobytes(), int(sample_rate), self._sample_rate
+                )
+                self._sounds[sound_name] = np.frombuffer(resampled, dtype=np.int16)
         except Exception as e:
             logger.error(f"Unable to open file {file_name}: {e}")
 

--- a/tests/test_soundfile_mixer.py
+++ b/tests/test_soundfile_mixer.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import numpy as np
+import pytest
+
+sf = pytest.importorskip("soundfile")
+
+from pipecat.audio.mixers.soundfile_mixer import SoundfileMixer  # noqa: E402
+
+MIXER_RATE = 16000
+
+
+def _write_wav(path, sample_rate: int, duration_s: float, channels: int = 1):
+    num_samples = int(sample_rate * duration_s)
+    t = np.linspace(0, duration_s, num_samples, endpoint=False)
+    tone = (np.sin(2 * np.pi * 440 * t) * 8000).astype(np.int16)
+    if channels > 1:
+        tone = np.column_stack([tone] * channels)
+    sf.write(str(path), tone, sample_rate)
+    return tone
+
+
+def _make_mixer(path):
+    return SoundfileMixer(sound_files={"test": str(path)}, default_sound="test")
+
+
+@pytest.mark.asyncio
+async def test_matching_rate_file_loaded_unchanged(tmp_path):
+    file_path = tmp_path / "match.wav"
+    tone = _write_wav(file_path, MIXER_RATE, 0.5)
+
+    mixer = _make_mixer(file_path)
+    await mixer.start(MIXER_RATE)
+
+    assert "test" in mixer._sounds
+    assert np.array_equal(mixer._sounds["test"], tone)
+
+
+@pytest.mark.asyncio
+async def test_off_rate_mono_file_is_resampled(tmp_path):
+    file_path = tmp_path / "44k.wav"
+    _write_wav(file_path, 44100, 0.5)
+
+    mixer = _make_mixer(file_path)
+    await mixer.start(MIXER_RATE)
+
+    assert "test" in mixer._sounds
+    expected = int(0.5 * MIXER_RATE)
+    assert abs(len(mixer._sounds["test"]) - expected) <= MIXER_RATE // 100
+
+
+@pytest.mark.asyncio
+async def test_stereo_off_rate_file_is_downmixed_and_resampled(tmp_path):
+    file_path = tmp_path / "48k_stereo.wav"
+    _write_wav(file_path, 48000, 0.5, channels=2)
+
+    mixer = _make_mixer(file_path)
+    await mixer.start(MIXER_RATE)
+
+    assert "test" in mixer._sounds
+    sound = mixer._sounds["test"]
+    assert sound.ndim == 1
+    expected = int(0.5 * MIXER_RATE)
+    assert abs(len(sound) - expected) <= MIXER_RATE // 100
+
+
+@pytest.mark.asyncio
+async def test_mix_uses_resampled_sound(tmp_path):
+    file_path = tmp_path / "44k.wav"
+    _write_wav(file_path, 44100, 0.5)
+
+    mixer = _make_mixer(file_path)
+    await mixer.start(MIXER_RATE)
+
+    silence = b"\x00\x00" * 160
+    mixed = await mixer.mix(silence)
+    assert len(mixed) == len(silence)
+    assert mixed != silence


### PR DESCRIPTION
SoundfileMixer currently drops any sound file whose sample rate doesn't match the transport rate: it logs a warning and the sound just never plays, which makes hold music at 44.1/48 kHz silently disappear. Multi-channel files break mixing too since the mixer assumes mono.

This resamples off-rate files on load with create_file_resampler and downmixes multi-channel files to mono. Matching-rate mono files load exactly as before. Loading happens in start() where the output rate is known.

Added tests for the resample, downmix, and unchanged paths (there were no mixer tests before).