### PR TITLE
fix(text): read numbers with a leading zero digit-by-digit

### DIFF
--- a/changelog/5212.fixed.md
+++ b/changelog/5212.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `expand_numbers` reading a number with a leading zero as a quantity and discarding the zero, so "Flight 007" now becomes "Flight 0 0 7" instead of "Flight seven". Leading-zero numbers are read digit-by-digit regardless of `digit_cutoff`, while "0" and "0.5" remain quantities.

--- a/src/pipecat/utils/text/transforms/numbers.py
+++ b/src/pipecat/utils/text/transforms/numbers.py
@@ -27,9 +27,13 @@ def expand_numbers(
     expanded as quantities (e.g. ``"42"`` → ``"forty two"``). Pass ``None``
     to expand all numbers as words regardless of magnitude.
 
+    A number written with a leading zero is always read digit-by-digit, whatever the
+    cutoff: the zero is significant, so ``"Flight 007"`` reads as ``"Flight 0 0 7"``.
+
     Args:
         digit_cutoff: Numbers larger than this value are read digit-by-digit.
             ``None`` disables the cutoff so every number is expanded as a word.
+            Numbers with a leading zero are read digit-by-digit regardless.
 
     Returns:
         An async transform callable compatible with ``text_transforms``.
@@ -45,6 +49,15 @@ def expand_numbers(
         whole_str = match.group(1).replace(",", "")
         frac_str = match.group(2)
         whole = int(whole_str)
+
+        # A leading zero marks an identifier rather than a quantity, and it is significant:
+        # reading it as a number both drops the zero and says the wrong thing, so "Flight 007"
+        # becomes "Flight seven". Read those digit-by-digit like an over-cutoff number.
+        if len(whole_str) > 1 and whole_str[0] == "0":
+            result = " ".join(whole_str)
+            if frac_str:
+                result += " point " + " ".join(frac_str)
+            return result
 
         if digit_cutoff is not None and whole > digit_cutoff:
             result = " ".join(whole_str)

--- a/src/pipecat/utils/text/transforms/voice_formatter.py
+++ b/src/pipecat/utils/text/transforms/voice_formatter.py
@@ -60,7 +60,9 @@ class VoiceFormatter:
                 ``num2words``.
             number_digit_cutoff: Numbers above this value are read digit-by-digit
                 instead of as a quantity. Defaults to ``None`` (expand all numbers
-                as words). Only used when ``expand_numbers=True``.
+                as words). A number written with a leading zero is read
+                digit-by-digit whatever the cutoff. Only used when
+                ``expand_numbers=True``.
             expand_percentages: Expand percentage expressions (e.g. ``"50%"`` →
                 ``"fifty percent"``). Requires ``num2words``.
             expand_units: Expand unit abbreviations (e.g. ``"5km"`` →

--- a/tests/test_voice_formatting.py
+++ b/tests/test_voice_formatting.py
@@ -519,6 +519,31 @@ class TestExpandNumbers(unittest.IsolatedAsyncioTestCase):
         self.assertIn("point", result)
         self.assertIn("7 5", result)
 
+    async def test_leading_zero_read_digit_by_digit(self):
+        # A leading zero marks an identifier, and reading it as a quantity also drops the
+        # zero: "007" would otherwise become "seven".
+        result = await expand_numbers(digit_cutoff=2025)("Flight 007 departs", "*")
+        self.assertIn("0 0 7", result)
+        self.assertNotIn("seven", result)
+
+    async def test_leading_zero_below_cutoff_not_expanded(self):
+        # Without the leading-zero check these depend on whether the digits happen to
+        # exceed the cutoff: "01234" expanded to words while "02134" did not.
+        result = await expand_numbers(digit_cutoff=2025)("zip code 01234", "*")
+        self.assertIn("0 1 2 3 4", result)
+        self.assertNotIn("thousand", result)
+
+    async def test_leading_zero_ignores_cutoff(self):
+        # `digit_cutoff=None` disables the magnitude rule, but a leading zero is
+        # significant regardless of magnitude.
+        result = await expand_numbers(digit_cutoff=None)("PIN 0451", "*")
+        self.assertIn("0 4 5 1", result)
+
+    async def test_bare_zero_still_expands(self):
+        # The check needs more than one digit, so a real zero quantity is unaffected.
+        self.assertIn("zero", await expand_numbers(digit_cutoff=2025)("0 results", "*"))
+        self.assertIn("zero point five", await expand_numbers(digit_cutoff=None)("0.5", "*"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_voice_formatting.py
+++ b/tests/test_voice_formatting.py
@@ -539,6 +539,14 @@ class TestExpandNumbers(unittest.IsolatedAsyncioTestCase):
         result = await expand_numbers(digit_cutoff=None)("PIN 0451", "*")
         self.assertIn("0 4 5 1", result)
 
+    async def test_leading_zero_preserves_fraction(self):
+        # Same as the above-cutoff case: the digits are read out, and the fractional
+        # part must not be dropped on the way.
+        result = await expand_numbers(digit_cutoff=2025)("version 01.5", "*")
+        self.assertIn("0 1", result)
+        self.assertIn("point", result)
+        self.assertIn("5", result)
+
     async def test_bare_zero_still_expands(self):
         # The check needs more than one digit, so a real zero quantity is unaffected.
         self.assertIn("zero", await expand_numbers(digit_cutoff=2025)("0 results", "*"))


### PR DESCRIPTION
## Problem

`expand_numbers` decides between a spoken quantity and digit-by-digit reading purely by magnitude, so a number written with a **leading zero** is read as a quantity — and `int()` discards the zero along the way:

```python
await expand_numbers(digit_cutoff=2025)("Flight 007 departs at gate 3", "*")
# "Flight seven departs at gate three"
```

The failure is inconsistent rather than uniformly wrong, which is what makes it easy to miss: whether an identifier survives depends on whether its digits happen to exceed `digit_cutoff`.

| input | before | after |
| --- | --- | --- |
| `Flight 007 departs` | `Flight seven departs` | `Flight 0 0 7 departs` |
| `zip code 01234` | `zip code one thousand, two hundred and thirty-four` | `zip code 0 1 2 3 4` |
| `Zip 02134` | `Zip 0 2 1 3 4` (already correct) | unchanged |
| `Room 042 is on the left` | `Room forty-two is on the left` | `Room 0 4 2 is on the left` |
| `PIN 0451` | `PIN four hundred and fifty-one` | `PIN 0 4 5 1` |
| `Package 00123 shipped` | `Package one hundred and twenty-three shipped` | `Package 0 0 1 2 3 shipped` |
| `The code is 000` | `The code is zero` | `The code is 0 0 0` |

`01234` and `02134` are the same kind of string — a zip code — and one reads correctly only by the accident of exceeding the cutoff.

## Fix

A leading zero is the same signal the cutoff already encodes: this is an identifier, not a quantity. So the check lives right next to the cutoff decision and reuses its digit-by-digit branch, including the existing fraction handling.

```python
# A leading zero marks an identifier rather than a quantity, and it is significant:
# reading it as a number both drops the zero and says the wrong thing, so "Flight 007"
# becomes "Flight seven". Read those digit-by-digit like an over-cutoff number.
if len(whole_str) > 1 and whole_str[0] == "0":
    result = " ".join(whole_str)
    if frac_str:
        result += " point " + " ".join(frac_str)
    return result
```

`len(whole_str) > 1` is what keeps genuine zero quantities intact — `"0"` stays `"zero"` and `"0.5"` stays `"zero point five"`. The rule applies regardless of `digit_cutoff`, including `digit_cutoff=None`: that parameter disables the *magnitude* rule, but a leading zero is significant at any magnitude.

## Verification

New tests fail at the merge base and pass with the fix — the A/B, not just the green run:

```
# new tests present, numbers.py at base
FAILED tests/test_voice_formatting.py::TestExpandNumbers::test_leading_zero_read_digit_by_digit
FAILED tests/test_voice_formatting.py::TestExpandNumbers::test_leading_zero_below_cutoff_not_expanded
FAILED tests/test_voice_formatting.py::TestExpandNumbers::test_leading_zero_ignores_cutoff
3 failed, 79 passed

AssertionError: '0 0 7' not found in 'Flight seven departs'
AssertionError: '0 4 5 1' not found in 'PIN four hundred and fifty-one'
```

```
# with the fix
82 passed in 1.81s
```

I also checked the cases most likely to regress — every one is unchanged: `0`, `0.5`, `3.14`, `Room 42`, `opens in 2026`, `2025` (cutoff boundary), `1,234`, `1,234.56`, `10,000 seats`, `Zip 90210`, `3000.5 units`, `2500.75`, and `digit_cutoff=None` with `9999` / `3.5`.

`ruff check` and `ruff format --check` are clean on both files.

## Notes

- `VoiceFormatter`'s `number_digit_cutoff` docstring gets the same note, since that is where the cutoff is documented for users.
- This is consistent with how the project already treats leading zeros elsewhere — #4887 fixed YAML silently rewriting DTMF sequences like `010`. Same principle at a different layer.
- Related to my #5205 (`expand_units` singular/plural) only in that both are `text/transforms` output-correctness fixes; `numbers.py` is untouched by that change.
- A changelog fragment can be added as `changelog/<pr>.fixed.md` once this has a number, matching the convention — happy to push it on request.
