### PR TITLE
Cancel timed-out function call handlers

### DIFF
--- a/changelog/5195.fixed.md
+++ b/changelog/5195.fixed.md
@@ -1,0 +1,1 @@
+- Fixed function-call timeouts leaving handlers running after a timeout. The service now requests cooperative cancellation, emits the timeout result without waiting for cleanup, and prevents timeout and interruption paths from publishing conflicting terminal frames.

--- a/src/pipecat/adapters/schemas/direct_function.py
+++ b/src/pipecat/adapters/schemas/direct_function.py
@@ -319,7 +319,9 @@ def tool_options(
         cancel_on_interruption: Whether to cancel this function call when an
             interruption occurs. Defaults to True.
         timeout_secs: Optional per-tool timeout in seconds. Defaults to None (uses
-            the LLM service default).
+            the LLM service default). Expiry requests cooperative cancellation of
+            the handler and emits a terminal ``None`` result without waiting for
+            cancellation cleanup.
 
     Returns:
         The decorated function, unchanged except for pipecat call-option metadata

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -173,7 +173,10 @@ class FunctionCallRegistryItem:
             continues the conversation immediately without waiting for the
             result, and the result is injected later via a developer message.
         timeout_secs: Optional per-tool timeout in seconds. Overrides the global
-            ``function_call_timeout_secs`` for this specific function.
+            ``function_call_timeout_secs`` for this specific function. When the
+            deadline expires, the service requests cooperative cancellation of
+            the handler and emits a terminal ``None`` result without waiting for
+            cancellation cleanup to finish.
         auto_registered: True only for a direct function that was auto-registered
             from an advertised tool set (listed in an ``LLMContext`` or
             ``LLMSetToolsFrame``). False for every explicitly registered handler —
@@ -203,6 +206,9 @@ class FunctionCallRunnerItem:
         group_id: Shared identifier for all function calls from the same LLM
             response batch. Used to trigger the LLM exactly once when the last
             call in the group completes.
+        terminal_state: Claimed terminal outcome for the call (``result`` or
+            ``cancel``). The first claimant wins so timeout and interruption
+            cannot publish conflicting terminal frames.
     """
 
     registry_item: FunctionCallRegistryItem
@@ -212,6 +218,7 @@ class FunctionCallRunnerItem:
     context: LLMContext
     run_llm: bool | None = None
     group_id: str | None = None
+    terminal_state: str | None = None
 
 
 # `default=BaseLLMAdapter` (PEP 696) so that unparameterized subclasses
@@ -286,8 +293,11 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
                 is triggered exactly once after all calls in the batch complete. When
                 False, each function call result triggers the LLM independently as it
                 arrives. Defaults to True.
-            function_call_timeout_secs: Optional timeout in seconds for deferred function
-                calls.
+            function_call_timeout_secs: Optional timeout in seconds for function calls.
+                When the deadline expires, the service requests cooperative cancellation
+                of the handler and emits a terminal ``None`` result without waiting for
+                cancellation cleanup to finish. Handlers that catch
+                :class:`asyncio.CancelledError` should re-raise it after bounded cleanup.
             enable_async_tool_cancellation: When True and at least one async function
                 (``cancel_on_interruption=False``) is registered, automatically injects
                 the ``cancel_async_tool_call`` built-in tool and its system instructions
@@ -338,6 +348,10 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         # again or stops being advertised (see _sync_registered_tool_handlers).
         self._explicitly_unregistered_function_names: set[str | None] = set()
         self._function_call_tasks: dict[asyncio.Task | None, FunctionCallRunnerItem] = {}
+        # Handler tasks whose timeout result has already been emitted. They no
+        # longer block their function-call runner, but remain service-owned so
+        # cleanup can cancel and drain cancellation-suppressing handlers.
+        self._timed_out_function_call_tasks: set[asyncio.Task] = set()
         self._sequential_runner_task: asyncio.Task | None = None
         self._skip_tts: bool | None = None
         self._summary_task: asyncio.Task | None = None
@@ -807,7 +821,8 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             timeout_secs: Optional per-tool timeout in seconds, overriding the
                 global ``function_call_timeout_secs``. Defaults to ``None`` (fall
                 back to the ``@tool_options`` decorator value, then to the global
-                timeout).
+                timeout). Expiry requests cooperative handler cancellation and
+                emits a terminal ``None`` result without waiting for cleanup.
         """
         if function_name == CANCEL_ASYNC_TOOL_NAME:
             raise ValueError(
@@ -878,7 +893,8 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             timeout_secs: Optional per-tool timeout in seconds, overriding the
                 global ``function_call_timeout_secs``. Defaults to ``None`` (fall
                 back to the ``@tool_options`` decorator value, then to the global
-                timeout).
+                timeout). Expiry requests cooperative handler cancellation and
+                emits a terminal ``None`` result without waiting for cleanup.
         """
         self._register_direct_function(
             handler,
@@ -1317,6 +1333,11 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
                 await self.cancel_task(task)
         self._function_call_tasks.clear()
 
+        for task in list(self._timed_out_function_call_tasks):
+            if not task.done():
+                await self.cancel_task(task)
+        self._timed_out_function_call_tasks.clear()
+
     async def _sequential_runner_handler(self):
         while True:
             runner_item = await self._sequential_runner_queue.get()
@@ -1378,7 +1399,24 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             group_id=runner_item.group_id,
         )
 
-        timeout_task: asyncio.Task | None = None
+        function_call_timeout: asyncio.Timeout | None = None
+        timeout_active = False
+        timed_out = False
+        handler_task: asyncio.Task | None = None
+        handler_error: Exception | None = None
+
+        async def broadcast_function_call_result(
+            result: Any, *, properties: FunctionCallResultProperties | None = None
+        ):
+            await self.broadcast_frame(
+                FunctionCallResultFrame,
+                function_name=runner_item.function_name,
+                tool_call_id=runner_item.tool_call_id,
+                arguments=runner_item.arguments,
+                result=result,
+                run_llm=runner_item.run_llm,
+                properties=properties,
+            )
 
         # Single callback for both intermediate updates and final results.
         # Pass properties=FunctionCallResultProperties(is_final=False) for updates.
@@ -1395,40 +1433,37 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
                 )
                 return
 
-            nonlocal timeout_task
+            nonlocal timeout_active
 
-            # Cancel timeout task if it exists
-            if timeout_task and not timeout_task.done():
-                await self.cancel_task(timeout_task)
-
-            await self.broadcast_frame(
-                FunctionCallResultFrame,
-                function_name=runner_item.function_name,
-                tool_call_id=runner_item.tool_call_id,
-                arguments=runner_item.arguments,
-                result=result,
-                run_llm=runner_item.run_llm,
-                properties=properties,
-            )
-
-        # Start a timeout task for deferred function calls
-        async def timeout_handler():
-            try:
-                effective_timeout = item.timeout_secs or self._function_call_timeout_secs
-                await asyncio.sleep(effective_timeout)
+            if runner_item.terminal_state == "cancel":
                 logger.warning(
-                    f"{self} Function call [{runner_item.function_name}:{runner_item.tool_call_id}] timed out after {effective_timeout} seconds."
-                    f" You can increase this timeout by passing `timeout_secs` to `register_function()`,"
-                    f" or set a global default via `function_call_timeout_secs` on the LLM constructor."
+                    f"{self} Ignoring result for cancelled function call"
+                    f" [{runner_item.function_name}:{runner_item.tool_call_id}]."
                 )
-                await function_call_result_callback(None)
-            except asyncio.CancelledError:
-                raise
+                return
 
-        if item.timeout_secs or self._function_call_timeout_secs:
-            timeout_task = self.create_task(timeout_handler())
+            if timed_out or (function_call_timeout and function_call_timeout.expired()):
+                logger.warning(
+                    f"{self} Ignoring late result for timed-out function call"
+                    f" [{runner_item.function_name}:{runner_item.tool_call_id}]."
+                )
+                return
 
-        try:
+            # A valid callback satisfies the timeout, even if the handler keeps
+            # running afterward (for example, to perform cleanup).
+            if function_call_timeout and timeout_active:
+                function_call_timeout.reschedule(None)
+                timeout_active = False
+
+            if is_final and runner_item.terminal_state is None:
+                # Claim the terminal outcome before the first broadcast await.
+                # Interruption paths consult this claim and leave the result
+                # broadcast intact once it has started.
+                runner_item.terminal_state = "result"
+
+            await broadcast_function_call_result(result, properties=properties)
+
+        async def invoke_handler():
             if isinstance(item.handler, DirectFunctionWrapper):
                 # Handler is a DirectFunctionWrapper
                 await item.handler.invoke(
@@ -1457,13 +1492,92 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
                     app_resources=self.pipeline_worker.app_resources,
                 )
                 await item.handler(params)
+
+        effective_timeout = item.timeout_secs or self._function_call_timeout_secs
+
+        async def run_handler():
+            nonlocal handler_error
+            try:
+                await invoke_handler()
+            except Exception as e:
+                # TaskManager logs and consumes regular task exceptions. Capture
+                # application errors here so the existing push_error path remains
+                # observable to callers of _run_function_call.
+                handler_error = e
+
+        def log_late_handler_completion(task: asyncio.Task):
+            self._timed_out_function_call_tasks.discard(task)
+            if timed_out and not task.cancelled():
+                if handler_error:
+                    logger.warning(
+                        f"{self} Function call handler [{runner_item.function_name}:{runner_item.tool_call_id}]"
+                        f" raised after timing out: {handler_error}"
+                    )
+                else:
+                    logger.warning(
+                        f"{self} Function call handler [{runner_item.function_name}:{runner_item.tool_call_id}]"
+                        " completed after its timeout cancellation request."
+                    )
+
+        try:
+            if effective_timeout:
+                handler_task = self.create_task(run_handler())
+                handler_task.add_done_callback(log_late_handler_completion)
+
+                try:
+                    async with asyncio.timeout(effective_timeout) as function_call_timeout:
+                        timeout_active = True
+                        # The cancellation scope owns the deadline, while shield
+                        # keeps handler cancellation non-blocking. On expiry we
+                        # explicitly cancel the managed handler task below.
+                        await asyncio.shield(handler_task)
+                except TimeoutError:
+                    # Preserve TimeoutError raised by application code. Only
+                    # consume the one produced by our cancellation scope.
+                    if not function_call_timeout.expired():
+                        raise
+                finally:
+                    timeout_active = False
+
+                if function_call_timeout.expired():
+                    if runner_item.terminal_state is None:
+                        # Claim the timeout result before the first broadcast
+                        # await. An interruption that arrives during broadcast
+                        # observes the claim and cannot replace it with a cancel.
+                        runner_item.terminal_state = "result"
+                        timed_out = True
+                        logger.warning(
+                            f"{self} Function call [{runner_item.function_name}:{runner_item.tool_call_id}] timed out after {effective_timeout} seconds."
+                            f" You can increase this timeout by passing `timeout_secs` to `register_function()`,"
+                            f" or set a global default via `function_call_timeout_secs` on the LLM constructor."
+                        )
+
+                        # Request cancellation before publishing the terminal
+                        # result. The managed handler remains service-owned, but
+                        # does not block this runner while it performs cleanup.
+                        if not handler_task.done():
+                            self._timed_out_function_call_tasks.add(handler_task)
+                            handler_task.cancel()
+                        await broadcast_function_call_result(None)
+
+                if handler_error and not timed_out:
+                    raise handler_error
+            else:
+                await invoke_handler()
+        except asyncio.CancelledError:
+            if handler_task and not handler_task.done():
+                await self.cancel_task(handler_task)
+            raise
         except Exception as e:
-            error_message = f"Error executing function call [{runner_item.function_name}]: {e}"
-            logger.error(f"{self} {error_message}")
-            await self.push_error(error_msg=error_message, exception=e, fatal=False)
-        finally:
-            if timeout_task and not timeout_task.done():
-                await self.cancel_task(timeout_task)
+            if timed_out:
+                logger.warning(
+                    f"{self} Function call handler [{runner_item.function_name}:{runner_item.tool_call_id}]"
+                    f" raised after timing out: {e}"
+                )
+            else:
+                error_message = f"Error executing function call [{runner_item.function_name}]: {e}"
+                logger.error(f"{self} {error_message}")
+                await self.push_error(error_msg=error_message, exception=e, fatal=False)
 
     def _build_missing_function_call_registry_item(
         self, function_name: str
@@ -1590,6 +1704,14 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         cancelled_items = []
         for task, runner_item in self._function_call_tasks.items():
             if runner_item.tool_call_id == tool_call_id:
+                if runner_item.terminal_state is not None:
+                    logger.debug(
+                        f"{self} Function call [{runner_item.function_name}:{runner_item.tool_call_id}]"
+                        f" already claimed terminal state '{runner_item.terminal_state}'; skipping cancellation"
+                    )
+                    continue
+                runner_item.terminal_state = "cancel"
+
                 name = runner_item.function_name
                 tool_call_id = runner_item.tool_call_id
 
@@ -1628,6 +1750,14 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         cancelled_items = []
         for task, runner_item in self._function_call_tasks.items():
             if runner_item.registry_item.function_name == function_name:
+                if runner_item.terminal_state is not None:
+                    logger.debug(
+                        f"{self} Function call [{runner_item.function_name}:{runner_item.tool_call_id}]"
+                        f" already claimed terminal state '{runner_item.terminal_state}'; skipping cancellation"
+                    )
+                    continue
+                runner_item.terminal_state = "cancel"
+
                 name = runner_item.function_name
                 tool_call_id = runner_item.tool_call_id
 

--- a/src/pipecat/workers/llm/tool_decorator.py
+++ b/src/pipecat/workers/llm/tool_decorator.py
@@ -38,8 +38,9 @@ def tool(fn=None, *, cancel_on_interruption=True, timeout_secs=None, timeout=Non
             an interruption occurs. Defaults to True. Only applies to
             ``LLMWorker`` tools.
         timeout_secs: Optional timeout in seconds for this tool call.
-            Defaults to None (uses the LLM service default). Only applies
-            to ``LLMWorker`` tools.
+            Defaults to None (uses the LLM service default). Expiry requests
+            cooperative handler cancellation and emits a terminal ``None`` result
+            without waiting for cleanup. Only applies to ``LLMWorker`` tools.
         timeout: Deprecated alias for ``timeout_secs``.
 
             .. deprecated:: 1.4.0

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 import unittest
 import warnings
 from types import SimpleNamespace
@@ -14,6 +15,7 @@ from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.open_ai_adapter import OpenAILLMAdapter
 from pipecat.frames.frames import (
+    FunctionCallCancelFrame,
     FunctionCallFromLLM,
     FunctionCallInProgressFrame,
     FunctionCallResultFrame,
@@ -30,6 +32,7 @@ from pipecat.services.settings import LLMSettings
 from pipecat.turns.user_mute.function_call_user_mute_strategy import FunctionCallUserMuteStrategy
 from pipecat.turns.user_turn_completion_mixin import UserTurnCompletionConfig
 from pipecat.utils.async_tool_cancellation import CANCEL_ASYNC_TOOL_NAME
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 def _expected_missing_tool_message(name: str) -> str:
@@ -130,6 +133,374 @@ class TestLLMService(unittest.IsolatedAsyncioTestCase):
         warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
         self.assertTrue(any("not in the currently advertised tool set" in w for w in warnings))
         self.assertFalse(any("just unregistered" in w for w in warnings))
+
+    async def test_function_call_timeout_cancels_handler(self):
+        """A timed-out function call must not keep running or emit a late result."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        results = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            if frame_cls is FunctionCallResultFrame:
+                results.append(kwargs["result"])
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        handler_cancelled = asyncio.Event()
+        side_effects = []
+
+        async def slow_handler(params):
+            try:
+                await asyncio.sleep(0.05)
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                raise
+
+            side_effects.append("completed")
+            await params.result_callback("late-success")
+
+        service.register_function("slow_tool", slow_handler, timeout_secs=0.01)
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="slow_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        await asyncio.wait_for(handler_cancelled.wait(), timeout=1.0)
+        self.assertEqual(side_effects, [])
+        self.assertEqual(results, [None])
+
+    async def test_function_call_timeout_does_not_wait_for_cancellation_cleanup(self):
+        """The timeout result is terminal even while cancellation cleanup is still running."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        results = []
+        timeout_result = asyncio.Event()
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            if frame_cls is FunctionCallResultFrame:
+                results.append(kwargs["result"])
+                timeout_result.set()
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        handler_cancelled = asyncio.Event()
+        finish_cleanup = asyncio.Event()
+        cleanup_completed = asyncio.Event()
+
+        async def handler_with_slow_cancellation_cleanup(params):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                await finish_cleanup.wait()
+                await params.result_callback("late-success")
+                cleanup_completed.set()
+
+        service.register_function(
+            "slow_cleanup_tool", handler_with_slow_cancellation_cleanup, timeout_secs=0.01
+        )
+
+        call_task = asyncio.create_task(
+            service.run_function_calls(
+                [
+                    FunctionCallFromLLM(
+                        function_name="slow_cleanup_tool",
+                        tool_call_id="call_1",
+                        arguments={},
+                        context=LLMContext(),
+                    )
+                ]
+            )
+        )
+
+        await asyncio.wait_for(timeout_result.wait(), timeout=1.0)
+        await asyncio.wait_for(call_task, timeout=1.0)
+
+        self.assertTrue(handler_cancelled.is_set())
+        self.assertTrue(call_task.done())
+        self.assertFalse(cleanup_completed.is_set())
+        self.assertEqual(results, [None])
+
+        finish_cleanup.set()
+        await asyncio.wait_for(cleanup_completed.wait(), timeout=1.0)
+        self.assertEqual(results, [None])
+
+    async def test_cleanup_drains_timed_out_handler_cleanup(self):
+        """A detached timeout handler remains owned by the service until cleanup."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        timeout_result = asyncio.Event()
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            if frame_cls is FunctionCallResultFrame:
+                timeout_result.set()
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        first_cancellation = asyncio.Event()
+        cleanup_exited = asyncio.Event()
+
+        async def cancellation_suppressing_handler(params):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                first_cancellation.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cleanup_exited.set()
+
+        service.register_function(
+            "cleanup_owned_tool", cancellation_suppressing_handler, timeout_secs=0.01
+        )
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="cleanup_owned_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        await asyncio.wait_for(timeout_result.wait(), timeout=1.0)
+        await asyncio.wait_for(first_cancellation.wait(), timeout=1.0)
+        self.assertEqual(len(service._timed_out_function_call_tasks), 1)
+
+        await asyncio.wait_for(service.cleanup(), timeout=1.0)
+
+        self.assertTrue(cleanup_exited.is_set())
+        self.assertEqual(service._timed_out_function_call_tasks, set())
+
+    async def test_function_call_timeout_stops_after_result_callback(self):
+        """A valid result callback satisfies the timeout while handler cleanup continues."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        results = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            if frame_cls is FunctionCallResultFrame:
+                results.append(kwargs["result"])
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        cleanup_completed = asyncio.Event()
+
+        async def handler_with_cleanup(params):
+            await params.result_callback("success")
+            await asyncio.sleep(0.05)
+            cleanup_completed.set()
+
+        service.register_function("cleanup_tool", handler_with_cleanup, timeout_secs=0.01)
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="cleanup_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        self.assertTrue(cleanup_completed.is_set())
+        self.assertEqual(results, ["success"])
+
+    async def test_function_call_interruption_cancels_owned_timeout_handler(self):
+        """External cancellation still propagates to a handler with a global timeout."""
+        service = MockLLMService(function_call_timeout_secs=1.0)
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        results = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            if frame_cls is FunctionCallResultFrame:
+                results.append(kwargs["result"])
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        handler_started = asyncio.Event()
+        handler_cancelled = asyncio.Event()
+
+        async def interrupted_handler(params):
+            handler_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                raise
+
+        service.register_function("interrupted_tool", interrupted_handler)
+
+        call_task = asyncio.create_task(
+            service.run_function_calls(
+                [
+                    FunctionCallFromLLM(
+                        function_name="interrupted_tool",
+                        tool_call_id="call_1",
+                        arguments={},
+                        context=LLMContext(),
+                    )
+                ]
+            )
+        )
+
+        await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+        call_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await call_task
+
+        self.assertTrue(handler_cancelled.is_set())
+        self.assertEqual(results, [])
+
+    async def test_timeout_terminal_claim_wins_over_interruption(self):
+        """Interruption cannot replace a timeout result whose broadcast has started."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+
+        result_broadcast_started = asyncio.Event()
+        finish_result_broadcast = asyncio.Event()
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls)
+            if frame_cls is FunctionCallResultFrame:
+                result_broadcast_started.set()
+                await finish_result_broadcast.wait()
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        async def slow_handler(params):
+            await asyncio.Event().wait()
+
+        service.register_function("racing_tool", slow_handler, timeout_secs=0.01)
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="racing_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        await asyncio.wait_for(result_broadcast_started.wait(), timeout=1.0)
+        function_call_task = next(iter(service._function_call_tasks))
+
+        await service._cancel_function_call("racing_tool")
+        self.assertNotIn(FunctionCallCancelFrame, recorded_frames)
+
+        finish_result_broadcast.set()
+        await asyncio.wait_for(function_call_task, timeout=1.0)
+        self.assertEqual(recorded_frames.count(FunctionCallResultFrame), 1)
+
+    async def test_interruption_terminal_claim_drops_cleanup_result(self):
+        """A handler cannot replace a claimed cancellation during cleanup."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+
+        recorded_frames = []
+
+        async def mock_broadcast_frame(frame_cls, **kwargs):
+            recorded_frames.append(frame_cls)
+
+        service.broadcast_frame = mock_broadcast_frame
+
+        handler_started = asyncio.Event()
+
+        async def cleanup_result_handler(params):
+            handler_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await params.result_callback("cleanup-result")
+
+        service.register_function("cleanup_result_tool", cleanup_result_handler)
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="cleanup_result_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        await asyncio.wait_for(handler_started.wait(), timeout=1.0)
+        await service._cancel_function_call("cleanup_result_tool")
+
+        terminal_frames = [
+            frame_cls
+            for frame_cls in recorded_frames
+            if frame_cls in (FunctionCallResultFrame, FunctionCallCancelFrame)
+        ]
+        self.assertEqual(terminal_frames, [FunctionCallCancelFrame])
+
+    async def test_function_call_preserves_handler_timeout_error(self):
+        """TimeoutError from application code follows the normal error path."""
+        service = MockLLMService()
+        service._task_manager = TaskManager()
+        service._call_event_handler = AsyncMock()
+        service.broadcast_frame = AsyncMock()
+        service.push_error = AsyncMock()
+        await self._run_function_calls_inline(service)
+
+        async def failing_handler(params):
+            raise TimeoutError("downstream request timed out")
+
+        service.register_function("failing_tool", failing_handler, timeout_secs=1.0)
+
+        await service.run_function_calls(
+            [
+                FunctionCallFromLLM(
+                    function_name="failing_tool",
+                    tool_call_id="call_1",
+                    arguments={},
+                    context=LLMContext(),
+                )
+            ]
+        )
+
+        service.push_error.assert_awaited_once()
+        self.assertIn(
+            "downstream request timed out", service.push_error.await_args.kwargs["error_msg"]
+        )
+        self.assertFalse(
+            any(
+                call.args and call.args[0] is FunctionCallResultFrame
+                for call in service.broadcast_frame.await_args_list
+            )
+        )
 
     async def test_function_unregistered_between_queue_and_execute(self):
         """Function unregistered between queuing and execution still terminates."""


### PR DESCRIPTION
## Summary

- actively cancel function-call handlers when their configured deadline expires
- emit the terminal timeout result without waiting for cancellation cleanup, while keeping slow cleanup owned through service teardown
- preserve valid callback semantics and application-raised `TimeoutError` behavior
- serialize timeout, successful-result, and interruption outcomes so only one terminal frame is published
- document cooperative timeout cancellation across the public registration APIs

Fixes #4936.

Explicit timeout-result representation remains out of scope because it overlaps #4298.

## Test plan

- [x] `uv run pytest tests/test_llm_service.py -q` (30 passed)
- [x] related tool, aggregator, realtime sync, and switcher tests (189 passed)
- [x] full Python 3.12 all-extras test suite (3595 passed, 144 skipped)
- [x] Ruff, formatting, Pyright, and `git diff --check`
- [x] `uv build`