### PR TITLE
fix(text): use the singular unit form for a quantity of one

### DIFF
--- a/changelog/5205.fixed.md
+++ b/changelog/5205.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `expand_units` reading a quantity of one with a plural unit, so "Only 1km left" now becomes "Only 1 kilometer left" instead of "Only 1 kilometers left". A decimal such as "1.0km" keeps the plural.

--- a/src/pipecat/utils/text/transforms/units.py
+++ b/src/pipecat/utils/text/transforms/units.py
@@ -10,33 +10,34 @@ import re
 
 from pipecat.frames.frames import AggregationType
 
-_UNIT_MAP: dict[str, str] = {
-    "km": "kilometers",
-    "m": "meters",
-    "cm": "centimeters",
-    "mm": "millimeters",
-    "mi": "miles",
-    "ft": "feet",
-    "in": "inches",
-    "yd": "yards",
-    "kg": "kilograms",
-    "g": "grams",
-    "mg": "milligrams",
-    "lb": "pounds",
-    "oz": "ounces",
-    "l": "liters",
-    "ml": "milliliters",
-    "mph": "miles per hour",
-    "kph": "kilometers per hour",
-    "kmh": "kilometers per hour",
-    "gb": "gigabytes",
-    "mb": "megabytes",
-    "kb": "kilobytes",
-    "tb": "terabytes",
-    "hz": "hertz",
-    "khz": "kilohertz",
-    "mhz": "megahertz",
-    "ghz": "gigahertz",
+# Maps unit abbreviation to (singular, plural) spoken forms.
+_UNIT_MAP: dict[str, tuple[str, str]] = {
+    "km": ("kilometer", "kilometers"),
+    "m": ("meter", "meters"),
+    "cm": ("centimeter", "centimeters"),
+    "mm": ("millimeter", "millimeters"),
+    "mi": ("mile", "miles"),
+    "ft": ("foot", "feet"),
+    "in": ("inch", "inches"),
+    "yd": ("yard", "yards"),
+    "kg": ("kilogram", "kilograms"),
+    "g": ("gram", "grams"),
+    "mg": ("milligram", "milligrams"),
+    "lb": ("pound", "pounds"),
+    "oz": ("ounce", "ounces"),
+    "l": ("liter", "liters"),
+    "ml": ("milliliter", "milliliters"),
+    "mph": ("mile per hour", "miles per hour"),
+    "kph": ("kilometer per hour", "kilometers per hour"),
+    "kmh": ("kilometer per hour", "kilometers per hour"),
+    "gb": ("gigabyte", "gigabytes"),
+    "mb": ("megabyte", "megabytes"),
+    "kb": ("kilobyte", "kilobytes"),
+    "tb": ("terabyte", "terabytes"),
+    "hz": ("hertz", "hertz"),
+    "khz": ("kilohertz", "kilohertz"),
+    "mhz": ("megahertz", "megahertz"),
+    "ghz": ("gigahertz", "gigahertz"),
 }
 
 # Single-letter units that are also common English words: only expand when
@@ -65,6 +66,8 @@ _AMBIGUOUS_UNIT_RE = re.compile(
 async def expand_units(text: str, aggregation_type: str | AggregationType) -> str:
     """Expand unit abbreviations to their full spoken form.
 
+    A quantity of exactly one takes the singular form of the unit.
+
     Args:
         text: Input text possibly containing unit expressions.
         aggregation_type: Aggregation type of the text frame (unused).
@@ -76,12 +79,17 @@ async def expand_units(text: str, aggregation_type: str | AggregationType) -> st
 
         result = await expand_units("Run 5km at 100kph", "*")
         # "Run 5 kilometers at 100 kilometers per hour"
+
+        result = await expand_units("Only 1km left", "*")
+        # "Only 1 kilometer left"
     """
 
     def _replace(match: re.Match) -> str:
         number = match.group(1)
-        unit = _UNIT_MAP[match.group(2).lower()]
-        return f"{number} {unit}"
+        singular, plural = _UNIT_MAP[match.group(2).lower()]
+        # Only a bare "1" takes the singular; a decimal such as "1.0" reads as
+        # plural in speech.
+        return f"{number} {singular if number == '1' else plural}"
 
     text = _UNIT_RE.sub(_replace, text)
     return _AMBIGUOUS_UNIT_RE.sub(_replace, text)

--- a/tests/test_voice_formatting.py
+++ b/tests/test_voice_formatting.py
@@ -236,6 +236,48 @@ class TestExpandUnits(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("grams", result)
 
 
+class TestExpandUnitsSingular(unittest.IsolatedAsyncioTestCase):
+    """A quantity of exactly one takes the singular form of the unit."""
+
+    async def test_singular_forms(self):
+        cases = {
+            "Only 1km left": "Only 1 kilometer left",
+            "Only 1mi left": "Only 1 mile left",
+            "Only 1ft left": "Only 1 foot left",
+            "Only 1in left": "Only 1 inch left",
+            "Only 1lb left": "Only 1 pound left",
+            "Only 1gb left": "Only 1 gigabyte left",
+            "Only 1mph left": "Only 1 mile per hour left",
+        }
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(await expand_units(text, "*"), expected)
+
+    async def test_singular_with_space(self):
+        result = await expand_units("1 km away", "*")
+        self.assertEqual(result, "1 kilometer away")
+
+    async def test_plural_forms_kept(self):
+        cases = {
+            "5km away": "5 kilometers away",
+            "0.5 mi away": "0.5 miles away",
+            "21 lb of flour": "21 pounds of flour",
+        }
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(await expand_units(text, "*"), expected)
+
+    async def test_decimal_one_is_plural(self):
+        """A decimal such as "1.0" reads as plural in speech, unlike a bare "1"."""
+        result = await expand_units("1.0km away", "*")
+        self.assertEqual(result, "1.0 kilometers away")
+
+    async def test_invariant_units_unchanged(self):
+        """Units whose singular and plural forms match expand identically."""
+        self.assertEqual(await expand_units("1hz tone", "*"), "1 hertz tone")
+        self.assertEqual(await expand_units("3 GHz processor", "*"), "3 gigahertz processor")
+
+
 class TestExpandUnitsUnambiguous(unittest.IsolatedAsyncioTestCase):
     """Units that are unambiguous even with a space before them should still expand."""
 


### PR DESCRIPTION
Closes #5204.

`expand_units` always emitted the plural spoken form, so a quantity of exactly one was read out with a plural unit — `"Only 1km left"` became `"Only 1 kilometers left"`. All 26 abbreviations in `_UNIT_MAP` were affected, and `expand_units` defaults to `True` in `VoiceFormatter`, so this reached TTS output in the default configuration.

`_UNIT_MAP` now holds a `(singular, plural)` pair per abbreviation and `_replace` selects the form from the matched number. This is the same shape `currency.py` already uses (`unit = singular if n == 1 else plural`). A decimal such as `"1.0km"` keeps the plural, matching how it reads in speech.

```
'Only 1km left'   ->  'Only 1 kilometer left'
'Only 1mi left'   ->  'Only 1 mile left'
'Only 1ft left'   ->  'Only 1 foot left'
'1 lb of flour'   ->  '1 pound of flour'
'1.0km away'      ->  '1.0 kilometers away'
'5km away'        ->  '5 kilometers away'
```

`hz`/`khz`/`mhz`/`ghz` have identical singular and plural forms and expand as before.

## Tests

`TestExpandUnitsSingular` in `tests/test_voice_formatting.py` covers the singular form across a spread of units (`km`, `mi`, `ft`, `in`, `lb`, `gb`, `mph`), with and without a space; the plural retained for `5`, `0.5`, `21` and for the decimal `1.0`; and the invariant `hz` family.

Two of the six new test methods fail on `main` at `b114a36` (all seven singular subcases plus the spaced variant); the other four are guards that pass both before and after.

`uv run pytest tests/test_voice_formatting.py` → 78 passed.

Full suite before and after the change, on Windows with the same 21 collection-error modules excluded both times (missing optional service extras in my environment): 2635 → 2641 passed, matching the 6 added tests. Three tests differ between the two failure sets — `test_startup_timing_observer.py::test_bot_and_client_connected`, `test_user_bot_latency_observer.py::test_first_bot_speech_latency` and `test_websocket_service.py::test_bounded_close_against_unresponsive_peer` — and each of them varies run to run on the unmodified tree (three consecutive baseline runs of just those files gave 3, 4 and 2 failures), so they are timing-sensitive on this machine rather than related to this change.

`uv run ruff check` and `uv run ruff format --check` are clean.
