### PR TITLE
fix(exotel): send stream_sid, not streamSid, on outbound events

### DIFF
--- a/changelog/5215.fixed.md
+++ b/changelog/5215.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `ExotelFrameSerializer` emitting the stream identifier as `streamSid` on
+  outbound `media` and `clear` events. Exotel's media stream protocol spells it
+  `stream_sid`. Exotel treats the identifier as optional on messages from the
+  bot, so existing integrations were unaffected.

--- a/changelog/5215.fixed.md
+++ b/changelog/5215.fixed.md
@@ -1,4 +1,0 @@
-- Fixed `ExotelFrameSerializer` emitting the stream identifier as `streamSid` on
-  outbound `media` and `clear` events. Exotel's media stream protocol spells it
-  `stream_sid`. Exotel treats the identifier as optional on messages from the
-  bot, so existing integrations were unaffected.

--- a/changelog/5219.fixed.md
+++ b/changelog/5219.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `ExotelFrameSerializer` sending the stream identifier as `streamSid` on outbound `media` and `clear` events. Exotel's media stream protocol spells it `stream_sid`. Exotel treats the identifier as optional on messages from the bot, so existing integrations were unaffected.

--- a/src/pipecat/serializers/exotel.py
+++ b/src/pipecat/serializers/exotel.py
@@ -96,7 +96,7 @@ class ExotelFrameSerializer(FrameSerializer):
             Serialized data as string or bytes, or None if the frame isn't handled.
         """
         if isinstance(frame, InterruptionFrame):
-            answer = {"event": "clear", "streamSid": self._stream_sid}
+            answer = {"event": "clear", "stream_sid": self._stream_sid}
             return json.dumps(answer)
         elif isinstance(frame, AudioRawFrame):
             data = frame.audio
@@ -113,7 +113,7 @@ class ExotelFrameSerializer(FrameSerializer):
 
             answer = {
                 "event": "media",
-                "streamSid": self._stream_sid,
+                "stream_sid": self._stream_sid,
                 "media": {"payload": payload},
             }
 

--- a/tests/test_exotel_serializer.py
+++ b/tests/test_exotel_serializer.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for ExotelFrameSerializer wire format."""
+
+import json
+import unittest
+
+from pipecat.frames.frames import InterruptionFrame, OutputAudioRawFrame, StartFrame
+from pipecat.serializers.exotel import ExotelFrameSerializer
+
+STREAM_SID = "stream123"
+SAMPLE_RATE = 8000
+
+
+class TestExotelSerializeWireFormat(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.serializer = ExotelFrameSerializer(stream_sid=STREAM_SID, call_sid="call123")
+        await self.serializer.setup(
+            StartFrame(audio_in_sample_rate=SAMPLE_RATE, audio_out_sample_rate=SAMPLE_RATE)
+        )
+
+    async def test_media_event(self):
+        frame = OutputAudioRawFrame(
+            audio=b"\x00\x00" * 160, sample_rate=SAMPLE_RATE, num_channels=1
+        )
+        message = json.loads(await self.serializer.serialize(frame))
+        self.assertEqual(message["event"], "media")
+        self.assertEqual(message["stream_sid"], STREAM_SID)
+        self.assertIn("payload", message["media"])
+
+    async def test_clear_event(self):
+        message = json.loads(await self.serializer.serialize(InterruptionFrame()))
+        self.assertEqual(message, {"event": "clear", "stream_sid": STREAM_SID})
+
+
+class TestExotelDeserialize(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.serializer = ExotelFrameSerializer(stream_sid=STREAM_SID)
+        await self.serializer.setup(
+            StartFrame(audio_in_sample_rate=SAMPLE_RATE, audio_out_sample_rate=SAMPLE_RATE)
+        )
+
+    async def test_media_round_trip(self):
+        audio = b"\x01\x02" * 160
+        outbound = await self.serializer.serialize(
+            OutputAudioRawFrame(audio=audio, sample_rate=SAMPLE_RATE, num_channels=1)
+        )
+        frame = await self.serializer.deserialize(outbound)
+        self.assertEqual(frame.audio, audio)
+        self.assertEqual(frame.sample_rate, SAMPLE_RATE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `ExotelFrameSerializer` sends the stream identifier as `stream_sid` on the outbound `media` and `clear` events, matching Exotel's documented media stream protocol and the spelling pipecat's Exotel inbound parsing already reads. It previously sent camelCase `streamSid` — the spelling `serializers/twilio.py` uses for Twilio's genuinely camelCase protocol.
- No behavior change on live calls: Exotel documents the identifier as optional on messages from the bot, and ships sample code that sends the camelCase spelling.

## Protocol evidence

The [Stream and Voicebot applet article](https://support.exotel.com/support/solutions/articles/3000108630-working-with-the-stream-and-voicebot-applet) documents `stream_sid` in both directions — 10 occurrences, zero of `streamSid` — including the "Websocket messages - To Exotel" section covering `media`, `mark`, and `clear`.

This is not a regression from a doc change. Wayback snapshots show `stream_sid` continuously since May 2022, and the serializer landed in June 2025 (`d2f4bb574`), so it has disagreed with the documented protocol since it was added.

Three things establish that Exotel ignores the key on the bot-to-Exotel direction, which is why existing integrations work:

- The article's field reference table types `stream_sid` as `*string`, **Optional: Yes**.
- The WebSocket connection is per-stream, so the identifier is redundant outbound.
- Exotel's own [`Agent-Stream`](https://github.com/exotel/Agent-Stream) sample sends `"streamSid"` on outbound media (`core/openai_realtime_sales_bot.py:181,662`), while [`Agent-Stream-echobot`](https://github.com/exotel/Agent-Stream-echobot) sends `stream_sid`. Both are published as working reference code.

## Testing

`uv run pytest tests/test_exotel_serializer.py` — new file; the serializer had no prior coverage. Asserts the outbound `media` and `clear` wire format and round-trips inbound media.

Not exercised against a live Exotel call, so the case for no behavioral impact rests on the documentation and sample code above.

## Out of scope

The outbound `mark` event is documented for the bot-to-Exotel direction and remains unimplemented. That is the same gap as #5011 (no `EndFrame`/`CancelFrame` handling) and belongs there.

## Fixes

- Fixes #5215

🤖 Generated with [Claude Code](https://claude.com/claude-code)