### PR TITLE
Update default models across five services

### DIFF
--- a/changelog/5246.changed.2.md
+++ b/changelog/5246.changed.2.md
@@ -1,0 +1,1 @@
+- Updated the default model for `DeepSeekLLMService` from `deepseek-chat` to `deepseek-v4-flash`. Set `model` in `DeepSeekLLMService.Settings` to pin the previous default.

--- a/changelog/5246.changed.3.md
+++ b/changelog/5246.changed.3.md
@@ -1,0 +1,1 @@
+- Updated the default model for `FishAudioTTSService` from `s2-pro` to `s2.1-pro`. Set `model` in `FishAudioTTSService.Settings` to pin the previous default.

--- a/changelog/5246.changed.4.md
+++ b/changelog/5246.changed.4.md
@@ -1,0 +1,1 @@
+- Updated the default model for `LmntTTSService` from `aurora` to `blizzard`. Set `model` in `LmntTTSService.Settings` to pin the previous default.

--- a/changelog/5246.changed.5.md
+++ b/changelog/5246.changed.5.md
@@ -1,0 +1,1 @@
+- Updated the default model for `MiniMaxHttpTTSService` from `speech-02-turbo` to `speech-2.8-turbo`. Set `model` in `MiniMaxHttpTTSService.Settings` to pin the previous default.

--- a/changelog/5246.changed.md
+++ b/changelog/5246.changed.md
@@ -1,0 +1,1 @@
+- Updated the default model for `AsyncAITTSService` and `AsyncAIHttpTTSService` from `async_flash_v1.0` to `async_flash_v1.5`. Set `model` in `AsyncAITTSService.Settings` or `AsyncAIHttpTTSService.Settings` to pin the previous default.

--- a/examples/function-calling/function-calling-deepseek.py
+++ b/examples/function-calling/function-calling-deepseek.py
@@ -90,7 +90,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = DeepSeekLLMService(
         api_key=os.environ["DEEPSEEK_API_KEY"],
         settings=DeepSeekLLMService.Settings(
-            model="deepseek-chat",
             system_instruction="""You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.
 
 You have one functions available:

--- a/examples/function-calling/function-calling-qwen.py
+++ b/examples/function-calling/function-calling-qwen.py
@@ -90,6 +90,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = QwenLLMService(
         api_key=os.environ["QWEN_API_KEY"],
         settings=QwenLLMService.Settings(
+            model="qwen3.6-27b",
+            extra={"extra_body": {"enable_thinking": False}},  # Disable thinking for better latency
             system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )

--- a/examples/update-settings/llm/llm-qwen.py
+++ b/examples/update-settings/llm/llm-qwen.py
@@ -67,7 +67,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = QwenLLMService(
         api_key=os.environ["QWEN_API_KEY"],
         settings=QwenLLMService.Settings(
-            model="qwen2.5-72b-instruct",
+            model="qwen3.6-27b",
+            extra={"extra_body": {"enable_thinking": False}},  # Disable thinking for better latency
             system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )

--- a/examples/update-settings/tts/tts-fish.py
+++ b/examples/update-settings/tts/tts-fish.py
@@ -60,8 +60,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = FishAudioTTSService(
         api_key=os.environ["FISH_API_KEY"],
         settings=FishAudioTTSService.Settings(
-            voice="4ce7e917cedd4bc2bb2e6ff3a46acaa1"
-        ),  # Barack Obama
+            voice="933563129e564b19a115bedd57b7406a",
+        ),
     )
 
     llm = OpenAILLMService(

--- a/examples/voice/voice-fish.py
+++ b/examples/voice/voice-fish.py
@@ -63,7 +63,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     tts = FishAudioTTSService(
         api_key=os.environ["FISH_API_KEY"],
         settings=FishAudioTTSService.Settings(
-            voice="4ce7e917cedd4bc2bb2e6ff3a46acaa1",  # Barack Obama
+            voice="933563129e564b19a115bedd57b7406a",
         ),
     )
 

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -130,7 +130,7 @@ class AsyncAITTSService(WebsocketTTSService):
 
             version: Async API version.
             url: WebSocket URL for Async TTS API.
-            model: TTS model to use (e.g., "async_flash_v1.0").
+            model: TTS model to use (e.g., "async_flash_v1.5").
 
                 .. deprecated:: 0.0.105
                     Use ``settings=AsyncAITTSService.Settings(model=...)`` instead.
@@ -158,7 +158,7 @@ class AsyncAITTSService(WebsocketTTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="async_flash_v1.0",
+            model="async_flash_v1.5",
             voice=None,
             language=None,
         )
@@ -517,7 +517,7 @@ class AsyncAIHttpTTSService(TTSService):
                     Will be removed in 2.0.0.
 
             aiohttp_session: An aiohttp session for making HTTP requests.
-            model: TTS model to use (e.g., "async_flash_v1.0").
+            model: TTS model to use (e.g., "async_flash_v1.5").
 
                 .. deprecated:: 0.0.105
                     Use ``settings=AsyncAIHttpTTSService.Settings(model=...)`` instead.
@@ -540,7 +540,7 @@ class AsyncAIHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="async_flash_v1.0",
+            model="async_flash_v1.5",
             voice=None,
             language=None,
         )

--- a/src/pipecat/services/camb/tts.py
+++ b/src/pipecat/services/camb/tts.py
@@ -20,8 +20,8 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any
 
-from camb import StreamTtsOutputConfiguration
 from camb.client import AsyncCambAI
+from camb.types import StreamTtsOutputConfiguration
 from loguru import logger
 from pydantic import BaseModel, Field
 

--- a/src/pipecat/services/deepseek/llm.py
+++ b/src/pipecat/services/deepseek/llm.py
@@ -50,7 +50,7 @@ class DeepSeekLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing DeepSeek's API.
             base_url: The base URL for DeepSeek API. Defaults to "https://api.deepseek.com/v1".
-            model: The model identifier to use. Defaults to "deepseek-chat".
+            model: The model identifier to use. Defaults to "deepseek-v4-flash".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=DeepSeekLLMService.Settings(model=...)`` instead.
@@ -61,7 +61,7 @@ class DeepSeekLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="deepseek-chat")
+        default_settings = self.Settings(model="deepseek-v4-flash")
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -133,7 +133,7 @@ class FishAudioTTSService(InterruptibleTTSService):
                     Use ``settings=FishAudioTTSService.Settings(voice=...)`` instead.
                     Will be removed in 2.0.0.
 
-            model_id: Specify which Fish Audio TTS model to use (e.g. "s1").
+            model_id: Specify which Fish Audio TTS model to use (e.g. "s2.1-pro").
 
                 .. deprecated:: 0.0.105
                     Use ``settings=FishAudioTTSService.Settings(model=...)`` instead.
@@ -153,7 +153,7 @@ class FishAudioTTSService(InterruptibleTTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="s2-pro",
+            model="s2.1-pro",
             voice=None,
             language=None,
             latency="balanced",

--- a/src/pipecat/services/lmnt/tts.py
+++ b/src/pipecat/services/lmnt/tts.py
@@ -129,7 +129,7 @@ class LmntTTSService(InterruptibleTTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="aurora",
+            model="blizzard",
             voice=None,
             language=Language.EN,
         )

--- a/src/pipecat/services/minimax/tts.py
+++ b/src/pipecat/services/minimax/tts.py
@@ -204,10 +204,7 @@ class MiniMaxHttpTTSService(TTSService):
                 Mainland China: https://api.minimaxi.chat/v1/t2a_v2
                 Western United States: https://api-uw.minimax.io/v1/t2a_v2
             group_id: MiniMax Group ID to identify project.
-            model: TTS model name. Defaults to "speech-02-turbo". Options include:
-                "speech-2.6-hd", "speech-2.6-turbo" (latest, supports Filipino/Tamil/Persian),
-                "speech-02-hd", "speech-02-turbo",
-                "speech-01-hd", "speech-01-turbo".
+            model: TTS model name. Defaults to "speech-2.8-turbo".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=MiniMaxHttpTTSService.Settings(model=...)`` instead.
@@ -234,7 +231,7 @@ class MiniMaxHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="speech-02-turbo",
+            model="speech-2.8-turbo",
             voice="Calm_Woman",
             language=None,
             speed=1.0,

--- a/uv.lock
+++ b/uv.lock
@@ -726,7 +726,7 @@ wheels = [
 
 [[package]]
 name = "camb-sdk"
-version = "1.5.13"
+version = "1.5.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -737,9 +737,9 @@ dependencies = [
     { name = "websocket-client" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/3e/b5ab4bb3b9c76c0cbad9f2a4696c504e80ecb9b44a09c811c6923c48dcbc/camb_sdk-1.5.13.tar.gz", hash = "sha256:a2e16d338419681f25973082386b6cdc5c1ae6b804c082d3a210fba9c446ef01", size = 101920, upload-time = "2026-05-27T08:52:55.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a2/dad5e1b03cc2b6582a7df90fe030e5381cb41328a6b04e40f3965454f522/camb_sdk-1.5.17.tar.gz", hash = "sha256:85fb1bfcf5f8edb710a3ebcb592e0e81275578c714004a522a7b7f4fb595819b", size = 108373, upload-time = "2026-07-27T14:31:13.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/79/758eb34167b174884ae100301cdb2cd06b9a129892b487af3e8de26eaf0d/camb_sdk-1.5.13-py3-none-any.whl", hash = "sha256:98954cc999584f16bd1726780cb21213996561329cd9f25c81423a8edc10fc0d", size = 174906, upload-time = "2026-05-27T08:52:53.529Z" },
+    { url = "https://files.pythonhosted.org/packages/76/25/fd42e743a9fb99e23e8eefd46c9128350204fdb993b4cdb5f6821bb3f14c/camb_sdk-1.5.17-py3-none-any.whl", hash = "sha256:9745df0db0650ce7f2bd6b5f219e8499760615754290bc916689fa881ed9366d", size = 183145, upload-time = "2026-07-27T14:31:10.974Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the default model for five services, and refreshes the examples that pinned older models or voices.

## Default model changes

| Service | Was | Now |
| --- | --- | --- |
| `AsyncAITTSService`, `AsyncAIHttpTTSService` | `async_flash_v1.0` | `async_flash_v1.5` |
| `DeepSeekLLMService` | `deepseek-chat` | `deepseek-v4-flash` |
| `FishAudioTTSService` | `s2-pro` | `s2.1-pro` |
| `LmntTTSService` | `aurora` | `blizzard` |
| `MiniMaxHttpTTSService` | `speech-02-turbo` | `speech-2.8-turbo` |

Each is a one-line `Settings(model=...)` override away from the previous behavior, and every changelog entry says so.

## Examples

- The DeepSeek function-calling example drops its explicit `model="deepseek-chat"` and inherits the new default.
- Both Qwen examples now run `qwen3.6-27b` with thinking disabled. Qwen's own default stays `qwen-plus`; these are deliberate pins.
- Both Fish Audio examples use the same voice.

## Dependencies

`camb-sdk` moves to 1.5.17 in the lock file, and `StreamTtsOutputConfiguration` is imported from `camb.types`. The `pyproject.toml` floor of `>=1.5.4` is unchanged — worth a look if `camb.types` is newer than that floor.

## Open question for review

`speech-2.8-turbo` is now the MiniMax default, but four places in `minimax/tts.py` still state that Filipino, Tamil, and Persian are only supported by `speech-2.6-*` models. If 2.8 inherits that support, those notes should widen; if it doesn't, this changes the default to a model that can't speak three languages in its own map, and both the code and the changelog entry need revising. Not verified against MiniMax's docs.
