### PR TITLE
fix(tts): finalize pending sentence before a Cartesia/Soniox settings re-mint drops it

### DIFF
--- a/changelog/5257.fixed.md
+++ b/changelog/5257.fixed.md
@@ -1,0 +1,7 @@
+- Fixed `CartesiaTTSService` and `SonioxTTSService` dropping an already-heard
+  sentence prefix from the transcript when a voice/model/language (or, for
+  Soniox, speed) settings change was applied mid-sentence. The re-mint of the
+  turn context now finalizes the old context's pending sentence first — so
+  word-timestamps arriving during the flushed playout still emit
+  `AggregatedTextProgressFrame`s — mirroring the existing end-of-turn and
+  `TTSSpeakFrame` close paths.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -665,6 +665,16 @@ class CartesiaTTSService(WebsocketTTSService):
             return changed
 
         if changed.keys() & {"voice", "model", "language"}:
+            if self._turn_context_id:
+                # Finalize the old context's still-pending sentence so its
+                # already-heard prefix still emits progress frames (mirrors the
+                # LLMFullResponseEnd / TTSSpeak close paths). A mid-sentence
+                # settings change would otherwise abandon it before promotion,
+                # dropping that prefix from the transcript.
+                await self._push_sequencer_frames(
+                    await self._aggregated_frame_sequencer.finalize(self._turn_context_id),
+                    self._turn_context_id,
+                )
             if self._turn_context_id and self.audio_context_available(self._turn_context_id):
                 await self.flush_audio(context_id=self._turn_context_id)
             # Assign a new turn context ID so subsequent sentences in this

--- a/src/pipecat/services/soniox/tts.py
+++ b/src/pipecat/services/soniox/tts.py
@@ -359,6 +359,16 @@ class SonioxTTSService(WebsocketTTSService):
             return changed
 
         if changed.keys() & {"voice", "model", "language", "speed"}:
+            if self._turn_context_id:
+                # Finalize the old context's still-pending sentence so its
+                # already-heard prefix still emits progress frames (mirrors the
+                # LLMFullResponseEnd / TTSSpeak close paths). A mid-sentence
+                # settings change would otherwise abandon it before promotion,
+                # dropping that prefix from the transcript.
+                await self._push_sequencer_frames(
+                    await self._aggregated_frame_sequencer.finalize(self._turn_context_id),
+                    self._turn_context_id,
+                )
             if self._turn_context_id and self.audio_context_available(self._turn_context_id):
                 await self.flush_audio(context_id=self._turn_context_id)
             # Assign a new turn context ID so subsequent sentences in this turn

--- a/tests/test_aggregated_frame_sequencer.py
+++ b/tests/test_aggregated_frame_sequencer.py
@@ -1674,6 +1674,45 @@ class TestFinalizeEndOfTurn(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# finalize rescues a mid-sentence prefix when a context is closed early
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeRescuesMidSentencePrefix(unittest.IsolatedAsyncioTestCase):
+    """A context closed mid-sentence (e.g. a TTS settings change re-mints the
+    turn context) must finalize its pending sentence, or the already-heard
+    prefix's word-timestamps land on no slot and are dropped from the transcript.
+    """
+
+    async def test_word_after_finalize_emits_progress_for_heard_prefix(self):
+        seq = _seq(streaming=True)
+        # A sentence is mid-stream: two tokens, no terminal boundary yet.
+        await _stream(seq, "ctx1", "Hi", " there")
+        self.assertEqual(seq._slots, [])
+        # The context is closed early — finalize force-promotes the prefix.
+        await seq.finalize("ctx1")
+        # A word-timestamp for the flushed prefix now lands on the promoted slot
+        # and emits both the word frame and a progress frame.
+        result = seq.process_word("Hi", pts=10, context_id="ctx1")
+        self.assertTrue(any(isinstance(f, TTSTextFrame) and f.text == "Hi" for f in result))
+        progress = [f for f in result if isinstance(f, AggregatedTextProgressFrame)]
+        self.assertEqual(len(progress), 1)
+        self.assertEqual(progress[0].accumulated_text, "Hi")
+
+    async def test_word_without_finalize_emits_no_progress(self):
+        # Same setup, but the prefix is never finalized (the pre-fix bug): the
+        # word for the still-pending sentence is buffered and no progress frame
+        # is emitted for the heard prefix.
+        seq = _seq(streaming=True)
+        await _stream(seq, "ctx1", "Hi", " there")
+        self.assertEqual(seq._slots, [])
+        result = seq.process_word("Hi", pts=10, context_id="ctx1")
+        self.assertEqual(result, [])
+        self.assertFalse(any(isinstance(f, AggregatedTextProgressFrame) for f in result))
+        self.assertEqual(len(seq._buffered_words), 1)
+
+
+# ---------------------------------------------------------------------------
 # Concurrent contexts — two audio contexts in flight at once must not bleed
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cartesia_tts.py
+++ b/tests/test_cartesia_tts.py
@@ -4,8 +4,18 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import unittest
+
+from pipecat.frames.frames import (
+    AggregatedTextFrame,
+    AggregatedTextProgressFrame,
+    AggregationType,
+    TTSTextFrame,
+)
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.settings import TTSSettings
+from pipecat.transcriptions.language import Language
+from pipecat.utils.context.aggregated_frame_sequencer import AggregatedFrameSequencer
 from pipecat.utils.string import TextPartForConcatenation, concatenate_aggregated_text
 
 
@@ -109,3 +119,85 @@ def test_cartesia_korean_timestamp_groups_reassemble_with_spaces():
         )
         == "저는 여러분의 AI 어시스턴트입니다."
     )
+
+
+class TestCartesiaUpdateSettingsFinalizesOldContext(unittest.IsolatedAsyncioTestCase):
+    """A mid-reply voice/model/language change re-mints the turn context. The old
+    context's still-pending sentence must be finalized first, or the already-heard
+    prefix's word-timestamps land on no slot and drop out of the transcript.
+    """
+
+    async def _service_with_pending_prefix(self, old_ctx: str):
+        service = CartesiaTTSService.__new__(CartesiaTTSService)
+        service._name = "CartesiaTTSService#0"
+        service._settings = CartesiaTTSService.Settings(
+            model="sonic-3.5",
+            voice="voiceA",
+            language=Language.EN,
+            generation_config=None,
+            pronunciation_dict_id=None,
+        )
+        # Real streaming sequencer with a mid-sentence prefix pending on the turn ctx.
+        seq = AggregatedFrameSequencer(name=service._name, streaming=True)
+        service._aggregated_frame_sequencer = seq
+        service._turn_context_id = old_ctx
+        for token in ("Hi", " there"):
+            frame = AggregatedTextFrame(token, AggregationType.SENTENCE, raw_text=token)
+            await seq.register_spoken(frame, old_ctx, token, append_to_context=True)
+        assert seq._slots == []  # nothing promoted — sentence has no boundary yet
+
+        # Stub I/O so _update_settings exercises the finalize/flush/re-mint logic
+        # without a websocket. Capture frames the finalize pushes.
+        pushed: list = []
+
+        async def fake_push(frames, context_id):
+            pushed.extend(frames)
+
+        async def fake_flush(context_id=None):
+            service._flushed = context_id
+
+        service._flushed = None
+        service._push_sequencer_frames = fake_push
+        service.flush_audio = fake_flush
+        service.audio_context_available = lambda context_id: True
+        service.create_context_id = lambda: "ctx-new"
+        return service, seq, pushed
+
+    async def test_voice_change_finalizes_and_rescues_prefix(self):
+        old_ctx = "ctx-old"
+        service, seq, pushed = await self._service_with_pending_prefix(old_ctx)
+
+        await service._update_settings(CartesiaTTSService.Settings(voice="voiceB"))
+
+        # The old context's pending sentence was force-promoted into a real slot.
+        self.assertEqual([s.frame.text for s in seq._slots], ["Hi there"])
+        self.assertEqual(seq._slots[0].context_id, old_ctx)
+        # The finalize pushed the promoted sentence anchor downstream.
+        self.assertTrue(
+            any(isinstance(f, AggregatedTextFrame) and f.text == "Hi there" for f in pushed)
+        )
+        # The context was flushed and the turn context re-minted afterwards.
+        self.assertEqual(service._flushed, old_ctx)
+        self.assertEqual(service._turn_context_id, "ctx-new")
+
+        # A word-timestamp for the flushed prefix (arriving on the OLD context during
+        # playout) still finds the promoted slot and emits a progress frame.
+        result = seq.process_word("Hi", pts=10, context_id=old_ctx)
+        self.assertTrue(any(isinstance(f, TTSTextFrame) and f.text == "Hi" for f in result))
+        progress = [f for f in result if isinstance(f, AggregatedTextProgressFrame)]
+        self.assertEqual(len(progress), 1)
+        self.assertEqual(progress[0].accumulated_text, "Hi")
+
+    async def test_non_remint_change_does_not_finalize(self):
+        # A change that does not re-mint the context (e.g. pronunciation_dict_id)
+        # must NOT finalize — that would prematurely promote and mis-segment the
+        # ongoing reply.
+        old_ctx = "ctx-old"
+        service, seq, pushed = await self._service_with_pending_prefix(old_ctx)
+
+        await service._update_settings(CartesiaTTSService.Settings(pronunciation_dict_id="dict-1"))
+
+        self.assertEqual(seq._slots, [])  # still pending, not promoted
+        self.assertEqual(pushed, [])
+        self.assertIsNone(service._flushed)
+        self.assertEqual(service._turn_context_id, old_ctx)

--- a/tests/test_soniox_tts.py
+++ b/tests/test_soniox_tts.py
@@ -4,8 +4,18 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import unittest
+
+from pipecat.frames.frames import (
+    AggregatedTextFrame,
+    AggregatedTextProgressFrame,
+    AggregationType,
+    TTSTextFrame,
+)
 from pipecat.services.settings import TTSSettings
 from pipecat.services.soniox.tts import SonioxTTSService
+from pipecat.transcriptions.language import Language
+from pipecat.utils.context.aggregated_frame_sequencer import AggregatedFrameSequencer
 from pipecat.utils.context.word_completion_tracker import WordCompletionTracker
 from pipecat.utils.string import TextPartForConcatenation, concatenate_aggregated_text
 
@@ -137,3 +147,77 @@ def test_soniox_japanese_punctuation_recovered_by_word_tracker():
 
     assert complete
     assert tracker.get_accumulated_user_facing_text() == text
+
+
+class TestSonioxUpdateSettingsFinalizesOldContext(unittest.IsolatedAsyncioTestCase):
+    """A mid-reply voice/model/language/speed change re-mints the turn context. The
+    old context's still-pending sentence must be finalized first, or the
+    already-heard prefix's word-timestamps land on no slot and drop from the
+    transcript.
+    """
+
+    async def _service_with_pending_prefix(self, old_ctx: str):
+        service = SonioxTTSService.__new__(SonioxTTSService)
+        service._name = "SonioxTTSService#0"
+        service._settings = SonioxTTSService.Settings(
+            model="tts-rt-v1",
+            voice="Adrian",
+            language=Language.EN,
+            speed=None,
+        )
+        # Real streaming sequencer with a mid-sentence prefix pending on the turn ctx.
+        seq = AggregatedFrameSequencer(name=service._name, streaming=True)
+        service._aggregated_frame_sequencer = seq
+        service._turn_context_id = old_ctx
+        for token in ("Hi", " there"):
+            frame = AggregatedTextFrame(token, AggregationType.SENTENCE, raw_text=token)
+            await seq.register_spoken(frame, old_ctx, token, append_to_context=True)
+        assert seq._slots == []  # nothing promoted — sentence has no boundary yet
+
+        pushed: list = []
+
+        async def fake_push(frames, context_id):
+            pushed.extend(frames)
+
+        async def fake_flush(context_id=None):
+            service._flushed = context_id
+
+        service._flushed = None
+        service._push_sequencer_frames = fake_push
+        service.flush_audio = fake_flush
+        service.audio_context_available = lambda context_id: True
+        service.create_context_id = lambda: "ctx-new"
+        return service, seq, pushed
+
+    async def test_voice_change_finalizes_and_rescues_prefix(self):
+        old_ctx = "ctx-old"
+        service, seq, pushed = await self._service_with_pending_prefix(old_ctx)
+
+        await service._update_settings(SonioxTTSService.Settings(voice="Hannah"))
+
+        # The old context's pending sentence was force-promoted into a real slot.
+        self.assertEqual([s.frame.text for s in seq._slots], ["Hi there"])
+        self.assertEqual(seq._slots[0].context_id, old_ctx)
+        self.assertTrue(
+            any(isinstance(f, AggregatedTextFrame) and f.text == "Hi there" for f in pushed)
+        )
+        self.assertEqual(service._flushed, old_ctx)
+        self.assertEqual(service._turn_context_id, "ctx-new")
+
+        # A word-timestamp for the flushed prefix (on the OLD context) still finds
+        # the promoted slot and emits a progress frame.
+        result = seq.process_word("Hi", pts=10, context_id=old_ctx)
+        self.assertTrue(any(isinstance(f, TTSTextFrame) and f.text == "Hi" for f in result))
+        progress = [f for f in result if isinstance(f, AggregatedTextProgressFrame)]
+        self.assertEqual(len(progress), 1)
+        self.assertEqual(progress[0].accumulated_text, "Hi")
+
+    async def test_speed_change_also_finalizes(self):
+        # Soniox additionally re-mints on a speed change, so it must finalize too.
+        old_ctx = "ctx-old"
+        service, seq, pushed = await self._service_with_pending_prefix(old_ctx)
+
+        await service._update_settings(SonioxTTSService.Settings(speed=1.2))
+
+        self.assertEqual([s.frame.text for s in seq._slots], ["Hi there"])
+        self.assertEqual(service._turn_context_id, "ctx-new")


### PR DESCRIPTION
## The bug

`CartesiaTTSService` and `SonioxTTSService` support changing voice/model/language (and, for Soniox, speed) mid-reply. When one of those changes, `_update_settings` flushes the current audio context and re-mints the turn context so the next sentence opens a fresh provider context with the new settings:

```python
if changed.keys() & {"voice", "model", "language"}:
    if self._turn_context_id and self.audio_context_available(self._turn_context_id):
        await self.flush_audio(context_id=self._turn_context_id)
    if self._turn_context_id:
        self._turn_context_id = None
        self._turn_context_id = self.create_context_id()
```

In `TextAggregationMode.TOKEN` (streaming) mode the `AggregatedFrameSequencer` groups streamed tokens back into sentences, and a sentence is only *promoted* into a real slot once its boundary is confirmed (by the next sentence's first token, or by an explicit `finalize`). If the settings change lands **mid-sentence**, the old context's still-pending sentence is never promoted — the re-mint abandons it. The provider still finishes synthesizing that flushed prefix and streams its word-timestamps back on the old context, but there is no live slot to match them, so no `AggregatedTextProgressFrame` is emitted and the already-heard prefix is dropped from the transcript.

## The fix

Finalize the old turn context **before** the flush + re-mint, inside the existing re-mint condition. This mirrors pipecat's own canonical context-close paths: both the `LLMFullResponseEndFrame` and `TTSSpeakFrame` branches in `tts_service.py` already call

```python
await self._push_sequencer_frames(
    await self._aggregated_frame_sequencer.finalize(self._turn_context_id),
    self._turn_context_id,
)
```

before completing a context. `AggregatedFrameSequencer.finalize(context_id)` force-promotes the pending sentence into a real slot **and deliberately keeps the context's entry alive**, so word-timestamps arriving later (during playback of the flushed audio) still register and emit progress frames. The settings re-mint was the one close/replace path that omitted it.

The finalize stays inside the `if changed.keys() & {...}` block so it only runs when a re-mint actually happens — finalizing on a non-re-mint change (e.g. a `pronunciation_dict_id` update) would prematurely promote and mis-segment the ongoing reply. No new machinery: it reuses the existing `_push_sequencer_frames` / `_aggregated_frame_sequencer` members.

Providers fixed:
- `src/pipecat/services/cartesia/tts.py`
- `src/pipecat/services/soniox/tts.py`

## Timestamp-vs-teardown ordering (verified)

The fix only helps if the flushed context's remaining `timestamps` are still delivered to the now-promoted slot before the context is torn down. Confirmed for the Cartesia path:

- Everything for a context — audio chunks, word-timestamp entries, and the terminal `TTSStoppedFrame` — flows through a **single per-context FIFO queue** drained by `_handle_audio_context`.
- Cartesia's `_process_messages` enqueues `timestamps` (via `add_word_timestamps` → `_WordTimestampEntry`) in wire order, and on `done` enqueues the `TTSStoppedFrame` and then a `None` deletion sentinel (`remove_audio_context` does **not** tear down synchronously). `done` is the terminal message for a context, so all of the prefix's timestamps are already queued ahead of it.
- The queue consumer processes those timestamp entries (→ `process_word` → the promoted slot → progress frames) **before** it reaches the `TTSStoppedFrame`, whose `_apply_force_complete` is what finally pops the context and makes any later word stale.

So the flushed prefix's timestamps land on the promoted slot before teardown, and the dropped-prefix window is closed. The same single-queue ordering holds for Soniox (`terminated` plays the role of `done`).

## Testing

`uv run pytest tests/test_aggregated_frame_sequencer.py tests/test_cartesia_tts.py tests/test_soniox_tts.py` → 154 passed.

- `tests/test_aggregated_frame_sequencer.py::TestFinalizeRescuesMidSentencePrefix` — using the real `AggregatedFrameSequencer`: with a partial sentence pending, `finalize(ctx)` promotes it so a subsequent word-timestamp emits an `AggregatedTextProgressFrame`; without the finalize the same word is buffered and no progress frame is emitted.
- `tests/test_cartesia_tts.py::TestCartesiaUpdateSettingsFinalizesOldContext` and `tests/test_soniox_tts.py::TestSonioxUpdateSettingsFinalizesOldContext` — drive the real `_update_settings` with a voice change (and a Soniox speed change) mid-sentence against a real streaming sequencer, asserting the old context's prefix is promoted, flushed, and re-minted, and that a later word-timestamp on the old context still emits a progress frame. A non-re-mint change (`pronunciation_dict_id`) is asserted **not** to finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)