### PR TITLE
Stop RTVI from re-broadcasting output transport errors (fixes ErrorFrame loop)

### DIFF
--- a/changelog/5201.fixed.md
+++ b/changelog/5201.fixed.md
@@ -1,0 +1,5 @@
+- Fixed a feedback loop between `RTVIProcessor` and the output transport. When a
+  transport failed to send a message it pushed an `ErrorFrame` upstream, RTVI turned
+  that into an `RTVI.Error` message and sent it back down to the same transport, which
+  failed again. RTVI no longer reports output-transport errors to the client. The
+  `ErrorFrame` still reaches the app and any observers.

--- a/src/pipecat/processors/frameworks/rtvi/processor.py
+++ b/src/pipecat/processors/frameworks/rtvi/processor.py
@@ -44,6 +44,7 @@ from pipecat.processors.frameworks.rtvi.observer import RTVIObserver, RTVIObserv
 from pipecat.services.llm_service import (
     FunctionCallParams,  # TODO(aleix): we shouldn't import `services` from `processors`
 )
+from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import BaseTransport
 
 
@@ -231,7 +232,14 @@ class RTVIProcessor(FrameProcessor):
             await self._cancel(frame)
             await self.push_frame(frame, direction)
         elif isinstance(frame, ErrorFrame):
-            await self._send_error_frame(frame)
+            # Errors raised by the output transport are not reported to the
+            # client. The RTVI message would have to travel over the same
+            # connection that just failed, and if that send fails too it raises
+            # another ErrorFrame, which lands back here: a loop that runs at
+            # event loop speed until the call ends. The frame still goes
+            # upstream, so the app and any observers see it.
+            if not isinstance(frame.processor, BaseOutputTransport):
+                await self._send_error_frame(frame)
             await self.push_frame(frame, direction)
         elif isinstance(frame, InputTransportMessageFrame):
             await self._handle_transport_message(frame)

--- a/tests/test_rtvi_error_loop.py
+++ b/tests/test_rtvi_error_loop.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Regression test for the RTVI / output transport ErrorFrame feedback loop.
+
+When an output transport fails to send a message it calls ``push_error``, which
+pushes an ``ErrorFrame`` upstream. If ``RTVIProcessor`` is upstream it turns that
+ErrorFrame into an ``RTVI.Error`` message and pushes it back down to the same
+transport, which fails again. That is a self-amplifying loop: one failed send
+becomes an unbounded stream of ErrorFrames at event loop speed.
+
+See support ticket T-2660: four production storms, roughly 1.4 million ErrorFrame
+allocations each, about 2,400 log lines per second for 10 minutes.
+
+The fake transport here caps its failures so a regression fails fast instead of
+hanging or exhausting memory.
+"""
+
+import asyncio
+import unittest
+
+from pipecat.frames.frames import ErrorFrame, OutputTransportMessageUrgentFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
+from pipecat.tests.utils import SleepFrame, run_test
+from pipecat.transports.base_output import BaseOutputTransport
+from pipecat.transports.base_transport import TransportParams
+
+# The loop is unbounded on a broken build. Stop failing after this many sends so
+# the test fails fast instead of hanging.
+MAX_FAILURES = 10
+
+# Guard against a build where the loop somehow keeps running past MAX_FAILURES.
+TEST_TIMEOUT_SECS = 20
+
+
+class _FailingOutputTransport(BaseOutputTransport):
+    """An output transport whose sends fail the way Daily's do when signaling dies.
+
+    Mirrors ``DailyOutputTransport.send_message``: the client returns an error and
+    the transport reports it with ``push_error``, which travels upstream.
+    """
+
+    def __init__(self, max_failures: int = MAX_FAILURES):
+        super().__init__(TransportParams())
+        self.send_message_count = 0
+        self._max_failures = max_failures
+
+    async def send_message(self, frame):
+        self.send_message_count += 1
+        if self.send_message_count <= self._max_failures:
+            await self.push_error("Unable to send message: fake signaling failure")
+
+
+class TestRTVIErrorFrameSendLoop(unittest.IsolatedAsyncioTestCase):
+    async def test_failed_transport_send_does_not_loop(self):
+        """One failed send produces one ErrorFrame, not a storm of them."""
+        transport = _FailingOutputTransport()
+        rtvi = RTVIProcessor()
+        pipeline = Pipeline([rtvi, transport])
+
+        # A single outbound message that the transport will fail to send. On a
+        # broken build the resulting ErrorFrame comes back down as an RTVI error
+        # message and the transport is asked to send again, and again.
+        kickoff = OutputTransportMessageUrgentFrame(message={"label": "test", "type": "kickoff"})
+
+        # The SleepFrame holds the EndFrame back so a looping build reaches its
+        # failure cap instead of being cut short by the pipeline shutting down.
+        _, up_frames = await asyncio.wait_for(
+            run_test(
+                pipeline,
+                enable_rtvi=True,
+                frames_to_send=[kickoff, SleepFrame(sleep=0.5)],
+            ),
+            timeout=TEST_TIMEOUT_SECS,
+        )
+
+        error_frames = [frame for frame in up_frames if isinstance(frame, ErrorFrame)]
+
+        self.assertEqual(
+            transport.send_message_count,
+            1,
+            f"send_message was called {transport.send_message_count} times for one "
+            "outbound message: the failed send is being re-broadcast over the same "
+            "dead connection",
+        )
+        self.assertEqual(
+            len(error_frames),
+            1,
+            f"{len(error_frames)} ErrorFrames reached the app for one failed send",
+        )


### PR DESCRIPTION
## The bug

A failed send on the output transport starts a feedback loop with RTVI that never stops on its own.

1. RTVI sends a message: `RTVIProcessor.push_transport_message` (`src/pipecat/processors/frameworks/rtvi/processor.py:172-177`) produces an `OutputTransportMessageUrgentFrame`, which `BaseOutputTransport.process_frame` routes to `send_message` (`src/pipecat/transports/base_output.py:350-351`).
2. The Daily signaling channel is dead, so the send returns an error and the transport reports it: `await self.push_error(f"Unable to send message: {error}")` (`src/pipecat/transports/daily/transport.py:2236-2238`).
3. `push_error` builds an `ErrorFrame`, stamps `error.processor = self`, and pushes it **upstream** (`src/pipecat/processors/frame_processor.py:710`, `:719-720`, `:733`).
4. Upstream is the RTVI processor. It matches `ErrorFrame` (`rtvi/processor.py:233-235`) and calls `_send_error_frame`, which builds an `RTVI.Error` and calls `push_transport_message` (`:550-553`).
5. Back to step 1.

`fatal` is `False`, so nothing stops the pipeline. There is no dedupe, no backoff, and no recursion guard, so the rate is just event loop speed.

## Production evidence

From support ticket T-2660 (Pipecat Cloud). A customer reported memory climbing on his agent, with new sessions landing on pods that were already nearly out of memory. His session logs show this loop firing four times in one week, on four different pods (2026-07-27, 07-28, 07-30, 08-03):

- about 2,400 log lines per second, for exactly 10 minutes each time
- roughly 1.4 million `ErrorFrame` allocations per occurrence
- 5,709,275 log lines total across the four storms

A warm Pipecat Cloud instance serves sequential sessions in one Python process that is never restarted, so whatever the storm costs in RSS stays on the pod for the rest of its life.

## The fix

`RTVIProcessor.process_frame` now skips the client notification when the `ErrorFrame` came from a `BaseOutputTransport`:

```python
elif isinstance(frame, ErrorFrame):
    if not isinstance(frame.processor, BaseOutputTransport):
        await self._send_error_frame(frame)
    await self.push_frame(frame, direction)
```

The `ErrorFrame` still travels upstream to the app and to observers. The only thing that stops is re-broadcasting it over the connection that just failed to carry it.

### Why this option

The alternative considered was an explicit marker on the frame: add something like `deliverable_to_client: bool = True` to `ErrorFrame` (`src/pipecat/frames/frames.py:949-970`), set it `False` at the Daily send-failure site, and gate `_send_error_frame` on it. That is more precise, but:

- It fixes one call site. The loop is a property of any output transport that reports send failures with `push_error`, not of Daily specifically. The marker approach needs every current and future transport to remember to opt in.
- It widens a public frame's schema for a condition that is already knowable from `frame.processor`.
- The guard here is the rule you actually want: never re-broadcast an error over the connection that produced it.

Trade-off worth a reviewer's opinion: this suppresses the client-facing RTVI error for **every** output-transport error, not only send failures. That seems right to me, because the RTVI channel runs over the same transport, so the notification is either redundant or the start of a loop. If you want it narrower, say so and I will switch to the marker.

Import direction is safe: `transports/base_output.py` does not import `processors/frameworks/rtvi`, and `rtvi/processor.py` already imports from `transports/base_transport`. No circular import.

## Test

New bounded repro, `tests/test_rtvi_error_loop.py`. A minimal `BaseOutputTransport` subclass fails its sends the way Daily's does, sits downstream of a real `RTVIProcessor`, and gets one outbound message. The fake transport stops failing after 10 sends, and the whole run is wrapped in `asyncio.wait_for`, so a regression fails fast instead of hanging or exhausting memory in CI.

### Before, on `main` at `b114a367a`

```
$ .venv/bin/python -m pytest tests/test_rtvi_error_loop.py -q

E       AssertionError: 11 != 1 : send_message was called 11 times for one outbound message: the failed send is being re-broadcast over the same dead connection

tests/test_rtvi_error_loop.py:83: AssertionError
=========================== short test summary info ============================
FAILED tests/test_rtvi_error_loop.py::TestRTVIErrorFrameSendLoop::test_failed_transport_send_does_not_loop
============================== 1 failed in 2.00s ===============================
```

11 is one kickoff message plus the 10 capped loop iterations. Without the cap it does not stop.

### After, with this change

```
$ .venv/bin/python -m pytest tests/test_rtvi_error_loop.py -q
tests/test_rtvi_error_loop.py .                                          [100%]
============================== 1 passed in 3.32s ===============================
```

### Neighbouring suites

```
$ .venv/bin/python -m pytest tests/test_rtvi_processor.py tests/test_rtvi_observer_config.py \
    tests/test_rtvi_observer_metrics.py tests/test_rtvi_ui.py tests/test_base_output_transport.py -q
======================= 50 passed, 10 warnings in 1.83s ========================
```

## Follow-up, not in this PR

`daily/transport.py` has three sibling `push_error` sites with the identical shape, all in `write_transport_frame`: SIP transfer (`:2290`), SIP REFER (`:2294`), and update remote participants (`:2298`). The guard in this PR covers them too, since they all report through the same output transport, so no separate change is needed to break the loop. What is worth a reviewer's decision is the other half: those three currently do notify the client, and this change stops that. If any of them should still reach the client, that argues for the explicit-marker approach instead.
