### PR TITLE
fix(elevenlabs): prevent duplicate final STT transcripts

### DIFF
--- a/changelog/5208.fixed.md
+++ b/changelog/5208.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ElevenLabsRealtimeSTTService` pushing two final `TranscriptionFrame`s per utterance when `include_language_detection` was enabled without `include_timestamps`.

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -937,9 +937,11 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         Args:
             data: Committed transcript data.
         """
-        # If timestamps are enabled, skip this message and wait for the
-        # committed_transcript_with_timestamps message which contains all the data
-        if self._include_timestamps:
+        # The server also sends committed_transcript_with_timestamps whenever
+        # timestamps or language detection is enabled, and only that message carries
+        # language_code. Skip this one so each segment is emitted exactly once, with
+        # the timestamped message as the single source of truth.
+        if self._include_timestamps or self._include_language_detection:
             return
 
         text = data.get("text", "").strip()

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -937,10 +937,9 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         Args:
             data: Committed transcript data.
         """
-        # The server also sends committed_transcript_with_timestamps whenever
-        # timestamps or language detection is enabled, and only that message carries
-        # language_code. Skip this one so each segment is emitted exactly once, with
-        # the timestamped message as the single source of truth.
+        # The server pairs every commit with a committed_transcript_with_timestamps
+        # message whenever timestamps or language detection is enabled, and only that
+        # message carries language_code. Skip this one so each commit is emitted once.
         if self._include_timestamps or self._include_language_detection:
             return
 
@@ -976,10 +975,12 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
     async def _on_committed_transcript_with_timestamps(self, data: dict):
         """Handle committed transcript with word-level timestamps.
 
-        This message is sent when include_timestamps=true. The result data includes:
+        This message is sent when include_timestamps=true or
+        include_language_detection=true. The result data includes:
         - text: The transcribed text
         - language_code: Detected language (if available)
-        - words: Array of word objects with timing information:
+        - words: Array of word objects with timing information, null when only
+          language detection was requested:
             - text: The word text
             - start: Start time in seconds
             - end: End time in seconds
@@ -1006,8 +1007,6 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
 
         finalized = self._commit_strategy == CommitStrategy.MANUAL
 
-        # This message is sent after committed_transcript when include_timestamps=true.
-        # It contains the full transcript data including text and word-level timestamps.
         await self.emit_stt_usage_metrics()
         await self.push_frame(
             TranscriptionFrame(

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -10,6 +10,7 @@ import aiohttp
 import pytest
 from aiohttp import web
 
+from pipecat.frames.frames import TranscriptionFrame
 from pipecat.services.elevenlabs.stt import (
     CommitStrategy,
     ElevenLabsRealtimeSTTService,
@@ -17,6 +18,32 @@ from pipecat.services.elevenlabs.stt import (
     audio_format_from_sample_rate,
 )
 from pipecat.transcriptions.language import Language
+
+COMMITTED_TEXT = "Hello. This is a test of the speech-to-text service."
+
+PLAIN_COMMITTED_MESSAGE = {
+    "message_type": "committed_transcript",
+    "text": COMMITTED_TEXT,
+}
+
+TIMESTAMPED_COMMITTED_MESSAGE = {
+    "message_type": "committed_transcript_with_timestamps",
+    "text": COMMITTED_TEXT,
+    "language_code": "en",
+    "words": [{"text": "Hello.", "start": 0.0, "end": 0.5, "type": "word"}],
+}
+
+
+def _capture_transcriptions(service: ElevenLabsRealtimeSTTService) -> list[TranscriptionFrame]:
+    """Collect the TranscriptionFrames a service pushes."""
+    captured: list[TranscriptionFrame] = []
+
+    async def push_frame(frame, direction=None):
+        if isinstance(frame, TranscriptionFrame):
+            captured.append(frame)
+
+    service.push_frame = push_frame
+    return captured
 
 
 @pytest.mark.asyncio
@@ -162,3 +189,71 @@ async def test_elevenlabs_realtime_websocket_url_omits_unset_filter_background_a
 
     query = parse_qs(urlparse(captured["url"]).query)
     assert "filter_background_audio" not in query
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_language_detection_emits_single_final():
+    """Language detection turns on the timestamped message, which alone carries language."""
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        include_language_detection=True,
+    )
+    captured = _capture_transcriptions(service)
+
+    # The server sends the timestamped message first in this configuration.
+    await service._process_response(TIMESTAMPED_COMMITTED_MESSAGE)
+    await service._process_response(PLAIN_COMMITTED_MESSAGE)
+
+    assert len(captured) == 1
+    assert captured[0].text == COMMITTED_TEXT
+    assert captured[0].language == "en"
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_timestamps_emits_single_final():
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        include_timestamps=True,
+    )
+    captured = _capture_transcriptions(service)
+
+    await service._process_response(PLAIN_COMMITTED_MESSAGE)
+    await service._process_response(TIMESTAMPED_COMMITTED_MESSAGE)
+
+    assert len(captured) == 1
+    assert captured[0].text == COMMITTED_TEXT
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_both_options_emit_single_final():
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        include_timestamps=True,
+        include_language_detection=True,
+    )
+    captured = _capture_transcriptions(service)
+
+    await service._process_response(PLAIN_COMMITTED_MESSAGE)
+    await service._process_response(TIMESTAMPED_COMMITTED_MESSAGE)
+
+    assert len(captured) == 1
+    assert captured[0].language == "en"
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_plain_committed_emitted_without_options():
+    """Without either option the server sends only the plain message, so it must be emitted."""
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+    )
+    captured = _capture_transcriptions(service)
+
+    await service._process_response(PLAIN_COMMITTED_MESSAGE)
+
+    assert len(captured) == 1
+    assert captured[0].text == COMMITTED_TEXT
+    assert captured[0].language is None


### PR DESCRIPTION
## Summary

`ElevenLabsRealtimeSTTService` pushes two final `TranscriptionFrame`s per utterance when `include_language_detection=True` and `include_timestamps=False` (the default). The duplicate registers as new user speech and cancels the in-flight LLM turn, so the bot goes quiet after a user turn. It also duplicates the user message in the LLM context and double-counts STT usage metrics.

Fixes #5196.

## Cause

The Scribe v2 realtime server sends `committed_transcript_with_timestamps` whenever either `include_timestamps` or `include_language_detection` is enabled. For language detection this is undocumented; the ElevenLabs docs tie that message to `include_timestamps` alone.

`_on_committed_transcript` guarded only on `self._include_timestamps`, so with language detection on, both it and `_on_committed_transcript_with_timestamps` pushed a frame for the same segment.

## Fix

Skip the plain `committed_transcript` when either option is enabled. Only the timestamped message carries `language_code`, so keeping that one preserves the detected language. Guarding the other way round would fix the duplicate but drop the language.

No changes to constructor arguments, defaults, or public API.

## Verification

Ran against the live ElevenLabs realtime API (`scribe_v2_realtime`), one utterance per session, counting frames off the pipeline's downstream queue.

| config | server messages | frames before | frames after |
|---|---|---|---|
| neither flag | `committed_transcript` only | 1 | 1 |
| `include_language_detection` | both, `language_code` on the timestamped one | 2 | 1 |
| `include_timestamps` | both, neither carries language | 1 | 1 |
| both | both, `language_code` on the timestamped one | 1 | 1 |

The fix depends on the timestamped message always arriving when language detection is on. I probed that across both commit strategies, four languages, and audio where detection fails:

| probe | timestamped message | frames |
|---|---|---|
| VAD strategy, English | arrived | 1 |
| VAD strategy, Spanish | arrived | 1 |
| MANUAL, Spanish / French / Hindi | arrived | 1 each |
| noise, detection failed (`language_code` null) | arrived | 0, both messages empty |

The plain message never carried `language_code` in any of these runs.

Untested: models other than `scribe_v2_realtime`. This also rests on undocumented server behavior, so it could change.

## Tests

Four cases in `tests/test_elevenlabs_stt.py`, one per configuration. The language-detection case fails on `main` with `assert 2 == 1`.

Full suite: 3812 passed, 29 skipped. `ruff check`, `ruff format --diff` and `pyright` are clean.
