### PR TITLE
Finish TaskManager and reset() deprecation migrations

### DIFF
--- a/changelog/5252.changed.md
+++ b/changelog/5252.changed.md
@@ -1,0 +1,1 @@
+- `SpeechTimeoutUserTurnStopStrategy` no longer overrides the deprecated `reset()` hook. Turn detection through `UserTurnController` is unaffected; code that calls `.reset()` directly on this strategy now reaches the inherited no-op instead — call `handle_user_turn_started()` (turn start) or `handle_user_turn_stopped()` (turn stop) instead.

--- a/src/pipecat/evals/speech.py
+++ b/src/pipecat/evals/speech.py
@@ -220,10 +220,9 @@ class EvalSpeech:
         from pipecat.clocks.system_clock import SystemClock
         from pipecat.frames.frames import StartFrame
         from pipecat.processors.frame_processor import FrameProcessorSetup
-        from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+        from pipecat.utils.asyncio.task_manager import TaskManager
 
         task_manager = TaskManager()
-        task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         clock = SystemClock()
         clock.start()
         # There deliberately is no PipelineWorker: the service runs out-of-pipeline,

--- a/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/speech_timeout_user_turn_stop_strategy.py
@@ -97,22 +97,16 @@ class SpeechTimeoutUserTurnStopStrategy(BaseUserTurnStopStrategy):
     def wait_for_transcript(self, value: bool) -> None:
         self._wait_for_transcript = value
 
-    async def reset(self):
-        """Reset the strategy to its initial state.
-
-        Note that ``_vad_user_speaking`` is intentionally left untouched: it
-        reflects the live physical VAD state, not turn-scoped bookkeeping.
-        VAD only re-emits a start after a stop, so if the user is still
-        speaking when a turn boundary resets this strategy, clearing the
-        flag would make the strategy believe there's no active VAD reference
-        and fall back to treating any transcript as a standalone utterance.
-        """
-        await super().reset()
-        await self._reset(clear_vad_user_speaking=False)
-
     async def handle_user_turn_started(self):
-        """Ready the strategy to detect the end of the turn now starting."""
-        await self.reset()
+        """Ready the strategy to detect the end of the turn now starting.
+
+        ``_vad_user_speaking`` is deliberately preserved: it reflects the live
+        physical VAD state, not turn-scoped bookkeeping. VAD only re-emits a
+        start after a stop, so clearing the flag for a turn that begins while
+        the user is still speaking would leave the strategy with no active VAD
+        reference, treating any transcript as a standalone utterance.
+        """
+        await self._reset(clear_vad_user_speaking=False)
 
     async def handle_user_turn_stopped(self):
         """Clear per-turn state once the turn has ended."""

--- a/tests/test_audio_buffer_processor.py
+++ b/tests/test_audio_buffer_processor.py
@@ -26,7 +26,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.tests.utils import run_test
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class _PassthroughResampler:
@@ -57,9 +57,7 @@ async def _make_processor(
     processor._input_resampler = _PassthroughResampler()
     processor._output_resampler = _PassthroughResampler()
 
-    loop = asyncio.get_event_loop()
     task_manager = TaskManager()
-    task_manager.setup(TaskManagerParams(loop=loop))
     await processor.setup(
         FrameProcessorSetup(
             clock=SystemClock(),

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -27,7 +27,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import TransportParams
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class _PassthroughMixer(BaseAudioMixer):
@@ -53,7 +53,6 @@ async def _make_transport(mixer: BaseAudioMixer | None = None) -> BaseOutputTran
     transport.write_audio_frame = AsyncMock(return_value=True)
 
     task_manager = TaskManager()
-    task_manager.setup(TaskManagerParams(loop=asyncio.get_event_loop()))
     await transport.setup(
         FrameProcessorSetup(
             clock=SystemClock(),

--- a/tests/test_base_worker.py
+++ b/tests/test_base_worker.py
@@ -35,7 +35,7 @@ from pipecat.processors.filters.identity_filter import IdentityFilter
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.registry import WorkerRegistry
 from pipecat.registry.types import WorkerReadyData
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.base_worker import BaseWorker
 from pipecat.workers.runner import WorkerRunner
 
@@ -55,7 +55,6 @@ async def create_test_bus():
     """Create an AsyncQueueBus with a TaskManager for testing."""
     bus = AsyncQueueBus()
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     return bus, tm
 

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -16,14 +16,13 @@ from pipecat.bus import (
     BusJobCancelMessage,
     BusSubscriber,
 )
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 async def create_test_bus():
     """Create an AsyncQueueBus with a TaskManager for testing."""
     bus = AsyncQueueBus()
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     return bus, tm
 

--- a/tests/test_context_summarization.py
+++ b/tests/test_context_summarization.py
@@ -814,10 +814,9 @@ class TestDedicatedLLMSummarization(unittest.IsolatedAsyncioTestCase):
     """Tests for dedicated LLM summarization in LLMContextSummarizer."""
 
     async def asyncSetUp(self):
-        from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+        from pipecat.utils.asyncio.task_manager import TaskManager
 
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     def _create_context_and_config(self, dedicated_llm):
         """Create a context with enough messages and a config with a dedicated LLM."""

--- a/tests/test_job_group.py
+++ b/tests/test_job_group.py
@@ -22,7 +22,7 @@ from pipecat.pipeline.job_context import (
 )
 from pipecat.registry import WorkerRegistry
 from pipecat.registry.types import WorkerReadyData
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.base_worker import BaseWorker
 
 
@@ -110,7 +110,6 @@ class SlowWorkerTask(BaseWorker):
 async def create_test_env():
     bus = AsyncQueueBus()
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     await bus.start()
     registry = WorkerRegistry(runner_name="test-runner")

--- a/tests/test_llm_context_summarizer.py
+++ b/tests/test_llm_context_summarizer.py
@@ -19,7 +19,7 @@ from pipecat.processors.aggregators.llm_context_summarizer import (
     LLMContextSummarizer,
     SummaryAppliedEvent,
 )
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.utils.context.llm_context_summarization import (
     LLMAutoContextSummarizationConfig,
     LLMContextSummaryConfig,
@@ -29,7 +29,6 @@ from pipecat.utils.context.llm_context_summarization import (
 class TestLLMContextSummarizer(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
         self.context = LLMContext(
             messages=[

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -15,7 +15,7 @@ from pipecat.bus import (
 )
 from pipecat.frames.frames import TextFrame
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class TestBusMessageRouting(unittest.IsolatedAsyncioTestCase):
@@ -33,7 +33,6 @@ class TestBusMessageRouting(unittest.IsolatedAsyncioTestCase):
         """Broadcast messages (no target) reach all subscribers."""
         bus = AsyncQueueBus()
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         received_a = []
         received_b = []

--- a/tests/test_pgmq_backends.py
+++ b/tests/test_pgmq_backends.py
@@ -23,7 +23,7 @@ import unittest
 from dataclasses import dataclass
 
 from pipecat.bus import BusDataMessage
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 try:
     from pipecat.bus.network.pgmq import PgmqBus
@@ -238,7 +238,6 @@ class TestPgmqBusBackendInjection(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
 
         await bus.start()

--- a/tests/test_pgmq_bus.py
+++ b/tests/test_pgmq_bus.py
@@ -22,7 +22,7 @@ from pipecat.bus import (
 from pipecat.bus.serializers import JSONMessageSerializer
 from pipecat.frames.frames import TextFrame
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.base_worker import BaseWorker
 
 try:
@@ -138,7 +138,6 @@ async def create_test_pgmq_bus(
         max_poll_seconds=1,
     )
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     return bus, pgmq, serializer
 
@@ -262,7 +261,6 @@ class TestPgmqBusBroadcast(unittest.IsolatedAsyncioTestCase):
         self.pgmq = FakePgmq()
         self.serializer = JSONMessageSerializer()
         self.tm = TaskManager()
-        self.tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
         self.bus_a = PgmqBus(
             pgmq=self.pgmq,
@@ -339,7 +337,6 @@ class TestPgmqBusEdgeCases(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         self.assertTrue(bus._queue_name.startswith("custom_channel_"))
@@ -355,7 +352,6 @@ class TestPgmqBusEdgeCases(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
 
@@ -371,7 +367,6 @@ class TestPgmqBusEdgeCases(unittest.IsolatedAsyncioTestCase):
         pgmq = FakePgmq()
         bus = PgmqBus(pgmq=pgmq, channel="cleanup_test", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
 
         await bus.start()
@@ -395,7 +390,6 @@ class TestPgmqBusEdgeCases(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
 
         received = []
@@ -426,7 +420,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
         pgmq = FakePgmq()
         bus = PgmqBus(pgmq=pgmq, channel="123corp", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -439,7 +432,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
         pgmq = FakePgmq()
         bus = PgmqBus(pgmq=pgmq, channel="cache_hit", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -475,7 +467,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -495,7 +486,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -525,7 +515,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
         pgmq = BadDropPgmq()
         bus = PgmqBus(pgmq=pgmq, channel="bad_drop", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
 
@@ -550,7 +539,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
         pgmq = FlakyReadPgmq()
         bus = PgmqBus(pgmq=pgmq, channel="flaky_read", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -576,7 +564,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
             max_poll_seconds=1,
         )
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
         await bus.start()
         try:
@@ -596,7 +583,6 @@ class TestPgmqBusErrorPaths(unittest.IsolatedAsyncioTestCase):
         pgmq = BadDeletePgmq()
         bus = PgmqBus(pgmq=pgmq, channel="bad_delete", poll_interval_ms=10, max_poll_seconds=1)
         tm = TaskManager()
-        tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         await bus.setup(tm)
 
         received = []

--- a/tests/test_redis_bus.py
+++ b/tests/test_redis_bus.py
@@ -19,7 +19,7 @@ from pipecat.bus import (
 from pipecat.bus.serializers import JSONMessageSerializer
 from pipecat.frames.frames import TextFrame
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.base_worker import BaseWorker
 
 try:
@@ -103,7 +103,6 @@ async def create_test_redis_bus():
     serializer = JSONMessageSerializer()
     bus = RedisBus(redis=redis, serializer=serializer, channel="test:bus")
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     return bus, redis, serializer
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -10,7 +10,7 @@ import asyncio
 import inspect
 import unittest
 
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class TestTaskManagerCreateTask(unittest.IsolatedAsyncioTestCase):
@@ -18,7 +18,6 @@ class TestTaskManagerCreateTask(unittest.IsolatedAsyncioTestCase):
 
     def _create_task_manager(self) -> TaskManager:
         task_manager = TaskManager()
-        task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         return task_manager
 
     async def test_cancel_before_run_closes_coroutine(self):

--- a/tests/test_ui_job_lifecycle.py
+++ b/tests/test_ui_job_lifecycle.py
@@ -31,7 +31,7 @@ from pipecat.bus.ui.messages import (
 from pipecat.frames.frames import LLMMessagesAppendFrame
 from pipecat.pipeline.job_context import JobGroup, JobStatus
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.ui import UIWorker
 
 
@@ -44,7 +44,6 @@ async def _make_solo_worker(**kwargs) -> UIWorker:
     """
     worker = UIWorker("ui", llm=MagicMock(), **kwargs)
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     worker._task_manager = tm
 
     recorded: list = []

--- a/tests/test_ui_worker.py
+++ b/tests/test_ui_worker.py
@@ -24,7 +24,7 @@ from pipecat.frames.frames import (
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.openai.llm import OpenAILLMService
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.ui import UI_STATE_PROMPT_GUIDE, UIWorker, ui_event
 
 
@@ -52,7 +52,6 @@ async def _make_worker(cls=_StubUIWorker, **kwargs) -> UIWorker:
     """
     worker = cls("ui", llm=MagicMock(), **kwargs)
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     worker._task_manager = tm
 
     recorded: list = []

--- a/tests/test_user_idle_controller.py
+++ b/tests/test_user_idle_controller.py
@@ -18,7 +18,7 @@ from pipecat.frames.frames import (
     UserStoppedSpeakingFrame,
 )
 from pipecat.turns.user_idle_controller import UserIdleController
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 USER_IDLE_TIMEOUT = 0.2
 
@@ -26,7 +26,6 @@ USER_IDLE_TIMEOUT = 0.2
 class TestUserIdleController(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def test_idle_after_bot_stops_speaking(self):
         """Test that idle event fires after BotStoppedSpeakingFrame + timeout."""

--- a/tests/test_user_turn_controller.py
+++ b/tests/test_user_turn_controller.py
@@ -32,7 +32,7 @@ from pipecat.turns.user_stop import (
 )
 from pipecat.turns.user_turn_controller import UserTurnController
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies, UserTurnStrategies
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 USER_TURN_STOP_TIMEOUT = 0.2
 TRANSCRIPTION_TIMEOUT = 0.1
@@ -41,7 +41,6 @@ TRANSCRIPTION_TIMEOUT = 0.1
 class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def test_completion_dropped_while_user_speaking(self):
         """A completion arriving while the user speaks must not stop the turn.

--- a/tests/test_user_turn_stop_strategy.py
+++ b/tests/test_user_turn_stop_strategy.py
@@ -23,7 +23,7 @@ from pipecat.turns.user_stop import (
     ExternalUserTurnStopStrategy,
     SpeechTimeoutUserTurnStopStrategy,
 )
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 AGGREGATION_TIMEOUT = 0.1
 # Use 0 STT timeout for deterministic test timing
@@ -33,7 +33,6 @@ STT_TIMEOUT = 0.0
 class TestSpeechTimeoutUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def _create_strategy(self, user_speech_timeout=AGGREGATION_TIMEOUT):
         """Create strategy and configure STT timeout via metadata frame."""
@@ -635,16 +634,17 @@ class TestSpeechTimeoutUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(AGGREGATION_TIMEOUT + 0.1)
         self.assertTrue(should_start)
 
-    async def test_reset_mid_utterance_falsely_stops_turn(self):
-        """Test that a mid-utterance reset does not falsely stop the turn.
+    async def test_turn_start_mid_utterance_falsely_stops_turn(self):
+        """Test that a mid-utterance turn start does not falsely stop the turn.
 
-        ``UserTurnController`` resets all stop strategies when a turn starts
-        (see ``_trigger_user_turn_start``), which can happen right after a
-        ``VADUserStartedSpeakingFrame`` with no matching stop yet — the user
-        is still speaking. ``reset()`` must preserve that live VAD state so a
-        finalized transcript for a mid-utterance segment (as streaming STT
-        services emit) is not treated as the no-VAD fallback and stopped by
-        ``user_speech_timeout`` while the user never stopped talking.
+        ``UserTurnController`` calls ``handle_user_turn_started`` on all stop
+        strategies when a turn starts (see ``_trigger_user_turn_start``),
+        which can happen right after a ``VADUserStartedSpeakingFrame`` with
+        no matching stop yet — the user is still speaking. The callback must
+        preserve that live VAD state so a finalized transcript for a
+        mid-utterance segment (as streaming STT services emit) is not
+        treated as the no-VAD fallback and stopped by ``user_speech_timeout``
+        while the user never stopped talking.
         """
         strategy = await self._create_strategy()
 
@@ -658,10 +658,10 @@ class TestSpeechTimeoutUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
         # User starts speaking; VAD reports start.
         await strategy.process_frame(VADUserStartedSpeakingFrame())
 
-        # Turn-start reset, as UserTurnController performs when the turn
-        # begins. No VADUserStoppedSpeakingFrame has been received — the
-        # user is still speaking.
-        await strategy.reset()
+        # Turn start, as UserTurnController performs when the turn begins.
+        # No VADUserStoppedSpeakingFrame has been received — the user is
+        # still speaking.
+        await strategy.handle_user_turn_started()
 
         # Streaming STT finalizes a mid-utterance segment while the user is
         # still talking (no VAD stop event was ever emitted).
@@ -726,7 +726,6 @@ class TestSpeechTimeoutStopSecsWarnings(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def _create_strategy(self, stt_timeout=0.35):
         strategy = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=AGGREGATION_TIMEOUT)
@@ -834,7 +833,6 @@ class TestExternalUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
 class TestExternalUserTurnCompletionStopStrategy(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def _create_strategy(self):
         strategy = ExternalUserTurnCompletionStopStrategy()

--- a/tests/test_vad_controller.py
+++ b/tests/test_vad_controller.py
@@ -11,7 +11,7 @@ from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams, VADState
 from pipecat.audio.vad.vad_controller import VADController
 from pipecat.frames.frames import Frame, InputAudioRawFrame, SpeechControlParamsFrame, StartFrame
 from pipecat.processors.frame_processor import FrameDirection
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class MockVADAnalyzer(VADAnalyzer):
@@ -213,7 +213,6 @@ AUDIO_IDLE_TIMEOUT = 0.1
 class TestVADControllerAudioIdle(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.task_manager = TaskManager()
-        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
 
     async def test_audio_idle_forces_speech_stop(self):
         """Test that on_speech_stopped fires when no audio arrives while SPEAKING."""

--- a/tests/test_vonage_video_connector.py
+++ b/tests/test_vonage_video_connector.py
@@ -32,7 +32,7 @@ from pipecat.frames.frames import (
     UserImageRawFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 # Mock the vonage_video module since it's not available in test environment
 vonage_video_mock = MagicMock()
@@ -250,7 +250,6 @@ class TestVonageVideoConnectorTransport:
 
         clock: SystemClock = SystemClock()  # type: ignore[no-untyped-call]
         task_manager = TaskManager()
-        task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
         self._frame_processor_setup = FrameProcessorSetup(
             clock=clock,
             task_manager=task_manager,

--- a/tests/test_wake_phrase_user_turn_start_strategy.py
+++ b/tests/test_wake_phrase_user_turn_start_strategy.py
@@ -19,7 +19,7 @@ from pipecat.turns.user_start.wake_phrase_user_turn_start_strategy import (
     WakePhraseUserTurnStartStrategy,
     _WakeState,
 )
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 
 
 class TestWakePhraseUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
@@ -30,8 +30,6 @@ class TestWakePhraseUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
 
     async def _setup_strategy(self, strategy: WakePhraseUserTurnStartStrategy):
         task_manager = TaskManager()
-        loop = asyncio.get_running_loop()
-        task_manager.setup(TaskManagerParams(loop=loop))
         await strategy.setup(task_manager)
         # The tests are quick, so make sure the schedule starts all tasks.
         await asyncio.sleep(0)

--- a/tests/test_websocket_proxy.py
+++ b/tests/test_websocket_proxy.py
@@ -15,7 +15,7 @@ from pipecat.bus import (
 )
 from pipecat.bus.serializers import JSONMessageSerializer
 from pipecat.registry import WorkerRegistry
-from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+from pipecat.utils.asyncio.task_manager import TaskManager
 from pipecat.workers.base_worker import BaseWorker
 
 
@@ -23,7 +23,6 @@ async def create_test_bus():
     """Create an AsyncQueueBus with a TaskManager for testing."""
     bus = AsyncQueueBus()
     tm = TaskManager()
-    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
     await bus.setup(tm)
     return bus, tm
 


### PR DESCRIPTION
## Summary

Finishes two deprecation migrations that were previously left with stragglers, so running the test suite no longer emits their warnings:

- **`reset()` on user turn stop strategies** (deprecated in 1.6.0): `SpeechTimeoutUserTurnStopStrategy` was the last override left in the tree. It's now split into `handle_user_turn_started` / `handle_user_turn_stopped`, following the pattern already used by `TurnAnalyzerUserTurnStopStrategy`. The `_vad_user_speaking`-preservation rationale moved onto `handle_user_turn_started`, since that's the boundary that actually skips clearing it.
- **`TaskManagerParams` + `TaskManager.setup()`** (deprecated in 1.5.0): removed every remaining call site across 21 test files and `evals/speech.py`. `TaskManager()`'s constructor already defaults `loop` to the running loop, so `TaskManager().setup(TaskManagerParams(loop=...))` was pure dead weight everywhere it appeared.

## Test plan

- [x] `uv run pytest tests/test_user_turn_stop_strategy.py` — 26 passed, 0 warnings (previously 51)
- [x] `uv run pytest tests/test_user_turn_controller.py tests/test_deprecation_markers.py` — 45 passed (deprecation bridge + enforcement gate still pass)
- [x] `uv run pytest tests/test_user_turn_processor.py tests/test_context_aggregators_universal.py tests/test_evals_services.py` — regression sweep over other consumers of the strategy and of `evals/speech.py`
- [x] All 22 touched files individually re-run — pass, with no `TaskManagerParams`/`TaskManager.setup` warnings anywhere in the repo (`grep -rln "TaskManagerParams" src tests` now only matches the deprecated class's own definition)
- [x] `uv run ruff check && uv run ruff format --check` — clean
