### PR TITLE
Fix duplicate Inworld context closure

### DIFF
--- a/changelog/5202.fixed.md
+++ b/changelog/5202.fixed.md
@@ -1,0 +1,1 @@
+- Fixed duplicate Inworld context closure when turn completion and interruption overlap.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -848,15 +848,18 @@ class InworldTTSService(WebsocketTTSService):
         return word_times
 
     async def _close_context(self, context_id: str | None):
-        if not context_id:
+        if not context_id or context_id not in self._sent_context_ids:
             return
+
+        # Claim the close before awaiting the provider so concurrent terminal
+        # lifecycle paths cannot close the same context twice.
+        self._sent_context_ids.discard(context_id)
         if self._websocket:
             logger.info(f"{self}: Closing context {context_id} due to interruption or completion")
             try:
                 await self._send_close_context(context_id)
             except Exception as e:
                 await self.push_error(error_msg=f"Unknown error occurred: {e}", exception=e)
-        self._sent_context_ids.discard(context_id)
 
     async def on_turn_context_completed(self):
         """Close the server-side context at end of turn.
@@ -993,7 +996,7 @@ class InworldTTSService(WebsocketTTSService):
                 audio_contexts = self.get_audio_contexts()
                 if audio_contexts:
                     for ctx_id in audio_contexts:
-                        await self._send_close_context(ctx_id)
+                        await self._close_context(ctx_id)
                 await self._websocket.close()
                 logger.debug("Disconnected from Inworld WebSocket TTS")
         except Exception as e:

--- a/tests/test_inworld_tts.py
+++ b/tests/test_inworld_tts.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the Inworld TTS service lifecycle."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.services.inworld.tts import InworldTTSService
+from pipecat.services.tts_service import TTSService
+from pipecat.utils.text.base_text_aggregator import AggregationType
+
+
+@pytest.mark.asyncio
+async def test_context_closes_once_across_completion_and_interruption():
+    """Completion followed by interruption should close one provider context once."""
+    service = InworldTTSService(api_key="test-key")
+    service._websocket = AsyncMock()
+    service._turn_context_id = "context-1"
+    service._sent_context_ids.add("context-1")
+    service._context_texts["context-1"] = "Hello there."
+    service._send_close_context = AsyncMock()
+    service.push_frame = AsyncMock()
+
+    with patch.object(TTSService, "on_turn_context_completed", new=AsyncMock()):
+        await service.on_turn_context_completed()
+    await service.on_audio_context_interrupted("context-1")
+
+    service._send_close_context.assert_awaited_once_with("context-1")
+    service.push_frame.assert_awaited_once()
+    fallback = service.push_frame.await_args.args[0]
+    assert fallback.text == "Hello there."
+    assert fallback.aggregated_by is AggregationType.SENTENCE
+    assert fallback.context_id == "context-1"


### PR DESCRIPTION
## Summary
- make Inworld context closure one-shot across turn completion, interruption, and disconnect
- claim the close before awaiting the provider so concurrent terminal paths cannot send duplicate close messages
- preserve the existing context-correlated fallback text behavior

## Why
The documented TTS lifecycle permits provider cleanup on turn completion and interruption. Inworld currently reaches the same close helper from both paths, but the helper does not guard already-closed contexts.

## Tests
- uv run ruff check src/pipecat/services/inworld/tts.py tests/test_inworld_tts.py
- uv run pytest tests/test_inworld_tts.py tests/test_inworld_tts_language.py -q