### PR TITLE
Deprecate cartesia_version in the Cartesia TTS services

### DIFF
--- a/changelog/5231.deprecated.md
+++ b/changelog/5231.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated the `cartesia_version` parameter of `CartesiaTTSService` and `CartesiaHttpTTSService`. Both services send the `Cartesia-Version` header they are written against, since their request payloads and response handling are tied to that version. Passing `cartesia_version` warns and still overrides the header until it is removed in 2.0.0.

--- a/scripts/deprecations/deprecations.json
+++ b/scripts/deprecations/deprecations.json
@@ -960,6 +960,17 @@
       "location": "pipecat/services/cartesia/stt.py"
     },
     {
+      "subject": "CartesiaHttpTTSService.cartesia_version",
+      "module": "pipecat.services.cartesia.tts",
+      "kind": "parameter",
+      "deprecated_in": "1.8.0",
+      "removed_in": "2.0.0",
+      "relation": "none",
+      "replacement": null,
+      "message": "No replacement. The API version is pinned to the one this service implements. Will be removed in 2.0.0.",
+      "location": "pipecat/services/cartesia/tts.py"
+    },
+    {
       "subject": "CartesiaHttpTTSService.model",
       "module": "pipecat.services.cartesia.tts",
       "kind": "parameter",
@@ -1001,6 +1012,17 @@
       "relation": "use_existing",
       "replacement": "text_aggregation_mode",
       "message": "Use ``text_aggregation_mode`` instead. Will be removed in 2.0.0.",
+      "location": "pipecat/services/cartesia/tts.py"
+    },
+    {
+      "subject": "CartesiaTTSService.cartesia_version",
+      "module": "pipecat.services.cartesia.tts",
+      "kind": "parameter",
+      "deprecated_in": "1.8.0",
+      "removed_in": "2.0.0",
+      "relation": "none",
+      "replacement": null,
+      "message": "No replacement. The API version is pinned to the one this service implements. Will be removed in 2.0.0.",
       "location": "pipecat/services/cartesia/tts.py"
     },
     {

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -9,6 +9,7 @@
 import base64
 import json
 import re
+import warnings
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -31,6 +32,26 @@ from pipecat.services.tts_service import TextAggregationMode, TTSService, Websoc
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.text.skip_tags_aggregator import SkipTagsAggregator
 from pipecat.utils.tracing.service_decorators import traced_tts
+
+# The Cartesia API version these services are written against. The request
+# payloads and message handling below are tied to it, so it is pinned here
+# rather than configured.
+_CARTESIA_API_VERSION = "2026-03-01"
+
+
+def _resolve_cartesia_version(cartesia_version: str | None) -> str:
+    """Resolve the API version header value, warning on a deprecated override."""
+    if cartesia_version is None:
+        return _CARTESIA_API_VERSION
+
+    warnings.warn(
+        "`cartesia_version` is deprecated since 1.8.0 and will be removed in 2.0.0. "
+        "No replacement. The service sends the API version it is written against, "
+        "so overriding it can break request and response handling.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return cartesia_version
 
 
 class GenerationConfig(BaseModel):
@@ -226,7 +247,7 @@ class CartesiaTTSService(WebsocketTTSService):
         *,
         api_key: str,
         voice_id: str | None = None,
-        cartesia_version: str = "2026-03-01",
+        cartesia_version: str | None = None,
         url: str = "wss://api.cartesia.ai/tts/websocket",
         model: str | None = None,
         sample_rate: int | None = None,
@@ -251,6 +272,11 @@ class CartesiaTTSService(WebsocketTTSService):
                     Will be removed in 2.0.0.
 
             cartesia_version: API version string for Cartesia service.
+
+                .. deprecated:: 1.8.0
+                    No replacement. The API version is pinned to the one this
+                    service implements. Will be removed in 2.0.0.
+
             url: WebSocket URL for Cartesia TTS API.
             model: TTS model to use.
 
@@ -352,7 +378,7 @@ class CartesiaTTSService(WebsocketTTSService):
         )
 
         self._api_key = api_key
-        self._cartesia_version = cartesia_version
+        self._cartesia_version = _resolve_cartesia_version(cartesia_version)
         self._url = url
         self._extra_headers = dict(extra_headers) if extra_headers else {}
 
@@ -765,7 +791,7 @@ class CartesiaHttpTTSService(TTSService):
         voice_id: str | None = None,
         model: str | None = None,
         base_url: str = "https://api.cartesia.ai",
-        cartesia_version: str = "2026-03-01",
+        cartesia_version: str | None = None,
         aiohttp_session: aiohttp.ClientSession | None = None,
         sample_rate: int | None = None,
         encoding: str = "pcm_s16le",
@@ -793,6 +819,11 @@ class CartesiaHttpTTSService(TTSService):
 
             base_url: Base URL for Cartesia HTTP API.
             cartesia_version: API version string for Cartesia service.
+
+                .. deprecated:: 1.8.0
+                    No replacement. The API version is pinned to the one this
+                    service implements. Will be removed in 2.0.0.
+
             aiohttp_session: Optional aiohttp ClientSession for HTTP requests.
                 If not provided, a session will be created and managed internally.
             sample_rate: Audio sample rate. If None, uses default.
@@ -852,7 +883,7 @@ class CartesiaHttpTTSService(TTSService):
 
         self._api_key = api_key
         self._base_url = base_url
-        self._cartesia_version = cartesia_version
+        self._cartesia_version = _resolve_cartesia_version(cartesia_version)
         self._extra_headers = dict(extra_headers) if extra_headers else {}
 
         # Audio output format — init-only, not runtime-updatable


### PR DESCRIPTION
Follow up based on this thread: https://github.com/pipecat-ai/pipecat/pull/5223#discussion_r3728767951.

## Summary

- Deprecated the `cartesia_version` parameter of `CartesiaTTSService` and `CartesiaHttpTTSService`. Both services send the `Cartesia-Version` header they are written against — request payloads and response handling are tied to that version, so it isn't a safe knob. The Cartesia STT services already send a pinned version with no parameter.
- Passing `cartesia_version` emits a `DeprecationWarning` and still overrides the header, so existing callers keep working until it is removed in 2.0.0.
- The pinned value lives in a module-level `_CARTESIA_API_VERSION` constant. The `.. deprecated:: 1.8.0` directives on both `__init__` docstrings feed `scripts/deprecations/deprecations.json`.

## Testing

- `uv run pytest tests/test_deprecation_markers.py` — covers the directive grammar and the deprecation-registry drift guard.
- Constructing either TTS service with `cartesia_version=...` emits the `DeprecationWarning` and uses the given value; omitting it sends the pinned version.