### PR TITLE
fix(stt): hold audio until the service can accept it

### DIFF
--- a/changelog/5250.fixed.md
+++ b/changelog/5250.fixed.md
@@ -1,0 +1,3 @@
+- Fixed `DeepgramSTTService` and `XAISTTService` dropping the speaker's first word or two when someone is already talking as a session starts. Audio arriving before the service can accept it is now held and transcribed once the connection is ready, instead of being discarded.
+
+  The new `max_pending_audio_seconds` parameter (default 5.0) caps how much audio is held; beyond that the oldest is discarded. Custom `STTService` subclasses whose connection is not usable by the time `start()` returns can opt in with `_clear_audio_ready()` and `_set_audio_ready()`.

--- a/changelog/5250.performance.md
+++ b/changelog/5250.performance.md
@@ -1,0 +1,1 @@
+- `SonioxSTTService` no longer delays pipeline startup while its WebSocket connects. The handshake runs in the background and audio is held until it completes, so pipelines using Soniox start roughly 150-280 ms sooner and the connection overlaps with the rest of the pipeline starting up.

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -618,6 +618,9 @@ class DeepgramSTTService(STTService):
 
     async def _connect(self):
         logger.debug("Connecting to Deepgram")
+        # The handshake runs in the background, so start() returns before the
+        # connection exists. Hold audio until it does.
+        self._clear_audio_ready()
         self._quick_failure_tracker.reset()
         self._connection_task = self.create_task(self._connection_handler())
 
@@ -660,6 +663,7 @@ class DeepgramSTTService(STTService):
                 async with self._client.listen.v1.connect(**connect_kwargs) as connection:
                     self._connection = connection
                     self._connection_ready.set()
+                    self._set_audio_ready()
                     connection.on(EventType.MESSAGE, self._on_message)
                     connection.on(EventType.ERROR, self._on_error)
 
@@ -681,6 +685,7 @@ class DeepgramSTTService(STTService):
                 await self.push_error(error_msg=f"connection error: {e}", exception=e)
             finally:
                 self._connection_ready.clear()
+                self._clear_audio_ready()
                 self._connection = None
                 if keepalive_task:
                     await self.cancel_task(keepalive_task)

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -395,6 +395,7 @@ class SonioxSTTService(WebsocketSTTService):
         self._user_turn_open = False
 
         self._receive_task = None
+        self._connect_task = None
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -451,11 +452,16 @@ class SonioxSTTService(WebsocketSTTService):
     async def start(self, frame: StartFrame):
         """Start the Soniox STT websocket connection.
 
+        The connection is established in the background so the handshake is not
+        added to pipeline startup. Audio arriving before the socket is ready is
+        held by the base class and transcribed once it is.
+
         Args:
             frame: The start frame containing initialization parameters.
         """
         await super().start(frame)
-        await self._connect()
+        self._clear_audio_ready()
+        self._connect_task = self.create_task(self._connect())
 
     async def _update_settings(self, delta: Settings) -> dict[str, Any]:
         """Apply settings delta and reconnect if anything changed.
@@ -570,6 +576,10 @@ class SonioxSTTService(WebsocketSTTService):
         """
         await super()._disconnect()
 
+        if self._connect_task:
+            await self.cancel_task(self._connect_task)
+            self._connect_task = None
+
         if self._receive_task:
             await self.cancel_task(self._receive_task)
             self._receive_task = None
@@ -580,6 +590,7 @@ class SonioxSTTService(WebsocketSTTService):
         """Establish the websocket connection to Soniox."""
         try:
             if self._websocket and self._websocket.state is State.OPEN:
+                self._set_audio_ready()
                 return
 
             logger.debug("Connecting to Soniox STT")
@@ -623,6 +634,8 @@ class SonioxSTTService(WebsocketSTTService):
             await self._websocket.send(json.dumps(config))
 
             await self._call_event_handler("on_connected")
+            # The config message is sent, so the socket can now carry audio.
+            self._set_audio_ready()
             logger.debug("Connected to Soniox STT")
         except Exception as e:
             self._websocket = None
@@ -638,6 +651,7 @@ class SonioxSTTService(WebsocketSTTService):
             await self.push_error(error_msg=f"Error closing websocket: {e}", exception=e)
         finally:
             self._websocket = None
+            self._clear_audio_ready()
             await self._call_event_handler("on_disconnected")
 
     def _get_websocket(self):

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -12,6 +12,7 @@ import time
 import warnings
 import wave
 from abc import abstractmethod
+from collections import deque
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -92,6 +93,7 @@ class STTService(AIService):
         ttfs_p99_latency: float | None = None,
         keepalive_timeout: float | None = None,
         keepalive_interval: float = 5.0,
+        max_pending_audio_seconds: float = 5.0,
         settings: STTSettings | None = None,
         **kwargs,
     ):
@@ -118,6 +120,9 @@ class STTService(AIService):
                 connection alive. None disables keepalive. Useful for services that
                 close idle connections (e.g. behind a ServiceSwitcher).
             keepalive_interval: Seconds between idle checks when keepalive is enabled.
+            max_pending_audio_seconds: Most audio, in seconds, held while the service
+                cannot accept it (see :meth:`_clear_audio_ready`). Once the buffer is
+                full the oldest audio is discarded to make room. Defaults to 5.0.
             settings: The runtime-updatable settings for the STT service.
             **kwargs: Additional arguments passed to the parent AIService.
         """
@@ -180,10 +185,18 @@ class STTService(AIService):
         self._can_reconnect: bool = True
         # Whether a reconnect has been requested but deferred until speaking ends.
         self._need_reconnect: bool = False
-        # Whether a reconnect cycle is currently in progress.
-        self._reconnecting: bool = False
-        # Audio frames received while _reconnecting is True, replayed after reconnect.
-        self._reconnect_audio_buffer: list[tuple[AudioRawFrame, FrameDirection]] = []
+
+        # Audio readiness state. Starts ready: services that establish their
+        # connection before start() returns never need the gate.
+        self._audio_ready = asyncio.Event()
+        self._audio_ready.set()
+        # Audio held while not ready, replayed in order once ready again.
+        self._pending_audio: deque[tuple[AudioRawFrame, FrameDirection]] = deque()
+        self._pending_audio_bytes: int = 0
+        self._max_pending_audio_seconds = max_pending_audio_seconds
+        # Whether audio has already been discarded from a full buffer, so the
+        # warning is logged once per hold rather than per frame.
+        self._pending_audio_trimmed: bool = False
 
         self._register_event_handler("on_connected")
         self._register_event_handler("on_disconnected")
@@ -370,7 +383,7 @@ class STTService(AIService):
         await super().cleanup()
         await self._cancel_ttfb_timeout()
         await self._cancel_keepalive_task()
-        self._reconnect_audio_buffer.clear()
+        self._clear_pending_audio()
 
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
         """Apply an STT settings delta.
@@ -412,19 +425,41 @@ class STTService(AIService):
     async def process_audio_frame(self, frame: AudioRawFrame, direction: FrameDirection):
         """Process an audio frame for speech recognition.
 
-        If a reconnect is in progress, the frame is buffered and replayed
-        once the connection is restored. If the service is muted, the frame
-        is dropped. Otherwise the frame is sent to the STT service and, if
-        a user_id is present, it is stored for use in transcription results.
+        While the service cannot accept audio, the frame is held and replayed
+        once it can, so nothing is lost across an initial connection or a
+        reconnect. Held audio is drained here, on the audio path, rather than
+        by whichever task signals readiness: that keeps every frame on one task
+        and so preserves ordering against audio still arriving.
 
         Args:
             frame: The audio frame to process.
             direction: The direction of frame processing.
         """
-        if self._reconnecting:
-            self._reconnect_audio_buffer.append((frame, direction))
+        if not self._audio_ready.is_set():
+            self._hold_audio(frame, direction)
             return
 
+        if self._pending_audio:
+            pending = self._pending_audio
+            self._pending_audio = deque()
+            self._pending_audio_bytes = 0
+            self._pending_audio_trimmed = False
+            for pending_frame, pending_direction in pending:
+                await self._send_audio_frame(pending_frame, pending_direction)
+
+        await self._send_audio_frame(frame, direction)
+
+    async def _send_audio_frame(self, frame: AudioRawFrame, direction: FrameDirection):
+        """Hand a single audio frame to the STT service.
+
+        If the service is muted the frame is dropped. Otherwise it is sent to
+        the service and, if a user_id is present, it is stored for use in
+        transcription results.
+
+        Args:
+            frame: The audio frame to send.
+            direction: The direction of frame processing.
+        """
         if self._muted:
             return
 
@@ -447,6 +482,58 @@ class STTService(AIService):
         self._record_stt_audio_usage(frame.audio)
 
         await self.process_generator(self.run_stt(frame.audio))
+
+    def _set_audio_ready(self):
+        """Signal that the service can accept audio again.
+
+        Held audio is not replayed here. It drains on the next audio frame, so
+        that replay and live audio stay on the same task and in order.
+        """
+        self._audio_ready.set()
+
+    def _clear_audio_ready(self):
+        """Signal that the service cannot currently accept audio.
+
+        Audio arriving from now on is held, up to ``max_pending_audio_seconds``,
+        until :meth:`_set_audio_ready` is called. Services whose connection is
+        not usable the moment ``start()`` returns should call this before
+        connecting, and :meth:`_set_audio_ready` once the connection can carry
+        audio — which is not always when the socket opens: a service that must
+        wait for the server to acknowledge a session should signal readiness
+        there instead.
+        """
+        self._audio_ready.clear()
+
+    def _hold_audio(self, frame: AudioRawFrame, direction: FrameDirection):
+        """Hold an audio frame until the service can accept it.
+
+        The buffer holds at most ``max_pending_audio_seconds`` of audio,
+        discarding the oldest to make room, so what survives is the most recent
+        speech — the part still worth transcribing. The budget is measured in
+        bytes, derived from the frame's own format, so the accounting stays
+        exact and does not depend on the service's sample rate being known yet.
+        """
+        self._pending_audio.append((frame, direction))
+        self._pending_audio_bytes += len(frame.audio)
+
+        max_bytes = int(
+            self._max_pending_audio_seconds * frame.sample_rate * frame.num_channels * 2
+        )
+        while self._pending_audio_bytes > max_bytes and len(self._pending_audio) > 1:
+            dropped_frame, _ = self._pending_audio.popleft()
+            self._pending_audio_bytes -= len(dropped_frame.audio)
+            if not self._pending_audio_trimmed:
+                self._pending_audio_trimmed = True
+                logger.warning(
+                    f"{self}: still not ready for audio with "
+                    f"{self._max_pending_audio_seconds}s held, discarding the oldest"
+                )
+
+    def _clear_pending_audio(self):
+        """Discard any held audio."""
+        self._pending_audio.clear()
+        self._pending_audio_bytes = 0
+        self._pending_audio_trimmed = False
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames, handling VAD events and audio segmentation.
@@ -494,6 +581,7 @@ class STTService(AIService):
             self._muted = frame.mute
             logger.debug(f"STT service {'muted' if frame.mute else 'unmuted'}")
         elif isinstance(frame, InterruptionFrame):
+            self._clear_pending_audio()
             await self._reset_stt_ttfb_state()
             await self.push_frame(frame, direction)
         elif isinstance(frame, LLMContextAssistantTurnFrame):
@@ -671,15 +759,20 @@ class STTService(AIService):
     async def _reconnect(self):
         """Perform a full reconnect cycle with audio buffering.
 
-        Sets ``_reconnecting`` so incoming audio frames are buffered rather than
-        sent to a dead connection. Delegates the actual connection reset to
-        ``_do_reconnect()``. After the new connection is established all buffered
-        frames are replayed. On failure the error is reported via ``push_error``
-        and the ``on_connection_error`` event handler.
+        Holds incoming audio rather than sending it to a dead connection, and
+        delegates the actual connection reset to ``_do_reconnect()``. Held audio
+        is replayed once the new connection is up.
+
+        Readiness is restored only on success, for two reasons: a service whose
+        reconnect failed cannot transcribe anyway, so continuing to hold means a
+        later successful reconnect still receives the most recent speech; and a
+        service that manages readiness itself must not have the gate reopened
+        underneath it. Failures are reported via ``push_error`` and the
+        ``on_connection_error`` event handler.
         """
         logger.info(f"{self} reconnecting...")
-        self._reconnect_audio_buffer.clear()
-        self._reconnecting = True
+        self._clear_pending_audio()
+        self._clear_audio_ready()
         self._need_reconnect = False
         try:
             await self._do_reconnect()
@@ -688,13 +781,7 @@ class STTService(AIService):
             await self._call_event_handler("on_connection_error", str(e))
             await self.push_error(f"{self} reconnect failed: {e}", exception=e)
             return
-        finally:
-            self._reconnecting = False
-
-        # Replay audio frames that arrived while the connection was down.
-        for buffered_frame, buffered_direction in self._reconnect_audio_buffer:
-            await self.process_audio_frame(buffered_frame, buffered_direction)
-        self._reconnect_audio_buffer.clear()
+        self._set_audio_ready()
 
     async def _do_reconnect(self):
         """Perform the service-specific connection reset.

--- a/src/pipecat/services/xai/stt.py
+++ b/src/pipecat/services/xai/stt.py
@@ -275,7 +275,11 @@ class XAISTTService(WebsocketSTTService):
                 return
 
             logger.debug("Connecting to xAI STT WebSocket")
+            # The socket opening is not enough to send audio: xAI acknowledges
+            # the session separately, and run_stt() waits for that. Hold audio
+            # until it arrives.
             self._session_ready.clear()
+            self._clear_audio_ready()
 
             ws_url = self._build_ws_url()
             headers = {
@@ -288,6 +292,7 @@ class XAISTTService(WebsocketSTTService):
         except Exception as e:
             self._websocket = None
             self._session_ready.clear()
+            self._clear_audio_ready()
             await self.push_error(error_msg=f"Unable to connect to xAI STT: {e}", exception=e)
 
     async def _disconnect_websocket(self):
@@ -301,6 +306,7 @@ class XAISTTService(WebsocketSTTService):
         finally:
             self._websocket = None
             self._session_ready.clear()
+            self._clear_audio_ready()
             await self._call_event_handler("on_disconnected")
 
     async def _receive_messages(self):
@@ -321,6 +327,7 @@ class XAISTTService(WebsocketSTTService):
 
         if msg_type == "transcript.created":
             self._session_ready.set()
+            self._set_audio_ready()
             logger.debug(f"{self} xAI STT session ready")
         elif msg_type == "transcript.partial":
             await self._handle_transcript(message)

--- a/tests/test_deepgram_stt.py
+++ b/tests/test_deepgram_stt.py
@@ -27,6 +27,7 @@ def _make_bare_service() -> DeepgramSTTService:
     service._name = "DeepgramSTTService"
     service._connection = None
     service._connection_ready = asyncio.Event()
+    service._audio_ready = asyncio.Event()
     service._quick_failure_tracker = QuickFailureTracker()
     service._build_connect_kwargs = MagicMock(return_value={})
     service.push_error = AsyncMock()

--- a/tests/test_stt_audio_readiness.py
+++ b/tests/test_stt_audio_readiness.py
@@ -1,0 +1,158 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    InterruptionFrame,
+    STTMetadataFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.ai_service import AIService
+from pipecat.services.stt_service import STTService
+from pipecat.tests.utils import run_test
+
+SAMPLE_RATE = 16000
+# 100ms of 16-bit mono audio per frame.
+FRAME_BYTES = SAMPLE_RATE // 10 * 2
+
+
+def _audio(marker: int) -> InputAudioRawFrame:
+    """Build an audio frame whose payload identifies it."""
+    return InputAudioRawFrame(
+        audio=bytes([marker]) * FRAME_BYTES, sample_rate=SAMPLE_RATE, num_channels=1
+    )
+
+
+def _make_capturing_service(**kwargs) -> STTService:
+    """Build an STTService that records the audio handed to run_stt().
+
+    Defined as a factory (not a module-level class) so this concrete subclass
+    isn't picked up by the service-discovery scan in test_service_init.py.
+    """
+
+    class _CapturingSTTService(STTService):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self.received: list[int] = []
+
+        async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame | None, None]:
+            self.received.append(audio[0])
+            yield None
+
+    service = _CapturingSTTService(**kwargs)
+    # Audio only reaches a service after StartFrame, which is what sets this.
+    service._sample_rate = SAMPLE_RATE
+    return service
+
+
+@pytest.mark.asyncio
+async def test_audio_is_held_until_ready_then_replayed_in_order():
+    service = _make_capturing_service()
+    service._clear_audio_ready()
+
+    for marker in (1, 2, 3):
+        await service.process_audio_frame(_audio(marker), FrameDirection.DOWNSTREAM)
+
+    assert service.received == []
+
+    # Readiness alone does not replay: held audio drains on the next audio
+    # frame, so replay stays on the audio path and cannot interleave.
+    service._set_audio_ready()
+    assert service.received == []
+
+    await service.process_audio_frame(_audio(4), FrameDirection.DOWNSTREAM)
+    assert service.received == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_held_audio_is_bounded_and_keeps_the_most_recent():
+    # Room for two 100ms frames.
+    service = _make_capturing_service(max_pending_audio_seconds=0.2)
+    service._clear_audio_ready()
+
+    for marker in (1, 2, 3, 4):
+        await service.process_audio_frame(_audio(marker), FrameDirection.DOWNSTREAM)
+
+    service._set_audio_ready()
+    await service.process_audio_frame(_audio(5), FrameDirection.DOWNSTREAM)
+
+    # The oldest audio is discarded, so the most recent speech survives.
+    assert service.received == [3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_bound_still_applies_after_an_earlier_hold_drained():
+    """A second hold, e.g. across a reconnect, is bounded like the first."""
+    service = _make_capturing_service(max_pending_audio_seconds=0.2)
+
+    service._clear_audio_ready()
+    await service.process_audio_frame(_audio(1), FrameDirection.DOWNSTREAM)
+    service._set_audio_ready()
+    await service.process_audio_frame(_audio(2), FrameDirection.DOWNSTREAM)
+    assert service.received == [1, 2]
+
+    service._clear_audio_ready()
+    for marker in (3, 4, 5, 6):
+        await service.process_audio_frame(_audio(marker), FrameDirection.DOWNSTREAM)
+    service._set_audio_ready()
+    await service.process_audio_frame(_audio(7), FrameDirection.DOWNSTREAM)
+
+    assert service.received == [1, 2, 5, 6, 7]
+
+
+@pytest.mark.asyncio
+async def test_interruption_discards_held_audio(monkeypatch):
+    # Only STTService's own frame handling is under test here; the base
+    # implementation needs a live pipeline to start an interruption.
+    monkeypatch.setattr(AIService, "process_frame", AsyncMock())
+
+    service = _make_capturing_service()
+    service._clear_audio_ready()
+
+    await service.process_audio_frame(_audio(1), FrameDirection.DOWNSTREAM)
+    await service.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+    service._set_audio_ready()
+    await service.process_audio_frame(_audio(2), FrameDirection.DOWNSTREAM)
+
+    # Audio from before the interruption is no longer worth transcribing.
+    assert service.received == [2]
+
+
+@pytest.mark.asyncio
+async def test_muted_audio_is_dropped_on_replay_not_when_held():
+    service = _make_capturing_service()
+    service._clear_audio_ready()
+
+    await service.process_audio_frame(_audio(1), FrameDirection.DOWNSTREAM)
+    service._muted = True
+
+    service._set_audio_ready()
+    await service.process_audio_frame(_audio(2), FrameDirection.DOWNSTREAM)
+
+    # Mute is applied when the audio is actually sent, so a service muted while
+    # audio was held does not transcribe it.
+    assert service.received == []
+
+
+@pytest.mark.asyncio
+async def test_service_is_ready_by_default():
+    """A service that never touches readiness passes audio straight through."""
+    service = _make_capturing_service()
+
+    await run_test(
+        service,
+        frames_to_send=[_audio(1), _audio(2)],
+        expected_down_frames=[STTMetadataFrame, InputAudioRawFrame, InputAudioRawFrame],
+    )
+
+    assert service.received == [1, 2]


### PR DESCRIPTION
tl;dr

A customer reported Deepgram dropping the first few words. Dom confirmed it in #5241. I reproduced it and surveyed the other STT services — xAI has the same bug.

Two possible fixes:
1. Delay start() until connected
2. Hold audio arriving after StartFrame until the service can accept it, then drain

1 is insufficient: xAI already delays start and still drops audio, because its readiness lands after the socket opens. It also adds the whole handshake to pipeline startup. So I've implemented 2, in STTService so any service can opt in. 14 services currently delay start (76 ms–1511 ms); migrating the biggest offenders is a follow-up.

I've implemented one migration in SonioxSTTService to where it connects using a connection_task now. We'll migrate the remaining in a follow up PR once we agree that this makes sense.
 
## Problem

STT services discard the speaker's first word or two when audio arrives before the service can accept it. `STTService`'s audio buffer is gated on `_reconnecting`, which only `_reconnect()` sets, so the reconnect window is protected and the initial-connect window is not.

Two services are affected, for different reasons:

- **Deepgram** — `_connect()` only spawns a background task, so `start()` returns with `_connection` still `None` and `run_stt()` silently discards everything arriving in that window.
- **xAI** — `start()` *does* await the WebSocket handshake, yet still loses audio. `run_stt()` also gates on `_session_ready`, which is set only when the server sends `transcript.created`, a round-trip after `start()` returns. The audio that queued during the handshake flushes as a burst into a closed gate.

Measured against the live services, with speech starting at the first frame:

| | audio dropped | transcript |
|---|---|---|
| Deepgram | 160–200 ms | `Hello` lost |
| xAI | 240–280 ms (3/3 runs) | `Hello` lost |

## Approach

`STTService` now holds audio whenever a service reports itself not ready and replays it, in order, once it is. Services signal with `_clear_audio_ready()` / `_set_audio_ready()`. Readiness starts open, so the services that establish their connection before `start()` returns are unaffected.

The alternative — blocking `start()` until connected — is what 13 of the 16 measured services already do, and it works for Deepgram. It was rejected as the general fix for two reasons:

1. **It doesn't generalize.** xAI already blocks in `start()` and still loses the audio. Blocking on the socket buys nothing when readiness has a second stage behind it.
2. **It costs pipeline startup.** `AIService.process_frame` awaits `_start()` before pushing `StartFrame` downstream, so blocking starts sum along the pipeline. Measured across services, `start()` blocks 76 ms (AssemblyAI) to 1511 ms (Gladia) — see the appendix.

Buffering costs nothing at the point that matters. Streaming ASR endpointing runs on the audio timeline, not the wall clock, and servers process far faster than realtime — holding 1920 ms of audio and flushing it took 3 ms, and speech-end-to-final-transcript latency was unchanged.

## Details

- Held audio drains **on the audio path**, not from whichever task signals readiness. Both `StartFrame` and `InputAudioRawFrame` are `SystemFrame`s handled serially by one task, so draining there keeps replay and live audio in order without a lock. `_set_audio_ready()` deliberately only flips the event.
- The buffer is a `deque`, bounded by the new `max_pending_audio_seconds` (default 5.0), discarding oldest-first so the most recent speech survives. The budget derives from the frame's own format, in integer bytes, so accounting is exact and independent of the service's sample rate.
- Held audio is discarded on an interruption, since it predates it.
- `_reconnect()` now uses the same gate, replacing `_reconnecting` / `_reconnect_audio_buffer`. This also bounds the reconnect buffer, which was previously unbounded.

## Results

| | before | after |
|---|---|---|
| Deepgram audio dropped | 160–200 ms | 0 |
| xAI audio dropped | 240–280 ms | 0 |
| pipeline ready after worker start | 6 ms | 5 ms |

Both transcripts come back complete against the live services.

## Testing

- Six new tests in `tests/test_stt_audio_readiness.py`: hold-and-replay ordering, the bound, the bound after an earlier drain, interruption, mute-on-replay, and the default-ready path.
- One existing fixture in `test_deepgram_stt.py` needed `_audio_ready`; it builds the service via `__new__` and bypasses `__init__`.
- Full suite: 3858 passed, 29 skipped. `ruff check` and `ruff format` clean.

## Soniox, as a worked example

Soniox was not losing audio — it blocks in `start()` until its socket is open, which is genuinely when it can accept audio. What it was doing is adding its handshake to pipeline startup. It is migrated here to show what adopting the gate costs for a service that is already correct:

| | before | after |
|---|---:|---:|
| `start()` blocks | 141–278 ms | 0 ms |
| leading words lost | 0 | 0 |
| pipeline-ready, Soniox + AssemblyAI in one pipeline | 218 ms | 76 ms |

15 lines across five edits: spawn the connect rather than awaiting it, signal readiness once the config message is sent, clear it on disconnect, and cancel an in-flight connect on teardown. `_connect()` itself still awaits, so the settings-update and reconnect paths are untouched.

The two connects now overlap instead of queueing, and Soniox finishes its handshake after the pipeline is already live:

```
49.952  Connecting to Soniox
49.957  Connecting to AssemblyAI     <- 5 ms later, concurrent
50.028  pipeline is now ready        <- gated only by AssemblyAI
50.115  Connected to Soniox          <- finished after the pipeline was live
```

The judgment call worth noting for anyone repeating this: readiness is "after the config message is sent," not "after the socket opens." Picking the wrong point is exactly the xAI bug, and it fails silently.

## Follow-ups, not in this PR

- The other 13 services that block in `start()` can follow the Soniox shape; the appendix ranks them by cost. Gladia is the best next target at 1157–1511 ms, and migrating it also deletes its hand-rolled audio buffer. xAI still blocks ~313 ms awaiting its socket — the gate fixes its audio loss but does not remove that cost.
- `aws/nova_sonic/session_continuation.py:174` implements the same duration-bounded audio buffer independently. Worth extracting a shared helper if a third caller appears.

## Appendix: how long `start()` blocks, by service

`start()` runs on the serial system-frame path and `AIService.process_frame` awaits it before pushing `StartFrame` downstream, so whatever it waits on is added to pipeline startup for every processor behind it.

**Delays pipeline start:**

| service | `start()` blocks for |
|---|---:|
| Gladia | 1511 ms |
| Sarvam | 749 ms |
| Smallest | 638 ms |
| Together | 606 ms |
| Mistral | 534 ms |
| xAI | 313 ms |
| Speechmatics | 311 ms |
| AWS Transcribe | 236 ms |
| OpenAI Realtime | 192 ms |
| Gradium | 132 ms |
| Cartesia | 120 ms |
| ElevenLabs Realtime | 94 ms |
| AssemblyAI | 76 ms |

**Does not:**

| service | `start()` blocks for | how |
|---|---:|---|
| NVIDIA | 3 ms | audio goes to an `AudioChunkIterator`, connection happens behind it |
| Azure | 2 ms | audio goes to a `PushAudioInputStream`, connection happens behind it |
| Deepgram | 0 ms | connects in a background task; holds audio via the gate added here |
| Soniox | 0 ms | migrated in this PR — see below |

Google is not measured (no credentials to hand) but belongs with the second group by inspection: `_connect()` creates `_request_queue`, spawns `_stream_audio()`, and returns without awaiting the network. Segmented services (Whisper, Groq, Fal, FunASR, Moonshine, NVIDIA Segmented, ElevenLabs, OpenAI Whisper) transcribe over HTTP per utterance, so they have no persistent connection to block on.

Single samples taken from one location, including DNS and TLS on first connect, so the ordering is meaningful and the absolute values are indicative. AWS Transcribe was measured in a separate run from the other fifteen.

