### PR TITLE
test(deepgram): cover language serialization in connect kwargs

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,6 +29,7 @@ from pipecat.services.settings import (
 )
 from pipecat.services.xai.realtime import events as grok_events
 from pipecat.services.xai.realtime.llm import GrokRealtimeLLMSettings
+from pipecat.transcriptions.language import Language
 
 # ---------------------------------------------------------------------------
 # NOT_GIVEN sentinel
@@ -602,6 +603,24 @@ class TestDeepgramSTTSettingsExtraSync:
         assert kwargs["language"] == "es"
         assert kwargs["punctuate"] == "true"
         assert kwargs["diarize"] == "false"
+
+    def test_build_connect_kwargs_serializes_language_enum_to_value(self):
+        """A Language member serializes to its code, not its enum name."""
+        svc = self._make_service(settings=DeepgramSTTService.Settings(language=Language.EN))
+
+        assert svc._build_connect_kwargs()["language"] == "en"
+
+    def test_build_connect_kwargs_serializes_regional_language_enum(self):
+        """Regional members keep the exact code, which differs from the member name."""
+        svc = self._make_service(settings=DeepgramSTTService.Settings(language=Language.ES_MX))
+
+        assert svc._build_connect_kwargs()["language"] == "es-MX"
+
+    def test_build_connect_kwargs_passes_through_unrecognized_language(self):
+        """A language code with no matching Language member is forwarded as given."""
+        svc = self._make_service(settings=DeepgramSTTService.Settings(language="en-XX-custom"))
+
+        assert svc._build_connect_kwargs()["language"] == "en-XX-custom"
 
     def test_unknown_params_stay_in_extra_and_appear_in_kwargs(self):
         """Unknown params (not matching fields) stay in extra and get forwarded."""


### PR DESCRIPTION
## Summary

Re: #5206 ("Deepgram STT: `Language` enum is serialized as `Language.EN` instead of `en` causing WebSocket handshake to fail").

I investigated this and **couldn't reproduce it against the current codebase**. `_build_connect_kwargs()` serializes the language setting with `str(s.language)`, and `Language` (`src/pipecat/transcriptions/language.py`) is a `StrEnum`, not a plain `Enum` — `str()` on a `StrEnum` member returns its value directly:

```python
>>> from pipecat.transcriptions.language import Language
>>> str(Language.EN)
'en'
>>> str(Language.ES_MX)
'es-MX'
```

So `kwargs["language"]` already comes out as `"en"` / `"es-MX"`, not `"Language.EN"`. This would be a real bug if `Language` were a plain `Enum` (where `str()` does produce the `"ClassName.MEMBER"` form), but that's not what's defined here.

Rather than open a "fix" for something that doesn't reproduce, I added regression tests to `tests/test_settings.py` pinning the three shapes `s.language` can take through `_build_connect_kwargs()`:
- a `Language` member (`EN` → `"en"`)
- a regional member whose code differs from its name (`ES_MX` → `"es-MX"`, the case closest to what the issue describes)
- an unrecognized code with no matching member, which `stt_service` leaves as a plain `str` and which should pass through unchanged

All three pass against `main` as-is. Posted the same finding as a comment on #5206 in case there's a different repro path I'm missing (different pipecat version, a wrapper/subclass with its own `Language`-like type, etc.) — happy to dig further if a maintainer can point me at one.

## Test plan

`pytest tests/test_settings.py -k "language_enum or regional_language or unrecognized_language"` — 3/3 pass on current `main`, no source changes needed.