### PR TITLE
fix(aggregators): do not start LLM run from incomplete-turn markers

### DIFF
--- a/changelog/5225.fixed.md
+++ b/changelog/5225.fixed.md
@@ -1,0 +1,1 @@
+- Fixed incomplete-turn markers (`○` / `◐`) being written to context without starting a new LLM run. Previously `_handle_marker_frame` emitted an `LLMContextFrame` that ended on a model turn (rejected by Gemini with 400) and cancelled the incomplete-timeout re-prompt watchdog.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -368,11 +368,11 @@ class LLMMarkerFrame(DataFrame):
             single character).
         append_to_context_immediately: If True, the marker is written
             to the context as its own standalone assistant message as
-            soon as it's received. If False, the marker is appended to
-            the running assistant aggregation and flushed to the
-            context together with the following text as a single
-            message (e.g. for the ✓ case the context message ends up
-            as "✓ <response>").
+            soon as it's received, without starting a new LLM run. If
+            False, the marker is appended to the running assistant
+            aggregation and flushed to the context together with the
+            following text as a single message (e.g. for the ✓ case
+            the context message ends up as "✓ <response>").
     """
 
     marker: str

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1960,8 +1960,13 @@ class LLMAssistantAggregator(LLMContextAggregator):
             # assistant turn — e.g. the ○ / ◐ incomplete-turn signals,
             # where the spoken response is suppressed and the marker
             # is the only artifact.
+            #
+            # Do not push an LLMContextFrame here. Emitting one would
+            # start a new inference that ends on a model turn (Gemini
+            # rejects that with 400) and would cancel the incomplete-
+            # timeout re-prompt watchdog that injects a developer
+            # nudge before running.
             self._context.add_message({"role": "assistant", "content": frame.marker})
-            await self.push_context_frame()
             timestamp_frame = LLMContextAssistantTimestampFrame(timestamp=time_now_iso8601())
             await self.push_frame(timestamp_frame)
             return

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -25,6 +25,7 @@ from pipecat.frames.frames import (
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
+    LLMMarkerFrame,
     LLMMessagesAppendFrame,
     LLMMessagesTransformFrame,
     LLMMessagesUpdateFrame,
@@ -1549,6 +1550,57 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         # The incomplete marker should be stripped (resulting in empty content)
         self.assertEqual(len(stop_messages), 1)
         self.assertEqual(stop_messages[0].content, "")
+
+    async def test_incomplete_marker_records_without_llm_run(self):
+        """Stand-alone ○/◐ markers must persist without emitting LLMContextFrame.
+
+        Emitting a context frame here would start an inference that ends on a
+        model turn (rejected by Gemini) and cancel the incomplete-timeout
+        re-prompt path that injects a developer nudge before running.
+        """
+        from pipecat.turns.user_turn_completion_mixin import (
+            USER_TURN_INCOMPLETE_LONG_MARKER,
+            USER_TURN_INCOMPLETE_SHORT_MARKER,
+        )
+
+        for marker in (
+            USER_TURN_INCOMPLETE_SHORT_MARKER,
+            USER_TURN_INCOMPLETE_LONG_MARKER,
+        ):
+            with self.subTest(marker=marker):
+                context = LLMContext(
+                    messages=[
+                        {"role": "assistant", "content": "What did you do last weekend?"},
+                        {"role": "user", "content": "I went to the"},
+                    ]
+                )
+                aggregator = LLMAssistantAggregator(context)
+
+                received_down, received_up = await run_test(
+                    aggregator,
+                    frames_to_send=[LLMMarkerFrame(marker)],
+                )
+
+                self.assertEqual(
+                    context.get_messages()[-1],
+                    {"role": "assistant", "content": marker},
+                )
+                context_frames = [
+                    f
+                    for f in (*received_down, *received_up)
+                    if isinstance(f, LLMContextFrame)
+                ]
+                self.assertEqual(
+                    context_frames,
+                    [],
+                    "incomplete marker must not start a new LLM run",
+                )
+                self.assertTrue(
+                    any(
+                        isinstance(f, LLMContextAssistantTimestampFrame)
+                        for f in (*received_down, *received_up)
+                    )
+                )
 
     async def test_llm_run(self):
         context = LLMContext()

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1586,9 +1586,7 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
                     {"role": "assistant", "content": marker},
                 )
                 context_frames = [
-                    f
-                    for f in (*received_down, *received_up)
-                    if isinstance(f, LLMContextFrame)
+                    f for f in (*received_down, *received_up) if isinstance(f, LLMContextFrame)
                 ]
                 self.assertEqual(
                     context_frames,


### PR DESCRIPTION
## Summary
- When an incomplete-turn marker (`○` / `◐`) is recorded as a stand-alone assistant message, do **not** emit `LLMContextFrame`.
- That emission started an LLM run ending on a model turn (Gemini `400`) and cancelled the incomplete-timeout re-prompt watchdog that injects a developer nudge first.

## Test plan
- [x] `test_incomplete_marker_records_without_llm_run` asserts context is updated and no `LLMContextFrame` is pushed
- [ ] Manual Gemini path with incomplete markers still recovers via the timeout re-prompt

Fixes #5225
