### PR TITLE
fix(utils): recognize start delimiters split across chunks in TOKEN mode

### DIFF
--- a/changelog/5268.fixed.md
+++ b/changelog/5268.fixed.md
@@ -1,0 +1,7 @@
+- Fixed `PatternPairAggregator` and `SkipTagsAggregator` in TOKEN mode
+  mishandling a start delimiter split across `aggregate()` calls: a trailing
+  partial start delimiter is now held back until the next chunk completes it
+  instead of being flushed (and spoken) as plain text. Also fixed
+  `SkipTagsAggregator` losing track of its tag-scan position after a
+  TOKEN-mode yield, which made every tag after the first closed one go
+  undetected.

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -220,6 +220,32 @@ def parse_start_end_tags(
     return (None, current_tag_index)
 
 
+def longest_trailing_partial_match(text: str, candidates: Sequence[str]) -> int:
+    """Find the length of the longest suffix of text that is a proper prefix of a candidate.
+
+    Used to detect a delimiter (e.g., an XML-style start tag) that has been
+    split across two text chunks: the trailing partial delimiter can be held
+    back from output until the next chunk completes it, rather than being
+    flushed as plain text and losing the delimiter.
+
+    Args:
+        text: The text to check for a trailing partial match.
+        candidates: Full strings to match a proper prefix of against the end of text.
+
+    Returns:
+        The length of the longest matching suffix, or 0 if no candidate has a
+        proper prefix matching the end of text.
+    """
+    longest = 0
+    for candidate in candidates:
+        max_len = min(len(text), len(candidate) - 1)
+        for length in range(max_len, longest, -1):
+            if text[-length:] == candidate[:length]:
+                longest = length
+                break
+    return longest
+
+
 @dataclass
 class TextPartForConcatenation:
     """Class representing a part of text for concatenation with concatenate_aggregated_text.

--- a/src/pipecat/utils/text/pattern_pair_aggregator.py
+++ b/src/pipecat/utils/text/pattern_pair_aggregator.py
@@ -17,6 +17,7 @@ from enum import Enum
 
 from loguru import logger
 
+from pipecat.utils.string import longest_trailing_partial_match
 from pipecat.utils.text.base_text_aggregator import Aggregation, AggregationType
 from pipecat.utils.text.simple_text_aggregator import SimpleTextAggregator
 
@@ -286,6 +287,10 @@ class PatternPairAggregator(SimpleTextAggregator):
 
         In TOKEN mode, pattern detection still works but non-pattern text is
         yielded as TOKEN aggregations instead of waiting for sentence boundaries.
+        Text ending in a partial start delimiter (e.g. ``<thin`` of
+        ``<think>``) is held back until a later chunk determines whether it
+        begins a pattern, so a delimiter split across chunks is still
+        recognized.
 
         Args:
             text: Text to aggregate.
@@ -356,15 +361,25 @@ class PatternPairAggregator(SimpleTextAggregator):
                     )
 
         # In TOKEN mode, yield any accumulated text after processing all chars,
-        # but only if there's no incomplete pattern being buffered.
+        # but only if there's no incomplete pattern being buffered. A trailing
+        # partial start delimiter (e.g. "<thin" of "<think>") is held back so a
+        # delimiter split across chunks isn't leaked as plain text; it's
+        # retained in the buffer to be completed by the next chunk.
         if self._aggregation_type == AggregationType.TOKEN and self._text:
             if self._match_start_of_pattern(self._text) is None:
-                yield PatternMatch(
-                    content=self._text,
-                    type=AggregationType.TOKEN,
-                    full_match=self._text,
+                held_back = longest_trailing_partial_match(
+                    self._text, [pattern["start"] for pattern in self._patterns.values()]
                 )
-                self._text = ""
+                yield_length = len(self._text) - held_back
+                if yield_length > 0:
+                    content = self._text[:yield_length]
+                    self._text = self._text[yield_length:]
+                    self._last_processed_position = len(self._text)
+                    yield PatternMatch(
+                        content=content,
+                        type=AggregationType.TOKEN,
+                        full_match=content,
+                    )
 
     async def handle_interruption(self):
         """Handle interruptions by clearing the buffer and pattern state.

--- a/src/pipecat/utils/text/skip_tags_aggregator.py
+++ b/src/pipecat/utils/text/skip_tags_aggregator.py
@@ -13,7 +13,11 @@ as a unit regardless of internal punctuation.
 
 from collections.abc import AsyncIterator, Sequence
 
-from pipecat.utils.string import StartEndTags, parse_start_end_tags
+from pipecat.utils.string import (
+    StartEndTags,
+    longest_trailing_partial_match,
+    parse_start_end_tags,
+)
 from pipecat.utils.text.base_text_aggregator import Aggregation, AggregationType
 from pipecat.utils.text.simple_text_aggregator import SimpleTextAggregator
 
@@ -52,7 +56,10 @@ class SkipTagsAggregator(SimpleTextAggregator):
         inside tags.
 
         In TOKEN mode, text is passed through immediately unless we're inside
-        a tag, in which case we buffer until the closing tag is found.
+        a tag, in which case we buffer until the closing tag is found. Text
+        ending in a partial start tag (e.g. ``<spe`` of ``<spell>``) is held
+        back until a later chunk determines whether it begins a tag, so a tag
+        split across chunks is still recognized.
 
         Args:
             text: Text to aggregate.
@@ -72,10 +79,21 @@ class SkipTagsAggregator(SimpleTextAggregator):
                     self._text, self._tags, self._current_tag, self._current_tag_index
                 )
 
-            # After processing all chars: if not inside a tag, yield accumulated text
+            # After processing all chars: if not inside a tag, yield accumulated text.
+            # A trailing partial start tag (e.g. "<spe" of "<spell>") is held back
+            # so a tag split across chunks isn't leaked as plain text; it's retained
+            # in the buffer to be completed by the next chunk. The tag-scan index
+            # resets to 0 so the retained partial tag is rescanned once complete.
             if not self._current_tag and self._text:
-                yield Aggregation(text=self._text, type=AggregationType.TOKEN)
-                self._text = ""
+                held_back = longest_trailing_partial_match(
+                    self._text, [start for start, _ in self._tags]
+                )
+                yield_length = len(self._text) - held_back
+                if yield_length > 0:
+                    content = self._text[:yield_length]
+                    self._text = self._text[yield_length:]
+                    self._current_tag_index = 0
+                    yield Aggregation(text=content, type=AggregationType.TOKEN)
             return
 
         # Process text character by character

--- a/tests/test_pattern_pair_aggregator.py
+++ b/tests/test_pattern_pair_aggregator.py
@@ -254,6 +254,120 @@ class TestPatternPairAggregatorTokenMode(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(results[0].type, "token")
         self.handler.assert_not_called()
 
+    async def test_token_start_delimiter_split_across_chunks(self):
+        """A start delimiter split across chunks is not leaked as plain text.
+
+        Regression test for https://github.com/pipecat-ai/pipecat/issues/5267:
+        on unmodified main, "<thin" is yielded as a token before the delimiter
+        reassembles, so the REMOVE pattern is never recognized and "secret" is
+        spoken.
+        """
+        results = []
+        for token in ["Hi ", "<thin", "k>secret</think>", " bye"]:
+            async for r in self.aggregator.aggregate(token):
+                results.append(r)
+
+        # The delimiter reassembles and the pattern is recognized: content is
+        # stripped and the handler fires exactly once with the right content.
+        self.handler.assert_called_once()
+        call_args = self.handler.call_args[0][0]
+        self.assertEqual(call_args.text, "secret")
+
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["Hi ", " bye"])
+
+    async def test_token_start_delimiter_split_across_three_chunks(self):
+        """A start delimiter split across three chunks reassembles correctly."""
+        results = []
+        for token in ["<th", "in", "k>secret</think>"]:
+            async for r in self.aggregator.aggregate(token):
+                results.append(r)
+
+        self.handler.assert_called_once()
+        call_args = self.handler.call_args[0][0]
+        self.assertEqual(call_args.text, "secret")
+
+        # Nothing should have leaked while the delimiter was reassembling.
+        self.assertEqual(results, [])
+
+    async def test_token_partial_delimiter_chunk_yields_nothing(self):
+        """A chunk that is entirely a partial delimiter yields nothing."""
+        results = [r async for r in self.aggregator.aggregate("<thin")]
+        self.assertEqual(results, [])
+        self.assertEqual(self.aggregator.text.text, "<thin")
+
+    async def test_token_trailing_prefix_char_held_then_emitted(self):
+        """A plain trailing '<' is held back and emitted with the next chunk once it no longer matches a delimiter."""
+        results = []
+        async for r in self.aggregator.aggregate("Hello <"):
+            results.append(r)
+        # "<" could be the start of "<think>", so it's held back.
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "Hello ")
+
+        async for r in self.aggregator.aggregate(" world"):
+            results.append(r)
+        # Once the held-back "<" is followed by something other than "t", it
+        # no longer matches a delimiter prefix and is emitted with the rest.
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[1].text, "< world")
+
+    async def test_token_split_aggregate_delimiter_recognized(self):
+        """A split AGGREGATE delimiter still reassembles: content is yielded as
+        its own aggregation instead of the fragments leaking as plain tokens.
+        """
+        code_handler = AsyncMock()
+        self.aggregator.add_pattern(
+            type="code_pattern",
+            start_pattern="<code>",
+            end_pattern="</code>",
+            action=MatchAction.AGGREGATE,
+        )
+        self.aggregator.on_pattern_match("code_pattern", code_handler)
+
+        results = []
+        for token in ["Here is code ", "<cod", "e>pattern content</code>", " more"]:
+            async for r in self.aggregator.aggregate(token):
+                results.append(r)
+
+        code_handler.assert_called_once()
+        call_args = code_handler.call_args[0][0]
+        self.assertEqual(call_args.text, "pattern content")
+
+        self.assertEqual(
+            [(r.type, r.text) for r in results],
+            [
+                ("token", "Here is code "),
+                ("code_pattern", "pattern content"),
+                ("token", " more"),
+            ],
+        )
+
+    async def test_token_split_keep_delimiter_recognized(self):
+        """A split KEEP delimiter still reassembles and triggers its handler."""
+        keep_handler = AsyncMock()
+        self.aggregator.add_pattern(
+            type="em",
+            start_pattern="<em>",
+            end_pattern="</em>",
+            action=MatchAction.KEEP,
+        )
+        self.aggregator.on_pattern_match("em", keep_handler)
+
+        results = []
+        for token in ["very <e", "m>excited</em> today"]:
+            async for r in self.aggregator.aggregate(token):
+                results.append(r)
+
+        keep_handler.assert_called_once()
+        call_args = keep_handler.call_args[0][0]
+        self.assertEqual(call_args.text, "excited")
+
+        # KEEP delimiters stay in the text; the split start delimiter
+        # reassembles intact instead of leaking as a fragment ("<e").
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["very ", "<em>excited</em> today"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skip_tags_aggregator.py
+++ b/tests/test_skip_tags_aggregator.py
@@ -118,6 +118,102 @@ class TestSkipTagsAggregatorTokenMode(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(results[2].text, " bye")
         self.assertEqual(results[2].type, "token")
 
+    async def test_token_start_tag_split_across_chunks(self):
+        """A start tag split across chunks is not leaked as plain text.
+
+        Regression test for https://github.com/pipecat-ai/pipecat/issues/5267:
+        on unmodified main, "<spe" is yielded as a token before the tag
+        reassembles, fragmenting content that should be emitted as one token.
+        """
+        results = []
+        for token in ["Call ", "<spe", "ll>a b c</spell>", " now"]:
+            async for agg in self.aggregator.aggregate(token):
+                results.append(agg)
+
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["Call ", "<spell>a b c</spell>", " now"])
+
+    async def test_token_start_tag_split_across_three_chunks(self):
+        """A start tag split across three chunks reassembles into one token."""
+        results = []
+        for token in ["<sp", "el", "l>abc</spell>"]:
+            async for agg in self.aggregator.aggregate(token):
+                results.append(agg)
+
+        # Nothing should have leaked while the tag was reassembling.
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "<spell>abc</spell>")
+
+    async def test_token_partial_tag_chunk_yields_nothing(self):
+        """A chunk that is entirely a partial start tag yields nothing."""
+        results = [agg async for agg in self.aggregator.aggregate("<spe")]
+        self.assertEqual(results, [])
+        self.assertEqual(self.aggregator.text.text, "<spe")
+
+    async def test_token_trailing_prefix_char_held_then_emitted(self):
+        """A plain trailing '<' is held back and emitted with the next chunk once it no longer matches a tag."""
+        results = []
+        async for agg in self.aggregator.aggregate("Hi <"):
+            results.append(agg)
+        # "<" could be the start of "<spell>", so it's held back.
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "Hi ")
+
+        async for agg in self.aggregator.aggregate(" there"):
+            results.append(agg)
+        # Once the held-back "<" is followed by something other than "s", it
+        # no longer matches a tag prefix and is emitted with the rest.
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[1].text, "< there")
+
+    async def test_token_partial_tag_after_yield_in_same_chunk(self):
+        """A chunk holding both yieldable text and a trailing partial tag keeps
+        the tag working: the retained partial tag is rescanned once complete,
+        so content split across later chunks still buffers as one unit.
+        """
+        results = []
+        for token in ["Call <spe", "ll>a b", " c</sp", "ell> now"]:
+            async for agg in self.aggregator.aggregate(token):
+                results.append(agg)
+
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["Call ", "<spell>a b c</spell> now"])
+
+    async def test_token_multiple_tag_pairs_split_across_chunks(self):
+        """With multiple registered tag pairs, a split start tag of either
+        pair is held back and reassembles.
+        """
+        from pipecat.utils.text.base_text_aggregator import AggregationType
+
+        aggregator = SkipTagsAggregator(
+            [("<spell>", "</spell>"), ("<code>", "</code>")],
+            aggregation_type=AggregationType.TOKEN,
+        )
+
+        results = []
+        for token in ["Call ", "<cod", "e>x</code>", " and ", "<spe", "ll>y</spell>", " done"]:
+            async for agg in aggregator.aggregate(token):
+                results.append(agg)
+
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["Call ", "<code>x</code>", " and ", "<spell>y</spell>", " done"])
+
+    async def test_token_second_tag_after_closed_tag_not_fragmented(self):
+        """A second tag opened after an earlier tag closes is not fragmented.
+
+        Regression test for https://github.com/pipecat-ai/pipecat/issues/5267:
+        on unmodified main, `_current_tag_index` is left pointing past the end
+        of the buffer once it's cleared after the first tag closes, making
+        `parse_start_end_tags` blind to every tag that follows.
+        """
+        results = []
+        for token in ["<spell>abc</spell>", "<spell>de", "f</spell>", " done"]:
+            async for agg in self.aggregator.aggregate(token):
+                results.append(agg)
+
+        texts = [r.text for r in results]
+        self.assertEqual(texts, ["<spell>abc</spell>", "<spell>def</spell>", " done"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -6,7 +6,11 @@
 
 import unittest
 
-from pipecat.utils.string import match_endofsentence, parse_start_end_tags
+from pipecat.utils.string import (
+    longest_trailing_partial_match,
+    match_endofsentence,
+    parse_start_end_tags,
+)
 
 
 class TestUtilsString(unittest.IsolatedAsyncioTestCase):
@@ -272,6 +276,34 @@ class TestStartEndTags(unittest.IsolatedAsyncioTestCase):
             ("<a>", "</a>"),
             41,
         )
+
+
+class TestLongestTrailingPartialMatch(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_and_no_match(self):
+        assert longest_trailing_partial_match("", ["<a>"]) == 0
+        assert longest_trailing_partial_match("Hello", []) == 0
+        assert longest_trailing_partial_match("Hello", ["<a>"]) == 0
+
+    async def test_single_candidate(self):
+        assert longest_trailing_partial_match("Hello <", ["<think>"]) == 1
+        assert longest_trailing_partial_match("Hello <thin", ["<think>"]) == 5
+        # A complete candidate is not a partial match (proper prefixes only).
+        assert longest_trailing_partial_match("Hello <think>", ["<think>"]) == 0
+
+    async def test_text_shorter_than_candidate(self):
+        assert longest_trailing_partial_match("<th", ["<think>"]) == 3
+
+    async def test_multiple_candidates_longest_wins(self):
+        # "<te" matches "<test>" (3) over the shared "<t" prefix of "<think>" (2).
+        assert longest_trailing_partial_match("Hi <te", ["<think>", "<test>"]) == 3
+        assert longest_trailing_partial_match("Hi <th", ["<think>", "<test>"]) == 3
+        # Shared prefix alone matches both; length is the same either way.
+        assert longest_trailing_partial_match("Hi <t", ["<think>", "<test>"]) == 2
+        # Candidate order doesn't change the result.
+        assert longest_trailing_partial_match("Hi <te", ["<test>", "<think>"]) == 3
+
+    async def test_single_char_candidate_has_no_proper_prefix(self):
+        assert longest_trailing_partial_match("Hello <", ["<"]) == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #5267

## Problem

In TOKEN mode, both `PatternPairAggregator` and `SkipTagsAggregator` yield the whole buffer at the end of each `aggregate()` call and clear it. A start delimiter split across two calls (`"<thin"` then `"k>secret</think>"`, which is how LLM token streams actually arrive) gets yielded as plain text before it can reassemble, so the pattern or tag is never recognized. For REMOVE patterns that means the hidden content gets spoken.

Separately, `SkipTagsAggregator` never reset `_current_tag_index` when the TOKEN-mode yield cleared the buffer, so after the first closed tag `parse_start_end_tags` was scanning past the end of the buffer and every later tag leaked through fragmented. That one doesn't even need a split delimiter to trigger.

## Fix

New `longest_trailing_partial_match()` helper in `utils/string.py` finds the longest suffix of the buffer that is a proper prefix of any registered start delimiter/tag. Both TOKEN-mode end-of-call yields now hold that suffix back in the buffer instead of flushing it, so the next chunk can complete it. Applies to all pattern actions (a split KEEP or AGGREGATE delimiter also breaks recognition, not just REMOVE).

A legitimate trailing `<` in prose gets held back one chunk and emitted with the next once it no longer matches a delimiter prefix. Delayed, never lost.

`SkipTagsAggregator` also resets `_current_tag_index` to 0 whenever the yield trims or clears the buffer, so the retained partial tag (or the next tag) is actually rescanned.

## Out of scope

Flush behavior for unclosed tags at end of response is #4891 / #5266. Two pre-existing bugs surfaced while testing this (same start/end delimiters like `**` are never detected by `_match_start_of_pattern`'s count comparison, and `parse_start_end_tags` short-circuits on the first registered tag pair with zero occurrences without checking later pairs); both reproduce identically before this change, happy to file them separately.

## Tests

12 new tests: split delimiter across two and three chunks for REMOVE/KEEP/AGGREGATE actions, a chunk that's entirely a partial delimiter, a plain trailing `<` held then emitted with the next chunk, multiple tag pairs each split, the stale-tag-index regression, and direct unit tests for `longest_trailing_partial_match`. All fail on unmodified main or pin behavior this change could regress. 42 tests pass across the three touched test files, patch coverage 100%, ruff clean.
