### PR TITLE
fix(transports): restore mid-call input-audio stall warning

### DIFF
--- a/src/pipecat/transports/base_input.py
+++ b/src/pipecat/transports/base_input.py
@@ -11,6 +11,7 @@ input processing.
 """
 
 import asyncio
+import time
 
 from loguru import logger
 
@@ -267,8 +268,11 @@ class BaseInputTransport(FrameProcessor):
     async def _audio_task_handler(self):
         """Main audio processing task handler."""
         # Skip timeout handling until the first audio frame arrives (e.g. client
-        # not yet connected).
+        # not yet connected). Warn once when audio stalls after that, and once
+        # when it recovers — not on every timeout poll (see #3633 / #5230).
         audio_received = False
+        stalled = False
+        last_audio_at = 0.0
         while True:
             try:
                 frame: InputAudioRawFrame = await asyncio.wait_for(
@@ -277,6 +281,14 @@ class BaseInputTransport(FrameProcessor):
 
                 # From now on, timeout should warn if there's no audio.
                 audio_received = True
+
+                if stalled:
+                    stalled = False
+                    logger.warning(
+                        f"{self}: input audio recovered after "
+                        f"{time.monotonic() - last_audio_at:.1f}s without a frame"
+                    )
+                last_audio_at = time.monotonic()
 
                 # Filter audio, if an audio filter is available.
                 if self._params.audio_in_filter:
@@ -295,3 +307,10 @@ class BaseInputTransport(FrameProcessor):
             except TimeoutError:
                 if not audio_received:
                     continue
+                if not stalled:
+                    stalled = True
+                    logger.warning(
+                        f"{self}: no input audio for {AUDIO_INPUT_TIMEOUT_SECS}s "
+                        f"(last frame {time.monotonic() - last_audio_at:.1f}s ago); "
+                        "input stream may have stalled"
+                    )

--- a/tests/test_base_input_transport.py
+++ b/tests/test_base_input_transport.py
@@ -6,17 +6,44 @@
 
 """Tests for frame-based audio handling in :class:`BaseInputTransport`."""
 
+import asyncio
 import unittest
 import warnings
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
+from pipecat.clocks.system_clock import SystemClock
 from pipecat.frames.frames import (
+    CancelFrame,
     InputAudioRawFrame,
     InputTransportStartAudioStreamingFrame,
+    StartFrame,
 )
-from pipecat.processors.frame_processor import FrameDirection
-from pipecat.transports.base_input import BaseInputTransport
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
+from pipecat.transports.base_input import AUDIO_INPUT_TIMEOUT_SECS, BaseInputTransport
 from pipecat.transports.base_transport import TransportParams
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+
+
+async def _make_ready_input_transport() -> BaseInputTransport:
+    """Start an input transport with its audio task running."""
+    params = TransportParams(audio_in_enabled=True, audio_in_passthrough=True)
+    transport = BaseInputTransport(params)
+    transport.push_frame = AsyncMock()
+
+    task_manager = TaskManager()
+    task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+    await transport.setup(
+        FrameProcessorSetup(
+            clock=SystemClock(),
+            task_manager=task_manager,
+            pipeline_worker=SimpleNamespace(app_resources=None),  # type: ignore[arg-type]
+        )
+    )
+    start_frame = StartFrame(audio_in_sample_rate=16000)
+    await transport.process_frame(start_frame, FrameDirection.DOWNSTREAM)
+    await transport.set_transport_ready(start_frame)
+    return transport
 
 
 class TestBaseInputTransportFrameAudio(unittest.IsolatedAsyncioTestCase):
@@ -48,6 +75,47 @@ class TestBaseInputTransportFrameAudio(unittest.IsolatedAsyncioTestCase):
             await transport.start_audio_in_streaming()
         self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
         transport._start_audio_in_streaming.assert_called_once()
+
+
+class TestBaseInputTransportAudioStallSignal(unittest.IsolatedAsyncioTestCase):
+    async def test_no_stall_warning_before_first_audio(self):
+        transport = await _make_ready_input_transport()
+        try:
+            with patch("pipecat.transports.base_input.logger") as mock_logger:
+                await asyncio.sleep(AUDIO_INPUT_TIMEOUT_SECS * 2.5)
+                mock_logger.warning.assert_not_called()
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_stall_warns_once_then_recovery(self):
+        transport = await _make_ready_input_transport()
+        try:
+            frame = InputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
+            await transport.push_audio_frame(frame)
+            # Let the audio task consume the first frame.
+            await asyncio.sleep(0.05)
+
+            with patch("pipecat.transports.base_input.logger") as mock_logger:
+                await asyncio.sleep(AUDIO_INPUT_TIMEOUT_SECS * 3.5)
+
+                stall_msgs = [
+                    call.args[0]
+                    for call in mock_logger.warning.call_args_list
+                    if "may have stalled" in call.args[0]
+                ]
+                self.assertEqual(len(stall_msgs), 1)
+
+                await transport.push_audio_frame(frame)
+                await asyncio.sleep(0.1)
+
+                recovery_msgs = [
+                    call.args[0]
+                    for call in mock_logger.warning.call_args_list
+                    if "recovered after" in call.args[0]
+                ]
+                self.assertEqual(len(recovery_msgs), 1)
+        finally:
+            await transport.cancel(CancelFrame())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Restore a mid-call input-audio stall warning in `BaseInputTransport._audio_task_handler` after the first frame has been received.
- Warn once on stall and once on recovery so connect-time silence stays quiet (avoids reintroducing #3633 log spam).

## Test plan
- [x] Unit coverage in `tests/test_base_input_transport.py` for stall + recovery logging
- [ ] Manual: start a call, stop sending mic audio mid-session, confirm a stall warning appears once

Fixes #5230
