### PR TITLE
Use a boolean for the sessionUrl attribution setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,6 @@
   "attribution": {
     "commit": "",
     "pr": "",
-    "sessionUrl": ""
+    "sessionUrl": false
   }
 }


### PR DESCRIPTION
## Summary

- `attribution.sessionUrl` is a boolean toggle, so an empty string fails settings validation with `Expected boolean, but received string`
- `attribution.commit` and `attribution.pr` take byline strings, where an empty string is the way to disable them — those stay as they are
- Attribution remains disabled across all three