### PR TITLE
feat(processors): hold frames at a processor until it is ready to act on them

### DIFF
--- a/changelog/5254.added.md
+++ b/changelog/5254.added.md
@@ -1,0 +1,3 @@
+- Added `FrameProcessor.pause_processing_all_frames_until(ready, timeout=...)`, which holds frames arriving at a processor until a condition resolves and then delivers them in order. Useful for a processor that establishes a connection in the background and cannot act on frames the moment it starts.
+
+  `ready` is anything awaitable, typically an `asyncio.Event.wait` the processor already owns, so each service decides what "ready" means. The pause takes hold from the frame after the one being processed, so a `StartFrame` that triggers it still travels on downstream and pipeline startup is not delayed. Both frame queues are held, so `timeout` bounds the wait and the pause is always lifted, at the latest during cleanup.

--- a/changelog/5254.fixed.md
+++ b/changelog/5254.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepgramSTTService` dropping the speaker's first word or two when someone is already talking as a session starts. The connection is established in the background, so audio arriving before there was a connection to carry it was discarded. Frames now wait at the service until the connection can carry them, and are transcribed in full once it can.

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -167,6 +167,10 @@ class FrameProcessorQueue(asyncio.PriorityQueue):
         return item
 
 
+# How long a processor holds frames waiting for a readiness condition before
+# giving up and resuming. See pause_processing_all_frames_until().
+PAUSE_UNTIL_READY_TIMEOUT_SECS = 5.0
+
 # Timeout in seconds for cancelling the input frame processing task.
 # This prevents hanging if a library swallows asyncio.CancelledError.
 INPUT_TASK_CANCEL_TIMEOUT_SECS = 3
@@ -258,6 +262,9 @@ class FrameProcessor(BaseObject):
         self.__input_queue = FrameProcessorQueue()
         self.__input_event: asyncio.Event | None = None
         self.__input_frame_task: asyncio.Task | None = None
+        # Watches the readiness condition passed to
+        # pause_processing_all_frames_until() and lifts the pause it took.
+        self.__pause_watcher_task: asyncio.Task | None = None
 
         # The process task processes non-system frames.  Non-system frames will
         # be processed as soon as they are received by the processing task
@@ -561,6 +568,7 @@ class FrameProcessor(BaseObject):
         by an override.
         """
         await super().cleanup()
+        await self.__cancel_pause_watcher()
         await self.__cancel_input_task()
         await self.__cancel_process_task()
         if self._metrics is not None:
@@ -644,6 +652,70 @@ class FrameProcessor(BaseObject):
         logger.trace(f"{self}: resuming system frame processing")
         if self.__input_event:
             self.__input_event.set()
+
+    async def pause_processing_all_frames_until(
+        self,
+        ready: Callable[[], Awaitable[Any]],
+        *,
+        timeout: float = PAUSE_UNTIL_READY_TIMEOUT_SECS,
+    ):
+        """Hold frames arriving at this processor until ``ready`` resolves.
+
+        Useful for a processor that cannot act on frames until some condition
+        holds, such as one that establishes a connection in the background.
+        Frames wait in the processor's queues and are delivered in order once
+        the condition resolves, so nothing is lost.
+
+        The frame being processed when this is called is unaffected: the pause
+        takes hold from the next frame onwards. A processor pausing while it
+        handles its ``StartFrame``, for instance, still passes that frame on
+        downstream, so pipeline startup is not delayed.
+
+        Both queues are held, so a processor left paused could not process the
+        frames that shut it down. The pause is therefore always lifted: when
+        ``ready`` resolves, when ``timeout`` elapses, or at teardown, whichever
+        comes first.
+
+        Args:
+            ready: Awaited to learn when frames can be acted on, e.g.
+                ``some_event.wait``.
+            timeout: Seconds to hold frames before giving up and resuming.
+        """
+        if self._enable_direct_mode:
+            logger.warning(f"{self}: cannot hold frames, this processor runs in direct mode")
+            return
+
+        await self.__cancel_pause_watcher()
+        await self.pause_processing_system_frames()
+        await self.pause_processing_frames()
+        self.__pause_watcher_task = self.create_task(
+            self.__pause_watcher_handler(ready, timeout), name=f"{self}::pause_watcher"
+        )
+
+    async def __pause_watcher_handler(self, ready: Callable[[], Awaitable[Any]], timeout: float):
+        """Lift the pause taken by pause_processing_all_frames_until()."""
+        try:
+            await asyncio.wait_for(ready(), timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                f"{self}: still not ready after {timeout}s, resuming frame processing anyway"
+            )
+        await self.__resume_processing_all_frames()
+
+    async def __cancel_pause_watcher(self):
+        """Stop watching, and lift the pause the watcher was going to lift."""
+        if not self.__pause_watcher_task:
+            return
+
+        task = self.__pause_watcher_task
+        self.__pause_watcher_task = None
+        await self.cancel_task(task)
+        await self.__resume_processing_all_frames()
+
+    async def __resume_processing_all_frames(self):
+        """Resume both queues held by pause_processing_all_frames_until()."""
+        await self.resume_processing_system_frames()
+        await self.resume_processing_frames()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process a frame.

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -516,6 +516,9 @@ class DeepgramSTTService(STTService):
         """
         await super().start(frame)
         await self._connect()
+        # _connect() only launches the handshake, so hold what follows the
+        # StartFrame until the connection can carry it.
+        await self.pause_processing_all_frames_until(self._connection_ready.wait)
 
     async def stop(self, frame: EndFrame):
         """Stop the Deepgram STT service.

--- a/tests/test_frame_processor.py
+++ b/tests/test_frame_processor.py
@@ -5,8 +5,11 @@
 #
 
 import asyncio
+import io
 import unittest
 from dataclasses import dataclass, field
+
+from loguru import logger
 
 from pipecat.frames.frames import (
     DataFrame,
@@ -14,6 +17,7 @@ from pipecat.frames.frames import (
     Frame,
     InterruptionFrame,
     OutputTransportMessageUrgentFrame,
+    StartFrame,
     StopFrame,
     SystemFrame,
     TextFrame,
@@ -472,6 +476,91 @@ class TestFrameProcessor(unittest.IsolatedAsyncioTestCase):
             expected_down_frames=expected_down_frames,
         )
         self.assertTrue(code_after_ran, "Code after broadcast_interruption() should execute")
+
+    async def test_pause_frames_until_holds_then_delivers_in_order(self):
+        """Frames arriving before the condition is met are delivered once it is."""
+        ready = asyncio.Event()
+        received = []
+
+        class HoldingProcessor(FrameProcessor):
+            async def process_frame(self, frame: Frame, direction: FrameDirection):
+                await super().process_frame(frame, direction)
+                if isinstance(frame, StartFrame):
+                    await self.pause_processing_all_frames_until(ready.wait)
+                elif isinstance(frame, TextFrame):
+                    received.append(frame.text)
+                await self.push_frame(frame, direction)
+
+        async def release_later():
+            await asyncio.sleep(0.2)
+            self.assertEqual(received, [], "frames should be held while not ready")
+            ready.set()
+
+        release = asyncio.create_task(release_later())
+        await run_test(
+            HoldingProcessor(),
+            frames_to_send=[TextFrame(text="a"), TextFrame(text="b"), SleepFrame(sleep=0.4)],
+            expected_down_frames=[TextFrame, TextFrame],
+        )
+        await release
+
+        self.assertEqual(received, ["a", "b"])
+
+    async def test_pause_frames_until_resumes_when_never_ready(self):
+        """A condition that is never met must not leave the processor paused.
+
+        The pause holds both frame queues, so a processor left paused could
+        not process the frames that shut it down.
+        """
+        never = asyncio.Event()
+        received = []
+
+        class HoldingProcessor(FrameProcessor):
+            async def process_frame(self, frame: Frame, direction: FrameDirection):
+                await super().process_frame(frame, direction)
+                if isinstance(frame, StartFrame):
+                    await self.pause_processing_all_frames_until(never.wait, timeout=0.2)
+                elif isinstance(frame, TextFrame):
+                    received.append(frame.text)
+                await self.push_frame(frame, direction)
+
+        await asyncio.wait_for(
+            run_test(
+                HoldingProcessor(),
+                frames_to_send=[TextFrame(text="a"), SleepFrame(sleep=0.5)],
+                expected_down_frames=[TextFrame],
+            ),
+            timeout=10,
+        )
+
+        self.assertEqual(received, ["a"])
+
+    async def test_pause_frames_until_holds_both_queues(self):
+        """Data frames already routed to the process queue must be held too.
+
+        The two queues pause independently, so frames that have already moved
+        to the process queue keep draining unless it is held as well.
+        """
+        processor = FrameProcessor()
+        processor.create_task = lambda coro, name=None: asyncio.create_task(coro)
+
+        await processor.pause_processing_all_frames_until(asyncio.Event().wait, timeout=5.0)
+
+        self.assertTrue(processor._FrameProcessor__should_block_system_frames)
+        self.assertTrue(processor._FrameProcessor__should_block_frames)
+
+    async def test_pause_frames_until_is_a_no_op_in_direct_mode(self):
+        """Direct mode bypasses the queues the pause acts on, so the call warns."""
+        ready = asyncio.Event()
+        processor = FrameProcessor(enable_direct_mode=True)
+
+        sink = io.StringIO()
+        handler_id = logger.add(sink, format="{message}")
+        try:
+            await processor.pause_processing_all_frames_until(ready.wait)
+            self.assertIn("direct mode", sink.getvalue())
+        finally:
+            logger.remove(handler_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`DeepgramSTTService` discards the speaker's first word or two. `_connect()` only launches the handshake in a background task, so `start()` returns with `self._connection` still `None`, and audio arriving in that window reaches `run_stt()` and is silently skipped.

Measured against live Deepgram, feeding speech from the first frame of the session:

| | before | after |
|---|---|---|
| audio reaching `run_stt` unconnected | 11 chunks (220 ms) | 0 |
| leading words lost | 1 | 0 |
| transcript | `My name is Mark, and I would like to check the balance on my account.` | `Hello. My name is Mark, and I would like to check the balance on my account.` |
| pipeline ready | 5 ms | 5 ms |

## Approach

A new `FrameProcessor.pause_processing_all_frames_until(ready, *, timeout)` holds frames arriving at a processor until a condition resolves, then delivers them in order. `DeepgramSTTService.start()` is its first caller:

```python
await self._connect()
# _connect() only launches the handshake, so hold what follows the
# StartFrame until the connection can carry it.
await self.pause_processing_all_frames_until(self._connection_ready.wait)
```

`ready` is anything awaitable, so each processor decides what readiness means while the machinery stays shared — a service holding an event passes its `wait` method. It builds on the existing `pause_processing_frames()` / `pause_processing_system_frames()` pairs, and holds both.

Two properties make it fit:

- The pause check sits **after** `__input_queue.get()`, so it takes effect on the *next* frame. The StartFrame finishes processing and travels on downstream, so pipeline startup is not delayed.
- Frames wait in the processor's existing queues, in order. No separate buffer, and it applies to any frame type and any processor rather than audio and STT specifically.

## Why both queues

The two pause independently: the input task routes non-system frames on to the process queue, which has its own pause and its own task. Holding only the input path would let frames that had already moved on keep draining.

At `StartFrame` the process queue is empty, so Deepgram alone would not notice — but the method is general and callable at any time, so it has to honour its contract. `test_pause_frames_until_holds_both_queues` guards it.

## Why the wait is bounded

Nothing gets through a held processor, `CancelFrame` (a system frame) and `EndFrame` (a control frame) included. Without a bound, a connection that never arrives leaves the pipeline unable to shut down. With a deliberately invalid API key:

```
Deepgram rejected the connection (status 401)
Closing. Waiting for EndFrame to reach the end of the pipeline...
Cancelling pipeline worker                       <- 25s later, harness timeout
...still alive at 45s                            <- CancelFrame stuck too
```

A watcher lifts the pause when `ready` resolves, when `timeout` elapses, or at teardown, whichever comes first. With it, the same invalid-key run shuts down cleanly in 5.0 s.

`timeout` defaults to `PAUSE_UNTIL_READY_TIMEOUT_SECS`, which lives with the mechanism, so a service wanting the standard bound passes nothing and carries no parameter of its own.

Because `FrameProcessor` owns the watcher, `cleanup()` cancels it **and lifts the pause in its place** — cancelling alone would leave a processor that cannot process the frames that shut it down. Discharging that obligation once in the base class is the main reason it does not live in each service.

Direct-mode processors bypass the queues this acts on, so the call warns and does nothing.

## Scope

Only Deepgram is migrated here. Any processor with an async startup condition can use the same call: the other STT services, the websocket TTS services, and the realtime S2S services all block pipeline start or drop input for the same reason. #5250 and #5251 explored an audio-buffer approach to the same bug and are closed in favour of this one; the 13 service migrations sketched in #5251 each reduce to a single `pause_processing_all_frames_until()` call on top of this.

## Testing

- Four new tests in `tests/test_frame_processor.py`: frames are held then delivered in order; the pause is lifted when the condition is never met; both queues are held; the call warns and does nothing in direct mode.
- Verified live against Deepgram for both the happy path and a rejected API key.
- Full suite: 3856 passed, 29 skipped. `ruff check` and `ruff format` clean.
