### PR TITLE
Disable Claude Code PR and session URL attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,7 @@
 {
   "attribution": {
-    "commit": ""
+    "commit": "",
+    "pr": "",
+    "sessionUrl": ""
   }
 }


### PR DESCRIPTION
## Summary

Extends the shared Claude Code attribution settings so that generated pull requests and commits carry no Claude attribution at all.

`.claude/settings.json` already blanked `attribution.commit`, which suppresses the co-authored-by trailer. This adds the two remaining knobs:

- `attribution.pr` — no attribution footer in PR descriptions
- `attribution.sessionUrl` — no session URL appended to commits or PR bodies