### PR TITLE
Record function calls in LLM span output

### DIFF
--- a/changelog/5194.fixed.md
+++ b/changelog/5194.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `@traced_llm` leaving the span output empty for responses that only contain function calls; tool calls are now recorded in a `tool_calls` attribute and used as the output when no text was generated.

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from opentelemetry import trace
 
 from pipecat.frames.frames import (
+    FunctionCallsStartedFrame,
     MetricsFrame,
     TranscriptionFrame,
     TTSStoppedFrame,
@@ -909,7 +910,7 @@ def traced_llm(func: Callable | None = None, *, name: str | None = None) -> Call
     - Tool configurations
     - Token usage metrics
     - Performance metrics like TTFB
-    - Aggregated output text
+    - Aggregated output text and function calls
 
     Args:
         func: The LLM method to trace.
@@ -944,6 +945,8 @@ def traced_llm(func: Callable | None = None, *, name: str | None = None) -> Call
                         # Store original method and output aggregator
                         original_push_frame = self.push_frame
                         output_text = ""  # Simple string accumulation
+                        output_tool_calls = []
+                        seen_tool_call_ids = set()
 
                         async def traced_push_frame(frame, direction=None):
                             nonlocal output_text
@@ -954,6 +957,15 @@ def traced_llm(func: Callable | None = None, *, name: str | None = None) -> Call
                                 and hasattr(frame, "text")
                             ):
                                 output_text += frame.text
+
+                            # The frame is broadcast both ways, so dedupe by id.
+                            if isinstance(frame, FunctionCallsStartedFrame):
+                                for fc in frame.function_calls:
+                                    if fc.tool_call_id not in seen_tool_call_ids:
+                                        seen_tool_call_ids.add(fc.tool_call_id)
+                                        output_tool_calls.append(
+                                            {"name": fc.function_name, "arguments": fc.arguments}
+                                        )
 
                             # Call original
                             if direction is not None:
@@ -1078,6 +1090,15 @@ def traced_llm(func: Callable | None = None, *, name: str | None = None) -> Call
                         # stream (e.g. interruption during LLM
                         # generation), rather than only on clean
                         # completion.
+                        if output_tool_calls:
+                            try:
+                                tool_calls_json = json.dumps(output_tool_calls)
+                                current_span.set_attribute("tool_calls", tool_calls_json)
+                                # Tool-only responses would otherwise have no output.
+                                if not output_text:
+                                    current_span.set_attribute("output", tool_calls_json)
+                            except (TypeError, ValueError):
+                                pass
                         if output_text:
                             current_span.set_attribute("output", output_text)
 

--- a/tests/test_traced_llm_tool_calls.py
+++ b/tests/test_traced_llm_tool_calls.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import json
+import unittest
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    HAS_OPENTELEMETRY = True
+except ImportError:
+    HAS_OPENTELEMETRY = False
+
+from pipecat.frames.frames import FunctionCallFromLLM, FunctionCallsStartedFrame, LLMTextFrame
+from pipecat.utils.tracing.service_decorators import traced_llm
+
+
+class _StubLLMService:
+    """Minimal stand-in exposing only what ``traced_llm`` reads."""
+
+    def __init__(self, frames):
+        self._tracing_enabled = True
+        self._frames = frames
+        self._model_name = "test-model"
+
+    async def push_frame(self, frame, direction=None):
+        return None
+
+    @traced_llm
+    async def _process_context(self, context):
+        for frame in self._frames:
+            await self.push_frame(frame)
+
+
+def _make_call(name, tool_call_id, arguments):
+    return FunctionCallFromLLM(
+        function_name=name, tool_call_id=tool_call_id, arguments=arguments, context=None
+    )
+
+
+@unittest.skipUnless(HAS_OPENTELEMETRY, "opentelemetry not installed")
+class TestTracedLLMToolCallOutput(unittest.IsolatedAsyncioTestCase):
+    """The LLM span records function calls, not just LLMTextFrame text."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._exporter = InMemorySpanExporter()
+        processor = SimpleSpanProcessor(cls._exporter)
+        existing = trace.get_tracer_provider()
+        # The global provider can only be set once per process; attach to an
+        # existing SDK provider if another test already installed one.
+        if isinstance(existing, TracerProvider):
+            existing.add_span_processor(processor)
+        else:
+            provider = TracerProvider()
+            provider.add_span_processor(processor)
+            trace.set_tracer_provider(provider)
+
+    def setUp(self):
+        self._exporter.clear()
+
+    def _llm_span(self):
+        spans = [s for s in self._exporter.get_finished_spans() if s.name == "llm"]
+        self.assertEqual(len(spans), 1)
+        return spans[0]
+
+    async def test_tool_only_response_records_output(self):
+        calls = [_make_call("get_weather", "call_1", {"city": "Berlin"})]
+        service = _StubLLMService([FunctionCallsStartedFrame(function_calls=calls)])
+        await service._process_context(context=None)
+
+        span = self._llm_span()
+        expected = [{"name": "get_weather", "arguments": {"city": "Berlin"}}]
+        self.assertEqual(json.loads(span.attributes["tool_calls"]), expected)
+        self.assertEqual(json.loads(span.attributes["output"]), expected)
+
+    async def test_mixed_response_records_text_and_tool_calls(self):
+        calls = [_make_call("get_weather", "call_1", {"city": "Berlin"})]
+        service = _StubLLMService(
+            [
+                LLMTextFrame(text="Let me check."),
+                FunctionCallsStartedFrame(function_calls=calls),
+            ]
+        )
+        await service._process_context(context=None)
+
+        span = self._llm_span()
+        self.assertEqual(span.attributes["output"], "Let me check.")
+        self.assertEqual(
+            json.loads(span.attributes["tool_calls"]),
+            [{"name": "get_weather", "arguments": {"city": "Berlin"}}],
+        )
+
+    async def test_broadcast_duplicates_are_deduped(self):
+        calls = [_make_call("get_weather", "call_1", {"city": "Berlin"})]
+        # broadcast_frame pushes the frame both downstream and upstream.
+        frames = [
+            FunctionCallsStartedFrame(function_calls=calls),
+            FunctionCallsStartedFrame(function_calls=calls),
+        ]
+        service = _StubLLMService(frames)
+        await service._process_context(context=None)
+
+        span = self._llm_span()
+        self.assertEqual(len(json.loads(span.attributes["tool_calls"])), 1)


### PR DESCRIPTION
LLM spans only aggregate output from LLMTextFrame, so a response that is just a function call ends up with no output at all. In Langfuse those turns show "undefined", and in tool-heavy agent pipelines that's a large share of all LLM calls.

This captures FunctionCallsStartedFrame in the same traced scope, records the calls as a tool_calls attribute (JSON list of name/arguments), and uses that as the span output when there's no text. Mixed text plus tool-call responses record both. The frame is broadcast in both directions, so calls are deduped by tool_call_id.

Tests use the in-memory exporter setup from the existing tracing tests.