### PR TITLE
fix(openai): push ErrorFrame when Responses HTTP stream ends in failure

### DIFF
--- a/changelog/5265.fixed.md
+++ b/changelog/5265.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `OpenAIResponsesHttpLLMService` silently swallowing `response.failed`,
+  `response.incomplete`, and in-stream `error` events. These now push an
+  `ErrorFrame` (matching the WebSocket variant) instead of ending the turn
+  empty with no signal, and a function call announced before the terminal
+  error is no longer executed with incomplete arguments.

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -22,9 +22,12 @@ from openai import NOT_GIVEN, AsyncOpenAI, AsyncStream, DefaultAsyncHttpxClient
 from openai._types import NotGiven as OpenAINotGiven
 from openai.types.responses import (
     ResponseCompletedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
+    ResponseIncompleteEvent,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
@@ -1211,6 +1214,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
         function_calls: dict[str, dict[str, str]] = {}  # item_id -> {name, call_id, arguments}
         current_arguments: dict[str, str] = {}  # item_id -> accumulated arguments
         reasoning_summary_open = False
+        stream_errored = False
 
         # Ensure stream and its async iterator are closed on cancellation/exception
         # to prevent socket leaks and uvloop crashes. Closing the iterator first
@@ -1319,8 +1323,30 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                     # model name in tracing spans
                     self._full_model_name = response.model
 
-        # Process any function calls
-        if function_calls:
+                elif isinstance(event, (ResponseFailedEvent, ResponseIncompleteEvent)):
+                    response = event.response
+                    error_msg = response.error.message if response.error else None
+                    if not error_msg:
+                        # Some third-party Responses API servers populate an
+                        # older status_details shape instead of `error`.
+                        status_details = getattr(response, "status_details", None) or {}
+                        if isinstance(status_details, dict):
+                            error_msg = (status_details.get("error") or {}).get("message")
+                    if not error_msg:
+                        error_msg = f"Response {event.type.split('.')[-1]}"
+                    await self.push_error(error_msg=f"LLM response error: {error_msg}")
+                    stream_errored = True
+                    break
+
+                elif isinstance(event, ResponseErrorEvent):
+                    await self.push_error(error_msg=f"LLM stream error: {event.message}")
+                    stream_errored = True
+                    break
+
+        # Process any function calls. A stream that ended in a terminal error
+        # may have announced a function call whose arguments never finished
+        # streaming — don't run those with fabricated empty arguments.
+        if function_calls and not stream_errored:
             fc_list = self._process_function_calls(context, function_calls)
             await self.run_function_calls(fc_list)
 

--- a/tests/test_openai_responses_http.py
+++ b/tests/test_openai_responses_http.py
@@ -11,6 +11,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from openai.types.responses import (
     ResponseCompletedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionToolCall,
+    ResponseIncompleteEvent,
+    ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningSummaryTextDeltaEvent,
@@ -22,13 +28,19 @@ from openai.types.responses.response_usage import (
 )
 
 from pipecat.frames.frames import (
+    ErrorFrame,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
     LLMMessagesAppendFrame,
+    LLMServiceMetadataFrame,
     LLMThoughtEndFrame,
     LLMThoughtStartFrame,
     LLMThoughtTextFrame,
 )
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.responses.llm import OpenAIResponsesHttpLLMService
+from pipecat.tests.utils import run_test
 
 
 def _make_service(**kwargs):
@@ -230,3 +242,157 @@ class TestHttpReasoningCapture:
             "summary": [{"type": "summary_text", "text": "Thinking..."}],
             "encrypted_content": "ENCRYPTED",
         }
+
+
+# ---------------------------------------------------------------------------
+# _process_context — terminal error stream events (regression for #5138)
+# ---------------------------------------------------------------------------
+
+
+def _failed_event(event_cls=ResponseFailedEvent, event_type="response.failed", **response_kwargs):
+    """Build a Response{Failed,Incomplete}Event carrying the given response fields."""
+    response = MagicMock(**response_kwargs)
+    event = MagicMock(spec=event_cls)
+    event.type = event_type
+    event.response = response
+    return event
+
+
+def _error_event(message="rate limited", code="rate_limit_exceeded"):
+    event = MagicMock(spec=ResponseErrorEvent)
+    event.type = "error"
+    event.message = message
+    event.code = code
+    return event
+
+
+class TestHttpStreamErrorEvents:
+    @pytest.mark.asyncio
+    async def test_response_failed_with_top_level_error_pushes_error(self):
+        """A ResponseFailedEvent with `response.error` populated must push an error."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+
+        error = MagicMock()
+        error.message = "upstream provider error"
+        event = _failed_event(error=error)
+
+        await _run(service, event)
+
+        service.push_error.assert_called_once()
+        assert "upstream provider error" in service.push_error.call_args.kwargs["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_response_failed_with_status_details_pushes_error(self):
+        """Some third-party servers populate the older `status_details` shape
+        instead of the typed `error` field. That must still surface an error."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+
+        event = _failed_event(
+            error=None,
+            status_details={"error": {"message": "provider outage"}},
+        )
+
+        await _run(service, event)
+
+        service.push_error.assert_called_once()
+        assert "provider outage" in service.push_error.call_args.kwargs["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_response_failed_with_no_error_details_uses_fallback_message(self):
+        """When neither `error` nor `status_details` carry a message, fall back
+        to a generic message derived from the event type rather than raising."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+
+        event = _failed_event(error=None, status_details=None)
+
+        await _run(service, event)
+
+        service.push_error.assert_called_once()
+        assert "failed" in service.push_error.call_args.kwargs["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_response_incomplete_pushes_error(self):
+        """A ResponseIncompleteEvent mid-stream must also push an error."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+
+        error = MagicMock()
+        error.message = "max output tokens reached"
+        event = _failed_event(
+            event_cls=ResponseIncompleteEvent,
+            event_type="response.incomplete",
+            error=error,
+        )
+
+        await _run(service, event)
+
+        service.push_error.assert_called_once()
+        assert "max output tokens reached" in service.push_error.call_args.kwargs["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_response_error_event_pushes_error(self):
+        """The generic in-stream `error` event must push an error with its message."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+
+        await _run(service, _error_event(message="rate limited"))
+
+        service.push_error.assert_called_once()
+        assert "rate limited" in service.push_error.call_args.kwargs["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_does_not_run_announced_function_call(self):
+        """A function call whose arguments never finished streaming before a
+        terminal error must not be executed with fabricated empty arguments."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        item = MagicMock(spec=ResponseFunctionToolCall)
+        item.id = "item_1"
+        item.name = "get_weather"
+        item.call_id = "call_1"
+        added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        added.item = item
+
+        delta = MagicMock(spec=ResponseFunctionCallArgumentsDeltaEvent)
+        delta.item_id = "item_1"
+        delta.delta = '{"city": "SF"'
+
+        error = MagicMock()
+        error.message = "upstream provider error"
+
+        await _run(service, added, delta, _failed_event(error=error))
+
+        service.push_error.assert_called_once()
+        service.run_function_calls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_response_failed_reaches_pipeline_as_error_frame(self):
+        """Full pipeline-level check: an in-stream response.failed event must
+        surface as an ErrorFrame, not a silent, empty turn."""
+        service = _make_service()
+
+        error = MagicMock()
+        error.message = "upstream provider error"
+        service._client.responses.create = AsyncMock(
+            return_value=_FakeAsyncStream([_failed_event(error=error)])
+        )
+
+        context = LLMContext()
+
+        down_frames, up_frames = await run_test(
+            service,
+            frames_to_send=[LLMContextFrame(context=context)],
+            expected_down_frames=[
+                LLMServiceMetadataFrame,
+                LLMFullResponseStartFrame,
+                LLMFullResponseEndFrame,
+            ],
+        )
+
+        error_frames = [f for f in list(down_frames) + list(up_frames) if isinstance(f, ErrorFrame)]
+        assert error_frames, "Expected an ErrorFrame after an in-stream response.failed event"


### PR DESCRIPTION
Fixes #5138

## Problem

`OpenAIResponsesHttpLLMService._process_context`'s stream loop only handles the successful-completion event. `response.failed`, `response.incomplete`, and in-stream `error` events (all members of the SDK's `ResponseStreamEvent` union) fall through the isinstance chain, the loop ends, and the method returns cleanly. No `ErrorFrame` is pushed, the pipeline sees a routine start/end pair with nothing in between, and the bot goes silent until the user speaks again. The WebSocket variant already handles the equivalent events; the HTTP variant had no counterpart.

## Fix

Mirror the WebSocket variant: on `ResponseFailedEvent` / `ResponseIncompleteEvent` / `ResponseErrorEvent`, push an error and stop reading the stream. Error extraction is defensive since third-party Responses API servers differ in shape: the typed `response.error` field first, then the older `status_details` dict (reachable through the SDK's extra-fields allowance), then a generic message derived from the event type.

One deliberate behavior choice: a function call announced before the terminal error is not executed. Its `arguments` never got a `done` event, so running it would invoke the tool with fabricated `{}` arguments right after the framework reported the turn failed. The WebSocket variant still has this fall-through after its own error breaks; happy to fix that in a follow-up if you want it, kept out of scope here.

## Tests

7 new tests in `tests/test_openai_responses_http.py`: failed event with typed `error`, with legacy `status_details`, with neither (fallback message), incomplete event, generic error event, announced-but-unfinished function call not executed after a terminal error, and a pipeline-level `run_test()` check that an `ErrorFrame` actually reaches the pipeline. All fail on `main`, pass here (except the function-call one, which guards the new break paths). `ruff check` / `ruff format --check` clean.
