### PR TITLE
evals: add the realtime services to the release suite

### DIFF
--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -142,6 +142,29 @@ suite:
     scenarios: [capital_question]
 
   #
+  # Realtime (speech-to-speech): one bot per provider, each exercising a
+  # function call end to end inside the provider's own realtime session. These
+  # are audio scenarios, audio being the modality these services consume.
+  # Ultravox runs its async-tool example because that's the one with the
+  # weather function the scenario expects.
+  #
+  - bot: realtime/realtime-aws-nova-sonic.py
+    scenarios: [weather_function_call_audio]
+  # Needs a deployed Azure realtime model for $AZURE_REALTIME_BASE_URL to resolve.
+  # - bot: realtime/realtime-azure.py
+  #   scenarios: [weather_function_call_audio]
+  - bot: realtime/realtime-gemini-live.py
+    scenarios: [weather_function_call_audio]
+  - bot: realtime/realtime-grok.py
+    scenarios: [weather_function_call_audio]
+  - bot: realtime/realtime-inworld.py
+    scenarios: [weather_function_call_audio]
+  - bot: realtime/realtime-openai.py
+    scenarios: [weather_function_call_audio]
+  - bot: realtime/realtime-ultravox-async-tool.py
+    scenarios: [weather_function_call_audio]
+
+  #
   # Function calling: exercise one or more function calls.
   #
   - bot: getting-started/07-function-calling.py

--- a/scripts/release-evals/scenarios/weather_function_call_audio.yaml
+++ b/scripts/release-evals/scenarios/weather_function_call_audio.yaml
@@ -1,0 +1,26 @@
+name: weather_function_call_audio
+
+# Audio modality: ask for the weather (which requires a tool call) as speech, and
+# judge the transcription of the bot's spoken answer. This is the native path for
+# speech-to-speech services — audio in, the provider's own turn detection, a
+# function call, and a spoken answer back. The text-modality
+# `weather_function_call` asserts the same behavior but injects the user's turn as
+# text, which never touches either audio path.
+
+user: !include user_audio.yaml
+
+judge: !include judge_audio.yaml
+
+turns:
+  # Wait for the bot's on-connect greeting before speaking (avoids barging into it).
+  - expect:
+      - event: response
+        eval: "the bot opens the conversation in some way (a greeting, an introduction, an offer to help, or a question to get the user started)"
+
+  - user: "What's the weather in San Francisco, California? Use Fahrenheit."
+    expect:
+      - event: function_call
+        calls:
+          - name: get_current_weather
+      - event: response
+        eval: "the response describes the weather in San Francisco, including a temperature in degrees"


### PR DESCRIPTION
## What

The release-eval suite covers voice, function calling, vision, flows, turn management and DTMF, but no speech-to-speech bot. This adds one realtime bot per provider, each exercising a function call end to end inside the provider's own realtime session rather than through a separate LLM service.

| Bot | Provider |
|---|---|
| `realtime/realtime-aws-nova-sonic.py` | AWS Nova Sonic |
| `realtime/realtime-gemini-live.py` | Google Gemini Live |
| `realtime/realtime-grok.py` | xAI Grok |
| `realtime/realtime-inworld.py` | Inworld |
| `realtime/realtime-openai.py` | OpenAI Realtime |
| `realtime/realtime-ultravox-async-tool.py` | Ultravox |

Ultravox runs its async-tool example because that's the one carrying `get_current_weather`; the base example's only tool is `get_secret_menu`. Azure is included but commented out — it needs a deployed realtime model for `$AZURE_REALTIME_BASE_URL` to resolve.

No example changes were needed: all seven already declare an `eval` transport.

## The new scenario

`scenarios/weather_function_call_audio.yaml` is an audio-modality variant of `weather_function_call` — same two turns, plus `user: !include user_audio.yaml` and `judge: !include judge_audio.yaml`. Kokoro synthesizes the user's turn, Moonshine transcribes the bot's spoken answer.

Audio is the modality these services consume, so this exercises the real path: audio in, the provider's own turn detection, a function call, a spoken answer back.

The text-modality scenario is not usable here. Four of these services (OpenAI Realtime, Azure, Grok, Gemini Live) drop a user message appended to an existing context — `_handle_context`'s else-branch forwards only newly-completed function-call results — so a text turn never reaches the session and the bot goes silent. Inworld is the exception; it diffs the message count and forwards new user messages. Nova Sonic needs continuous audio regardless and its session times out without it. That gap is worth its own issue and is not addressed here.

## Results

```
✓ realtime-gemini-live.py          26895ms
✓ realtime-aws-nova-sonic.py       35428ms
✓ realtime-grok.py                 36596ms
✓ realtime-inworld.py              30355ms
✓ realtime-openai.py               22873ms
✓ realtime-ultravox-async-tool.py  32690ms

6/6 passed · 1m 11s
```

Run them with `./run.sh -p realtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)