### PR TITLE
fix: LiveKit RTVI inbound messages reach RTVIProcessor

### DIFF
--- a/changelog/5218.fixed.md
+++ b/changelog/5218.fixed.md
@@ -1,0 +1,1 @@
+- Fixed LiveKitTransport app messages not reaching RTVIProcessor; inbound RTVI messages now reach the processor instead of being re-sent to clients by SID.

--- a/scripts/deprecations/deprecations.json
+++ b/scripts/deprecations/deprecations.json
@@ -4,3842 +4,3864 @@
   "deprecations": [
     {
       "subject": "AICFilter.create_vad_analyzer",
-      "module": "pipecat.audio.filters.aic_filter",
+      "module": "pipecat\\audio\\filters\\aic_filter",
       "kind": "method",
       "deprecated_in": "1.4.0",
       "removed_in": "1.6.0",
       "relation": "use_existing",
       "replacement": "AICQuailVADAnalyzer",
       "message": "`AICFilter.create_vad_analyzer` is deprecated since 1.4.0 and will be removed in 1.6.0. Use `AICQuailVADAnalyzer` instead.",
-      "location": "pipecat/audio/filters/aic_filter.py"
+      "location": "pipecat\\audio\\filters\\aic_filter.py"
     },
     {
       "subject": "ResampyResampler",
-      "module": "pipecat.audio.resamplers.resampy_resampler",
+      "module": "pipecat\\audio\\resamplers\\resampy_resampler",
       "kind": "class",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SOXRAudioResampler",
       "message": "`ResampyResampler` is deprecated since 1.2.0 and will be removed in 2.0.0. Use `SOXRAudioResampler`, `create_file_resampler()`, or `create_stream_resampler()` instead.",
-      "location": "pipecat/audio/resamplers/resampy_resampler.py"
+      "location": "pipecat\\audio\\resamplers\\resampy_resampler.py"
     },
     {
       "subject": "LocalCoreMLSmartTurnAnalyzer",
-      "module": "pipecat.audio.turn.smart_turn.local_coreml_smart_turn",
+      "module": "pipecat\\audio\\turn\\smart_turn\\local_coreml_smart_turn",
       "kind": "class",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LocalSmartTurnAnalyzerV3",
       "message": "`LocalCoreMLSmartTurnAnalyzer` is deprecated since 0.0.106 and will be removed in 2.0.0. Use `LocalSmartTurnAnalyzerV3` instead.",
-      "location": "pipecat/audio/turn/smart_turn/local_coreml_smart_turn.py"
+      "location": "pipecat\\audio\\turn\\smart_turn\\local_coreml_smart_turn.py"
     },
     {
       "subject": "LocalSmartTurnAnalyzerV2",
-      "module": "pipecat.audio.turn.smart_turn.local_smart_turn_v2",
+      "module": "pipecat\\audio\\turn\\smart_turn\\local_smart_turn_v2",
       "kind": "class",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LocalSmartTurnAnalyzerV3",
       "message": "`LocalSmartTurnAnalyzerV2` is deprecated since 0.0.106 and will be removed in 2.0.0. Use `LocalSmartTurnAnalyzerV3` instead.",
-      "location": "pipecat/audio/turn/smart_turn/local_smart_turn_v2.py"
+      "location": "pipecat\\audio\\turn\\smart_turn\\local_smart_turn_v2.py"
     },
     {
       "subject": "AICQuailVADAnalyzer.minimum_speech_duration",
-      "module": "pipecat.audio.vad.aic_quail_vad",
+      "module": "pipecat\\audio\\vad\\aic_quail_vad",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "VADParams",
       "message": "Use :class:`VADParams` (``start_secs``/``stop_secs``) instead. ``minimum_speech_duration`` is ignored and will be removed in 2.0.0.",
-      "location": "pipecat/audio/vad/aic_quail_vad.py"
+      "location": "pipecat\\audio\\vad\\aic_quail_vad.py"
     },
     {
       "subject": "AICQuailVADAnalyzer.sensitivity",
-      "module": "pipecat.audio.vad.aic_quail_vad",
+      "module": "pipecat\\audio\\vad\\aic_quail_vad",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "VADParams",
       "message": "Use :class:`VADParams` (``confidence``) instead. ``sensitivity`` is ignored and will be removed in 2.0.0.",
-      "location": "pipecat/audio/vad/aic_quail_vad.py"
+      "location": "pipecat\\audio\\vad\\aic_quail_vad.py"
     },
     {
       "subject": "AICQuailVADAnalyzer.speech_hold_duration",
-      "module": "pipecat.audio.vad.aic_quail_vad",
+      "module": "pipecat\\audio\\vad\\aic_quail_vad",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "VADParams",
       "message": "Use :class:`VADParams` (``start_secs``/``stop_secs``) instead. ``speech_hold_duration`` is ignored and will be removed in 2.0.0.",
-      "location": "pipecat/audio/vad/aic_quail_vad.py"
+      "location": "pipecat\\audio\\vad\\aic_quail_vad.py"
     },
     {
       "subject": "AICVADAnalyzer",
-      "module": "pipecat.audio.vad.aic_vad",
+      "module": "pipecat\\audio\\vad\\aic_vad",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "1.6.0",
       "relation": "use_existing",
       "replacement": "AICQuailVADAnalyzer",
       "message": "`AICVADAnalyzer` is deprecated since 1.4.0 and will be removed in 1.6.0. Use `AICQuailVADAnalyzer` instead.",
-      "location": "pipecat/audio/vad/aic_vad.py"
+      "location": "pipecat\\audio\\vad\\aic_vad.py"
     },
     {
-      "subject": "pipecat.audio.vad.aic_vad",
-      "module": "pipecat.audio.vad.aic_vad",
+      "subject": "pipecat\\audio\\vad\\aic_vad",
+      "module": "pipecat\\audio\\vad\\aic_vad",
       "kind": "module",
       "deprecated_in": "1.4.0",
       "removed_in": "1.6.0",
       "relation": "use_existing",
       "replacement": "AICQuailVADAnalyzer",
       "message": "Use :class:`AICQuailVADAnalyzer` instead. Will be removed in 1.6.0.",
-      "location": "pipecat/audio/vad/aic_vad.py"
+      "location": "pipecat\\audio\\vad\\aic_vad.py"
     },
     {
       "subject": "FlowManager.task",
-      "module": "pipecat.flows.manager",
+      "module": "pipecat\\flows\\manager",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "worker",
       "message": "Use ``worker`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/flows/manager.py"
+      "location": "pipecat\\flows\\manager.py"
     },
     {
       "subject": "FlowManager.task",
-      "module": "pipecat.flows.manager",
+      "module": "pipecat\\flows\\manager",
       "kind": "property",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FlowManager.worker",
       "message": "`FlowManager.task` is deprecated since 1.5.0 and will be removed in 2.0.0. Use `FlowManager.worker` instead.",
-      "location": "pipecat/flows/manager.py"
+      "location": "pipecat\\flows\\manager.py"
     },
     {
       "subject": "ContextStrategy.RESET_WITH_SUMMARY",
-      "module": "pipecat.flows.types",
+      "module": "pipecat\\flows\\types",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMSummarizeContextFrame",
       "message": "Use :class:`LLMSummarizeContextFrame` instead — push it in a pre-action to trigger on-demand summarization during a node transition. See https://docs.pipecat.ai/guides/fundamentals/context-summarization. Will be removed in 2.0.0.",
-      "location": "pipecat/flows/types.py"
+      "location": "pipecat\\flows\\types.py"
     },
     {
       "subject": "ContextStrategyConfig.summary_prompt",
-      "module": "pipecat.flows.types",
+      "module": "pipecat\\flows\\types",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMContextSummaryConfig.summarization_prompt",
       "message": "Use ``LLMContextSummaryConfig.summarization_prompt`` instead. Deprecated together with ``RESET_WITH_SUMMARY``. Will be removed in 2.0.0.",
-      "location": "pipecat/flows/types.py"
+      "location": "pipecat\\flows\\types.py"
     },
     {
       "subject": "FlowResult",
-      "module": "pipecat.flows.types",
+      "module": "pipecat\\flows\\types",
       "kind": "class",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "`FlowResult` is deprecated since 1.5.0 and will be removed in 2.0.0. No replacement.",
-      "location": "pipecat/flows/types.py"
+      "location": "pipecat\\flows\\types.py"
     },
     {
       "subject": "NodeConfig.role_messages",
-      "module": "pipecat.flows.types",
+      "module": "pipecat\\flows\\types",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "role_message",
       "message": "Use ``role_message`` (str) instead. Will be removed in 2.0.0.",
-      "location": "pipecat/flows/types.py"
+      "location": "pipecat\\flows\\types.py"
     },
     {
       "subject": "flows_direct_function",
-      "module": "pipecat.flows.types",
+      "module": "pipecat\\flows\\types",
       "kind": "function",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "rename",
       "replacement": "flows_tool_options",
       "message": "`flows_direct_function` is deprecated since 1.5.0 and will be removed in 2.0.0. Use `flows_tool_options` instead.",
-      "location": "pipecat/flows/types.py"
+      "location": "pipecat\\flows\\types.py"
     },
     {
       "subject": "CancelTaskFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "CancelWorkerFrame",
       "message": "`CancelTaskFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `CancelWorkerFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "EndTaskFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "EndWorkerFrame",
       "message": "`EndTaskFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `EndWorkerFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "InterruptionTaskFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "InterruptionWorkerFrame",
       "message": "`InterruptionTaskFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `InterruptionWorkerFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "ServiceUpdateSettingsFrame.settings",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "delta",
       "message": "Use ``delta`` with a typed settings object instead. Will be removed in 2.0.0.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "StopTaskFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "StopWorkerFrame",
       "message": "`StopTaskFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `StopWorkerFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "TaskFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WorkerFrame",
       "message": "`TaskFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `WorkerFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "TaskSystemFrame",
-      "module": "pipecat.frames.frames",
+      "module": "pipecat\\frames\\frames",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WorkerSystemFrame",
       "message": "`TaskSystemFrame` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `WorkerSystemFrame` instead.",
-      "location": "pipecat/frames/frames.py"
+      "location": "pipecat\\frames\\frames.py"
     },
     {
       "subject": "SmartTurnMetricsData",
-      "module": "pipecat.metrics.metrics",
+      "module": "pipecat\\metrics\\metrics",
       "kind": "class",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TurnMetricsData",
       "message": "`SmartTurnMetricsData` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `TurnMetricsData` instead.",
-      "location": "pipecat/metrics/metrics.py"
+      "location": "pipecat\\metrics\\metrics.py"
     },
     {
       "subject": "LLMSwitcher.register_direct_function",
-      "module": "pipecat.pipeline.llm_switcher",
+      "module": "pipecat\\pipeline\\llm_switcher",
       "kind": "method",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMContext(tools=[...])",
       "message": "`LLMSwitcher.register_direct_function` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `LLMContext(tools=[...])` instead.",
-      "location": "pipecat/pipeline/llm_switcher.py"
+      "location": "pipecat\\pipeline\\llm_switcher.py"
     },
     {
       "subject": "PipelineRunner",
-      "module": "pipecat.pipeline.runner",
+      "module": "pipecat\\pipeline\\runner",
       "kind": "class",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WorkerRunner",
       "message": "`PipelineRunner` is deprecated since 1.3.0 and will be removed in 2.0.0. Use `WorkerRunner` instead.",
-      "location": "pipecat/pipeline/runner.py"
+      "location": "pipecat\\pipeline\\runner.py"
     },
     {
-      "subject": "pipecat.pipeline.task",
-      "module": "pipecat.pipeline.task",
+      "subject": "pipecat\\pipeline\\task",
+      "module": "pipecat\\pipeline\\task",
       "kind": "module",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "move",
       "replacement": "pipecat.pipeline.worker",
       "message": "Import from :mod:`pipecat.pipeline.worker` instead. Constructing :class:`PipelineTask` directly is also deprecated; use :class:`PipelineWorker`. Will be removed in 2.0.0.",
-      "location": "pipecat/pipeline/task.py"
+      "location": "pipecat\\pipeline\\task.py"
     },
     {
       "subject": "PipelineTask",
-      "module": "pipecat.pipeline.worker",
+      "module": "pipecat\\pipeline\\worker",
       "kind": "class",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "PipelineWorker",
       "message": "`PipelineTask` is deprecated since 1.3.0 and will be removed in 2.0.0. Use `PipelineWorker` instead.",
-      "location": "pipecat/pipeline/worker.py"
+      "location": "pipecat\\pipeline\\worker.py"
     },
     {
       "subject": "PipelineTaskParams",
-      "module": "pipecat.pipeline.worker",
+      "module": "pipecat\\pipeline\\worker",
       "kind": "class",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WorkerParams",
       "message": "`PipelineTaskParams` is deprecated since 1.3.0 and will be removed in 2.0.0. Use `WorkerParams` instead.",
-      "location": "pipecat/pipeline/worker.py"
+      "location": "pipecat\\pipeline\\worker.py"
     },
     {
       "subject": "PipelineWorker.tool_resources",
-      "module": "pipecat.pipeline.worker",
+      "module": "pipecat\\pipeline\\worker",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "app_resources",
       "message": "Use ``app_resources`` instead. ``tool_resources`` will be removed in 2.0.0.",
-      "location": "pipecat/pipeline/worker.py"
+      "location": "pipecat\\pipeline\\worker.py"
     },
     {
       "subject": "LLMAssistantAggregatorParams.context_summarization_config",
-      "module": "pipecat.processors.aggregators.llm_response_universal",
+      "module": "pipecat\\processors\\aggregators\\llm_response_universal",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "auto_context_summarization_config",
       "message": "Use :attr:`auto_context_summarization_config` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/aggregators/llm_response_universal.py"
+      "location": "pipecat\\processors\\aggregators\\llm_response_universal.py"
     },
     {
       "subject": "LLMAssistantAggregatorParams.enable_context_summarization",
-      "module": "pipecat.processors.aggregators.llm_response_universal",
+      "module": "pipecat\\processors\\aggregators\\llm_response_universal",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "enable_auto_context_summarization",
       "message": "Use :attr:`enable_auto_context_summarization` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/aggregators/llm_response_universal.py"
+      "location": "pipecat\\processors\\aggregators\\llm_response_universal.py"
     },
     {
       "subject": "LLMUserAggregatorParams.filter_incomplete_user_turns",
-      "module": "pipecat.processors.aggregators.llm_response_universal",
+      "module": "pipecat\\processors\\aggregators\\llm_response_universal",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "user_turn_strategies=FilterIncompleteUserTurnStrategies()",
       "message": "Use ``user_turn_strategies=FilterIncompleteUserTurnStrategies()`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/aggregators/llm_response_universal.py"
+      "location": "pipecat\\processors\\aggregators\\llm_response_universal.py"
     },
     {
       "subject": "LLMUserAggregatorParams.user_turn_completion_config",
-      "module": "pipecat.processors.aggregators.llm_response_universal",
+      "module": "pipecat\\processors\\aggregators\\llm_response_universal",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FilterIncompleteUserTurnStrategies(config=...)",
       "message": "Pass the config directly to ``FilterIncompleteUserTurnStrategies(config=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/aggregators/llm_response_universal.py"
+      "location": "pipecat\\processors\\aggregators\\llm_response_universal.py"
     },
     {
       "subject": "WakeCheckFilter",
-      "module": "pipecat.processors.filters.wake_check_filter",
+      "module": "pipecat\\processors\\filters\\wake_check_filter",
       "kind": "class",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WakePhraseUserTurnStartStrategy",
       "message": "`WakeCheckFilter` is deprecated since 0.0.106 and will be removed in 2.0.0. Use `WakePhraseUserTurnStartStrategy` instead.",
-      "location": "pipecat/processors/filters/wake_check_filter.py"
+      "location": "pipecat\\processors\\filters\\wake_check_filter.py"
     },
     {
-      "subject": "pipecat.processors.filters.wake_check_filter",
-      "module": "pipecat.processors.filters.wake_check_filter",
+      "subject": "pipecat\\processors\\filters\\wake_check_filter",
+      "module": "pipecat\\processors\\filters\\wake_check_filter",
       "kind": "module",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "pipecat.turns.user_start.WakePhraseUserTurnStartStrategy",
       "message": "Use :class:`~pipecat.turns.user_start.WakePhraseUserTurnStartStrategy` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/filters/wake_check_filter.py"
+      "location": "pipecat\\processors\\filters\\wake_check_filter.py"
     },
     {
       "subject": "FrameProcessor.pipeline_task",
-      "module": "pipecat.processors.frame_processor",
+      "module": "pipecat\\processors\\frame_processor",
       "kind": "property",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "pipeline_worker",
       "message": "`FrameProcessor.pipeline_task` is deprecated since 1.3.0 and will be removed in 2.0.0. Use `pipeline_worker` instead.",
-      "location": "pipecat/processors/frame_processor.py"
+      "location": "pipecat\\processors\\frame_processor.py"
     },
     {
       "subject": "FrameProcessor.push_interruption_task_frame_and_wait",
-      "module": "pipecat.processors.frame_processor",
+      "module": "pipecat\\processors\\frame_processor",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "broadcast_interruption",
       "message": "`FrameProcessor.push_interruption_task_frame_and_wait` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `broadcast_interruption` instead.",
-      "location": "pipecat/processors/frame_processor.py"
+      "location": "pipecat\\processors\\frame_processor.py"
     },
     {
       "subject": "FrameProcessorSetup.tool_resources",
-      "module": "pipecat.processors.frame_processor",
+      "module": "pipecat\\processors\\frame_processor",
       "kind": "parameter",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "setup.pipeline_worker.app_resources",
       "message": "Read ``setup.pipeline_worker.app_resources`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/frame_processor.py"
+      "location": "pipecat\\processors\\frame_processor.py"
     },
     {
       "subject": "LLMFunctionCallMessage",
-      "module": "pipecat.processors.frameworks.rtvi.models",
+      "module": "pipecat\\processors\\frameworks\\rtvi\\models",
       "kind": "class",
       "deprecated_in": "0.0.102",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMFunctionCallInProgressMessage",
       "message": "`LLMFunctionCallMessage` is deprecated since 0.0.102 and will be removed in 2.0.0. Use `LLMFunctionCallInProgressMessage` instead.",
-      "location": "pipecat/processors/frameworks/rtvi/models.py"
+      "location": "pipecat\\processors\\frameworks\\rtvi\\models.py"
     },
     {
       "subject": "LLMFunctionCallMessageData",
-      "module": "pipecat.processors.frameworks.rtvi.models",
+      "module": "pipecat\\processors\\frameworks\\rtvi\\models",
       "kind": "class",
       "deprecated_in": "0.0.102",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMFunctionCallInProgressMessageData",
       "message": "`LLMFunctionCallMessageData` is deprecated since 0.0.102 and will be removed in 2.0.0. Use `LLMFunctionCallInProgressMessageData` instead.",
-      "location": "pipecat/processors/frameworks/rtvi/models.py"
+      "location": "pipecat\\processors\\frameworks\\rtvi\\models.py"
     },
     {
       "subject": "RTVIProcessor.handle_function_call",
-      "module": "pipecat.processors.frameworks.rtvi.processor",
+      "module": "pipecat\\processors\\frameworks\\rtvi\\processor",
       "kind": "method",
       "deprecated_in": "0.0.102",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "RTVIObserver",
       "message": "This method is deprecated. Function call events are now automatically sent by :class:`RTVIObserver` using the ``llm-function-call-in-progress`` event. Configure reporting level via ``RTVIObserverParams.function_call_report_level``. Will be removed in 2.0.0.",
-      "location": "pipecat/processors/frameworks/rtvi/processor.py"
+      "location": "pipecat\\processors\\frameworks\\rtvi\\processor.py"
     },
     {
       "subject": "RTVIProcessor.transport",
-      "module": "pipecat.processors.frameworks.rtvi.processor",
+      "module": "pipecat\\processors\\frameworks\\rtvi\\processor",
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "No replacement; the parameter is ignored. Will be removed in 2.0.0. The processor no longer needs a transport reference — audio input and audio-streaming start are driven by frames (:class:`InputAudioRawFrame` and :class:`InputTransportStartAudioStreamingFrame`) pushed downstream. For client-ready audio gating, set ``audio_in_stream_on_start=False`` on the transport params.",
-      "location": "pipecat/processors/frameworks/rtvi/processor.py"
+      "location": "pipecat\\processors\\frameworks\\rtvi\\processor.py"
     },
     {
       "subject": "AnthropicLLMService.InputParams",
-      "module": "pipecat.services.anthropic.llm",
+      "module": "pipecat\\services\\anthropic\\llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AnthropicLLMService.Settings",
       "message": "`AnthropicLLMService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AnthropicLLMService.Settings` instead.",
-      "location": "pipecat/services/anthropic/llm.py"
+      "location": "pipecat\\services\\anthropic\\llm.py"
     },
     {
       "subject": "AnthropicLLMService.model",
-      "module": "pipecat.services.anthropic.llm",
+      "module": "pipecat\\services\\anthropic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AnthropicLLMService.Settings(model=...)",
       "message": "Use ``settings=AnthropicLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/anthropic/llm.py"
+      "location": "pipecat\\services\\anthropic\\llm.py"
     },
     {
       "subject": "AnthropicLLMService.params",
-      "module": "pipecat.services.anthropic.llm",
+      "module": "pipecat\\services\\anthropic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AnthropicLLMService.Settings(...)",
       "message": "Use ``settings=AnthropicLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/anthropic/llm.py"
+      "location": "pipecat\\services\\anthropic\\llm.py"
     },
     {
       "subject": "AssemblyAIConnectionParams",
-      "module": "pipecat.services.assemblyai.models",
+      "module": "pipecat\\services\\assemblyai\\models",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AssemblyAISTTService.Settings",
       "message": "`AssemblyAIConnectionParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AssemblyAISTTService.Settings` instead.",
-      "location": "pipecat/services/assemblyai/models.py"
+      "location": "pipecat\\services\\assemblyai\\models.py"
     },
     {
       "subject": "AssemblyAISTTService.connection_params",
-      "module": "pipecat.services.assemblyai.stt",
+      "module": "pipecat\\services\\assemblyai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AssemblyAISTTService.Settings(...)",
       "message": "Use ``settings=AssemblyAISTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/assemblyai/stt.py"
+      "location": "pipecat\\services\\assemblyai\\stt.py"
     },
     {
       "subject": "AssemblyAISTTService.language",
-      "module": "pipecat.services.assemblyai.stt",
+      "module": "pipecat\\services\\assemblyai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AssemblyAISTTService.Settings(language=...)",
       "message": "Use ``settings=AssemblyAISTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/assemblyai/stt.py"
+      "location": "pipecat\\services\\assemblyai\\stt.py"
     },
     {
       "subject": "AsyncAIHttpTTSService.InputParams",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AsyncAIHttpTTSService.Settings",
       "message": "`AsyncAIHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AsyncAIHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAIHttpTTSService.model",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAIHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=AsyncAIHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAIHttpTTSService.params",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAIHttpTTSService.Settings(...)",
       "message": "Use ``settings=AsyncAIHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAIHttpTTSService.voice_id",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAIHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=AsyncAIHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAITTSService.InputParams",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AsyncAITTSService.Settings",
       "message": "`AsyncAITTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AsyncAITTSService.Settings` instead.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAITTSService.aggregate_sentences",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAITTSService.model",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAITTSService.Settings(model=...)",
       "message": "Use ``settings=AsyncAITTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAITTSService.params",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAITTSService.Settings(...)",
       "message": "Use ``settings=AsyncAITTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AsyncAITTSService.voice_id",
-      "module": "pipecat.services.asyncai.tts",
+      "module": "pipecat\\services\\asyncai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AsyncAITTSService.Settings(voice=...)",
       "message": "Use ``settings=AsyncAITTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/asyncai/tts.py"
+      "location": "pipecat\\services\\asyncai\\tts.py"
     },
     {
       "subject": "AWSBedrockLLMService.InputParams",
-      "module": "pipecat.services.aws.llm",
+      "module": "pipecat\\services\\aws\\llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AWSBedrockLLMService.Settings",
       "message": "`AWSBedrockLLMService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AWSBedrockLLMService.Settings` instead.",
-      "location": "pipecat/services/aws/llm.py"
+      "location": "pipecat\\services\\aws\\llm.py"
     },
     {
       "subject": "AWSBedrockLLMService.model",
-      "module": "pipecat.services.aws.llm",
+      "module": "pipecat\\services\\aws\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSBedrockLLMService.Settings(model=...)",
       "message": "Use ``settings=AWSBedrockLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/llm.py"
+      "location": "pipecat\\services\\aws\\llm.py"
     },
     {
       "subject": "AWSBedrockLLMService.params",
-      "module": "pipecat.services.aws.llm",
+      "module": "pipecat\\services\\aws\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSBedrockLLMService.Settings(...)",
       "message": "Use ``settings=AWSBedrockLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/llm.py"
+      "location": "pipecat\\services\\aws\\llm.py"
     },
     {
       "subject": "AWSBedrockLLMService.stop_sequences",
-      "module": "pipecat.services.aws.llm",
+      "module": "pipecat\\services\\aws\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSBedrockLLMService.Settings(stop_sequences=...)",
       "message": "Use ``settings=AWSBedrockLLMService.Settings(stop_sequences=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/llm.py"
+      "location": "pipecat\\services\\aws\\llm.py"
     },
     {
       "subject": "AWSNovaSonicLLMService.model",
-      "module": "pipecat.services.aws.nova_sonic.llm",
+      "module": "pipecat\\services\\aws\\nova_sonic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSNovaSonicLLMService.Settings(model=...)",
       "message": "Use ``settings=AWSNovaSonicLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/nova_sonic/llm.py"
+      "location": "pipecat\\services\\aws\\nova_sonic\\llm.py"
     },
     {
       "subject": "AWSNovaSonicLLMService.params",
-      "module": "pipecat.services.aws.nova_sonic.llm",
+      "module": "pipecat\\services\\aws\\nova_sonic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSNovaSonicLLMService.Settings(...)",
       "message": "Use ``settings=AWSNovaSonicLLMService.Settings(...)`` for inference settings and ``audio_config=AudioConfig(...)`` for audio configuration. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/nova_sonic/llm.py"
+      "location": "pipecat\\services\\aws\\nova_sonic\\llm.py"
     },
     {
       "subject": "AWSNovaSonicLLMService.system_instruction",
-      "module": "pipecat.services.aws.nova_sonic.llm",
+      "module": "pipecat\\services\\aws\\nova_sonic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSNovaSonicLLMService.Settings(system_instruction=...)",
       "message": "Use ``settings=AWSNovaSonicLLMService.Settings(system_instruction=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/nova_sonic/llm.py"
+      "location": "pipecat\\services\\aws\\nova_sonic\\llm.py"
     },
     {
       "subject": "AWSNovaSonicLLMService.voice_id",
-      "module": "pipecat.services.aws.nova_sonic.llm",
+      "module": "pipecat\\services\\aws\\nova_sonic\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSNovaSonicLLMService.Settings(voice=...)",
       "message": "Use ``settings=AWSNovaSonicLLMService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/nova_sonic/llm.py"
+      "location": "pipecat\\services\\aws\\nova_sonic\\llm.py"
     },
     {
       "subject": "Params",
-      "module": "pipecat.services.aws.nova_sonic.llm",
+      "module": "pipecat\\services\\aws\\nova_sonic\\llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AWSNovaSonicLLMService.Settings",
       "message": "`Params` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AWSNovaSonicLLMService.Settings` instead.",
-      "location": "pipecat/services/aws/nova_sonic/llm.py"
+      "location": "pipecat\\services\\aws\\nova_sonic\\llm.py"
     },
     {
       "subject": "AWSTranscribeSTTService.language",
-      "module": "pipecat.services.aws.stt",
+      "module": "pipecat\\services\\aws\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSTranscribeSTTService.Settings(language=...)",
       "message": "Use ``settings=AWSTranscribeSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/stt.py"
+      "location": "pipecat\\services\\aws\\stt.py"
     },
     {
       "subject": "AWSPollyTTSService.InputParams",
-      "module": "pipecat.services.aws.tts",
+      "module": "pipecat\\services\\aws\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AWSPollyTTSService.Settings",
       "message": "`AWSPollyTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AWSPollyTTSService.Settings` instead.",
-      "location": "pipecat/services/aws/tts.py"
+      "location": "pipecat\\services\\aws\\tts.py"
     },
     {
       "subject": "AWSPollyTTSService.params",
-      "module": "pipecat.services.aws.tts",
+      "module": "pipecat\\services\\aws\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSPollyTTSService.Settings(...)",
       "message": "Use ``settings=AWSPollyTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/tts.py"
+      "location": "pipecat\\services\\aws\\tts.py"
     },
     {
       "subject": "AWSPollyTTSService.voice_id",
-      "module": "pipecat.services.aws.tts",
+      "module": "pipecat\\services\\aws\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AWSPollyTTSService.Settings(voice=...)",
       "message": "Use ``settings=AWSPollyTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/aws/tts.py"
+      "location": "pipecat\\services\\aws\\tts.py"
     },
     {
       "subject": "AzureImageGenServiceREST.image_size",
-      "module": "pipecat.services.azure.image",
+      "module": "pipecat\\services\\azure\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureImageGenServiceREST.Settings(image_size=...)",
       "message": "Use ``settings=AzureImageGenServiceREST.Settings(image_size=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/image.py"
+      "location": "pipecat\\services\\azure\\image.py"
     },
     {
       "subject": "AzureImageGenServiceREST.model",
-      "module": "pipecat.services.azure.image",
+      "module": "pipecat\\services\\azure\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureImageGenServiceREST.Settings(model=...)",
       "message": "Use ``settings=AzureImageGenServiceREST.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/image.py"
+      "location": "pipecat\\services\\azure\\image.py"
     },
     {
       "subject": "AzureLLMService.model",
-      "module": "pipecat.services.azure.llm",
+      "module": "pipecat\\services\\azure\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureLLMService.Settings(model=...)",
       "message": "Use ``settings=AzureLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/llm.py"
+      "location": "pipecat\\services\\azure\\llm.py"
     },
     {
       "subject": "AzureSTTService.language",
-      "module": "pipecat.services.azure.stt",
+      "module": "pipecat\\services\\azure\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureSTTService.Settings(language=...)",
       "message": "Use ``settings=AzureSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/stt.py"
+      "location": "pipecat\\services\\azure\\stt.py"
     },
     {
       "subject": "AzureBaseTTSService.InputParams",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "AzureBaseTTSService.Settings",
       "message": "`AzureBaseTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `AzureBaseTTSService.Settings` instead.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "AzureHttpTTSService.params",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureHttpTTSService.Settings(...)",
       "message": "Use ``settings=AzureHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "AzureHttpTTSService.voice",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=AzureHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "AzureTTSService.aggregate_sentences",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "AzureTTSService.params",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureTTSService.Settings(...)",
       "message": "Use ``settings=AzureTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "AzureTTSService.voice",
-      "module": "pipecat.services.azure.tts",
+      "module": "pipecat\\services\\azure\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=AzureTTSService.Settings(voice=...)",
       "message": "Use ``settings=AzureTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/azure/tts.py"
+      "location": "pipecat\\services\\azure\\tts.py"
     },
     {
       "subject": "CambTTSService.InputParams",
-      "module": "pipecat.services.camb.tts",
+      "module": "pipecat\\services\\camb\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "CambTTSService.Settings",
       "message": "`CambTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `CambTTSService.Settings` instead.",
-      "location": "pipecat/services/camb/tts.py"
+      "location": "pipecat\\services\\camb\\tts.py"
     },
     {
       "subject": "CambTTSService.model",
-      "module": "pipecat.services.camb.tts",
+      "module": "pipecat\\services\\camb\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CambTTSService.Settings(model=...)",
       "message": "Use ``settings=CambTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/camb/tts.py"
+      "location": "pipecat\\services\\camb\\tts.py"
     },
     {
       "subject": "CambTTSService.params",
-      "module": "pipecat.services.camb.tts",
+      "module": "pipecat\\services\\camb\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CambTTSService.Settings(...)",
       "message": "Use ``settings=CambTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/camb/tts.py"
+      "location": "pipecat\\services\\camb\\tts.py"
     },
     {
       "subject": "CambTTSService.voice_id",
-      "module": "pipecat.services.camb.tts",
+      "module": "pipecat\\services\\camb\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CambTTSService.Settings(voice=...)",
       "message": "Use ``settings=CambTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/camb/tts.py"
+      "location": "pipecat\\services\\camb\\tts.py"
     },
     {
       "subject": "CartesiaLiveOptions",
-      "module": "pipecat.services.cartesia.stt",
+      "module": "pipecat\\services\\cartesia\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "CartesiaSTTService.Settings",
       "message": "`CartesiaLiveOptions` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `CartesiaSTTService.Settings` instead.",
-      "location": "pipecat/services/cartesia/stt.py"
+      "location": "pipecat\\services\\cartesia\\stt.py"
     },
     {
       "subject": "CartesiaSTTService.live_options",
-      "module": "pipecat.services.cartesia.stt",
+      "module": "pipecat\\services\\cartesia\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaSTTService.Settings(...)",
       "message": "Use ``settings=CartesiaSTTService.Settings(...)`` for model/language and direct init parameters for encoding/sample_rate instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/stt.py"
+      "location": "pipecat\\services\\cartesia\\stt.py"
     },
     {
       "subject": "CartesiaHttpTTSService.model",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=CartesiaHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaHttpTTSService.params",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaHttpTTSService.Settings(...)",
       "message": "Use ``settings=CartesiaHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaHttpTTSService.voice_id",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=CartesiaHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaTTSService.aggregate_sentences",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaTTSService.model",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaTTSService.Settings(model=...)",
       "message": "Use ``settings=CartesiaTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaTTSService.params",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaTTSService.Settings(...)",
       "message": "Use ``settings=CartesiaTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CartesiaTTSService.voice_id",
-      "module": "pipecat.services.cartesia.tts",
+      "module": "pipecat\\services\\cartesia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CartesiaTTSService.Settings(voice=...)",
       "message": "Use ``settings=CartesiaTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cartesia/tts.py"
+      "location": "pipecat\\services\\cartesia\\tts.py"
     },
     {
       "subject": "CerebrasLLMService.model",
-      "module": "pipecat.services.cerebras.llm",
+      "module": "pipecat\\services\\cerebras\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=CerebrasLLMService.Settings(model=...)",
       "message": "Use ``settings=CerebrasLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/cerebras/llm.py"
+      "location": "pipecat\\services\\cerebras\\llm.py"
     },
     {
       "subject": "DeepgramFluxSTTService.InputParams",
-      "module": "pipecat.services.deepgram.flux.stt",
+      "module": "pipecat\\services\\deepgram\\flux\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "DeepgramFluxSTTService.Settings",
       "message": "`DeepgramFluxSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `DeepgramFluxSTTService.Settings` instead.",
-      "location": "pipecat/services/deepgram/flux/stt.py"
+      "location": "pipecat\\services\\deepgram\\flux\\stt.py"
     },
     {
       "subject": "DeepgramFluxSTTService.model",
-      "module": "pipecat.services.deepgram.flux.stt",
+      "module": "pipecat\\services\\deepgram\\flux\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramFluxSTTService.Settings(model=...)",
       "message": "Use ``settings=DeepgramFluxSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/flux/stt.py"
+      "location": "pipecat\\services\\deepgram\\flux\\stt.py"
     },
     {
       "subject": "DeepgramFluxSTTService.params",
-      "module": "pipecat.services.deepgram.flux.stt",
+      "module": "pipecat\\services\\deepgram\\flux\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramFluxSTTService.Settings(...)",
       "message": "Use ``settings=DeepgramFluxSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/flux/stt.py"
+      "location": "pipecat\\services\\deepgram\\flux\\stt.py"
     },
     {
       "subject": "DeepgramSageMakerSTTService.live_options",
-      "module": "pipecat.services.deepgram.sagemaker.stt",
+      "module": "pipecat\\services\\deepgram\\sagemaker\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramSageMakerSTTService.Settings(...)",
       "message": "Use ``settings=DeepgramSageMakerSTTService.Settings(...)`` for runtime-updatable fields and direct init parameters for connection-level config. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/sagemaker/stt.py"
+      "location": "pipecat\\services\\deepgram\\sagemaker\\stt.py"
     },
     {
       "subject": "DeepgramSageMakerTTSService.voice",
-      "module": "pipecat.services.deepgram.sagemaker.tts",
+      "module": "pipecat\\services\\deepgram\\sagemaker\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramSageMakerTTSService.Settings(voice=...)",
       "message": "Use ``settings=DeepgramSageMakerTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/sagemaker/tts.py"
+      "location": "pipecat\\services\\deepgram\\sagemaker\\tts.py"
     },
     {
       "subject": "DeepgramSTTService.live_options",
-      "module": "pipecat.services.deepgram.stt",
+      "module": "pipecat\\services\\deepgram\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramSTTService.Settings(...)",
       "message": "Use ``settings=DeepgramSTTService.Settings(...)`` for runtime-updatable fields and direct init parameters for connection-level config. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/stt.py"
+      "location": "pipecat\\services\\deepgram\\stt.py"
     },
     {
       "subject": "LiveOptions",
-      "module": "pipecat.services.deepgram.stt",
+      "module": "pipecat\\services\\deepgram\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "DeepgramSTTService.Settings",
       "message": "`LiveOptions` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `DeepgramSTTService.Settings` instead.",
-      "location": "pipecat/services/deepgram/stt.py"
+      "location": "pipecat\\services\\deepgram\\stt.py"
     },
     {
       "subject": "DeepgramHttpTTSService.voice",
-      "module": "pipecat.services.deepgram.tts",
+      "module": "pipecat\\services\\deepgram\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=DeepgramHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/tts.py"
+      "location": "pipecat\\services\\deepgram\\tts.py"
     },
     {
       "subject": "DeepgramTTSService.voice",
-      "module": "pipecat.services.deepgram.tts",
+      "module": "pipecat\\services\\deepgram\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepgramTTSService.Settings(voice=...)",
       "message": "Use ``settings=DeepgramTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepgram/tts.py"
+      "location": "pipecat\\services\\deepgram\\tts.py"
     },
     {
       "subject": "DeepSeekLLMService.model",
-      "module": "pipecat.services.deepseek.llm",
+      "module": "pipecat\\services\\deepseek\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=DeepSeekLLMService.Settings(model=...)",
       "message": "Use ``settings=DeepSeekLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/deepseek/llm.py"
+      "location": "pipecat\\services\\deepseek\\llm.py"
     },
     {
       "subject": "ElevenLabsRealtimeSTTService.InputParams",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "ElevenLabsRealtimeSTTService.Settings",
       "message": "`ElevenLabsRealtimeSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `ElevenLabsRealtimeSTTService.Settings` instead.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsRealtimeSTTService.model",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsRealtimeSTTService.Settings(model=...)",
       "message": "Use ``settings=ElevenLabsRealtimeSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsRealtimeSTTService.params",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsRealtimeSTTService.Settings(...)",
       "message": "Use ``settings=ElevenLabsRealtimeSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsSTTService.InputParams",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "ElevenLabsSTTService.Settings",
       "message": "`ElevenLabsSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `ElevenLabsSTTService.Settings` instead.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsSTTService.model",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsSTTService.Settings(model=...)",
       "message": "Use ``settings=ElevenLabsSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsSTTService.params",
-      "module": "pipecat.services.elevenlabs.stt",
+      "module": "pipecat\\services\\elevenlabs\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsSTTService.Settings(...)",
       "message": "Use ``settings=ElevenLabsSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/stt.py"
+      "location": "pipecat\\services\\elevenlabs\\stt.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.InputParams",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "ElevenLabsHttpTTSService.Settings",
       "message": "`ElevenLabsHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `ElevenLabsHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.aggregate_sentences",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.model",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=ElevenLabsHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.params",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsHttpTTSService.Settings(...)",
       "message": "Use ``settings=ElevenLabsHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.pronunciation_dictionary_locators",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "1.6.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_transforms",
       "message": "Use the ``text_transforms`` parameter with :func:`pipecat.utils.text.transforms.replace_text` instead. Pronunciation dictionary substitutions can rewrite the spoken words in ways that no longer match the text sent to synthesis, which breaks the alignment-based word-completion tracking used to attribute spoken text back to the conversation context. ``replace_text`` transforms happen client-side, so they're tracked correctly. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsHttpTTSService.voice_id",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=ElevenLabsHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.InputParams",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "ElevenLabsTTSService.Settings",
       "message": "`ElevenLabsTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `ElevenLabsTTSService.Settings` instead.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.aggregate_sentences",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.model",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsTTSService.Settings(model=...)",
       "message": "Use ``settings=ElevenLabsTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.params",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsTTSService.Settings(...)",
       "message": "Use ``settings=ElevenLabsTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.pronunciation_dictionary_locators",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "1.6.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_transforms",
       "message": "Use the ``text_transforms`` parameter with :func:`pipecat.utils.text.transforms.replace_text` instead. Pronunciation dictionary substitutions can rewrite the spoken words in ways that no longer match the text sent to synthesis, which breaks the alignment-based word-completion tracking used to attribute spoken text back to the conversation context. ``replace_text`` transforms happen client-side, so they're tracked correctly. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "ElevenLabsTTSService.voice_id",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ElevenLabsTTSService.Settings(voice=...)",
       "message": "Use ``settings=ElevenLabsTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "PronunciationDictionaryLocator",
-      "module": "pipecat.services.elevenlabs.tts",
+      "module": "pipecat\\services\\elevenlabs\\tts",
       "kind": "class",
       "deprecated_in": "1.6.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_transforms",
       "message": "`PronunciationDictionaryLocator` is deprecated since 1.6.0 and will be removed in 2.0.0. Use `text_transforms` -> `replace_text` instead.",
-      "location": "pipecat/services/elevenlabs/tts.py"
+      "location": "pipecat\\services\\elevenlabs\\tts.py"
     },
     {
       "subject": "FalImageGenService.InputParams",
-      "module": "pipecat.services.fal.image",
+      "module": "pipecat\\services\\fal\\image",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FalImageGenService.Settings",
       "message": "`FalImageGenService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `FalImageGenService.Settings` instead.",
-      "location": "pipecat/services/fal/image.py"
+      "location": "pipecat\\services\\fal\\image.py"
     },
     {
       "subject": "FalImageGenService.model",
-      "module": "pipecat.services.fal.image",
+      "module": "pipecat\\services\\fal\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FalImageGenService.Settings(model=...)",
       "message": "Use ``settings=FalImageGenService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fal/image.py"
+      "location": "pipecat\\services\\fal\\image.py"
     },
     {
       "subject": "FalImageGenService.params",
-      "module": "pipecat.services.fal.image",
+      "module": "pipecat\\services\\fal\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FalImageGenService.Settings(...)",
       "message": "Use ``settings=FalImageGenService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fal/image.py"
+      "location": "pipecat\\services\\fal\\image.py"
     },
     {
       "subject": "FalSTTService.InputParams",
-      "module": "pipecat.services.fal.stt",
+      "module": "pipecat\\services\\fal\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FalSTTService.Settings",
       "message": "`FalSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `FalSTTService.Settings` instead.",
-      "location": "pipecat/services/fal/stt.py"
+      "location": "pipecat\\services\\fal\\stt.py"
     },
     {
       "subject": "FalSTTService.params",
-      "module": "pipecat.services.fal.stt",
+      "module": "pipecat\\services\\fal\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FalSTTService.Settings(...)",
       "message": "Use ``settings=FalSTTService.Settings(...)`` for model/language and direct init parameters for task/chunk_level/version instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fal/stt.py"
+      "location": "pipecat\\services\\fal\\stt.py"
     },
     {
       "subject": "FireworksLLMService.model",
-      "module": "pipecat.services.fireworks.llm",
+      "module": "pipecat\\services\\fireworks\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FireworksLLMService.Settings(model=...)",
       "message": "Use ``settings=FireworksLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fireworks/llm.py"
+      "location": "pipecat\\services\\fireworks\\llm.py"
     },
     {
       "subject": "FishAudioTTSService.InputParams",
-      "module": "pipecat.services.fish.tts",
+      "module": "pipecat\\services\\fish\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FishAudioTTSService.Settings",
       "message": "`FishAudioTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `FishAudioTTSService.Settings` instead.",
-      "location": "pipecat/services/fish/tts.py"
+      "location": "pipecat\\services\\fish\\tts.py"
     },
     {
       "subject": "FishAudioTTSService.model_id",
-      "module": "pipecat.services.fish.tts",
+      "module": "pipecat\\services\\fish\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FishAudioTTSService.Settings(model=...)",
       "message": "Use ``settings=FishAudioTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fish/tts.py"
+      "location": "pipecat\\services\\fish\\tts.py"
     },
     {
       "subject": "FishAudioTTSService.params",
-      "module": "pipecat.services.fish.tts",
+      "module": "pipecat\\services\\fish\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FishAudioTTSService.Settings(...)",
       "message": "Use ``settings=FishAudioTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fish/tts.py"
+      "location": "pipecat\\services\\fish\\tts.py"
     },
     {
       "subject": "FishAudioTTSService.reference_id",
-      "module": "pipecat.services.fish.tts",
+      "module": "pipecat\\services\\fish\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=FishAudioTTSService.Settings(voice=...)",
       "message": "Use ``settings=FishAudioTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/fish/tts.py"
+      "location": "pipecat\\services\\fish\\tts.py"
     },
     {
       "subject": "GladiaInputParams",
-      "module": "pipecat.services.gladia.config",
+      "module": "pipecat\\services\\gladia\\config",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GladiaSTTService.Settings",
       "message": "`GladiaInputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GladiaSTTService.Settings` instead.",
-      "location": "pipecat/services/gladia/config.py"
+      "location": "pipecat\\services\\gladia\\config.py"
     },
     {
       "subject": "GladiaSTTService.model",
-      "module": "pipecat.services.gladia.stt",
+      "module": "pipecat\\services\\gladia\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GladiaSTTService.Settings(model=...)",
       "message": "Use ``settings=GladiaSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gladia/stt.py"
+      "location": "pipecat\\services\\gladia\\stt.py"
     },
     {
       "subject": "GladiaSTTService.params",
-      "module": "pipecat.services.gladia.stt",
+      "module": "pipecat\\services\\gladia\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GladiaSTTService.Settings(...)",
       "message": "Use ``settings=GladiaSTTService.Settings(...)`` for runtime-updatable fields and direct init parameters for encoding/bit_depth/channels. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gladia/stt.py"
+      "location": "pipecat\\services\\gladia\\stt.py"
     },
     {
       "subject": "GeminiLiveLLMService.model",
-      "module": "pipecat.services.google.gemini_live.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveLLMService.Settings(model=...)",
       "message": "Use ``settings=GeminiLiveLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\llm.py"
     },
     {
       "subject": "GeminiLiveLLMService.params",
-      "module": "pipecat.services.google.gemini_live.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveLLMService.Settings(...)",
       "message": "Use ``settings=GeminiLiveLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\llm.py"
     },
     {
       "subject": "GeminiLiveLLMService.voice_id",
-      "module": "pipecat.services.google.gemini_live.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveLLMService.Settings(voice=...)",
       "message": "Use ``settings=GeminiLiveLLMService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\llm.py"
     },
     {
       "subject": "InputParams",
-      "module": "pipecat.services.google.gemini_live.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GeminiLiveLLMService.Settings",
       "message": "`InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GeminiLiveLLMService.Settings` instead.",
-      "location": "pipecat/services/google/gemini_live/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\llm.py"
     },
     {
       "subject": "GeminiLiveVertexLLMService.model",
-      "module": "pipecat.services.google.gemini_live.vertex.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveVertexLLMService.Settings(model=...)",
       "message": "Use ``settings=GeminiLiveVertexLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/vertex/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\vertex\\llm.py"
     },
     {
       "subject": "GeminiLiveVertexLLMService.params",
-      "module": "pipecat.services.google.gemini_live.vertex.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveVertexLLMService.Settings(...)",
       "message": "Use ``settings=GeminiLiveVertexLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/vertex/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\vertex\\llm.py"
     },
     {
       "subject": "GeminiLiveVertexLLMService.voice_id",
-      "module": "pipecat.services.google.gemini_live.vertex.llm",
+      "module": "pipecat\\services\\google\\gemini_live\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiLiveVertexLLMService.Settings(voice=...)",
       "message": "Use ``settings=GeminiLiveVertexLLMService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/gemini_live/vertex/llm.py"
+      "location": "pipecat\\services\\google\\gemini_live\\vertex\\llm.py"
     },
     {
       "subject": "GoogleImageGenService.InputParams",
-      "module": "pipecat.services.google.image",
+      "module": "pipecat\\services\\google\\image",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GoogleImageGenService.Settings",
       "message": "`GoogleImageGenService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GoogleImageGenService.Settings` instead.",
-      "location": "pipecat/services/google/image.py"
+      "location": "pipecat\\services\\google\\image.py"
     },
     {
       "subject": "GoogleImageGenService.params",
-      "module": "pipecat.services.google.image",
+      "module": "pipecat\\services\\google\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleImageGenService.Settings(...)",
       "message": "Use ``settings=GoogleImageGenService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/image.py"
+      "location": "pipecat\\services\\google\\image.py"
     },
     {
       "subject": "GoogleLLMService.InputParams",
-      "module": "pipecat.services.google.llm",
+      "module": "pipecat\\services\\google\\llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GoogleLLMService.Settings",
       "message": "`GoogleLLMService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GoogleLLMService.Settings` instead.",
-      "location": "pipecat/services/google/llm.py"
+      "location": "pipecat\\services\\google\\llm.py"
     },
     {
       "subject": "GoogleLLMService.model",
-      "module": "pipecat.services.google.llm",
+      "module": "pipecat\\services\\google\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleLLMService.Settings(model=...)",
       "message": "Use ``settings=GoogleLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/llm.py"
+      "location": "pipecat\\services\\google\\llm.py"
     },
     {
       "subject": "GoogleLLMService.params",
-      "module": "pipecat.services.google.llm",
+      "module": "pipecat\\services\\google\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleLLMService.Settings(...)",
       "message": "Use ``settings=GoogleLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/llm.py"
+      "location": "pipecat\\services\\google\\llm.py"
     },
     {
       "subject": "GoogleLLMService.system_instruction",
-      "module": "pipecat.services.google.llm",
+      "module": "pipecat\\services\\google\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleLLMService.Settings(system_instruction=...)",
       "message": "Use ``settings=GoogleLLMService.Settings(system_instruction=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/llm.py"
+      "location": "pipecat\\services\\google\\llm.py"
     },
     {
       "subject": "GoogleSTTService.InputParams",
-      "module": "pipecat.services.google.stt",
+      "module": "pipecat\\services\\google\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GoogleSTTService.Settings",
       "message": "`GoogleSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GoogleSTTService.Settings` instead.",
-      "location": "pipecat/services/google/stt.py"
+      "location": "pipecat\\services\\google\\stt.py"
     },
     {
       "subject": "GoogleSTTService.params",
-      "module": "pipecat.services.google.stt",
+      "module": "pipecat\\services\\google\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleSTTService.Settings(...)",
       "message": "Use ``settings=GoogleSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/stt.py"
+      "location": "pipecat\\services\\google\\stt.py"
     },
     {
       "subject": "GoogleSTTService.set_languages",
-      "module": "pipecat.services.google.stt",
+      "module": "pipecat\\services\\google\\stt",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame",
       "message": "`GoogleSTTService.set_languages` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame` instead.",
-      "location": "pipecat/services/google/stt.py"
+      "location": "pipecat\\services\\google\\stt.py"
     },
     {
       "subject": "GoogleSTTService.update_options",
-      "module": "pipecat.services.google.stt",
+      "module": "pipecat\\services\\google\\stt",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame",
       "message": "`GoogleSTTService.update_options` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame` instead.",
-      "location": "pipecat/services/google/stt.py"
+      "location": "pipecat\\services\\google\\stt.py"
     },
     {
       "subject": "GoogleSTTSettings.language_codes",
-      "module": "pipecat.services.google.stt",
+      "module": "pipecat\\services\\google\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "languages",
       "message": "Use ``languages`` instead. If both are provided, ``languages`` takes precedence. This field is here just for backward compatibility with dict-based settings updates. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/stt.py"
+      "location": "pipecat\\services\\google\\stt.py"
     },
     {
       "subject": "GeminiTTSService.InputParams",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GeminiTTSService.Settings",
       "message": "`GeminiTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GeminiTTSService.Settings` instead.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GeminiTTSService.model",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiTTSService.Settings(model=...)",
       "message": "Use ``settings=GeminiTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GeminiTTSService.params",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiTTSService.Settings(...)",
       "message": "Use ``settings=GeminiTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GeminiTTSService.voice_id",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GeminiTTSService.Settings(voice=...)",
       "message": "Use ``settings=GeminiTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleHttpTTSService.InputParams",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GoogleHttpTTSService.Settings",
       "message": "`GoogleHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GoogleHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleHttpTTSService.params",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleHttpTTSService.Settings(...)",
       "message": "Use ``settings=GoogleHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleHttpTTSService.voice_id",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=GoogleHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleTTSService.InputParams",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GoogleTTSService.Settings",
       "message": "`GoogleTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GoogleTTSService.Settings` instead.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleTTSService.params",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleTTSService.Settings(...)",
       "message": "Use ``settings=GoogleTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleTTSService.voice_id",
-      "module": "pipecat.services.google.tts",
+      "module": "pipecat\\services\\google\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleTTSService.Settings(voice=...)",
       "message": "Use ``settings=GoogleTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/tts.py"
+      "location": "pipecat\\services\\google\\tts.py"
     },
     {
       "subject": "GoogleVertexLLMService.model",
-      "module": "pipecat.services.google.vertex.llm",
+      "module": "pipecat\\services\\google\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleVertexLLMService.Settings(model=...)",
       "message": "Use ``settings=GoogleVertexLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/vertex/llm.py"
+      "location": "pipecat\\services\\google\\vertex\\llm.py"
     },
     {
       "subject": "GoogleVertexLLMService.params",
-      "module": "pipecat.services.google.vertex.llm",
+      "module": "pipecat\\services\\google\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleVertexLLMService.Settings(...)",
       "message": "Use ``settings=GoogleVertexLLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/vertex/llm.py"
+      "location": "pipecat\\services\\google\\vertex\\llm.py"
     },
     {
       "subject": "GoogleVertexLLMService.system_instruction",
-      "module": "pipecat.services.google.vertex.llm",
+      "module": "pipecat\\services\\google\\vertex\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GoogleVertexLLMService.Settings(system_instruction=...)",
       "message": "Use ``settings=GoogleVertexLLMService.Settings(system_instruction=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/google/vertex/llm.py"
+      "location": "pipecat\\services\\google\\vertex\\llm.py"
     },
     {
       "subject": "GradiumSTTService.InputParams",
-      "module": "pipecat.services.gradium.stt",
+      "module": "pipecat\\services\\gradium\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GradiumSTTService.Settings",
       "message": "`GradiumSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GradiumSTTService.Settings` instead.",
-      "location": "pipecat/services/gradium/stt.py"
+      "location": "pipecat\\services\\gradium\\stt.py"
     },
     {
       "subject": "GradiumSTTService.json_config",
-      "module": "pipecat.services.gradium.stt",
+      "module": "pipecat\\services\\gradium\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.101",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "params",
       "message": "Use `params` instead for type-safe configuration. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gradium/stt.py"
+      "location": "pipecat\\services\\gradium\\stt.py"
     },
     {
       "subject": "GradiumSTTService.params",
-      "module": "pipecat.services.gradium.stt",
+      "module": "pipecat\\services\\gradium\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GradiumSTTService.Settings(...)",
       "message": "Use ``settings=GradiumSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gradium/stt.py"
+      "location": "pipecat\\services\\gradium\\stt.py"
     },
     {
       "subject": "GradiumTTSService.InputParams",
-      "module": "pipecat.services.gradium.tts",
+      "module": "pipecat\\services\\gradium\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GradiumTTSService.Settings",
       "message": "`GradiumTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GradiumTTSService.Settings` instead.",
-      "location": "pipecat/services/gradium/tts.py"
+      "location": "pipecat\\services\\gradium\\tts.py"
     },
     {
       "subject": "GradiumTTSService.model",
-      "module": "pipecat.services.gradium.tts",
+      "module": "pipecat\\services\\gradium\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GradiumTTSService.Settings(model=...)",
       "message": "Use ``settings=GradiumTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gradium/tts.py"
+      "location": "pipecat\\services\\gradium\\tts.py"
     },
     {
       "subject": "GradiumTTSService.params",
-      "module": "pipecat.services.gradium.tts",
+      "module": "pipecat\\services\\gradium\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GradiumTTSService.Settings(...)",
       "message": "Use ``settings=GradiumTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gradium/tts.py"
+      "location": "pipecat\\services\\gradium\\tts.py"
     },
     {
       "subject": "GradiumTTSService.voice_id",
-      "module": "pipecat.services.gradium.tts",
+      "module": "pipecat\\services\\gradium\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GradiumTTSService.Settings(voice=...)",
       "message": "Use ``settings=GradiumTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/gradium/tts.py"
+      "location": "pipecat\\services\\gradium\\tts.py"
     },
     {
-      "subject": "pipecat.services.grok.llm",
-      "module": "pipecat.services.grok.llm",
+      "subject": "pipecat\\services\\grok\\llm",
+      "module": "pipecat\\services\\grok\\llm",
       "kind": "module",
       "deprecated_in": "0.0.108",
       "removed_in": "2.0.0",
       "relation": "move",
       "replacement": "pipecat.services.xai.llm",
       "message": "Use :mod:`pipecat.services.xai.llm` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/grok/llm.py"
+      "location": "pipecat\\services\\grok\\llm.py"
     },
     {
-      "subject": "pipecat.services.grok.realtime.events",
-      "module": "pipecat.services.grok.realtime.events",
+      "subject": "pipecat\\services\\grok\\realtime\\events",
+      "module": "pipecat\\services\\grok\\realtime\\events",
       "kind": "module",
       "deprecated_in": "0.0.108",
       "removed_in": "2.0.0",
       "relation": "move",
       "replacement": "pipecat.services.xai.realtime.events",
       "message": "Use :mod:`pipecat.services.xai.realtime.events` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/grok/realtime/events.py"
+      "location": "pipecat\\services\\grok\\realtime\\events.py"
     },
     {
-      "subject": "pipecat.services.grok.realtime.llm",
-      "module": "pipecat.services.grok.realtime.llm",
+      "subject": "pipecat\\services\\grok\\realtime\\llm",
+      "module": "pipecat\\services\\grok\\realtime\\llm",
       "kind": "module",
       "deprecated_in": "0.0.108",
       "removed_in": "2.0.0",
       "relation": "move",
       "replacement": "pipecat.services.xai.realtime.llm",
       "message": "Use :mod:`pipecat.services.xai.realtime.llm` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/grok/realtime/llm.py"
+      "location": "pipecat\\services\\grok\\realtime\\llm.py"
     },
     {
       "subject": "GroqLLMService.model",
-      "module": "pipecat.services.groq.llm",
+      "module": "pipecat\\services\\groq\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqLLMService.Settings(model=...)",
       "message": "Use ``settings=GroqLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/llm.py"
+      "location": "pipecat\\services\\groq\\llm.py"
     },
     {
       "subject": "GroqSTTService.language",
-      "module": "pipecat.services.groq.stt",
+      "module": "pipecat\\services\\groq\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqSTTService.Settings(language=...)",
       "message": "Use ``settings=GroqSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/stt.py"
+      "location": "pipecat\\services\\groq\\stt.py"
     },
     {
       "subject": "GroqSTTService.model",
-      "module": "pipecat.services.groq.stt",
+      "module": "pipecat\\services\\groq\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqSTTService.Settings(model=...)",
       "message": "Use ``settings=GroqSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/stt.py"
+      "location": "pipecat\\services\\groq\\stt.py"
     },
     {
       "subject": "GroqSTTService.prompt",
-      "module": "pipecat.services.groq.stt",
+      "module": "pipecat\\services\\groq\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqSTTService.Settings(prompt=...)",
       "message": "Use ``settings=GroqSTTService.Settings(prompt=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/stt.py"
+      "location": "pipecat\\services\\groq\\stt.py"
     },
     {
       "subject": "GroqSTTService.temperature",
-      "module": "pipecat.services.groq.stt",
+      "module": "pipecat\\services\\groq\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqSTTService.Settings(temperature=...)",
       "message": "Use ``settings=GroqSTTService.Settings(temperature=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/stt.py"
+      "location": "pipecat\\services\\groq\\stt.py"
     },
     {
       "subject": "GroqTTSService.InputParams",
-      "module": "pipecat.services.groq.tts",
+      "module": "pipecat\\services\\groq\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "GroqTTSService.Settings",
       "message": "`GroqTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `GroqTTSService.Settings` instead.",
-      "location": "pipecat/services/groq/tts.py"
+      "location": "pipecat\\services\\groq\\tts.py"
     },
     {
       "subject": "GroqTTSService.model_name",
-      "module": "pipecat.services.groq.tts",
+      "module": "pipecat\\services\\groq\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqTTSService.Settings(model=...)",
       "message": "Use ``settings=GroqTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/tts.py"
+      "location": "pipecat\\services\\groq\\tts.py"
     },
     {
       "subject": "GroqTTSService.params",
-      "module": "pipecat.services.groq.tts",
+      "module": "pipecat\\services\\groq\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqTTSService.Settings(...)",
       "message": "Use ``settings=GroqTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/tts.py"
+      "location": "pipecat\\services\\groq\\tts.py"
     },
     {
       "subject": "GroqTTSService.voice_id",
-      "module": "pipecat.services.groq.tts",
+      "module": "pipecat\\services\\groq\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GroqTTSService.Settings(voice=...)",
       "message": "Use ``settings=GroqTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/groq/tts.py"
+      "location": "pipecat\\services\\groq\\tts.py"
     },
     {
       "subject": "HumeTTSService.InputParams",
-      "module": "pipecat.services.hume.tts",
+      "module": "pipecat\\services\\hume\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "HumeTTSService.Settings",
       "message": "`HumeTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `HumeTTSService.Settings` instead.",
-      "location": "pipecat/services/hume/tts.py"
+      "location": "pipecat\\services\\hume\\tts.py"
     },
     {
       "subject": "HumeTTSService.params",
-      "module": "pipecat.services.hume.tts",
+      "module": "pipecat\\services\\hume\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=HumeTTSService.Settings(...)",
       "message": "Use ``settings=HumeTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/hume/tts.py"
+      "location": "pipecat\\services\\hume\\tts.py"
     },
     {
       "subject": "HumeTTSService.update_setting",
-      "module": "pipecat.services.hume.tts",
+      "module": "pipecat\\services\\hume\\tts",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TTSUpdateSettingsFrame",
       "message": "`HumeTTSService.update_setting` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `TTSUpdateSettingsFrame` instead.",
-      "location": "pipecat/services/hume/tts.py"
+      "location": "pipecat\\services\\hume\\tts.py"
     },
     {
       "subject": "HumeTTSService.voice_id",
-      "module": "pipecat.services.hume.tts",
+      "module": "pipecat\\services\\hume\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=HumeTTSService.Settings(voice=...)",
       "message": "Use ``settings=HumeTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/hume/tts.py"
+      "location": "pipecat\\services\\hume\\tts.py"
     },
     {
       "subject": "InworldHttpTTSService.InputParams",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "InworldHttpTTSService.Settings",
       "message": "`InworldHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `InworldHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldHttpTTSService.model",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=InworldHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldHttpTTSService.params",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldHttpTTSService.Settings(...)",
       "message": "Use ``settings=InworldHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldHttpTTSService.voice_id",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=InworldHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldTTSService.InputParams",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "InworldTTSService.Settings",
       "message": "`InworldTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `InworldTTSService.Settings` instead.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldTTSService.aggregate_sentences",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldTTSService.model",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldTTSService.Settings(model=...)",
       "message": "Use ``settings=InworldTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldTTSService.params",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldTTSService.Settings(...)",
       "message": "Use ``settings=InworldTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "InworldTTSService.voice_id",
-      "module": "pipecat.services.inworld.tts",
+      "module": "pipecat\\services\\inworld\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=InworldTTSService.Settings(voice=...)",
       "message": "Use ``settings=InworldTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/inworld/tts.py"
+      "location": "pipecat\\services\\inworld\\tts.py"
     },
     {
       "subject": "KokoroTTSService.InputParams",
-      "module": "pipecat.services.kokoro.tts",
+      "module": "pipecat\\services\\kokoro\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "KokoroTTSService.Settings",
       "message": "`KokoroTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `KokoroTTSService.Settings` instead.",
-      "location": "pipecat/services/kokoro/tts.py"
+      "location": "pipecat\\services\\kokoro\\tts.py"
     },
     {
       "subject": "KokoroTTSService.params",
-      "module": "pipecat.services.kokoro.tts",
+      "module": "pipecat\\services\\kokoro\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=KokoroTTSService.Settings(...)",
       "message": "Use ``settings=KokoroTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/kokoro/tts.py"
+      "location": "pipecat\\services\\kokoro\\tts.py"
     },
     {
       "subject": "KokoroTTSService.voice_id",
-      "module": "pipecat.services.kokoro.tts",
+      "module": "pipecat\\services\\kokoro\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=KokoroTTSService.Settings(voice=...)",
       "message": "Use ``settings=KokoroTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/kokoro/tts.py"
+      "location": "pipecat\\services\\kokoro\\tts.py"
     },
     {
       "subject": "FunctionCallParams.tool_resources",
-      "module": "pipecat.services.llm_service",
+      "module": "pipecat\\services\\llm_service",
       "kind": "property",
       "deprecated_in": "1.2.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "app_resources",
       "message": "`FunctionCallParams.tool_resources` is deprecated since 1.2.0 and will be removed in 2.0.0. Use `app_resources` instead.",
-      "location": "pipecat/services/llm_service.py"
+      "location": "pipecat\\services\\llm_service.py"
     },
     {
       "subject": "LLMService.register_direct_function",
-      "module": "pipecat.services.llm_service",
+      "module": "pipecat\\services\\llm_service",
       "kind": "method",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMContext(tools=[...])",
       "message": "`LLMService.register_direct_function` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `LLMContext(tools=[...])` instead.",
-      "location": "pipecat/services/llm_service.py"
+      "location": "pipecat\\services\\llm_service.py"
     },
     {
       "subject": "LLMService.unregister_direct_function",
-      "module": "pipecat.services.llm_service",
+      "module": "pipecat\\services\\llm_service",
       "kind": "method",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMSetToolsFrame",
       "message": "`LLMService.unregister_direct_function` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `LLMSetToolsFrame` instead.",
-      "location": "pipecat/services/llm_service.py"
+      "location": "pipecat\\services\\llm_service.py"
     },
     {
       "subject": "LmntTTSService.language",
-      "module": "pipecat.services.lmnt.tts",
+      "module": "pipecat\\services\\lmnt\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=LmntTTSService.Settings(language=...)",
       "message": "Use ``settings=LmntTTSService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/lmnt/tts.py"
+      "location": "pipecat\\services\\lmnt\\tts.py"
     },
     {
       "subject": "LmntTTSService.model",
-      "module": "pipecat.services.lmnt.tts",
+      "module": "pipecat\\services\\lmnt\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=LmntTTSService.Settings(model=...)",
       "message": "Use ``settings=LmntTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/lmnt/tts.py"
+      "location": "pipecat\\services\\lmnt\\tts.py"
     },
     {
       "subject": "LmntTTSService.voice_id",
-      "module": "pipecat.services.lmnt.tts",
+      "module": "pipecat\\services\\lmnt\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=LmntTTSService.Settings(voice=...)",
       "message": "Use ``settings=LmntTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/lmnt/tts.py"
+      "location": "pipecat\\services\\lmnt\\tts.py"
     },
     {
       "subject": "Mem0MemoryService.InputParams.api_version",
-      "module": "pipecat.services.mem0.memory",
+      "module": "pipecat\\services\\mem0\\memory",
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "No replacement. Mem0 2.0.0 removed the ``api_version`` / ``output_format`` parameters from the client. Will be removed in 2.0.0.",
-      "location": "pipecat/services/mem0/memory.py"
+      "location": "pipecat\\services\\mem0\\memory.py"
     },
     {
       "subject": "MiniMaxHttpTTSService.InputParams",
-      "module": "pipecat.services.minimax.tts",
+      "module": "pipecat\\services\\minimax\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "MiniMaxHttpTTSService.Settings",
       "message": "`MiniMaxHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `MiniMaxHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/minimax/tts.py"
+      "location": "pipecat\\services\\minimax\\tts.py"
     },
     {
       "subject": "MiniMaxHttpTTSService.model",
-      "module": "pipecat.services.minimax.tts",
+      "module": "pipecat\\services\\minimax\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=MiniMaxHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=MiniMaxHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/minimax/tts.py"
+      "location": "pipecat\\services\\minimax\\tts.py"
     },
     {
       "subject": "MiniMaxHttpTTSService.params",
-      "module": "pipecat.services.minimax.tts",
+      "module": "pipecat\\services\\minimax\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=MiniMaxHttpTTSService.Settings(...)",
       "message": "Use ``settings=MiniMaxHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/minimax/tts.py"
+      "location": "pipecat\\services\\minimax\\tts.py"
     },
     {
       "subject": "MiniMaxHttpTTSService.voice_id",
-      "module": "pipecat.services.minimax.tts",
+      "module": "pipecat\\services\\minimax\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=MiniMaxHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=MiniMaxHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/minimax/tts.py"
+      "location": "pipecat\\services\\minimax\\tts.py"
     },
     {
       "subject": "MistralLLMService.model",
-      "module": "pipecat.services.mistral.llm",
+      "module": "pipecat\\services\\mistral\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=MistralLLMService.Settings(model=...)",
       "message": "Use ``settings=MistralLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/mistral/llm.py"
+      "location": "pipecat\\services\\mistral\\llm.py"
     },
     {
       "subject": "MoondreamService.model",
-      "module": "pipecat.services.moondream.vision",
+      "module": "pipecat\\services\\moondream\\vision",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=MoondreamService.Settings(model=...)",
       "message": "Use ``settings=MoondreamService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/moondream/vision.py"
+      "location": "pipecat\\services\\moondream\\vision.py"
     },
     {
       "subject": "NeuphonicHttpTTSService.InputParams",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "NeuphonicHttpTTSService.Settings",
       "message": "`NeuphonicHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `NeuphonicHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicHttpTTSService.params",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NeuphonicHttpTTSService.Settings(...)",
       "message": "Use ``settings=NeuphonicHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicHttpTTSService.voice_id",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NeuphonicHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=NeuphonicHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicTTSService.InputParams",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "NeuphonicTTSService.Settings",
       "message": "`NeuphonicTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `NeuphonicTTSService.Settings` instead.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicTTSService.aggregate_sentences",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicTTSService.params",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NeuphonicTTSService.Settings(...)",
       "message": "Use ``settings=NeuphonicTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NeuphonicTTSService.voice_id",
-      "module": "pipecat.services.neuphonic.tts",
+      "module": "pipecat\\services\\neuphonic\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NeuphonicTTSService.Settings(voice=...)",
       "message": "Use ``settings=NeuphonicTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/neuphonic/tts.py"
+      "location": "pipecat\\services\\neuphonic\\tts.py"
     },
     {
       "subject": "NvidiaLLMService.model",
-      "module": "pipecat.services.nvidia.llm",
+      "module": "pipecat\\services\\nvidia\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NvidiaLLMService.Settings(model=...)",
       "message": "Use ``settings=NvidiaLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/nvidia/llm.py"
+      "location": "pipecat\\services\\nvidia\\llm.py"
     },
     {
       "subject": "NvidiaSTTService.InputParams",
-      "module": "pipecat.services.nvidia.stt",
+      "module": "pipecat\\services\\nvidia\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "NvidiaSTTService.Settings",
       "message": "`NvidiaSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `NvidiaSTTService.Settings` instead.",
-      "location": "pipecat/services/nvidia/stt.py"
+      "location": "pipecat\\services\\nvidia\\stt.py"
     },
     {
       "subject": "NvidiaSTTService.params",
-      "module": "pipecat.services.nvidia.stt",
+      "module": "pipecat\\services\\nvidia\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NvidiaSTTService.Settings(...)",
       "message": "Use ``settings=NvidiaSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/nvidia/stt.py"
+      "location": "pipecat\\services\\nvidia\\stt.py"
     },
     {
       "subject": "NvidiaSTTService.set_model",
-      "module": "pipecat.services.nvidia.stt",
+      "module": "pipecat\\services\\nvidia\\stt",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "`NvidiaSTTService.set_model` is deprecated since 0.0.104 and will be removed in 2.0.0. No replacement.",
-      "location": "pipecat/services/nvidia/stt.py"
+      "location": "pipecat\\services\\nvidia\\stt.py"
     },
     {
       "subject": "NvidiaSegmentedSTTService.InputParams",
-      "module": "pipecat.services.nvidia.stt",
+      "module": "pipecat\\services\\nvidia\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "NvidiaSegmentedSTTService.Settings",
       "message": "`NvidiaSegmentedSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `NvidiaSegmentedSTTService.Settings` instead.",
-      "location": "pipecat/services/nvidia/stt.py"
+      "location": "pipecat\\services\\nvidia\\stt.py"
     },
     {
       "subject": "NvidiaSegmentedSTTService.params",
-      "module": "pipecat.services.nvidia.stt",
+      "module": "pipecat\\services\\nvidia\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NvidiaSegmentedSTTService.Settings(...)",
       "message": "Use ``settings=NvidiaSegmentedSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/nvidia/stt.py"
+      "location": "pipecat\\services\\nvidia\\stt.py"
     },
     {
       "subject": "NvidiaTTSService.InputParams",
-      "module": "pipecat.services.nvidia.tts",
+      "module": "pipecat\\services\\nvidia\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "NvidiaTTSService.Settings",
       "message": "`NvidiaTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `NvidiaTTSService.Settings` instead.",
-      "location": "pipecat/services/nvidia/tts.py"
+      "location": "pipecat\\services\\nvidia\\tts.py"
     },
     {
       "subject": "NvidiaTTSService.params",
-      "module": "pipecat.services.nvidia.tts",
+      "module": "pipecat\\services\\nvidia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NvidiaTTSService.Settings(...)",
       "message": "Use ``settings=NvidiaTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/nvidia/tts.py"
+      "location": "pipecat\\services\\nvidia\\tts.py"
     },
     {
       "subject": "NvidiaTTSService.set_model",
-      "module": "pipecat.services.nvidia.tts",
+      "module": "pipecat\\services\\nvidia\\tts",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "`NvidiaTTSService.set_model` is deprecated since 0.0.104 and will be removed in 2.0.0. No replacement.",
-      "location": "pipecat/services/nvidia/tts.py"
+      "location": "pipecat\\services\\nvidia\\tts.py"
     },
     {
       "subject": "NvidiaTTSService.voice_id",
-      "module": "pipecat.services.nvidia.tts",
+      "module": "pipecat\\services\\nvidia\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=NvidiaTTSService.Settings(voice=...)",
       "message": "Use ``settings=NvidiaTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/nvidia/tts.py"
+      "location": "pipecat\\services\\nvidia\\tts.py"
     },
     {
       "subject": "OLLamaLLMService.model",
-      "module": "pipecat.services.ollama.llm",
+      "module": "pipecat\\services\\ollama\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OLLamaLLMService.Settings(model=...)",
       "message": "Use ``settings=OLLamaLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/ollama/llm.py"
+      "location": "pipecat\\services\\ollama\\llm.py"
     },
     {
       "subject": "BaseOpenAILLMService.InputParams",
-      "module": "pipecat.services.openai.base_llm",
+      "module": "pipecat\\services\\openai\\base_llm",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "BaseOpenAILLMService.Settings",
       "message": "`BaseOpenAILLMService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `BaseOpenAILLMService.Settings` instead.",
-      "location": "pipecat/services/openai/base_llm.py"
+      "location": "pipecat\\services\\openai\\base_llm.py"
     },
     {
       "subject": "BaseOpenAILLMService.model",
-      "module": "pipecat.services.openai.base_llm",
+      "module": "pipecat\\services\\openai\\base_llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseOpenAILLMService.Settings(model=...)",
       "message": "Use ``settings=BaseOpenAILLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/base_llm.py"
+      "location": "pipecat\\services\\openai\\base_llm.py"
     },
     {
       "subject": "BaseOpenAILLMService.params",
-      "module": "pipecat.services.openai.base_llm",
+      "module": "pipecat\\services\\openai\\base_llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseOpenAILLMService.Settings(...)",
       "message": "Use ``settings=BaseOpenAILLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/base_llm.py"
+      "location": "pipecat\\services\\openai\\base_llm.py"
     },
     {
       "subject": "OpenAIImageGenService.image_size",
-      "module": "pipecat.services.openai.image",
+      "module": "pipecat\\services\\openai\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIImageGenService.Settings(image_size=...)",
       "message": "Use ``settings=OpenAIImageGenService.Settings(image_size=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/image.py"
+      "location": "pipecat\\services\\openai\\image.py"
     },
     {
       "subject": "OpenAIImageGenService.model",
-      "module": "pipecat.services.openai.image",
+      "module": "pipecat\\services\\openai\\image",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIImageGenService.Settings(model=...)",
       "message": "Use ``settings=OpenAIImageGenService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/image.py"
+      "location": "pipecat\\services\\openai\\image.py"
     },
     {
       "subject": "OpenAILLMService.model",
-      "module": "pipecat.services.openai.llm",
+      "module": "pipecat\\services\\openai\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAILLMService.Settings(model=...)",
       "message": "Use ``settings=OpenAILLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/llm.py"
+      "location": "pipecat\\services\\openai\\llm.py"
     },
     {
       "subject": "OpenAILLMService.params",
-      "module": "pipecat.services.openai.llm",
+      "module": "pipecat\\services\\openai\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAILLMService.Settings(...)",
       "message": "Use ``settings=OpenAILLMService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/llm.py"
+      "location": "pipecat\\services\\openai\\llm.py"
     },
     {
       "subject": "OpenAIRealtimeLLMService.model",
-      "module": "pipecat.services.openai.realtime.llm",
+      "module": "pipecat\\services\\openai\\realtime\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeLLMService.Settings(model=...)",
       "message": "Use ``settings=OpenAIRealtimeLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/realtime/llm.py"
+      "location": "pipecat\\services\\openai\\realtime\\llm.py"
     },
     {
       "subject": "OpenAIRealtimeLLMService.session_properties",
-      "module": "pipecat.services.openai.realtime.llm",
+      "module": "pipecat\\services\\openai\\realtime\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeLLMService.Settings(session_properties=...)",
       "message": "Use ``settings=OpenAIRealtimeLLMService.Settings(session_properties=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/realtime/llm.py"
+      "location": "pipecat\\services\\openai\\realtime\\llm.py"
     },
     {
       "subject": "OpenAIRealtimeSTTService.language",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeSTTService.Settings(language=...)",
       "message": "Use ``settings=OpenAIRealtimeSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAIRealtimeSTTService.model",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeSTTService.Settings(model=...)",
       "message": "Use ``settings=OpenAIRealtimeSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAIRealtimeSTTService.noise_reduction",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeSTTService.Settings(noise_reduction=...)",
       "message": "Use ``settings=OpenAIRealtimeSTTService.Settings(noise_reduction=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAIRealtimeSTTService.prompt",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAIRealtimeSTTService.Settings(prompt=...)",
       "message": "Use ``settings=OpenAIRealtimeSTTService.Settings(prompt=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAISTTService.language",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAISTTService.Settings(language=...)",
       "message": "Use ``settings=OpenAISTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAISTTService.model",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAISTTService.Settings(model=...)",
       "message": "Use ``settings=OpenAISTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAISTTService.prompt",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAISTTService.Settings(prompt=...)",
       "message": "Use ``settings=OpenAISTTService.Settings(prompt=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAISTTService.temperature",
-      "module": "pipecat.services.openai.stt",
+      "module": "pipecat\\services\\openai\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAISTTService.Settings(temperature=...)",
       "message": "Use ``settings=OpenAISTTService.Settings(temperature=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/stt.py"
+      "location": "pipecat\\services\\openai\\stt.py"
     },
     {
       "subject": "OpenAITTSService.InputParams",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "OpenAITTSService.Settings",
       "message": "`OpenAITTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `OpenAITTSService.Settings` instead.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenAITTSService.instructions",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAITTSService.Settings(instructions=...)",
       "message": "Use ``settings=OpenAITTSService.Settings(instructions=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenAITTSService.model",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAITTSService.Settings(model=...)",
       "message": "Use ``settings=OpenAITTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenAITTSService.params",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAITTSService.Settings(...)",
       "message": "Use ``settings=OpenAITTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenAITTSService.speed",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAITTSService.Settings(speed=...)",
       "message": "Use ``settings=OpenAITTSService.Settings(speed=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenAITTSService.voice",
-      "module": "pipecat.services.openai.tts",
+      "module": "pipecat\\services\\openai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenAITTSService.Settings(voice=...)",
       "message": "Use ``settings=OpenAITTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openai/tts.py"
+      "location": "pipecat\\services\\openai\\tts.py"
     },
     {
       "subject": "OpenRouterLLMService.model",
-      "module": "pipecat.services.openrouter.llm",
+      "module": "pipecat\\services\\openrouter\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=OpenRouterLLMService.Settings(model=...)",
       "message": "Use ``settings=OpenRouterLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/openrouter/llm.py"
+      "location": "pipecat\\services\\openrouter\\llm.py"
     },
     {
       "subject": "PerplexityLLMService.model",
-      "module": "pipecat.services.perplexity.llm",
+      "module": "pipecat\\services\\perplexity\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=PerplexityLLMService.Settings(model=...)",
       "message": "Use ``settings=PerplexityLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/perplexity/llm.py"
+      "location": "pipecat\\services\\perplexity\\llm.py"
     },
     {
       "subject": "PiperHttpTTSService.voice_id",
-      "module": "pipecat.services.piper.tts",
+      "module": "pipecat\\services\\piper\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=PiperHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=PiperHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/piper/tts.py"
+      "location": "pipecat\\services\\piper\\tts.py"
     },
     {
       "subject": "PiperTTSService.voice_id",
-      "module": "pipecat.services.piper.tts",
+      "module": "pipecat\\services\\piper\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=PiperTTSService.Settings(voice=...)",
       "message": "Use ``settings=PiperTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/piper/tts.py"
+      "location": "pipecat\\services\\piper\\tts.py"
     },
     {
       "subject": "QwenLLMService.model",
-      "module": "pipecat.services.qwen.llm",
+      "module": "pipecat\\services\\qwen\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=QwenLLMService.Settings(model=...)",
       "message": "Use ``settings=QwenLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/qwen/llm.py"
+      "location": "pipecat\\services\\qwen\\llm.py"
     },
     {
       "subject": "ResembleAITTSService.voice_id",
-      "module": "pipecat.services.resembleai.tts",
+      "module": "pipecat\\services\\resembleai\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=ResembleAITTSService.Settings(voice=...)",
       "message": "Use ``settings=ResembleAITTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/resembleai/tts.py"
+      "location": "pipecat\\services\\resembleai\\tts.py"
     },
     {
       "subject": "RimeHttpTTSService.InputParams",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "RimeHttpTTSService.Settings",
       "message": "`RimeHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `RimeHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeHttpTTSService.model",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=RimeHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeHttpTTSService.params",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeHttpTTSService.Settings(...)",
       "message": "Use ``settings=RimeHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeHttpTTSService.voice_id",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=RimeHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "class",
       "deprecated_in": "0.0.102",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "RimeTTSService",
       "message": "`RimeNonJsonTTSService` is deprecated since 0.0.102 and will be removed in 2.0.0. Use `RimeTTSService` instead.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService.InputParams",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "RimeNonJsonTTSService.Settings",
       "message": "`RimeNonJsonTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `RimeNonJsonTTSService.Settings` instead.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService.aggregate_sentences",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Set to ``TextAggregationMode.SENTENCE`` to aggregate text into sentences before synthesis, or ``TextAggregationMode.TOKEN`` to stream tokens directly for lower latency. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService.model",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeNonJsonTTSService.Settings(model=...)",
       "message": "Use ``settings=RimeNonJsonTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService.params",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeNonJsonTTSService.Settings(...)",
       "message": "Use ``settings=RimeNonJsonTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeNonJsonTTSService.voice_id",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeNonJsonTTSService.Settings(voice=...)",
       "message": "Use ``settings=RimeNonJsonTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeTTSService.InputParams",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "RimeTTSService.Settings",
       "message": "`RimeTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `RimeTTSService.Settings` instead.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeTTSService.aggregate_sentences",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeTTSService.model",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeTTSService.Settings(model=...)",
       "message": "Use ``settings=RimeTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeTTSService.params",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeTTSService.Settings(...)",
       "message": "Use ``settings=RimeTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "RimeTTSService.voice_id",
-      "module": "pipecat.services.rime.tts",
+      "module": "pipecat\\services\\rime\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=RimeTTSService.Settings(voice=...)",
       "message": "Use ``settings=RimeTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/rime/tts.py"
+      "location": "pipecat\\services\\rime\\tts.py"
     },
     {
       "subject": "SambaNovaLLMService.model",
-      "module": "pipecat.services.sambanova.llm",
+      "module": "pipecat\\services\\sambanova\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SambaNovaLLMService.Settings(model=...)",
       "message": "Use ``settings=SambaNovaLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sambanova/llm.py"
+      "location": "pipecat\\services\\sambanova\\llm.py"
     },
     {
       "subject": "SarvamSTTService.InputParams",
-      "module": "pipecat.services.sarvam.stt",
+      "module": "pipecat\\services\\sarvam\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SarvamSTTService.Settings",
       "message": "`SarvamSTTService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `SarvamSTTService.Settings` instead.",
-      "location": "pipecat/services/sarvam/stt.py"
+      "location": "pipecat\\services\\sarvam\\stt.py"
     },
     {
       "subject": "SarvamSTTService.model",
-      "module": "pipecat.services.sarvam.stt",
+      "module": "pipecat\\services\\sarvam\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamSTTService.Settings(model=...)",
       "message": "Use ``settings=SarvamSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/stt.py"
+      "location": "pipecat\\services\\sarvam\\stt.py"
     },
     {
       "subject": "SarvamSTTService.params",
-      "module": "pipecat.services.sarvam.stt",
+      "module": "pipecat\\services\\sarvam\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamSTTService.Settings(...)",
       "message": "Use ``settings=SarvamSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/stt.py"
+      "location": "pipecat\\services\\sarvam\\stt.py"
     },
     {
       "subject": "SarvamSTTService.set_prompt",
-      "module": "pipecat.services.sarvam.stt",
+      "module": "pipecat\\services\\sarvam\\stt",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame(SarvamSTTService.Settings(prompt=...))",
       "message": "`SarvamSTTService.set_prompt` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame(SarvamSTTService.Settings(prompt=...))` instead.",
-      "location": "pipecat/services/sarvam/stt.py"
+      "location": "pipecat\\services\\sarvam\\stt.py"
     },
     {
       "subject": "SarvamHttpTTSService.InputParams",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SarvamHttpTTSService.Settings",
       "message": "`SarvamHttpTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `SarvamHttpTTSService.Settings` instead.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamHttpTTSService.model",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamHttpTTSService.Settings(model=...)",
       "message": "Use ``settings=SarvamHttpTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamHttpTTSService.params",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamHttpTTSService.Settings(...)",
       "message": "Use ``settings=SarvamHttpTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamHttpTTSService.voice_id",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamHttpTTSService.Settings(voice=...)",
       "message": "Use ``settings=SarvamHttpTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamTTSService.InputParams",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SarvamTTSService.Settings",
       "message": "`SarvamTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `SarvamTTSService.Settings` instead.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamTTSService.aggregate_sentences",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamTTSService.model",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamTTSService.Settings(model=...)",
       "message": "Use ``settings=SarvamTTSService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamTTSService.params",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamTTSService.Settings(...)",
       "message": "Use ``settings=SarvamTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "SarvamTTSService.voice_id",
-      "module": "pipecat.services.sarvam.tts",
+      "module": "pipecat\\services\\sarvam\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SarvamTTSService.Settings(voice=...)",
       "message": "Use ``settings=SarvamTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/sarvam/tts.py"
+      "location": "pipecat\\services\\sarvam\\tts.py"
     },
     {
       "subject": "LLMSettings.filter_incomplete_user_turns",
-      "module": "pipecat.services.settings",
+      "module": "pipecat\\services\\settings",
       "kind": "parameter",
       "deprecated_in": "1.7.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "user_turn_strategies=FilterIncompleteUserTurnStrategies()",
       "message": "Use ``user_turn_strategies=FilterIncompleteUserTurnStrategies()`` on :class:`~pipecat.processors.aggregators.llm_response_universal.LLMUserAggregatorParams` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/settings.py"
+      "location": "pipecat\\services\\settings.py"
     },
     {
       "subject": "LLMSettings.user_turn_completion_config",
-      "module": "pipecat.services.settings",
+      "module": "pipecat\\services\\settings",
       "kind": "parameter",
       "deprecated_in": "1.7.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "FilterIncompleteUserTurnStrategies(config=...)",
       "message": "Pass the config to ``FilterIncompleteUserTurnStrategies(config=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/settings.py"
+      "location": "pipecat\\services\\settings.py"
     },
     {
       "subject": "SimliVideoService.InputParams",
-      "module": "pipecat.services.simli.video",
+      "module": "pipecat\\services\\simli\\video",
       "kind": "class",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SimliVideoService.Settings",
       "message": "`SimliVideoService.InputParams` is deprecated since 0.0.106 and will be removed in 2.0.0. Use `SimliVideoService.Settings` instead.",
-      "location": "pipecat/services/simli/video.py"
+      "location": "pipecat\\services\\simli\\video.py"
     },
     {
       "subject": "SimliVideoService.params",
-      "module": "pipecat.services.simli.video",
+      "module": "pipecat\\services\\simli\\video",
       "kind": "parameter",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SimliVideoService.Settings(...)",
       "message": "Use ``settings=SimliVideoService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/simli/video.py"
+      "location": "pipecat\\services\\simli\\video.py"
     },
     {
       "subject": "SonioxInputParams",
-      "module": "pipecat.services.soniox.stt",
+      "module": "pipecat\\services\\soniox\\stt",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SonioxSTTService.Settings",
       "message": "`SonioxInputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `SonioxSTTService.Settings` instead.",
-      "location": "pipecat/services/soniox/stt.py"
+      "location": "pipecat\\services\\soniox\\stt.py"
     },
     {
       "subject": "SonioxSTTService.model",
-      "module": "pipecat.services.soniox.stt",
+      "module": "pipecat\\services\\soniox\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SonioxSTTService.Settings(model=...)",
       "message": "Use ``settings=SonioxSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/soniox/stt.py"
+      "location": "pipecat\\services\\soniox\\stt.py"
     },
     {
       "subject": "SonioxSTTService.params",
-      "module": "pipecat.services.soniox.stt",
+      "module": "pipecat\\services\\soniox\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SonioxSTTService.Settings(...)",
       "message": "Use ``settings=SonioxSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/soniox/stt.py"
+      "location": "pipecat\\services\\soniox\\stt.py"
     },
     {
       "subject": "SpeechmaticsSTTService.UpdateParams",
-      "module": "pipecat.services.speechmatics.stt",
+      "module": "pipecat\\services\\speechmatics\\stt",
       "kind": "class",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SpeechmaticsSTTService.Settings",
       "message": "`SpeechmaticsSTTService.UpdateParams` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `SpeechmaticsSTTService.Settings` instead.",
-      "location": "pipecat/services/speechmatics/stt.py"
+      "location": "pipecat\\services\\speechmatics\\stt.py"
     },
     {
       "subject": "SpeechmaticsSTTService.params",
-      "module": "pipecat.services.speechmatics.stt",
+      "module": "pipecat\\services\\speechmatics\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SpeechmaticsSTTService.Settings(...)",
       "message": "Use ``settings=SpeechmaticsSTTService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/speechmatics/stt.py"
+      "location": "pipecat\\services\\speechmatics\\stt.py"
     },
     {
       "subject": "SpeechmaticsSTTService.update_params",
-      "module": "pipecat.services.speechmatics.stt",
+      "module": "pipecat\\services\\speechmatics\\stt",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame",
       "message": "`SpeechmaticsSTTService.update_params` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame` instead.",
-      "location": "pipecat/services/speechmatics/stt.py"
+      "location": "pipecat\\services\\speechmatics\\stt.py"
     },
     {
       "subject": "SpeechmaticsTTSService.InputParams",
-      "module": "pipecat.services.speechmatics.tts",
+      "module": "pipecat\\services\\speechmatics\\tts",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SpeechmaticsTTSService.Settings",
       "message": "`SpeechmaticsTTSService.InputParams` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `SpeechmaticsTTSService.Settings` instead.",
-      "location": "pipecat/services/speechmatics/tts.py"
+      "location": "pipecat\\services\\speechmatics\\tts.py"
     },
     {
       "subject": "SpeechmaticsTTSService.params",
-      "module": "pipecat.services.speechmatics.tts",
+      "module": "pipecat\\services\\speechmatics\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SpeechmaticsTTSService.Settings(...)",
       "message": "Use ``settings=SpeechmaticsTTSService.Settings(...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/speechmatics/tts.py"
+      "location": "pipecat\\services\\speechmatics\\tts.py"
     },
     {
       "subject": "SpeechmaticsTTSService.voice_id",
-      "module": "pipecat.services.speechmatics.tts",
+      "module": "pipecat\\services\\speechmatics\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=SpeechmaticsTTSService.Settings(voice=...)",
       "message": "Use ``settings=SpeechmaticsTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/speechmatics/tts.py"
+      "location": "pipecat\\services\\speechmatics\\tts.py"
     },
     {
       "subject": "STTService.set_language",
-      "module": "pipecat.services.stt_service",
+      "module": "pipecat\\services\\stt_service",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame(language=...)",
       "message": "`STTService.set_language` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame(language=...)` instead.",
-      "location": "pipecat/services/stt_service.py"
+      "location": "pipecat\\services\\stt_service.py"
     },
     {
       "subject": "STTService.set_model",
-      "module": "pipecat.services.stt_service",
+      "module": "pipecat\\services\\stt_service",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "STTUpdateSettingsFrame(model=...)",
       "message": "`STTService.set_model` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `STTUpdateSettingsFrame(model=...)` instead.",
-      "location": "pipecat/services/stt_service.py"
+      "location": "pipecat\\services\\stt_service.py"
     },
     {
       "subject": "TogetherLLMService.model",
-      "module": "pipecat.services.together.llm",
+      "module": "pipecat\\services\\together\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=TogetherLLMService.Settings(model=...)",
       "message": "Use ``settings=TogetherLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/together/llm.py"
+      "location": "pipecat\\services\\together\\llm.py"
     },
     {
       "subject": "AudioContextTTSService",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WebsocketTTSService",
       "message": "`AudioContextTTSService` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `WebsocketTTSService` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "AudioContextWordTTSService",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WebsocketTTSService",
       "message": "`AudioContextWordTTSService` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `WebsocketTTSService` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "InterruptibleWordTTSService",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "InterruptibleTTSService",
       "message": "`InterruptibleWordTTSService` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `InterruptibleTTSService` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "TTSService.aggregate_sentences",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "parameter",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Set to ``TextAggregationMode.SENTENCE`` to aggregate text into sentences before synthesis, or ``TextAggregationMode.TOKEN`` to stream tokens directly for lower latency. Will be removed in 2.0.0.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "TTSService.set_model",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TTSUpdateSettingsFrame(model=...)",
       "message": "`TTSService.set_model` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `TTSUpdateSettingsFrame(model=...)` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "TTSService.set_voice",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "method",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TTSUpdateSettingsFrame(voice=...)",
       "message": "`TTSService.set_voice` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `TTSUpdateSettingsFrame(voice=...)` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "WebsocketWordTTSService",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "WebsocketTTSService",
       "message": "`WebsocketWordTTSService` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `WebsocketTTSService` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "WordTTSService",
-      "module": "pipecat.services.tts_service",
+      "module": "pipecat\\services\\tts_service",
       "kind": "class",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TTSService",
       "message": "`WordTTSService` is deprecated since 0.0.105 and will be removed in 2.0.0. Use `TTSService` instead.",
-      "location": "pipecat/services/tts_service.py"
+      "location": "pipecat\\services\\tts_service.py"
     },
     {
       "subject": "BaseWhisperSTTService.language",
-      "module": "pipecat.services.whisper.base_stt",
+      "module": "pipecat\\services\\whisper\\base_stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseWhisperSTTService.Settings(language=...)",
       "message": "Use ``settings=BaseWhisperSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/base_stt.py"
+      "location": "pipecat\\services\\whisper\\base_stt.py"
     },
     {
       "subject": "BaseWhisperSTTService.model",
-      "module": "pipecat.services.whisper.base_stt",
+      "module": "pipecat\\services\\whisper\\base_stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseWhisperSTTService.Settings(model=...)",
       "message": "Use ``settings=BaseWhisperSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/base_stt.py"
+      "location": "pipecat\\services\\whisper\\base_stt.py"
     },
     {
       "subject": "BaseWhisperSTTService.prompt",
-      "module": "pipecat.services.whisper.base_stt",
+      "module": "pipecat\\services\\whisper\\base_stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseWhisperSTTService.Settings(prompt=...)",
       "message": "Use ``settings=BaseWhisperSTTService.Settings(prompt=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/base_stt.py"
+      "location": "pipecat\\services\\whisper\\base_stt.py"
     },
     {
       "subject": "BaseWhisperSTTService.temperature",
-      "module": "pipecat.services.whisper.base_stt",
+      "module": "pipecat\\services\\whisper\\base_stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=BaseWhisperSTTService.Settings(temperature=...)",
       "message": "Use ``settings=BaseWhisperSTTService.Settings(temperature=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/base_stt.py"
+      "location": "pipecat\\services\\whisper\\base_stt.py"
     },
     {
       "subject": "WhisperSTTService.language",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTService.Settings(language=...)",
       "message": "Use ``settings=WhisperSTTService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTService.model",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTService.Settings(model=...)",
       "message": "Use ``settings=WhisperSTTService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTService.no_speech_prob",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTService.Settings(no_speech_prob=...)",
       "message": "Use ``settings=WhisperSTTService.Settings(no_speech_prob=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTServiceMLX.language",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTServiceMLX.Settings(language=...)",
       "message": "Use ``settings=WhisperSTTServiceMLX.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTServiceMLX.model",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTServiceMLX.Settings(model=...)",
       "message": "Use ``settings=WhisperSTTServiceMLX.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTServiceMLX.no_speech_prob",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTServiceMLX.Settings(no_speech_prob=...)",
       "message": "Use ``settings=WhisperSTTServiceMLX.Settings(no_speech_prob=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "WhisperSTTServiceMLX.temperature",
-      "module": "pipecat.services.whisper.stt",
+      "module": "pipecat\\services\\whisper\\stt",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=WhisperSTTServiceMLX.Settings(temperature=...)",
       "message": "Use ``settings=WhisperSTTServiceMLX.Settings(temperature=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/whisper/stt.py"
+      "location": "pipecat\\services\\whisper\\stt.py"
     },
     {
       "subject": "GrokLLMService.model",
-      "module": "pipecat.services.xai.llm",
+      "module": "pipecat\\services\\xai\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GrokLLMService.Settings(model=...)",
       "message": "Use ``settings=GrokLLMService.Settings(model=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/xai/llm.py"
+      "location": "pipecat\\services\\xai\\llm.py"
     },
     {
       "subject": "GrokRealtimeLLMService.session_properties",
-      "module": "pipecat.services.xai.realtime.llm",
+      "module": "pipecat\\services\\xai\\realtime\\llm",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=GrokRealtimeLLMService.Settings(session_properties=...)",
       "message": "Use ``settings=GrokRealtimeLLMService.Settings(session_properties=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/xai/realtime/llm.py"
+      "location": "pipecat\\services\\xai\\realtime\\llm.py"
     },
     {
       "subject": "XTTSService",
-      "module": "pipecat.services.xtts.tts",
+      "module": "pipecat\\services\\xtts\\tts",
       "kind": "class",
       "deprecated_in": "1.7.0",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "`XTTSService` is deprecated since 1.7.0 and will be removed in 2.0.0. No replacement. `KokoroTTSService` and `PiperTTSService` are the maintained local TTS services.",
-      "location": "pipecat/services/xtts/tts.py"
+      "location": "pipecat\\services\\xtts\\tts.py"
     },
     {
       "subject": "XTTSService.language",
-      "module": "pipecat.services.xtts.tts",
+      "module": "pipecat\\services\\xtts\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.106",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=XTTSService.Settings(language=...)",
       "message": "Use ``settings=XTTSService.Settings(language=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/xtts/tts.py"
+      "location": "pipecat\\services\\xtts\\tts.py"
     },
     {
       "subject": "XTTSService.voice_id",
-      "module": "pipecat.services.xtts.tts",
+      "module": "pipecat\\services\\xtts\\tts",
       "kind": "parameter",
       "deprecated_in": "0.0.105",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "settings=XTTSService.Settings(voice=...)",
       "message": "Use ``settings=XTTSService.Settings(voice=...)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/services/xtts/tts.py"
+      "location": "pipecat\\services\\xtts\\tts.py"
     },
     {
-      "subject": "pipecat.services.xtts.tts",
-      "module": "pipecat.services.xtts.tts",
+      "subject": "pipecat\\services\\xtts\\tts",
+      "module": "pipecat\\services\\xtts\\tts",
       "kind": "module",
       "deprecated_in": "1.7.0",
       "removed_in": "2.0.0",
       "relation": "none",
       "replacement": null,
       "message": "No replacement. :class:`~pipecat.services.kokoro.tts.KokoroTTSService` and :class:`~pipecat.services.piper.tts.PiperTTSService` are the maintained local TTS services. Will be removed in 2.0.0.",
-      "location": "pipecat/services/xtts/tts.py"
+      "location": "pipecat\\services\\xtts\\tts.py"
     },
     {
       "subject": "BaseInputTransport.start_audio_in_streaming",
-      "module": "pipecat.transports.base_input",
+      "module": "pipecat\\transports\\base_input",
       "kind": "method",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "InputTransportStartAudioStreamingFrame",
       "message": "`BaseInputTransport.start_audio_in_streaming` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `InputTransportStartAudioStreamingFrame` instead.",
-      "location": "pipecat/transports/base_input.py"
+      "location": "pipecat\\transports\\base_input.py"
     },
     {
       "subject": "TransportParams.video_out_bitrate",
-      "module": "pipecat.transports.base_transport",
+      "module": "pipecat\\transports\\base_transport",
       "kind": "parameter",
       "deprecated_in": "1.1.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "DailyParams.camera_out_send_settings",
       "message": "Use provider-specific settings instead (e.g., ``DailyParams.camera_out_send_settings``). Will be removed in 2.0.0.",
-      "location": "pipecat/transports/base_transport.py"
+      "location": "pipecat\\transports\\base_transport.py"
     },
     {
       "subject": "WebsocketServerCallbacks",
-      "module": "pipecat.transports.websocket.server",
+      "module": "pipecat\\transports\\websocket\\server",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SingleClientWebsocketServerCallbacks",
       "message": "`WebsocketServerCallbacks` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `SingleClientWebsocketServerCallbacks` instead.",
-      "location": "pipecat/transports/websocket/server.py"
+      "location": "pipecat\\transports\\websocket\\server.py"
     },
     {
       "subject": "WebsocketServerInputTransport",
-      "module": "pipecat.transports.websocket.server",
+      "module": "pipecat\\transports\\websocket\\server",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SingleClientWebsocketServerInputTransport",
       "message": "`WebsocketServerInputTransport` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `SingleClientWebsocketServerInputTransport` instead.",
-      "location": "pipecat/transports/websocket/server.py"
+      "location": "pipecat\\transports\\websocket\\server.py"
     },
     {
       "subject": "WebsocketServerOutputTransport",
-      "module": "pipecat.transports.websocket.server",
+      "module": "pipecat\\transports\\websocket\\server",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SingleClientWebsocketServerOutputTransport",
       "message": "`WebsocketServerOutputTransport` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `SingleClientWebsocketServerOutputTransport` instead.",
-      "location": "pipecat/transports/websocket/server.py"
+      "location": "pipecat\\transports\\websocket\\server.py"
     },
     {
       "subject": "WebsocketServerParams",
-      "module": "pipecat.transports.websocket.server",
+      "module": "pipecat\\transports\\websocket\\server",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SingleClientWebsocketServerParams",
       "message": "`WebsocketServerParams` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `SingleClientWebsocketServerParams` instead.",
-      "location": "pipecat/transports/websocket/server.py"
+      "location": "pipecat\\transports\\websocket\\server.py"
     },
     {
       "subject": "WebsocketServerTransport",
-      "module": "pipecat.transports.websocket.server",
+      "module": "pipecat\\transports\\websocket\\server",
       "kind": "class",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "SingleClientWebsocketServerTransport",
       "message": "`WebsocketServerTransport` is deprecated since 1.4.0 and will be removed in 2.0.0. Use `SingleClientWebsocketServerTransport` instead.",
-      "location": "pipecat/transports/websocket/server.py"
+      "location": "pipecat\\transports\\websocket\\server.py"
     },
     {
       "subject": "WhatsAppClient.handle_webhook_request.connection_callback",
-      "module": "pipecat.transports.whatsapp.client",
+      "module": "pipecat\\transports\\whatsapp\\client",
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "(connection,)",
       "message": "The single-argument ``(connection,)`` signature is deprecated. Use ``(connection, call: WhatsAppConnectCall)`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/transports/whatsapp/client.py"
+      "location": "pipecat\\transports\\whatsapp\\client.py"
     },
     {
       "subject": "BaseUserTurnStartStrategy.reset",
-      "module": "pipecat.turns.user_start.base_user_turn_start_strategy",
+      "module": "pipecat\\turns\\user_start\\base_user_turn_start_strategy",
       "kind": "method",
       "deprecated_in": "1.6.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "handle_user_turn_started",
       "message": "Use :meth:`handle_user_turn_started` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/turns/user_start/base_user_turn_start_strategy.py"
+      "location": "pipecat\\turns\\user_start\\base_user_turn_start_strategy.py"
     },
     {
       "subject": "BaseUserTurnStopStrategy.reset",
-      "module": "pipecat.turns.user_stop.base_user_turn_stop_strategy",
+      "module": "pipecat\\turns\\user_stop\\base_user_turn_stop_strategy",
       "kind": "method",
       "deprecated_in": "1.6.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "handle_user_turn_started",
       "message": "Use :meth:`handle_user_turn_started` and :meth:`handle_user_turn_stopped` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/turns/user_stop/base_user_turn_stop_strategy.py"
+      "location": "pipecat\\turns\\user_stop\\base_user_turn_stop_strategy.py"
     },
     {
       "subject": "TaskManager.setup",
-      "module": "pipecat.utils.asyncio.task_manager",
+      "module": "pipecat\\utils\\asyncio\\task_manager",
       "kind": "method",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TaskManager",
       "message": "`TaskManager.setup` is deprecated since 1.5.0 and will be removed in 2.0.0. Use `TaskManager` instead.",
-      "location": "pipecat/utils/asyncio/task_manager.py"
+      "location": "pipecat\\utils\\asyncio\\task_manager.py"
     },
     {
       "subject": "TaskManagerParams",
-      "module": "pipecat.utils.asyncio.task_manager",
+      "module": "pipecat\\utils\\asyncio\\task_manager",
       "kind": "class",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "TaskManager",
       "message": "`TaskManagerParams` is deprecated since 1.5.0 and will be removed in 2.0.0. Use `TaskManager` instead.",
-      "location": "pipecat/utils/asyncio/task_manager.py"
+      "location": "pipecat\\utils\\asyncio\\task_manager.py"
     },
     {
       "subject": "LLMContextSummarizationConfig",
-      "module": "pipecat.utils.context.llm_context_summarization",
+      "module": "pipecat\\utils\\context\\llm_context_summarization",
       "kind": "class",
       "deprecated_in": "0.0.104",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "LLMAutoContextSummarizationConfig",
       "message": "`LLMContextSummarizationConfig` is deprecated since 0.0.104 and will be removed in 2.0.0. Use `LLMAutoContextSummarizationConfig` instead.",
-      "location": "pipecat/utils/context/llm_context_summarization.py"
+      "location": "pipecat\\utils\\context\\llm_context_summarization.py"
+    },
+    {
+      "subject": "pipecat\\utils\\deprecation",
+      "module": "pipecat\\utils\\deprecation",
+      "kind": "module",
+      "deprecated_in": "1.3.0",
+      "removed_in": "2.0.0",
+      "relation": "use_existing",
+      "replacement": "NewService",
+      "message": "Use :class:`NewService` instead. Will be removed in 2.0.0.",
+      "location": "pipecat\\utils\\deprecation.py"
+    },
+    {
+      "subject": "pipecat\\utils\\deprecation",
+      "module": "pipecat\\utils\\deprecation",
+      "kind": "module",
+      "deprecated_in": "1.3.0",
+      "removed_in": "2.0.0",
+      "relation": "use_existing",
+      "replacement": "PipelineWorker",
+      "message": "Use :class:`PipelineWorker` instead. Will be removed in 2.0.0.",
+      "location": "pipecat\\utils\\deprecation.py"
     },
     {
       "subject": "tool.timeout",
-      "module": "pipecat.workers.llm.tool_decorator",
+      "module": "pipecat\\workers\\llm\\tool_decorator",
       "kind": "parameter",
       "deprecated_in": "1.4.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "timeout_secs",
       "message": "Use ``timeout_secs`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/workers/llm/tool_decorator.py"
+      "location": "pipecat\\workers\\llm\\tool_decorator.py"
     },
     {
       "subject": "WorkerRunner.loop",
-      "module": "pipecat.workers.runner",
+      "module": "pipecat\\workers\\runner",
       "kind": "parameter",
       "deprecated_in": "1.5.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "task_manager",
       "message": "Use ``task_manager`` (which owns its own loop) instead. ``loop`` will be removed in 2.0.0.",
-      "location": "pipecat/workers/runner.py"
+      "location": "pipecat\\workers\\runner.py"
     },
     {
       "subject": "WorkerRunner.run.worker",
-      "module": "pipecat.workers.runner",
+      "module": "pipecat\\workers\\runner",
       "kind": "parameter",
       "deprecated_in": "1.3.0",
       "removed_in": "2.0.0",
       "relation": "use_existing",
       "replacement": "add_workers",
       "message": "Register the worker with :meth:`add_workers` before calling ``run()`` instead. Will be removed in 2.0.0.",
-      "location": "pipecat/workers/runner.py"
+      "location": "pipecat\\workers\\runner.py"
     }
   ]
 }

--- a/scripts/repro_livekit_rtvi_inbound.py
+++ b/scripts/repro_livekit_rtvi_inbound.py
@@ -1,0 +1,137 @@
+"""Inbound RTVI over LiveKitTransport never reaches RTVIProcessor.
+
+  A. does RTVIProcessor fire on_client_ready?          expected False
+  B. does the frame instead reach the OUTPUT transport
+     and get re-sent to the client?                    expected True
+  C. is that re-send addressed by SID or identity?     control: SID is undeliverable
+
+Run:  LK_URL=wss://... LK_KEY=... LK_SECRET=... python repro.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+from livekit import api, rtc
+from loguru import logger
+
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineWorker
+from pipecat.processors.frameworks.rtvi import RTVIObserver, RTVIProcessor
+from pipecat.transports.livekit.transport import LiveKitParams, LiveKitTransport
+from pipecat.workers.runner import WorkerRunner
+
+URL, KEY, SECRET = os.environ["LK_URL"], os.environ["LK_KEY"], os.environ["LK_SECRET"]
+ROOM = os.environ.get("LK_ROOM", "repro-rtvi-inbound")
+
+logger.remove()
+logger.add(sys.stderr, level="WARNING")
+
+# The simplest well-formed RTVI message. Any type would do; client-ready is the one
+# whose absence is most visible, since a session cannot become ready without it.
+CLIENT_READY = {"id": "repro-1", "label": "rtvi-ai", "type": "client-ready", "data": {}}
+
+
+def token(identity: str) -> str:
+    return (
+        api.AccessToken(KEY, SECRET)
+        .with_identity(identity)
+        .with_grants(
+            api.VideoGrants(room_join=True, room=ROOM, can_publish=True, can_subscribe=True)
+        )
+        .to_jwt()
+    )
+
+
+async def main() -> int:
+    rtvi_handled = asyncio.Event()  # check A
+    received: list[dict] = []  # everything the client gets back
+    resent: list[tuple[str, str]] = []  # check B: (participant_id, message) at output.send_message
+
+    # Bot side: a normal pipeline. No STT/LLM/TTS — the bug is in message routing,
+    # so nothing between input and output is needed to show it.
+    transport = LiveKitTransport(
+        url=URL,
+        token=token("repro-bot"),
+        room_name=ROOM,
+        params=LiveKitParams(audio_in_enabled=True, audio_out_enabled=True),
+    )
+    rtvi = RTVIProcessor()
+
+    @rtvi.event_handler("on_client_ready")
+    async def _on_client_ready(_p):
+        rtvi_handled.set()
+
+    # Wrap the output transport's send_message. Without this, a message that is misrouted
+    # and then dropped is indistinguishable from one that was never received at all —
+    # which is what makes this bug hard to see from the outside.
+    out = transport.output()
+    _orig_send = out.send_message
+
+    async def _traced_send(frame):
+        resent.append((getattr(frame, "participant_id", None), frame.message))
+        return await _orig_send(frame)
+
+    out.send_message = _traced_send
+
+    worker = PipelineWorker(
+        Pipeline([transport.input(), rtvi, out]), observers=[RTVIObserver(rtvi)]
+    )
+    runner = WorkerRunner(handle_sigint=False)
+    await runner.add_workers(worker)
+    runner_task = asyncio.create_task(runner.run())
+    await asyncio.sleep(6)  # let the bot finish joining before the client arrives
+
+    # Client side: a bare LiveKit room, standing in for a client-side transport
+    # (pipecat does not publish one for LiveKit).
+    client = rtc.Room()
+
+    @client.on("data_received")
+    def _on_data(packet: rtc.DataPacket):
+        try:
+            received.append(json.loads(bytes(packet.data).decode()))
+        except Exception:
+            received.append({"undecodable": len(packet.data)})
+
+    await client.connect(URL, token("repro-client"))
+    me = client.local_participant
+    await asyncio.sleep(2)
+
+    # The one inbound message under test.
+    await client.local_participant.publish_data(json.dumps(CLIENT_READY).encode(), reliable=True)
+    await asyncio.sleep(6)
+
+    # Controls for check C. Same directed send, same recipient, two different keys —
+    # isolating the addressing defect from everything else above.
+    await transport.send_message(json.dumps({"probe": "by-sid"}), me.sid)
+    await asyncio.sleep(3)
+    by_sid = any(m.get("probe") == "by-sid" for m in received)
+
+    await transport.send_message(json.dumps({"probe": "by-identity"}), me.identity)
+    await asyncio.sleep(3)
+    by_identity = any(m.get("probe") == "by-identity" for m in received)
+
+    # Did the output transport try to send the client its own message back?
+    echoed = [(pid, msg) for pid, msg in resent if json.loads(msg) == CLIENT_READY]
+
+    print(f"A. RTVIProcessor fired on_client_ready    : {rtvi_handled.is_set()}   (expected False)")
+    print(f"B. client's own message re-sent by OUTPUT : {bool(echoed)}   (expected True)")
+    for pid, _ in echoed:
+        print(f"     addressed to {pid!r}; sid={me.sid!r} identity={me.identity!r}")
+    print(f"C. directed send delivered by SID         : {by_sid}   (expected False)")
+    print(f"   directed send delivered by IDENTITY    : {by_identity}   (expected True)")
+
+    ok = (not rtvi_handled.is_set()) and bool(echoed) and (not by_sid) and by_identity
+
+    await client.disconnect()
+    await runner.cancel()
+    try:
+        await asyncio.wait_for(runner_task, timeout=10)
+    except (TimeoutError, asyncio.CancelledError):
+        pass
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -31,6 +31,7 @@ from pipecat.frames.frames import (
     Frame,
     ImageRawFrame,
     InputDTMFFrame,
+    InputTransportMessageFrame,
     InterruptionFrame,
     OutputAudioRawFrame,
     OutputDTMFFrame,
@@ -149,16 +150,7 @@ class LiveKitTransportClient:
         callbacks: LiveKitCallbacks,
         transport_name: str,
     ):
-        """Initialize the LiveKit transport client.
-
-        Args:
-            url: LiveKit server URL to connect to.
-            token: Authentication token for the room.
-            room_name: Name of the LiveKit room to join.
-            params: Configuration parameters for the transport.
-            callbacks: Event callback handlers.
-            transport_name: Name identifier for the transport.
-        """
+        """Initialize the LiveKit transport client."""
         self._url = url
         self._token = token
         self._room_name = room_name
@@ -173,13 +165,9 @@ class LiveKitTransportClient:
         self._audio_track: rtc.LocalAudioTrack | None = None
         self._audio_tracks = {}
         self._audio_queue = asyncio.Queue()
-        # Per-participant ``(AudioStream, Task)`` so unsubscribe can close
-        # the owned native stream and cancel its producer task instead of
-        # leaking both on every track republish.
         self._audio_streams: dict[str, tuple[rtc.AudioStream, asyncio.Task]] = {}
         self._video_tracks = {}
         self._video_queue = asyncio.Queue()
-        # Symmetric registry for video streams.
         self._video_streams: dict[str, tuple[rtc.VideoStream, asyncio.Task]] = {}
         self._other_participant_has_joined = False
         self._task_manager: BaseTaskManager | None = None
@@ -187,33 +175,16 @@ class LiveKitTransportClient:
 
     @property
     def participant_id(self) -> str:
-        """Get the participant ID for this client.
-
-        Returns:
-            The participant ID assigned by LiveKit.
-        """
         return self._participant_id
 
     @property
     def room(self) -> rtc.Room:
-        """Get the LiveKit room instance.
-
-        Returns:
-            The LiveKit room object.
-
-        Raises:
-            Exception: If room object is not available.
-        """
         if not self._room:
             raise Exception(f"{self}: missing room object (pipeline not started?)")
         return self._room
 
     async def setup(self, setup: FrameProcessorSetup):
-        """Setup the client with task manager and room initialization.
-
-        Args:
-            setup: The frame processor setup configuration.
-        """
+        """Set up the LiveKit client with the shared frame processor."""
         if self._task_manager:
             return
 
@@ -231,23 +202,15 @@ class LiveKitTransportClient:
         self.room.on("sip_dtmf_received")(self._on_sip_dtmf_received_wrapper)
 
     async def cleanup(self):
-        """Cleanup client resources."""
         await self.disconnect()
 
     async def start(self, frame: StartFrame):
-        """Start the client and initialize audio components.
-
-        Args:
-            frame: The start frame containing initialization parameters.
-        """
         self._out_sample_rate = self._params.audio_out_sample_rate or frame.audio_out_sample_rate
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
     async def connect(self):
-        """Connect to the LiveKit room with retry logic."""
         async with self._async_lock:
             if self._connected:
-                # Increment disconnect counter if already connected.
                 self._disconnect_counter += 1
                 return
 
@@ -260,13 +223,11 @@ class LiveKitTransportClient:
                     options=rtc.RoomOptions(auto_subscribe=True),
                 )
                 self._connected = True
-                # Increment disconnect counter if we successfully connected.
                 self._disconnect_counter += 1
 
                 self._participant_id = self.room.local_participant.sid
                 logger.info(f"Connected to {self._room_name}")
 
-                # Set up audio source and track
                 self._audio_source = rtc.AudioSource(
                     self._out_sample_rate, self._params.audio_out_channels
                 )
@@ -279,7 +240,6 @@ class LiveKitTransportClient:
 
                 await self._callbacks.on_connected()
 
-                # Check if there are already participants in the room
                 participants = self.get_participants()
                 if participants and not self._other_participant_has_joined:
                     self._other_participant_has_joined = True
@@ -289,9 +249,7 @@ class LiveKitTransportClient:
                 raise
 
     async def disconnect(self):
-        """Disconnect from the LiveKit room."""
         async with self._async_lock:
-            # Decrement leave counter when leaving.
             self._disconnect_counter -= 1
 
             if not self._connected or self._disconnect_counter > 0:
@@ -301,19 +259,11 @@ class LiveKitTransportClient:
             await self._callbacks.on_before_disconnect()
             await self.room.disconnect()
             self._connected = False
-            # Close any remaining per-participant streams and cancel their
-            # producer tasks so they do not outlive the connection.
             await self._close_all_streams()
             logger.info(f"Disconnected from {self._room_name}")
             await self._callbacks.on_disconnected()
 
     async def send_data(self, data: bytes, participant_id: str | None = None):
-        """Send data to participants in the room.
-
-        Args:
-            data: The data bytes to send.
-            participant_id: Optional specific participant to send to.
-        """
         if not self._connected:
             return
 
@@ -328,67 +278,33 @@ class LiveKitTransportClient:
             logger.error(f"Error sending data: {e}")
 
     async def send_dtmf(self, digit: str):
-        r"""Send DTMF tone to the room.
-
-        Args:
-            digit: The DTMF digit to send (0-9, \*, #).
-        """
         if not self._connected:
             return
-
         if digit not in DTMF_CODE_MAP:
             logger.warning(f"Invalid DTMF digit: {digit}")
             return
 
         code = DTMF_CODE_MAP[digit]
-
         try:
             await self.room.local_participant.publish_dtmf(code=code, digit=digit)
         except Exception as e:
             logger.error(f"Error sending DTMF tone {digit}: {e}")
 
     async def publish_audio(self, audio_frame: rtc.AudioFrame) -> bool:
-        """Publish an audio frame to the room.
-
-        Args:
-            audio_frame: The LiveKit audio frame to publish.
-        """
         if not self._connected or not self._audio_source:
             return False
-
         try:
             await self._audio_source.capture_frame(audio_frame)
             return True
         except Exception as e:
-            # When using an audio mixer, the base output transport's
-            # with_mixer() generator continuously yields frames (mixed with
-            # background audio) even when no TTS audio is queued. During
-            # interruptions, the audio task is cancelled and recreated, but
-            # there is a brief window where the native LiveKit AudioSource
-            # rejects capture_frame() with an InvalidState error. This is a
-            # transient condition — the mixer will produce a new frame within
-            # milliseconds, so we silently drop these frames.
             if "InvalidState" not in str(e):
                 logger.error(f"Error publishing audio: {e}")
             return False
 
     def get_participants(self) -> list[str]:
-        """Get list of participant IDs in the room.
-
-        Returns:
-            List of participant IDs.
-        """
         return [p.sid for p in self.room.remote_participants.values()]
 
     async def get_participant_metadata(self, participant_id: str) -> dict:
-        """Get metadata for a specific participant.
-
-        Args:
-            participant_id: ID of the participant to get metadata for.
-
-        Returns:
-            Dictionary containing participant metadata.
-        """
         participant = self.room.remote_participants.get(participant_id)
         if participant:
             return {
@@ -400,19 +316,9 @@ class LiveKitTransportClient:
         return {}
 
     async def set_participant_metadata(self, metadata: str):
-        """Set metadata for the local participant.
-
-        Args:
-            metadata: Metadata string to set.
-        """
         await self.room.local_participant.set_metadata(metadata)
 
     async def mute_participant(self, participant_id: str):
-        """Mute a specific participant's audio tracks.
-
-        Args:
-            participant_id: ID of the participant to mute.
-        """
         participant = self.room.remote_participants.get(participant_id)
         if participant:
             for track in participant.tracks.values():
@@ -420,11 +326,6 @@ class LiveKitTransportClient:
                     await track.set_enabled(False)
 
     async def unmute_participant(self, participant_id: str):
-        """Unmute a specific participant's audio tracks.
-
-        Args:
-            participant_id: ID of the participant to unmute.
-        """
         participant = self.room.remote_participants.get(participant_id)
         if participant:
             for track in participant.tracks.values():
@@ -433,14 +334,12 @@ class LiveKitTransportClient:
 
     # Wrapper methods for event handlers
     def _on_participant_connected_wrapper(self, participant: rtc.RemoteParticipant):
-        """Wrapper for participant connected events."""
         self._task_manager.create_task(
             self._async_on_participant_connected(participant),
             f"{self}::_async_on_participant_connected",
         )
 
     def _on_participant_disconnected_wrapper(self, participant: rtc.RemoteParticipant):
-        """Wrapper for participant disconnected events."""
         self._task_manager.create_task(
             self._async_on_participant_disconnected(participant),
             f"{self}::_async_on_participant_disconnected",
@@ -452,7 +351,6 @@ class LiveKitTransportClient:
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ):
-        """Wrapper for track subscribed events."""
         self._task_manager.create_task(
             self._async_on_track_subscribed(track, publication, participant),
             f"{self}::_async_on_track_subscribed",
@@ -464,31 +362,26 @@ class LiveKitTransportClient:
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ):
-        """Wrapper for track unsubscribed events."""
         self._task_manager.create_task(
             self._async_on_track_unsubscribed(track, publication, participant),
             f"{self}::_async_on_track_unsubscribed",
         )
 
     def _on_data_received_wrapper(self, data: rtc.DataPacket):
-        """Wrapper for data received events."""
         self._task_manager.create_task(
             self._async_on_data_received(data),
             f"{self}::_async_on_data_received",
         )
 
     def _on_connected_wrapper(self):
-        """Wrapper for connected events."""
         self._task_manager.create_task(self._async_on_connected(), f"{self}::_async_on_connected")
 
     def _on_disconnected_wrapper(self):
-        """Wrapper for disconnected events."""
         self._task_manager.create_task(
             self._async_on_disconnected(), f"{self}::_async_on_disconnected"
         )
 
     def _on_sip_dtmf_received_wrapper(self, dtmf: rtc.SipDTMF):
-        """Wrapper for inbound SIP DTMF events."""
         self._task_manager.create_task(
             self._async_on_sip_dtmf_received(dtmf),
             f"{self}::_async_on_sip_dtmf_received",
@@ -496,7 +389,6 @@ class LiveKitTransportClient:
 
     # Async methods for event handling
     async def _async_on_participant_connected(self, participant: rtc.RemoteParticipant):
-        """Handle participant connected events."""
         logger.info(f"Participant connected: {participant.identity}")
         await self._callbacks.on_participant_connected(participant.sid)
         if not self._other_participant_has_joined:
@@ -504,7 +396,6 @@ class LiveKitTransportClient:
             await self._callbacks.on_first_participant_joined(participant.sid)
 
     async def _async_on_participant_disconnected(self, participant: rtc.RemoteParticipant):
-        """Handle participant disconnected events."""
         logger.info(f"Participant disconnected: {participant.identity}")
         await self._callbacks.on_participant_disconnected(participant.sid)
         if len(self.get_participants()) == 0:
@@ -516,13 +407,8 @@ class LiveKitTransportClient:
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ):
-        """Handle track subscribed events."""
         if track.kind == rtc.TrackKind.KIND_AUDIO:
             logger.info(f"Audio track subscribed: {track.sid} from participant {participant.sid}")
-            # If the participant is re-publishing (e.g. mute/unmute cycle),
-            # close + cancel the previous stream/task before replacing the
-            # registry entry, so two producers never feed ``_audio_queue``
-            # for the same participant.
             await self._close_audio_stream(participant.sid)
             self._audio_tracks[participant.sid] = track
             audio_stream = rtc.AudioStream(track)
@@ -534,12 +420,8 @@ class LiveKitTransportClient:
             await self._callbacks.on_audio_track_subscribed(participant.sid)
         elif track.kind == rtc.TrackKind.KIND_VIDEO:
             logger.info(f"Video track subscribed: {track.sid} from participant {participant.sid}")
-            # Symmetric: clean up any prior video stream/task for the same
-            # participant before replacing.
             await self._close_video_stream(participant.sid)
             self._video_tracks[participant.sid] = track
-            # Only process video stream if video input is enabled to prevent
-            # unbounded queue growth when there is no consumer for video frames.
             if self._params.video_in_enabled:
                 video_stream = rtc.VideoStream(track)
                 task = self._task_manager.create_task(
@@ -555,7 +437,6 @@ class LiveKitTransportClient:
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ):
-        """Handle track unsubscribed events."""
         logger.info(f"Track unsubscribed: {publication.sid} from {participant.identity}")
         if track.kind == rtc.TrackKind.KIND_AUDIO:
             await self._close_audio_stream(participant.sid)
@@ -565,11 +446,6 @@ class LiveKitTransportClient:
             await self._callbacks.on_video_track_unsubscribed(participant.sid)
 
     async def _close_audio_stream(self, participant_id: str) -> None:
-        """Close a participant's owned audio stream and cancel its producer task.
-
-        Idempotent: no-op when there is no registered stream for the
-        participant.
-        """
         entry = self._audio_streams.pop(participant_id, None)
         if entry is None:
             return
@@ -582,11 +458,6 @@ class LiveKitTransportClient:
             task.cancel()
 
     async def _close_video_stream(self, participant_id: str) -> None:
-        """Close a participant's owned video stream and cancel its producer task.
-
-        Idempotent: no-op when there is no registered stream for the
-        participant.
-        """
         entry = self._video_streams.pop(participant_id, None)
         if entry is None:
             return
@@ -599,10 +470,6 @@ class LiveKitTransportClient:
             task.cancel()
 
     async def _close_all_streams(self) -> None:
-        """Close every per-participant audio/video stream and cancel its task.
-
-        Idempotent: no-op when no streams are registered.
-        """
         for participant_id in list(self._audio_streams.keys()):
             await self._close_audio_stream(participant_id)
         for participant_id in list(self._video_streams.keys()):
@@ -610,20 +477,17 @@ class LiveKitTransportClient:
 
     async def _async_on_data_received(self, data: rtc.DataPacket):
         """Handle data received events."""
-        await self._callbacks.on_data_received(data.data, data.participant.sid)
+        await self._callbacks.on_data_received(data.data, data.participant.identity)
 
     async def _async_on_connected(self):
-        """Handle connected events."""
         await self._callbacks.on_connected()
 
     async def _async_on_disconnected(self, reason=None):
-        """Handle disconnected events."""
         self._connected = False
         logger.info(f"Disconnected from {self._room_name}. Reason: {reason}")
         await self._callbacks.on_disconnected()
 
     async def _async_on_sip_dtmf_received(self, dtmf: rtc.SipDTMF):
-        """Handle inbound SIP DTMF events from LiveKit telephony."""
         participant = getattr(dtmf, "participant", None)
         participant_id = getattr(participant, "sid", None) if participant else None
         data = {
@@ -636,7 +500,6 @@ class LiveKitTransportClient:
         await self._callbacks.on_dtmf_event(data)
 
     async def _process_audio_stream(self, audio_stream: rtc.AudioStream, participant_id: str):
-        """Process incoming audio stream from a participant."""
         logger.info(f"Started processing audio stream for participant {participant_id}")
         async for event in audio_stream:
             if isinstance(event, rtc.AudioFrameEvent):
@@ -645,13 +508,12 @@ class LiveKitTransportClient:
                 logger.warning(f"Received unexpected event type: {type(event)}")
 
     async def get_next_audio_frame(self):
-        """Get the next audio frame from the queue."""
+        """Yield the next audio frame and participant id from the queue."""
         while True:
             frame, participant_id = await self._audio_queue.get()
             yield frame, participant_id
 
     async def _process_video_stream(self, video_stream: rtc.VideoStream, participant_id: str):
-        """Process incoming video stream from a participant."""
         logger.info(f"Started processing video stream for participant {participant_id}")
         async for event in video_stream:
             if isinstance(event, rtc.VideoFrameEvent):
@@ -660,22 +522,16 @@ class LiveKitTransportClient:
                 logger.warning(f"Received unexpected event type: {type(event)}")
 
     async def get_next_video_frame(self):
-        """Get the next video frame from the queue."""
         while True:
             frame, participant_id = await self._video_queue.get()
             yield frame, participant_id
 
     def __str__(self):
-        """String representation of the LiveKit transport client."""
         return f"{self._transport_name}::LiveKitTransportClient"
 
 
 class LiveKitInputTransport(BaseInputTransport):
-    """Handles incoming media streams and events from LiveKit rooms.
-
-    Processes incoming audio streams from room participants and forwards them
-    as Pipecat frames, including audio resampling and VAD integration.
-    """
+    """Handles incoming media streams and events from LiveKit rooms."""
 
     def __init__(
         self,
@@ -684,38 +540,19 @@ class LiveKitInputTransport(BaseInputTransport):
         params: LiveKitParams,
         **kwargs,
     ):
-        """Initialize the LiveKit input transport.
-
-        Args:
-            transport: The parent transport instance.
-            client: LiveKitTransportClient instance.
-            params: Configuration parameters.
-            **kwargs: Additional arguments passed to parent class.
-        """
         super().__init__(params, **kwargs)
         self._transport = transport
         self._client = client
-
         self._audio_in_task = None
         self._video_in_task = None
         self._resampler = create_stream_resampler()
-
-        # Whether we have seen a StartFrame already.
         self._initialized = False
 
     async def start(self, frame: StartFrame):
-        """Start the input transport and connect to LiveKit room.
-
-        Args:
-            frame: The start frame containing initialization parameters.
-        """
         await super().start(frame)
-
         if self._initialized:
             return
-
         self._initialized = True
-
         await self._client.start(frame)
         await self._client.connect()
         if not self._audio_in_task and self._params.audio_in_enabled:
@@ -726,45 +563,24 @@ class LiveKitInputTransport(BaseInputTransport):
         logger.info("LiveKitInputTransport started")
 
     async def stop(self, frame: EndFrame):
-        """Stop the input transport and disconnect from LiveKit room.
-
-        Args:
-            frame: The end frame signaling transport shutdown.
-        """
         await super().stop(frame)
         await self._teardown()
         logger.info("LiveKitInputTransport stopped")
 
     async def cancel(self, frame: CancelFrame):
-        """Cancel the input transport and disconnect from LiveKit room.
-
-        Args:
-            frame: The cancel frame signaling immediate cancellation.
-        """
         await super().cancel(frame)
         await self._teardown()
 
     async def setup(self, setup: FrameProcessorSetup):
-        """Setup the input transport with shared client setup.
-
-        Args:
-            setup: The frame processor setup configuration.
-        """
         await super().setup(setup)
         await self._client.setup(setup)
 
     async def cleanup(self):
-        """Release input transport resources at teardown."""
         await super().cleanup()
         await self._teardown()
         await self._transport.cleanup()
 
     async def _teardown(self):
-        """Disconnect the client and cancel the media input tasks.
-
-        Single idempotent teardown body shared by ``stop``, ``cancel`` and
-        ``cleanup``.
-        """
         await self._client.disconnect()
         if self._audio_in_task:
             await self.cancel_task(self._audio_in_task)
@@ -774,17 +590,15 @@ class LiveKitInputTransport(BaseInputTransport):
             self._video_in_task = None
 
     async def push_app_message(self, message: Any, sender: str):
-        """Push an application message as an urgent transport frame.
+        """Push an application message as an input transport frame.
 
         Args:
-            message: The message data to send.
+            message: The message data to send (e.g., RTVI dict).
             sender: ID of the message sender.
         """
-        frame = LiveKitOutputTransportMessageUrgentFrame(message=message, participant_id=sender)
-        await self.push_frame(frame)
+        await self.broadcast_frame(InputTransportMessageFrame, message=message)
 
     async def _audio_in_task_handler(self):
-        """Handle incoming audio frames from participants."""
         logger.info("Audio input task started")
         audio_iterator = self._client.get_next_audio_frame()
         async for audio_data in audio_iterator:
@@ -793,11 +607,8 @@ class LiveKitInputTransport(BaseInputTransport):
                 pipecat_audio_frame = await self._convert_livekit_audio_to_pipecat(
                     audio_frame_event
                 )
-
-                # Skip frames with no audio data
                 if len(pipecat_audio_frame.audio) == 0:
                     continue
-
                 input_audio_frame = UserAudioRawFrame(
                     user_id=participant_id,
                     audio=pipecat_audio_frame.audio,
@@ -807,7 +618,6 @@ class LiveKitInputTransport(BaseInputTransport):
                 await self.push_audio_frame(input_audio_frame)
 
     async def _video_in_task_handler(self):
-        """Handle incoming video frames from participants."""
         logger.info("Video input task started")
         video_iterator = self._client.get_next_video_frame()
         async for video_data in video_iterator:
@@ -816,11 +626,8 @@ class LiveKitInputTransport(BaseInputTransport):
                 pipecat_video_frame = await self._convert_livekit_video_to_pipecat(
                     video_frame_event=video_frame_event
                 )
-
-                # Skip frames with no video data
                 if len(pipecat_video_frame.image) == 0:
                     continue
-
                 input_video_frame = UserImageRawFrame(
                     user_id=participant_id,
                     image=pipecat_video_frame.image,
@@ -832,13 +639,10 @@ class LiveKitInputTransport(BaseInputTransport):
     async def _convert_livekit_audio_to_pipecat(
         self, audio_frame_event: rtc.AudioFrameEvent
     ) -> AudioRawFrame:
-        """Convert LiveKit audio frame to Pipecat audio frame."""
         audio_frame = audio_frame_event.frame
-
         audio_data = await self._resampler.resample(
             audio_frame.data.tobytes(), audio_frame.sample_rate, self.sample_rate
         )
-
         return AudioRawFrame(
             audio=audio_data,
             sample_rate=self.sample_rate,
@@ -849,7 +653,6 @@ class LiveKitInputTransport(BaseInputTransport):
         self,
         video_frame_event: rtc.VideoFrameEvent,
     ) -> ImageRawFrame:
-        """Convert LiveKit video frame to Pipecat video frame."""
         rgb_frame = video_frame_event.frame.convert(proto_video_frame.VideoBufferType.RGB24)
         image_frame = ImageRawFrame(
             image=rgb_frame.data,
@@ -860,11 +663,7 @@ class LiveKitInputTransport(BaseInputTransport):
 
 
 class LiveKitOutputTransport(BaseOutputTransport):
-    """Handles outgoing media streams and events to LiveKit rooms.
-
-    Manages sending audio frames and data messages to LiveKit room participants,
-    including audio format conversion for LiveKit compatibility.
-    """
+    """Handles outgoing media streams and events to LiveKit rooms."""
 
     def __init__(
         self,
@@ -873,84 +672,40 @@ class LiveKitOutputTransport(BaseOutputTransport):
         params: LiveKitParams,
         **kwargs,
     ):
-        """Initialize the LiveKit output transport.
-
-        Args:
-            transport: The parent transport instance.
-            client: LiveKitTransportClient instance.
-            params: Configuration parameters.
-            **kwargs: Additional arguments passed to parent class.
-        """
         super().__init__(params, **kwargs)
         self._transport = transport
         self._client = client
-
-        # Whether we have seen a StartFrame already.
         self._initialized = False
 
     async def start(self, frame: StartFrame):
-        """Start the output transport and connect to LiveKit room.
-
-        Args:
-            frame: The start frame containing initialization parameters.
-        """
         await super().start(frame)
-
         if self._initialized:
             return
-
         self._initialized = True
-
         await self._client.start(frame)
         await self._client.connect()
         await self.set_transport_ready(frame)
         logger.info("LiveKitOutputTransport started")
 
     async def stop(self, frame: EndFrame):
-        """Stop the output transport and disconnect from LiveKit room.
-
-        Args:
-            frame: The end frame signaling transport shutdown.
-        """
         await super().stop(frame)
         await self._client.disconnect()
         logger.info("LiveKitOutputTransport stopped")
 
     async def cancel(self, frame: CancelFrame):
-        """Cancel the output transport and disconnect from LiveKit room.
-
-        Args:
-            frame: The cancel frame signaling immediate cancellation.
-        """
         await super().cancel(frame)
         await self._client.disconnect()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Process frames, clearing the LiveKit AudioSource buffer on interruption.
-
-        When an InterruptionFrame arrives, any audio already submitted to the
-        LiveKit AudioSource (but not yet played out) is cleared immediately so
-        the bot stops speaking without delay.
-
-        Args:
-            frame: The frame to process.
-            direction: The direction of frame flow in the pipeline.
-        """
         await super().process_frame(frame, direction)
         if isinstance(frame, InterruptionFrame) and self._client._audio_source is not None:
             self._client._audio_source.clear_queue()
 
     async def setup(self, setup: FrameProcessorSetup):
-        """Setup the output transport with shared client setup.
-
-        Args:
-            setup: The frame processor setup configuration.
-        """
         await super().setup(setup)
         await self._client.setup(setup)
 
     async def cleanup(self):
-        """Release output transport resources at teardown."""
         await super().cleanup()
         await self._client.disconnect()
         await self._transport.cleanup()
@@ -958,14 +713,8 @@ class LiveKitOutputTransport(BaseOutputTransport):
     async def send_message(
         self, frame: OutputTransportMessageFrame | OutputTransportMessageUrgentFrame
     ):
-        """Send a transport message to participants.
-
-        Args:
-            frame: The transport message frame to send.
-        """
         message = frame.message
         if isinstance(message, dict):
-            # fix message encoding for dict-like messages, e.g. RTVI messages.
             message = json.dumps(message, ensure_ascii=False)
         if isinstance(
             frame, (LiveKitOutputTransportMessageFrame, LiveKitOutputTransportMessageUrgentFrame)
@@ -975,45 +724,21 @@ class LiveKitOutputTransport(BaseOutputTransport):
             await self._client.send_data(message.encode())
 
     async def write_audio_frame(self, frame: OutputAudioRawFrame) -> bool:
-        """Write an audio frame to the LiveKit room.
-
-        Args:
-            frame: The audio frame to write.
-
-        Returns:
-            True if the audio frame was written successfully, False otherwise.
-        """
         livekit_audio = self._convert_pipecat_audio_to_livekit(frame.audio)
         return await self._client.publish_audio(livekit_audio)
 
     def _supports_native_dtmf(self) -> bool:
-        """LiveKit supports native DTMF via telephone events.
-
-        Returns:
-            True, as LiveKit supports native DTMF transmission.
-        """
         return True
 
     async def _write_dtmf_native(self, frame: OutputDTMFFrame | OutputDTMFUrgentFrame):
-        """Use LiveKit's native publish_dtmf method for telephone events.
-
-        LiveKit's DTMF API sends a single tone per call, so when
-        ``frame.buttons`` contains multiple entries only the first one is
-        sent.
-
-        Args:
-            frame: The DTMF frame to write.
-        """
         if not frame.buttons:
             return
         await self._client.send_dtmf(frame.buttons[0].value)
 
     def _convert_pipecat_audio_to_livekit(self, pipecat_audio: bytes) -> rtc.AudioFrame:
-        """Convert Pipecat audio data to LiveKit audio frame."""
-        bytes_per_sample = 2  # Assuming 16-bit audio
+        bytes_per_sample = 2
         total_samples = len(pipecat_audio) // bytes_per_sample
         samples_per_channel = total_samples // self._params.audio_out_channels
-
         return rtc.AudioFrame(
             data=pipecat_audio,
             sample_rate=self.sample_rate,
@@ -1023,51 +748,7 @@ class LiveKitOutputTransport(BaseOutputTransport):
 
 
 class LiveKitTransport(BaseTransport):
-    """Transport implementation for LiveKit real-time communication.
-
-    Provides comprehensive LiveKit integration including audio streaming, data
-    messaging, participant management, and room event handling for conversational
-    AI applications.
-
-    Event handlers available:
-
-    - on_connected: Called when the bot connects to the room.
-    - on_disconnected: Called when the bot disconnects from the room.
-    - on_before_disconnect: [sync] Called just before the bot disconnects.
-    - on_call_state_updated: Called when the call state changes. Args: (state: str)
-    - on_first_participant_joined: Called when the first participant joins.
-      Args: (participant_id: str)
-    - on_participant_connected: Called when a participant connects.
-      Args: (participant_id: str)
-    - on_participant_disconnected: Called when a participant disconnects.
-      Args: (participant_id: str)
-    - on_participant_left: Called when a participant leaves.
-      Args: (participant_id: str, reason: str)
-    - on_audio_track_subscribed: Called when an audio track is subscribed.
-      Args: (participant_id: str)
-    - on_audio_track_unsubscribed: Called when an audio track is unsubscribed.
-      Args: (participant_id: str)
-    - on_video_track_subscribed: Called when a video track is subscribed.
-      Args: (participant_id: str)
-    - on_video_track_unsubscribed: Called when a video track is unsubscribed.
-      Args: (participant_id: str)
-    - on_data_received: Called when data is received from a participant.
-      Args: (data: bytes, participant_id: str)
-    - on_dtmf_event: Called when a SIP DTMF tone is received from a participant.
-      Args: (data: dict) with keys ``tone``/``digit``, ``code``, and
-      ``participant_id``. Also pushes an ``InputDTMFFrame`` so
-      ``DTMFAggregator`` works on LiveKit SIP calls.
-
-    Example::
-
-        @transport.event_handler("on_first_participant_joined")
-        async def on_first_participant_joined(transport, participant_id):
-            await task.queue_frame(TTSSpeakFrame("Hello!"))
-
-        @transport.event_handler("on_participant_disconnected")
-        async def on_participant_disconnected(transport, participant_id):
-            await task.queue_frame(EndFrame())
-    """
+    """Transport implementation for LiveKit real-time communication."""
 
     def __init__(
         self,
@@ -1078,16 +759,6 @@ class LiveKitTransport(BaseTransport):
         input_name: str | None = None,
         output_name: str | None = None,
     ):
-        """Initialize the LiveKit transport.
-
-        Args:
-            url: LiveKit server URL to connect to.
-            token: Authentication token for the room.
-            room_name: Name of the LiveKit room to join.
-            params: Configuration parameters for the transport.
-            input_name: Optional name for the input transport.
-            output_name: Optional name for the output transport.
-        """
         super().__init__(input_name=input_name, output_name=output_name)
 
         callbacks = LiveKitCallbacks(
@@ -1100,7 +771,7 @@ class LiveKitTransport(BaseTransport):
             on_audio_track_unsubscribed=self._on_audio_track_unsubscribed,
             on_video_track_subscribed=self._on_video_track_subscribed,
             on_video_track_unsubscribed=self._on_video_track_unsubscribed,
-            on_data_received=self._on_data_received,
+            on_data_received=self.on_data_received,
             on_first_participant_joined=self._on_first_participant_joined,
             on_dtmf_event=self._on_dtmf_event,
         )
@@ -1128,11 +799,6 @@ class LiveKitTransport(BaseTransport):
         self._register_event_handler("on_dtmf_event")
 
     def input(self) -> LiveKitInputTransport:
-        """Get the input transport for receiving media and events.
-
-        Returns:
-            The LiveKit input transport instance.
-        """
         if not self._input:
             self._input = LiveKitInputTransport(
                 self, self._client, self._params, name=self._input_name
@@ -1140,11 +806,6 @@ class LiveKitTransport(BaseTransport):
         return self._input
 
     def output(self) -> LiveKitOutputTransport:
-        """Get the output transport for sending media and events.
-
-        Returns:
-            The LiveKit output transport instance.
-        """
         if not self._output:
             self._output = LiveKitOutputTransport(
                 self, self._client, self._params, name=self._output_name
@@ -1153,92 +814,49 @@ class LiveKitTransport(BaseTransport):
 
     @property
     def participant_id(self) -> str:
-        """Get the participant ID for this transport.
-
-        Returns:
-            The participant ID assigned by LiveKit.
-        """
+        """Return the LiveKit participant id for this client."""
         return self._client.participant_id
 
     async def send_audio(self, frame: OutputAudioRawFrame):
-        """Send an audio frame to the LiveKit room.
-
-        Args:
-            frame: The audio frame to send.
-        """
         if self._output:
             await self._output.queue_frame(frame, FrameDirection.DOWNSTREAM)
 
     def get_participants(self) -> list[str]:
-        """Get list of participant IDs in the room.
-
-        Returns:
-            List of participant IDs.
-        """
         return self._client.get_participants()
 
     async def get_participant_metadata(self, participant_id: str) -> dict:
-        """Get metadata for a specific participant.
-
-        Args:
-            participant_id: ID of the participant to get metadata for.
-
-        Returns:
-            Dictionary containing participant metadata.
-        """
         return await self._client.get_participant_metadata(participant_id)
 
     async def set_metadata(self, metadata: str):
-        """Set metadata for the local participant.
-
-        Args:
-            metadata: Metadata string to set.
-        """
         await self._client.set_participant_metadata(metadata)
 
     async def mute_participant(self, participant_id: str):
-        """Mute a specific participant's audio tracks.
-
-        Args:
-            participant_id: ID of the participant to mute.
-        """
         await self._client.mute_participant(participant_id)
 
     async def unmute_participant(self, participant_id: str):
-        """Unmute a specific participant's audio tracks.
-
-        Args:
-            participant_id: ID of the participant to unmute.
-        """
         await self._client.unmute_participant(participant_id)
 
     async def _on_connected(self):
-        """Handle room connected events."""
         await self._call_event_handler("on_connected")
         if self._input:
             await self._input.push_frame(BotConnectedFrame())
 
     async def _on_disconnected(self):
-        """Handle room disconnected events."""
         await self._call_event_handler("on_disconnected")
 
     async def _on_before_disconnect(self):
-        """Handle before disconnection room events."""
         await self._call_event_handler("on_before_disconnect")
 
     async def _on_participant_connected(self, participant_id: str):
-        """Handle participant connected events."""
         await self._call_event_handler("on_participant_connected", participant_id)
         if self._input:
             await self._input.push_frame(ClientConnectedFrame())
 
     async def _on_participant_disconnected(self, participant_id: str):
-        """Handle participant disconnected events."""
         await self._call_event_handler("on_participant_disconnected", participant_id)
         await self._call_event_handler("on_participant_left", participant_id, "disconnected")
 
     async def _on_audio_track_subscribed(self, participant_id: str):
-        """Handle audio track subscribed events."""
         await self._call_event_handler("on_audio_track_subscribed", participant_id)
         participant = self._client.room.remote_participants.get(participant_id)
         if participant:
@@ -1248,11 +866,9 @@ class LiveKitTransport(BaseTransport):
                 )
 
     async def _on_audio_track_unsubscribed(self, participant_id: str):
-        """Handle audio track unsubscribed events."""
         await self._call_event_handler("on_audio_track_unsubscribed", participant_id)
 
     async def _on_video_track_subscribed(self, participant_id: str):
-        """Handle video track subscribed events."""
         await self._call_event_handler("on_video_track_subscribed", participant_id)
         participant = self._client.room.remote_participants.get(participant_id)
         if participant:
@@ -1262,21 +878,14 @@ class LiveKitTransport(BaseTransport):
                 )
 
     async def _on_video_track_unsubscribed(self, participant_id: str):
-        """Handle video track unsubscribed events."""
         await self._call_event_handler("on_video_track_unsubscribed", participant_id)
 
-    async def _on_data_received(self, data: bytes, participant_id: str):
+    async def on_data_received(self, data: bytes, participant_id: str):
         """Handle data received events."""
         if self._input:
-            await self._input.push_app_message(data.decode(), participant_id)
-        await self._call_event_handler("on_data_received", data, participant_id)
+            await self._input.push_app_message(json.loads(data.decode()), participant_id)
 
     async def _on_dtmf_event(self, data: Any):
-        """Handle inbound SIP DTMF events.
-
-        Mirrors Daily transport behavior: expose ``on_dtmf_event`` to user code
-        and push ``InputDTMFFrame`` so ``DTMFAggregator`` can consume digits.
-        """
         logger.debug(f"{self} DTMF event: {data}")
         await self._call_event_handler("on_dtmf_event", data)
 
@@ -1293,12 +902,6 @@ class LiveKitTransport(BaseTransport):
         await self._input.push_frame(InputDTMFFrame(button=button))
 
     async def send_message(self, message: str, participant_id: str | None = None):
-        """Send a message to participants in the room.
-
-        Args:
-            message: The message string to send.
-            participant_id: Optional specific participant to send to.
-        """
         if self._output:
             frame = LiveKitOutputTransportMessageFrame(
                 message=message, participant_id=participant_id
@@ -1306,12 +909,6 @@ class LiveKitTransport(BaseTransport):
             await self._output.send_message(frame)
 
     async def send_message_urgent(self, message: str, participant_id: str | None = None):
-        """Send an urgent message to participants in the room.
-
-        Args:
-            message: The urgent message string to send.
-            participant_id: Optional specific participant to send to.
-        """
         if self._output:
             frame = LiveKitOutputTransportMessageUrgentFrame(
                 message=message, participant_id=participant_id
@@ -1319,36 +916,16 @@ class LiveKitTransport(BaseTransport):
             await self._output.send_message(frame)
 
     async def on_room_event(self, event):
-        """Handle room events.
-
-        Args:
-            event: The room event to handle.
-        """
-        # Handle room events
         pass
 
     async def on_participant_event(self, event):
-        """Handle participant events.
-
-        Args:
-            event: The participant event to handle.
-        """
-        # Handle participant events
         pass
 
     async def on_track_event(self, event):
-        """Handle track events.
-
-        Args:
-            event: The track event to handle.
-        """
-        # Handle track events
         pass
 
     async def _on_call_state_updated(self, state: str):
-        """Handle call state update events."""
         await self._call_event_handler("on_call_state_updated", state)
 
     async def _on_first_participant_joined(self, participant_id: str):
-        """Handle first participant joined events."""
         await self._call_event_handler("on_first_participant_joined", participant_id)

--- a/src/pipecat/utils/deprecation.py
+++ b/src/pipecat/utils/deprecation.py
@@ -51,10 +51,8 @@ target, or an explicit "No replacement." — enforced by
 ``tests/test_deprecation_markers.py``::
 
     .. deprecated:: 1.3.0
-        Use :class:`PipelineWorker` instead.        # rename / use-existing
-        Merged into :class:`LLMContext`.            # capability absorbed
-        Moved to :mod:`pipecat.services.xai.llm`.   # module move
-        No replacement.                             # nothing to migrate to
+        Use :class:`PipelineWorker` instead.
+        Will be removed in 2.0.0.
 
 Prefer Sphinx cross-reference roles (``:class:``, ``:meth:``, ``:func:``,
 ``:attr:``, ``:mod:``) for the target — they encode its kind and resolve in


### PR DESCRIPTION
On Windows, pre-commit Ruff and CLI imports hooks were failing due to missing docstrings in existing LiveKit transport code and a cp1252 encoding error in update_imports.py. The functional fix is tested via scripts/repro_livekit_rtvi_inbound.py and tests/test_deprecation_markers.py