### PR TITLE
fix(openai): skip unfinished function calls after a terminal Responses stream error

### DIFF
--- a/changelog/5270.fixed.md
+++ b/changelog/5270.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `OpenAIResponsesHttpLLMService` running a function call with fabricated
+  empty arguments when the stream ended in a terminal error (`response.failed`,
+  `response.incomplete`, or `error`) before the call's arguments finished
+  streaming. Calls whose arguments did finish streaming still run.

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -1213,7 +1213,9 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
         # Track function calls across stream events
         function_calls: dict[str, dict[str, str]] = {}  # item_id -> {name, call_id, arguments}
         current_arguments: dict[str, str] = {}  # item_id -> accumulated arguments
+        completed_calls: set[str] = set()  # item_ids whose arguments finished streaming
         reasoning_summary_open = False
+        stream_errored = False
 
         # Ensure stream and its async iterator are closed on cancellation/exception
         # to prevent socket leaks and uvloop crashes. Closing the iterator first
@@ -1270,6 +1272,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                     item_id = event.item_id
                     if item_id in function_calls:
                         function_calls[item_id]["arguments"] = event.arguments
+                        completed_calls.add(item_id)
 
                 elif isinstance(event, ResponseOutputItemDoneEvent):
                     item = event.item
@@ -1279,6 +1282,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                             function_calls[item_id]["name"] = item.name
                             function_calls[item_id]["call_id"] = item.call_id
                             function_calls[item_id]["arguments"] = item.arguments
+                            completed_calls.add(item_id)
                     elif isinstance(item, ResponseReasoningItem):
                         if reasoning_summary_open:
                             await self.push_frame(LLMThoughtEndFrame())
@@ -1331,6 +1335,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                     await self.push_error(
                         error_msg=f"LLM response error: {message or 'Response failed'}"
                     )
+                    stream_errored = True
                     break
 
                 elif isinstance(event, ResponseIncompleteEvent):
@@ -1339,11 +1344,25 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                     await self.push_error(
                         error_msg=f"LLM response error: {reason or 'Response incomplete'}"
                     )
+                    stream_errored = True
                     break
 
                 elif isinstance(event, ResponseErrorEvent):
                     await self.push_error(error_msg=f"Responses API error: {event.message}")
+                    stream_errored = True
                     break
+
+        # A stream that ended in a terminal error may have announced a function
+        # call whose arguments never finished streaming — drop those rather than
+        # run them with fabricated empty arguments. Calls whose arguments did
+        # finish (e.g. parallel tool calls completed before a later item was
+        # truncated) still run.
+        if stream_errored:
+            function_calls = {
+                item_id: call
+                for item_id, call in function_calls.items()
+                if item_id in completed_calls
+            }
 
         # Process any function calls
         if function_calls:

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -1213,7 +1213,6 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
         # Track function calls across stream events
         function_calls: dict[str, dict[str, str]] = {}  # item_id -> {name, call_id, arguments}
         current_arguments: dict[str, str] = {}  # item_id -> accumulated arguments
-        completed_calls: set[str] = set()  # item_ids whose arguments finished streaming
         reasoning_summary_open = False
         stream_errored = False
 
@@ -1272,7 +1271,6 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                     item_id = event.item_id
                     if item_id in function_calls:
                         function_calls[item_id]["arguments"] = event.arguments
-                        completed_calls.add(item_id)
 
                 elif isinstance(event, ResponseOutputItemDoneEvent):
                     item = event.item
@@ -1282,7 +1280,6 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                             function_calls[item_id]["name"] = item.name
                             function_calls[item_id]["call_id"] = item.call_id
                             function_calls[item_id]["arguments"] = item.arguments
-                            completed_calls.add(item_id)
                     elif isinstance(item, ResponseReasoningItem):
                         if reasoning_summary_open:
                             await self.push_frame(LLMThoughtEndFrame())
@@ -1354,14 +1351,13 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
 
         # A stream that ended in a terminal error may have announced a function
         # call whose arguments never finished streaming — drop those rather than
-        # run them with fabricated empty arguments. Calls whose arguments did
-        # finish (e.g. parallel tool calls completed before a later item was
-        # truncated) still run.
+        # run them with fabricated empty arguments. `arguments` is only written
+        # by the Done events, so a non-empty string means the call completed
+        # (e.g. parallel tool calls finished before a later item was truncated)
+        # and it still runs.
         if stream_errored:
             function_calls = {
-                item_id: call
-                for item_id, call in function_calls.items()
-                if item_id in completed_calls
+                item_id: call for item_id, call in function_calls.items() if call["arguments"]
             }
 
         # Process any function calls

--- a/tests/test_openai_responses_http.py
+++ b/tests/test_openai_responses_http.py
@@ -13,7 +13,11 @@ from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseErrorEvent,
     ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
     ResponseIncompleteEvent,
+    ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningSummaryTextDeltaEvent,
@@ -26,13 +30,19 @@ from openai.types.responses.response_usage import (
 )
 
 from pipecat.frames.frames import (
+    ErrorFrame,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
     LLMMessagesAppendFrame,
+    LLMServiceMetadataFrame,
     LLMThoughtEndFrame,
     LLMThoughtStartFrame,
     LLMThoughtTextFrame,
 )
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.openai.responses.llm import OpenAIResponsesHttpLLMService
+from pipecat.tests.utils import run_test
 
 
 def _make_service(**kwargs):
@@ -404,3 +414,110 @@ class TestHttpStreamErrorEvents:
 
         service.push_error.assert_called_once()
         service._push_llm_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_does_not_run_announced_function_call(self):
+        """A function call whose arguments never finished streaming before a
+        terminal error must not be executed with fabricated empty arguments."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        item = MagicMock(spec=ResponseFunctionToolCall)
+        item.id = "item_1"
+        item.name = "get_weather"
+        item.call_id = "call_1"
+        added = MagicMock(spec=ResponseOutputItemAddedEvent)
+        added.item = item
+
+        delta = MagicMock(spec=ResponseFunctionCallArgumentsDeltaEvent)
+        delta.item_id = "item_1"
+        delta.delta = '{"city": "SF"'
+
+        error = MagicMock()
+        error.message = "upstream provider error"
+
+        await _run(service, added, delta, _failed_event(error))
+
+        service.push_error.assert_called_once()
+        service.run_function_calls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_still_runs_completed_function_calls(self):
+        """Parallel tool calls: a call whose arguments finished streaming before
+        the terminal error (e.g. a later item truncated by max_output_tokens)
+        must still run — only the unfinished call is dropped."""
+        service = _make_service()
+        service.push_error = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        def _tool_call_added(item_id, name, call_id):
+            item = MagicMock(spec=ResponseFunctionToolCall)
+            item.id = item_id
+            item.name = name
+            item.call_id = call_id
+            event = MagicMock(spec=ResponseOutputItemAddedEvent)
+            event.item = item
+            return event
+
+        args_done = MagicMock(spec=ResponseFunctionCallArgumentsDoneEvent)
+        args_done.item_id = "item_1"
+        args_done.arguments = '{"city": "SF"}'
+
+        done_item = MagicMock(spec=ResponseFunctionToolCall)
+        done_item.id = "item_1"
+        done_item.name = "get_weather"
+        done_item.call_id = "call_1"
+        done_item.arguments = '{"city": "SF"}'
+        item_done = MagicMock(spec=ResponseOutputItemDoneEvent)
+        item_done.item = done_item
+
+        partial_delta = MagicMock(spec=ResponseFunctionCallArgumentsDeltaEvent)
+        partial_delta.item_id = "item_2"
+        partial_delta.delta = '{"city": "NY'
+
+        details = MagicMock()
+        details.reason = "max_output_tokens"
+
+        await _run(
+            service,
+            _tool_call_added("item_1", "get_weather", "call_1"),
+            args_done,
+            item_done,
+            _tool_call_added("item_2", "get_time", "call_2"),
+            partial_delta,
+            _incomplete_event(details),
+        )
+
+        service.push_error.assert_called_once()
+        service.run_function_calls.assert_called_once()
+        fc_list = service.run_function_calls.call_args.args[0]
+        assert [fc.function_name for fc in fc_list] == ["get_weather"]
+        assert fc_list[0].arguments == {"city": "SF"}
+
+    @pytest.mark.asyncio
+    async def test_response_failed_reaches_pipeline_as_error_frame(self):
+        """Pipeline-level check: an in-stream response.failed event must surface
+        as an ErrorFrame, which is what failover strategies react to."""
+        service = _make_service()
+
+        error = MagicMock()
+        error.message = "upstream provider error"
+        service._client.responses.create = AsyncMock(
+            return_value=_FakeAsyncStream([_failed_event(error)])
+        )
+
+        context = LLMContext()
+
+        down_frames, up_frames = await run_test(
+            service,
+            frames_to_send=[LLMContextFrame(context=context)],
+            expected_down_frames=[
+                LLMServiceMetadataFrame,
+                LLMFullResponseStartFrame,
+                LLMFullResponseEndFrame,
+            ],
+        )
+
+        error_frames = [f for f in list(down_frames) + list(up_frames) if isinstance(f, ErrorFrame)]
+        assert error_frames, "Expected an ErrorFrame after an in-stream response.failed event"


### PR DESCRIPTION
Follow-up to #5265, per the [review there](https://github.com/pipecat-ai/pipecat/pull/5265#issuecomment-5234945613) — the two pieces that didn't land with #5141:

## The function call guard

A stream that ends in `response.failed`, `response.incomplete`, or `error` may have announced a function call (via `ResponseOutputItemAddedEvent`) whose arguments never got a done event. `_process_function_calls` coalesces the empty accumulated string to `{}`, so the tool ran with fabricated empty arguments.

One change from what #5265 had: the guard is per-call, not per-stream. On a terminal event, only calls that never received `ResponseFunctionCallArgumentsDoneEvent` / `ResponseOutputItemDoneEvent` are dropped. A call whose arguments finished streaming before the error still runs — with parallel tool calls, one call can complete normally before a later item is truncated by `max_output_tokens`, and a whole-stream boolean would silently discard the valid call.

No `status_details` reads this time.

## The pipeline-level ErrorFrame test

`test_response_failed_reaches_pipeline_as_error_frame` drives the service through `run_test()` and asserts an `ErrorFrame` actually reaches the pipeline, covering the path failover strategies depend on rather than just the `push_error` call.

## Tests

Three new tests: announced-but-unfinished call doesn't run after a terminal error, a completed call alongside an unfinished one still runs (only the unfinished one is dropped), and the `run_test()` ErrorFrame check. 16 tests pass in the file, patch coverage 100%, ruff clean. The unfinished-call test fails on current main.
