### PR TITLE
Create the runner before the event handlers in every example

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -205,14 +205,21 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(...)
 
     pipeline = Pipeline([...])
-    task = PipelineTask(pipeline, params=..., observers=[...])
+    worker = PipelineWorker(pipeline, params=..., observers=[...])
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
-        await task.queue_frames([LLMRunFrame()])
+        await worker.queue_frames([LLMRunFrame()])
 
-    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.run(task)
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        await runner.cancel()
+
+    await runner.run()
 
 async def bot(runner_args: RunnerArguments):
     """Main bot entry point compatible with Pipecat Cloud."""

--- a/examples/audio/audio-bot-background-sound.py
+++ b/examples/audio/audio-bot-background-sound.py
@@ -119,6 +119,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, participant):
         # Show how to use mixer control frames.
@@ -141,11 +145,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/audio/audio-recording.py
+++ b/examples/audio/audio-recording.py
@@ -162,6 +162,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -174,7 +178,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @audiobuffer.event_handler("on_recording_started")
     async def on_recording_started(buffer):
@@ -206,8 +210,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         bot_filename = f"recordings/bot_{timestamp}.wav"
         await save_audio_file(bot_audio, bot_filename, sample_rate, 1)
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/audio/audio-sound-effects.py
+++ b/examples/audio/audio-sound-effects.py
@@ -154,6 +154,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -164,11 +168,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/context-summarization/context-summarization-dedicated-llm.py
+++ b/examples/context-summarization/context-summarization-dedicated-llm.py
@@ -193,6 +193,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -205,11 +209,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/context-summarization/context-summarization-google.py
+++ b/examples/context-summarization/context-summarization-google.py
@@ -154,6 +154,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -166,11 +170,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/context-summarization/context-summarization-manual-openai.py
+++ b/examples/context-summarization/context-summarization-manual-openai.py
@@ -131,6 +131,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -143,11 +147,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/context-summarization/context-summarization-openai.py
+++ b/examples/context-summarization/context-summarization-openai.py
@@ -154,6 +154,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -166,11 +170,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-add-tool-change-messages.py
+++ b/examples/features/features-add-tool-change-messages.py
@@ -159,6 +159,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Phase controller: roughly 4 turns per phase.
     user_turn_count = 0
     REMOVE_AT_TURN = 5  # tool gone for turn N onward
@@ -204,10 +208,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-app-resources.py
+++ b/examples/features/features-app-resources.py
@@ -275,6 +275,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         app_resources=resources,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -287,11 +291,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
     # The session has ended; read whatever state the handlers built up.

--- a/examples/features/features-before-and-after-events.py
+++ b/examples/features/features-before-and-after-events.py
@@ -111,6 +111,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.output().event_handler("on_before_process_frame")
     async def transport_on_before_process_frame(transport, frame):
         if isinstance(frame, CustomBeforeProcessFrame):
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-concurrent-llm-evaluation.py
+++ b/examples/features/features-concurrent-llm-evaluation.py
@@ -144,6 +144,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,11 +163,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-concurrent-llm-rtvi-ignored-sources.py
+++ b/examples/features/features-concurrent-llm-rtvi-ignored-sources.py
@@ -156,6 +156,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -170,11 +174,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-custom-frame-processor.py
+++ b/examples/features/features-custom-frame-processor.py
@@ -142,6 +142,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -154,11 +158,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-dtmf-menu.py
+++ b/examples/features/features-dtmf-menu.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -137,11 +141,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-gpu-container-local-bot.py
+++ b/examples/features/features-gpu-container-local-bot.py
@@ -109,6 +109,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # When the first participant joins, the bot should introduce itself.
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -151,11 +155,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-live-translation.py
+++ b/examples/features/features-live-translation.py
@@ -113,6 +113,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -128,11 +132,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-pattern-pair-voice-switching.py
+++ b/examples/features/features-pattern-pair-voice-switching.py
@@ -230,6 +230,10 @@ Remember: Use narrator voice for EVERYTHING except the actual quoted dialogue.""
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -239,10 +243,8 @@ Remember: Use narrator voice for EVERYTHING except the actual quoted dialogue.""
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-service-switcher.py
+++ b/examples/features/features-service-switcher.py
@@ -147,6 +147,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -168,11 +172,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-switch-languages.py
+++ b/examples/features/features-switch-languages.py
@@ -152,6 +152,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -167,11 +171,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-switch-voices.py
+++ b/examples/features/features-switch-voices.py
@@ -159,6 +159,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -174,11 +178,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-text-transforms.py
+++ b/examples/features/features-text-transforms.py
@@ -183,6 +183,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -203,10 +207,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-user-email-gathering.py
+++ b/examples/features/features-user-email-gathering.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,10 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-voice-formatter.py
+++ b/examples/features/features-voice-formatter.py
@@ -141,6 +141,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -160,10 +164,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-voicemail-detection.py
+++ b/examples/features/features-voicemail-detection.py
@@ -105,6 +105,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,7 +116,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @voicemail.event_handler("on_conversation_detected")
     async def on_conversation_detected(processor):
@@ -133,9 +137,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         # Uncomment the following line to end the pipeline after leaving the voicemail.
         # await processor.push_frame(EndWorkerFrame())
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/features/features-wake-phrase.py
+++ b/examples/features/features-wake-phrase.py
@@ -121,6 +121,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -133,11 +137,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/food_ordering.py
+++ b/examples/flows/food_ordering.py
@@ -322,6 +322,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Define "global" functions available at every node
     async def get_delivery_estimate(
         flow_manager: FlowManager,
@@ -350,10 +354,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/food_ordering_advanced_functionschema.py
+++ b/examples/flows/food_ordering_advanced_functionschema.py
@@ -400,6 +400,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Define "global" functions available at every node
     async def get_delivery_estimate(
         args: FlowArgs, flow_manager: FlowManager
@@ -436,10 +440,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/hello_world.py
+++ b/examples/flows/hello_world.py
@@ -153,6 +153,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Initialize flow manager
     flow_manager = FlowManager(
         worker=worker,
@@ -170,10 +174,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/insurance_quote.py
+++ b/examples/flows/insurance_quote.py
@@ -341,6 +341,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Initialize flow manager
     flow_manager = FlowManager(
         worker=worker,
@@ -358,10 +362,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/llm_switching.py
+++ b/examples/flows/llm_switching.py
@@ -234,6 +234,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Initialize flow manager
     flow_manager = FlowManager(
         worker=worker,
@@ -249,10 +253,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/multi_worker_handoff.py
+++ b/examples/flows/multi_worker_handoff.py
@@ -466,6 +466,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         reservation_system=MockReservationSystem(),
     )
 
+    await runner.add_workers(router, reservation, worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -493,8 +495,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(router, reservation, worker)
 
     await runner.run()
 

--- a/examples/flows/patient_intake.py
+++ b/examples/flows/patient_intake.py
@@ -386,6 +386,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Initialize flow manager
     flow_manager = FlowManager(
         worker=worker,
@@ -403,10 +407,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/podcast_interview.py
+++ b/examples/flows/podcast_interview.py
@@ -246,6 +246,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     flow_manager = FlowManager(
         worker=worker,
         llm=llm,
@@ -261,11 +265,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/restaurant_reservation.py
+++ b/examples/flows/restaurant_reservation.py
@@ -303,6 +303,10 @@ async def run_bot(
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Initialize flow manager
     flow_manager = FlowManager(
         worker=worker,
@@ -320,10 +324,8 @@ async def run_bot(
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/flows/warm_transfer.py
+++ b/examples/flows/warm_transfer.py
@@ -622,6 +622,10 @@ async def main():
             ),
         )
 
+        runner = WorkerRunner()
+
+        await runner.add_workers(worker)
+
         # Initialize flow manager
         flow_manager = FlowManager(
             worker=worker,
@@ -665,7 +669,7 @@ async def main():
                 if v.get("info", {}).get("userId") in {"agent", "customer"}
             }
             if not human_participants:
-                await worker.cancel()
+                await runner.cancel()
 
         # Print URL for joining as customer, and store URL for joining as human agent, to be printed later
         customer_token = await get_customer_token(
@@ -703,9 +707,6 @@ async def main():
 
         atexit.register(cleanup_hold_music_process)
 
-        # Run the pipeline
-        runner = WorkerRunner()
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/function-calling/function-calling-advanced-functionschema.py
+++ b/examples/function-calling/function-calling-advanced-functionschema.py
@@ -163,6 +163,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -181,11 +185,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-anthropic-async-stream.py
+++ b/examples/function-calling/function-calling-anthropic-async-stream.py
@@ -168,6 +168,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -180,11 +184,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-anthropic-async.py
+++ b/examples/function-calling/function-calling-anthropic-async.py
@@ -132,6 +132,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -144,11 +148,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-anthropic-video.py
+++ b/examples/function-calling/function-calling-anthropic-video.py
@@ -139,6 +139,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -160,11 +164,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-anthropic.py
+++ b/examples/function-calling/function-calling-anthropic.py
@@ -119,6 +119,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -131,11 +135,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-aws-video.py
+++ b/examples/function-calling/function-calling-aws-video.py
@@ -144,6 +144,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -165,11 +169,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-aws.py
+++ b/examples/function-calling/function-calling-aws.py
@@ -123,6 +123,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -135,11 +139,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-azure.py
+++ b/examples/function-calling/function-calling-azure.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-baseten.py
+++ b/examples/function-calling/function-calling-baseten.py
@@ -120,6 +120,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,11 +136,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-cerebras.py
+++ b/examples/function-calling/function-calling-cerebras.py
@@ -135,6 +135,10 @@ Start by asking me for my location. Then, use 'get_current_weather' to give me a
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -147,11 +151,8 @@ Start by asking me for my location. Then, use 'get_current_weather' to give me a
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-crusoe.py
+++ b/examples/function-calling/function-calling-crusoe.py
@@ -120,6 +120,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,11 +136,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-deepseek.py
+++ b/examples/function-calling/function-calling-deepseek.py
@@ -135,6 +135,10 @@ Start by asking me for my location. Then, use 'get_current_weather' to give me a
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -147,11 +151,8 @@ Start by asking me for my location. Then, use 'get_current_weather' to give me a
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-direct.py
+++ b/examples/function-calling/function-calling-direct.py
@@ -129,6 +129,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -141,11 +145,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-fireworks.py
+++ b/examples/function-calling/function-calling-fireworks.py
@@ -130,6 +130,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -142,11 +146,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-google-async-stream.py
+++ b/examples/function-calling/function-calling-google-async-stream.py
@@ -176,6 +176,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -188,11 +192,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-google-async.py
+++ b/examples/function-calling/function-calling-google-async.py
@@ -189,6 +189,10 @@ indicate you should use the get_image tool are:
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -209,11 +213,8 @@ indicate you should use the get_image tool are:
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-google-vertex.py
+++ b/examples/function-calling/function-calling-google-vertex.py
@@ -129,6 +129,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -144,11 +148,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-google-video.py
+++ b/examples/function-calling/function-calling-google-video.py
@@ -139,6 +139,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -160,11 +164,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-google.py
+++ b/examples/function-calling/function-calling-google.py
@@ -177,6 +177,10 @@ indicate you should use the get_image tool are:
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -197,11 +201,8 @@ indicate you should use the get_image tool are:
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-grok.py
+++ b/examples/function-calling/function-calling-grok.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/function-calling/function-calling-groq.py
+++ b/examples/function-calling/function-calling-groq.py
@@ -125,6 +125,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -137,11 +141,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-inception.py
+++ b/examples/function-calling/function-calling-inception.py
@@ -126,6 +126,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(task)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -138,11 +142,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await task.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(task)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-inception.py
+++ b/examples/function-calling/function-calling-inception.py
@@ -14,7 +14,7 @@ from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.evals.transport import EvalTransportParams
 from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
@@ -117,7 +117,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
-    task = PipelineTask(
+    worker = PipelineWorker(
         pipeline,
         params=PipelineParams(
             enable_metrics=True,
@@ -128,7 +128,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
-    await runner.add_workers(task)
+    await runner.add_workers(worker)
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -137,7 +137,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         context.add_message(
             {"role": "developer", "content": "Please introduce yourself to the user."}
         )
-        await task.queue_frames([LLMRunFrame()])
+        await worker.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/examples/function-calling/function-calling-missing-handler.py
+++ b/examples/function-calling/function-calling-missing-handler.py
@@ -157,6 +157,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -179,10 +183,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-mistral.py
+++ b/examples/function-calling/function-calling-mistral.py
@@ -120,6 +120,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,11 +136,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-moondream-video.py
+++ b/examples/function-calling/function-calling-moondream-video.py
@@ -177,6 +177,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -198,11 +202,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-nebius.py
+++ b/examples/function-calling/function-calling-nebius.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-novita.py
+++ b/examples/function-calling/function-calling-novita.py
@@ -125,6 +125,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -137,11 +141,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-nvidia.py
+++ b/examples/function-calling/function-calling-nvidia.py
@@ -128,6 +128,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -140,11 +144,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-ollama.py
+++ b/examples/function-calling/function-calling-ollama.py
@@ -125,6 +125,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -137,11 +141,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-async-stream.py
+++ b/examples/function-calling/function-calling-openai-async-stream.py
@@ -177,6 +177,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -189,11 +193,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-async.py
+++ b/examples/function-calling/function-calling-openai-async.py
@@ -140,6 +140,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -152,11 +156,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses-async-stream.py
+++ b/examples/function-calling/function-calling-openai-responses-async-stream.py
@@ -176,6 +176,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -188,11 +192,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses-async.py
+++ b/examples/function-calling/function-calling-openai-responses-async.py
@@ -145,6 +145,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -157,11 +161,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses-http.py
+++ b/examples/function-calling/function-calling-openai-responses-http.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses-video-http.py
+++ b/examples/function-calling/function-calling-openai-responses-video-http.py
@@ -139,6 +139,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,15 +163,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @tts.event_handler("on_tts_request")
     async def on_tts_request(tts, context_id: str, text: str):
         logger.debug(f"On TTS request: {context_id}: {text}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses-video.py
+++ b/examples/function-calling/function-calling-openai-responses-video.py
@@ -139,6 +139,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,15 +163,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @tts.event_handler("on_tts_request")
     async def on_tts_request(tts, context_id: str, text: str):
         logger.debug(f"On TTS request: {context_id}: {text}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-responses.py
+++ b/examples/function-calling/function-calling-openai-responses.py
@@ -132,6 +132,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -144,11 +148,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai-video.py
+++ b/examples/function-calling/function-calling-openai-video.py
@@ -139,6 +139,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,15 +163,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @tts.event_handler("on_tts_request")
     async def on_tts_request(tts, context_id: str, text: str):
         logger.debug(f"On TTS request: {context_id}: {text}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openai.py
+++ b/examples/function-calling/function-calling-openai.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-openrouter.py
+++ b/examples/function-calling/function-calling-openrouter.py
@@ -120,6 +120,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,11 +136,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-perplexity.py
+++ b/examples/function-calling/function-calling-perplexity.py
@@ -112,6 +112,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -124,11 +128,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-qwen.py
+++ b/examples/function-calling/function-calling-qwen.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-sambanova.py
+++ b/examples/function-calling/function-calling-sambanova.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-sarvam.py
+++ b/examples/function-calling/function-calling-sarvam.py
@@ -129,6 +129,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -141,11 +145,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/function-calling/function-calling-together.py
+++ b/examples/function-calling/function-calling-together.py
@@ -125,6 +125,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -137,11 +141,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/01-say-one-thing.py
+++ b/examples/getting-started/01-say-one-thing.py
@@ -52,14 +52,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Register an event handler so we can play the audio when the client joins
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         await worker.queue_frames([TTSSpeakFrame(f"Hello there!"), EndFrame()])
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/01a-local-audio.py
+++ b/examples/getting-started/01a-local-audio.py
@@ -38,13 +38,14 @@ async def main():
 
     worker = PipelineWorker(pipeline)
 
+    runner = WorkerRunner(handle_sigint=False if sys.platform == "win32" else True)
+
+    await runner.add_workers(worker)
+
     async def say_something():
         await asyncio.sleep(1)
         await worker.queue_frames([TTSSpeakFrame("Hello there, how is it going!"), EndFrame()])
 
-    runner = WorkerRunner(handle_sigint=False if sys.platform == "win32" else True)
-
-    await runner.add_workers(worker)
     await asyncio.gather(runner.run(), say_something())
 
 

--- a/examples/getting-started/02-llm-say-one-thing.py
+++ b/examples/getting-started/02-llm-say-one-thing.py
@@ -61,6 +61,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Register an event handler so we can play the audio when the client joins
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -68,9 +72,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         context.add_message({"role": "developer", "content": "Say hello to the world."})
         await worker.queue_frames([LLMContextFrame(context), EndFrame()])
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/03-still-frame.py
+++ b/examples/getting-started/03-still-frame.py
@@ -59,6 +59,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Register an event handler so we can play the audio when the client joins
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -69,11 +73,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/03a-local-still-frame.py
+++ b/examples/getting-started/03a-local-still-frame.py
@@ -51,13 +51,14 @@ async def main():
 
         runner = WorkerRunner()
 
+        await runner.add_workers(worker)
+
         async def run_tk():
             while not worker.has_finished():
                 tk_root.update()
                 tk_root.update_idletasks()
                 await asyncio.sleep(0.1)
 
-        await runner.add_workers(worker)
         await asyncio.gather(runner.run(), run_tk())
 
 

--- a/examples/getting-started/04-sync-speech-and-image.py
+++ b/examples/getting-started/04-sync-speech-and-image.py
@@ -196,6 +196,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         # Set up transport event handlers
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
@@ -206,11 +210,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        # Run the pipeline
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/getting-started/05-speaking-state.py
+++ b/examples/getting-started/05-speaking-state.py
@@ -150,6 +150,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,10 +163,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/06-voice-agent.py
+++ b/examples/getting-started/06-voice-agent.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/getting-started/06a-voice-agent-local.py
+++ b/examples/getting-started/06a-voice-agent-local.py
@@ -82,12 +82,13 @@ async def main():
         ),
     )
 
-    context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
-    await worker.queue_frames([LLMRunFrame()])
-
     runner = WorkerRunner()
 
     await runner.add_workers(worker)
+
+    context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
+    await worker.queue_frames([LLMRunFrame()])
+
     await runner.run()
 
 

--- a/examples/getting-started/07-function-calling.py
+++ b/examples/getting-started/07-function-calling.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/mcp/mcp-multiple-mcp.py
+++ b/examples/mcp/mcp-multiple-mcp.py
@@ -144,6 +144,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected: {client}")
@@ -153,11 +157,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/mcp/mcp-stdio.py
+++ b/examples/mcp/mcp-stdio.py
@@ -122,6 +122,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected: {client}")
@@ -131,11 +135,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/mcp/mcp-streamable-http-gemini-live.py
+++ b/examples/mcp/mcp-streamable-http-gemini-live.py
@@ -119,6 +119,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected: {client}")
@@ -128,11 +132,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/mcp/mcp-streamable-http.py
+++ b/examples/mcp/mcp-streamable-http.py
@@ -126,6 +126,10 @@ Just respond with short sentences when you are carrying out tool calls.
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected: {client}")
@@ -135,11 +139,8 @@ Just respond with short sentences when you are carrying out tool calls.
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/multi-worker/code-assistant/code-assistant.py
+++ b/examples/multi-worker/code-assistant/code-assistant.py
@@ -97,8 +97,6 @@ async def ask_code(params: FunctionCallParams, question: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting code assistant")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -150,6 +148,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(CodeWorker("code-worker", project_path=PROJECT_PATH), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -165,8 +167,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(CodeWorker("code-worker", project_path=PROJECT_PATH), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/distributed-handoff/pgmq-handoff/main.py
+++ b/examples/multi-worker/distributed-handoff/pgmq-handoff/main.py
@@ -134,6 +134,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    await runner.add_workers(worker)
+
     # The remote LLM workers may take a moment to register on the bus.
     # We only activate ``greeter`` once *both* the client is connected
     # and the worker has been observed via the registry.
@@ -174,7 +176,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Client disconnected")
         await runner.cancel()
 
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/multi-worker/distributed-handoff/redis-handoff/main.py
+++ b/examples/multi-worker/distributed-handoff/redis-handoff/main.py
@@ -115,6 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    await runner.add_workers(worker)
+
     # The remote LLM workers may take a moment to register on the bus.
     # We only activate ``greeter`` once *both* the client is connected
     # and the worker has been observed via the registry.
@@ -155,7 +157,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Client disconnected")
         await runner.cancel()
 
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/multi-worker/local-handoff/local-handoff-two-agents-tts.py
+++ b/examples/multi-worker/local-handoff/local-handoff-two-agents-tts.py
@@ -233,6 +233,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    await runner.add_workers(build_greeter(), build_support(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -255,8 +257,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(build_greeter(), build_support(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/local-handoff/local-handoff-two-agents.py
+++ b/examples/multi-worker/local-handoff/local-handoff-two-agents.py
@@ -206,6 +206,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    await runner.add_workers(build_greeter(), build_support(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -228,8 +230,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(build_greeter(), build_support(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/parallel-debate/parallel-debate.py
+++ b/examples/multi-worker/parallel-debate/parallel-debate.py
@@ -154,8 +154,6 @@ async def debate(params: FunctionCallParams, topic: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting parallel-debate bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -204,6 +202,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(
+        DebateWorker("advocate"),
+        DebateWorker("critic"),
+        DebateWorker("analyst"),
+        worker,
+    )
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -222,13 +229,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(
-        DebateWorker("advocate"),
-        DebateWorker("critic"),
-        DebateWorker("analyst"),
-        worker,
-    )
 
     await runner.run()
 

--- a/examples/multi-worker/remote-proxy-assistant/assistant.py
+++ b/examples/multi-worker/remote-proxy-assistant/assistant.py
@@ -82,8 +82,6 @@ async def websocket_endpoint(websocket: WebSocket):
     """Handle a WebSocket connection from the main bot's proxy."""
     await websocket.accept()
 
-    runner = WorkerRunner(handle_sigint=False)
-
     proxy = WebSocketProxyServer(
         "gateway",
         websocket=websocket,
@@ -91,6 +89,12 @@ async def websocket_endpoint(websocket: WebSocket):
         remote_worker_name="acme",
         forward_messages=(BusFrameMessage,),
     )
+
+    assistant = AcmeAssistant()
+
+    runner = WorkerRunner(handle_sigint=False)
+
+    await runner.add_workers(proxy, assistant)
 
     @proxy.event_handler("on_client_connected")
     async def on_client_connected(proxy, client):
@@ -100,10 +104,6 @@ async def websocket_endpoint(websocket: WebSocket):
     async def on_client_disconnected(proxy, client):
         logger.info("WebSocket client disconnected")
         await runner.cancel()
-
-    assistant = AcmeAssistant()
-
-    await runner.add_workers(proxy, assistant)
 
     logger.info("Assistant server ready, waiting for activation")
     await runner.run()

--- a/examples/multi-worker/remote-proxy-assistant/main.py
+++ b/examples/multi-worker/remote-proxy-assistant/main.py
@@ -122,6 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         forward_messages=(BusFrameMessage,),
     )
 
+    await runner.add_workers(proxy, worker)
+
     async def on_assistant_ready(_data: WorkerReadyData) -> None:
         logger.info("Remote assistant ready, activating")
         await worker.activate_worker(
@@ -150,8 +152,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(proxy, worker)
 
     await runner.run()
 

--- a/examples/multi-worker/sensor-controller/sensor-controller.py
+++ b/examples/multi-worker/sensor-controller/sensor-controller.py
@@ -295,6 +295,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
+    await runner.add_workers(build_sensor_controller(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -313,8 +315,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(build_sensor_controller(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/sensor-controller/sensor-controller.py
+++ b/examples/multi-worker/sensor-controller/sensor-controller.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Voice agent + sensor-controller worker, both as plain PipelineTasks.
+"""Voice agent + sensor-controller worker, both as plain PipelineWorkers.
 
 Two ``PipelineWorker`` instances run side by side:
 

--- a/examples/multi-worker/ui-worker/async-tasks/bot.py
+++ b/examples/multi-worker/ui-worker/async-tasks/bot.py
@@ -303,8 +303,6 @@ async def answer_about_screen(params: FunctionCallParams, query: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting async-tasks bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -342,6 +340,16 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(
+        ResearchWorker(),
+        WikipediaResearcher("wikipedia"),
+        NewsResearcher("news"),
+        ScholarResearcher("scholar"),
+        worker,
+    )
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -360,14 +368,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(
-        ResearchWorker(),
-        WikipediaResearcher("wikipedia"),
-        NewsResearcher("news"),
-        ScholarResearcher("scholar"),
-        worker,
-    )
 
     await runner.run()
 

--- a/examples/multi-worker/ui-worker/deixis/bot.py
+++ b/examples/multi-worker/ui-worker/deixis/bot.py
@@ -218,8 +218,6 @@ async def answer_about_screen(params: FunctionCallParams, query: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting deixis bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -257,6 +255,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(DeixisWorker(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -276,8 +278,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(DeixisWorker(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/ui-worker/document-review/bot.py
+++ b/examples/multi-worker/ui-worker/document-review/bot.py
@@ -434,8 +434,6 @@ async def answer_about_screen(params: FunctionCallParams, query: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting document-review bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -473,6 +471,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(
+        ReviewWorker(),
+        ClarityReviewer("clarity"),
+        ToneReviewer("tone"),
+        worker,
+    )
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -492,13 +499,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(
-        ReviewWorker(),
-        ClarityReviewer("clarity"),
-        ToneReviewer("tone"),
-        worker,
-    )
 
     await runner.run()
 

--- a/examples/multi-worker/ui-worker/form-fill/bot.py
+++ b/examples/multi-worker/ui-worker/form-fill/bot.py
@@ -239,8 +239,6 @@ async def answer_about_screen(params: FunctionCallParams, query: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting form-fill bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -278,6 +276,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(FormWorker(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -297,8 +299,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(FormWorker(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/ui-worker/hello-snapshot/bot.py
+++ b/examples/multi-worker/ui-worker/hello-snapshot/bot.py
@@ -197,8 +197,6 @@ async def answer_about_screen(params: FunctionCallParams, query: str):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting hello-snapshot bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -239,6 +237,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(HelloWorker(), worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -257,8 +259,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(HelloWorker(), worker)
 
     await runner.run()
 

--- a/examples/multi-worker/ui-worker/shopping-list/bot.py
+++ b/examples/multi-worker/ui-worker/shopping-list/bot.py
@@ -279,8 +279,6 @@ class ListWorker(UIWorker):
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting shopping-list bot")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     tts = CartesiaTTSService(
         api_key=os.environ["CARTESIA_API_KEY"],
@@ -294,8 +292,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     )
 
     # The UI worker owns the list; create it up front so the voice layer's
-    # read-only ``check_list`` tool can look at its live snapshot. It's added
-    # to the runner at the end alongside the main worker.
+    # read-only ``check_list`` tool can look at its live snapshot.
     list_worker = ListWorker()
 
     @tool_options(timeout_secs=10)
@@ -339,6 +336,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(list_worker, worker)
+
     # Every user turn drives the UI: forward the transcript to the UIWorker
     # as a respond job (a bus message). Fire it from the turn-stopped event
     # so the voice LLM (which runs from the same turn) and the UIWorker act
@@ -378,8 +379,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
         await runner.cancel()
-
-    await runner.add_workers(list_worker, worker)
 
     await runner.run()
 

--- a/examples/observability/observability-heartbeats.py
+++ b/examples/observability/observability-heartbeats.py
@@ -38,13 +38,14 @@ async def main():
 
     worker = PipelineWorker(pipeline, params=PipelineParams(enable_heartbeats=True))
 
+    runner = WorkerRunner()
+
+    await runner.add_workers(worker)
+
     @worker.event_handler("on_heartbeat_timeout")
     async def on_heartbeat_timeout(worker: PipelineWorker):
         logger.warning("Heartbeat timeout detected — pipeline may be stalled")
 
-    runner = WorkerRunner()
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/observability/observability-observer.py
+++ b/examples/observability/observability-observer.py
@@ -159,6 +159,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -171,11 +175,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/observability/observability-sentry-metrics.py
+++ b/examples/observability/observability-sentry-metrics.py
@@ -112,6 +112,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -124,11 +128,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-anthropic.py
+++ b/examples/persistent-context/persistent-context-anthropic.py
@@ -183,6 +183,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -198,11 +202,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-aws-nova-sonic.py
+++ b/examples/persistent-context/persistent-context-aws-nova-sonic.py
@@ -235,6 +235,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -251,11 +255,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-gemini.py
+++ b/examples/persistent-context/persistent-context-gemini.py
@@ -237,6 +237,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -257,11 +261,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-grok-realtime.py
+++ b/examples/persistent-context/persistent-context-grok-realtime.py
@@ -195,6 +195,10 @@ Remember, your responses should be short - just one or two sentences usually."""
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -203,11 +207,8 @@ Remember, your responses should be short - just one or two sentences usually."""
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-openai-realtime.py
+++ b/examples/persistent-context/persistent-context-openai-realtime.py
@@ -209,6 +209,10 @@ Remember, your responses should be short. Just one or two sentences, usually."""
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -218,11 +222,8 @@ Remember, your responses should be short. Just one or two sentences, usually."""
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-openai-responses-http.py
+++ b/examples/persistent-context/persistent-context-openai-responses-http.py
@@ -184,6 +184,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -193,11 +197,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-openai-responses.py
+++ b/examples/persistent-context/persistent-context-openai-responses.py
@@ -184,6 +184,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -193,11 +197,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/persistent-context/persistent-context-openai.py
+++ b/examples/persistent-context/persistent-context-openai.py
@@ -182,6 +182,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -191,11 +195,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/rag/rag-gemini-grounding-metadata.py
+++ b/examples/rag/rag-gemini-grounding-metadata.py
@@ -153,6 +153,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[LLMSearchLoggerObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -162,10 +166,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/rag/rag-gemini.py
+++ b/examples/rag/rag-gemini.py
@@ -237,6 +237,10 @@ Your response will be turned into speech so use only simple words and punctuatio
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -249,10 +253,8 @@ Your response will be turned into speech so use only simple words and punctuatio
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/rag/rag-mem0.py
+++ b/examples/rag/rag-mem0.py
@@ -241,6 +241,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -256,10 +260,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-aws-nova-sonic-async-tool.py
+++ b/examples/realtime/realtime-aws-nova-sonic-async-tool.py
@@ -144,6 +144,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -155,10 +159,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-aws-nova-sonic.py
+++ b/examples/realtime/realtime-aws-nova-sonic.py
@@ -171,6 +171,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Handle client connection event
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -189,7 +193,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # See comment above the user_aggregator for details on why this is
     # commented out and instructions for enabling it.
@@ -213,9 +217,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    # Run the pipeline
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-azure-async-tool.py
+++ b/examples/realtime/realtime-azure-async-tool.py
@@ -144,6 +144,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -155,10 +159,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-azure.py
+++ b/examples/realtime/realtime-azure.py
@@ -173,6 +173,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -182,7 +186,7 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # Subscribe to user turn lifecycle events. Azure Realtime emits its
     # own user-turn frames from server VAD, so on_user_turn_stopped fires
@@ -212,9 +216,6 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-async-tool.py
+++ b/examples/realtime/realtime-gemini-live-async-tool.py
@@ -161,6 +161,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -172,10 +176,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-files-api.py
+++ b/examples/realtime/realtime-gemini-live-files-api.py
@@ -200,6 +200,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Handle client connection event
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -211,11 +215,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    # Run the pipeline
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
     # Clean up: delete the uploaded file and temporary file

--- a/examples/realtime/realtime-gemini-live-google-search.py
+++ b/examples/realtime/realtime-gemini-live-google-search.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -133,11 +137,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-graceful-end.py
+++ b/examples/realtime/realtime-gemini-live-graceful-end.py
@@ -186,6 +186,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -195,11 +199,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-grounding-metadata.py
+++ b/examples/realtime/realtime-gemini-live-grounding-metadata.py
@@ -152,6 +152,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -167,11 +171,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-locally-driven-turns.py
+++ b/examples/realtime/realtime-gemini-live-locally-driven-turns.py
@@ -130,6 +130,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -139,7 +143,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # In realtime mode the user transcript isn't finalized at turn-stop
     # time, so on_user_turn_stopped carries no content; subscribe to
@@ -166,9 +170,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-vertex.py
+++ b/examples/realtime/realtime-gemini-live-vertex.py
@@ -162,6 +162,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -171,11 +175,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live-video.py
+++ b/examples/realtime/realtime-gemini-live-video.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -120,11 +124,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-gemini-live.py
+++ b/examples/realtime/realtime-gemini-live.py
@@ -181,6 +181,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -193,7 +197,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # See comment above the user_aggregator for details on why this is
     # commented out and instructions for enabling it.
@@ -217,9 +221,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-grok-async-tool.py
+++ b/examples/realtime/realtime-grok-async-tool.py
@@ -148,6 +148,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,10 +163,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-grok-locally-driven-turns.py
+++ b/examples/realtime/realtime-grok-locally-driven-turns.py
@@ -191,6 +191,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -199,7 +203,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # In realtime mode the user transcript isn't finalized at turn-stop
     # time, so on_user_turn_stopped carries no content; subscribe to
@@ -226,9 +230,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-grok.py
+++ b/examples/realtime/realtime-grok.py
@@ -229,6 +229,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -238,7 +242,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # Subscribe to user turn lifecycle events. Grok emits its own
     # user-turn frames from server VAD, so on_user_turn_stopped fires at
@@ -268,9 +272,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-inworld-locally-driven-turns.py
+++ b/examples/realtime/realtime-inworld-locally-driven-turns.py
@@ -182,6 +182,10 @@ Always be helpful and proactive in offering assistance.""",
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -190,7 +194,7 @@ Always be helpful and proactive in offering assistance.""",
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # In realtime mode the user transcript isn't finalized at turn-stop
     # time, so on_user_turn_stopped carries no content; subscribe to
@@ -215,9 +219,6 @@ Always be helpful and proactive in offering assistance.""",
         timestamp = f"[{message.timestamp}] " if message.timestamp else ""
         logger.info(f"Transcript: {timestamp}assistant: {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-inworld.py
+++ b/examples/realtime/realtime-inworld.py
@@ -160,6 +160,10 @@ Always be helpful and proactive in offering assistance.""",
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -168,7 +172,7 @@ Always be helpful and proactive in offering assistance.""",
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # Subscribe to user turn lifecycle events. Inworld emits its own
     # user-turn frames from server-side semantic VAD, so
@@ -197,9 +201,6 @@ Always be helpful and proactive in offering assistance.""",
         timestamp = f"[{message.timestamp}] " if message.timestamp else ""
         logger.info(f"Transcript: {timestamp}assistant: {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-openai-async-tool.py
+++ b/examples/realtime/realtime-openai-async-tool.py
@@ -147,6 +147,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -158,10 +162,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-openai-live-video.py
+++ b/examples/realtime/realtime-openai-live-video.py
@@ -131,6 +131,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
@@ -143,11 +147,8 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-openai-locally-driven-turns.py
+++ b/examples/realtime/realtime-openai-locally-driven-turns.py
@@ -200,6 +200,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -213,7 +217,7 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # In realtime mode the user transcript isn't finalized at turn-stop
     # time, so on_user_turn_stopped carries no content; subscribe to
@@ -240,9 +244,6 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-openai-text.py
+++ b/examples/realtime/realtime-openai-text.py
@@ -174,6 +174,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -183,11 +187,8 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-openai.py
+++ b/examples/realtime/realtime-openai.py
@@ -180,6 +180,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -231,7 +235,7 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # Subscribe to user turn lifecycle events. OpenAI Realtime emits its
     # own user-turn frames from server VAD, so on_user_turn_stopped fires
@@ -261,9 +265,6 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-ultravox-async-tool.py
+++ b/examples/realtime/realtime-ultravox-async-tool.py
@@ -162,6 +162,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -169,10 +173,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-ultravox-text.py
+++ b/examples/realtime/realtime-ultravox-text.py
@@ -222,6 +222,10 @@ There is also a secret menu that changes daily. If the user asks about it, use t
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Handle client connection event
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -231,7 +235,7 @@ There is also a secret menu that changes daily. If the user asks about it, use t
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # Ultravox doesn't emit user-turn frames; subscribe to the
     # *_message_added events for the finalized message text.
@@ -247,9 +251,6 @@ There is also a secret menu that changes daily. If the user asks about it, use t
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    # Run the pipeline
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/realtime/realtime-ultravox.py
+++ b/examples/realtime/realtime-ultravox.py
@@ -223,6 +223,10 @@ There is also a secret menu that changes daily. If the user asks about it, use t
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Handle client connection event
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
@@ -232,7 +236,7 @@ There is also a secret menu that changes daily. If the user asks about it, use t
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     # See comment above the user_aggregator for details on why this is
     # commented out and instructions for enabling it.
@@ -256,9 +260,6 @@ There is also a secret menu that changes daily. If the user asks about it, use t
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    # Run the pipeline
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-anthropic.py
+++ b/examples/thinking/thinking-anthropic.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -124,15 +128,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-functions-anthropic.py
+++ b/examples/thinking/thinking-functions-anthropic.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -143,15 +147,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-functions-google-vertex.py
+++ b/examples/thinking/thinking-functions-google-vertex.py
@@ -131,6 +131,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -150,15 +154,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-functions-google.py
+++ b/examples/thinking/thinking-functions-google.py
@@ -128,6 +128,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -147,15 +151,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-functions-openai-responses.py
+++ b/examples/thinking/thinking-functions-openai-responses.py
@@ -134,6 +134,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -152,15 +156,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-google-vertex.py
+++ b/examples/thinking/thinking-google-vertex.py
@@ -111,6 +111,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,15 +136,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-google.py
+++ b/examples/thinking/thinking-google.py
@@ -108,6 +108,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -129,15 +133,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-openai-responses-http.py
+++ b/examples/thinking/thinking-openai-responses-http.py
@@ -114,6 +114,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -134,15 +138,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/thinking/thinking-openai-responses.py
+++ b/examples/thinking/thinking-openai-responses.py
@@ -114,6 +114,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -134,15 +138,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @assistant_aggregator.event_handler("on_assistant_thought")
     async def on_assistant_thought(aggregator, message: AssistantThoughtMessage):
         logger.info(f"Thought (timestamp: {message.timestamp}): {message.content}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/transcription/transcription-assemblyai.py
+++ b/examples/transcription/transcription-assemblyai.py
@@ -74,14 +74,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-azure.py
+++ b/examples/transcription/transcription-azure.py
@@ -76,14 +76,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-cartesia-turns.py
+++ b/examples/transcription/transcription-cartesia-turns.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-cartesia.py
+++ b/examples/transcription/transcription-cartesia.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-deepgram-flux.py
+++ b/examples/transcription/transcription-deepgram-flux.py
@@ -74,14 +74,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-deepgram.py
+++ b/examples/transcription/transcription-deepgram.py
@@ -74,14 +74,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-elevenlabs.py
+++ b/examples/transcription/transcription-elevenlabs.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-funasr.py
+++ b/examples/transcription/transcription-funasr.py
@@ -74,14 +74,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-gladia-translation.py
+++ b/examples/transcription/transcription-gladia-translation.py
@@ -94,14 +94,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-gladia.py
+++ b/examples/transcription/transcription-gladia.py
@@ -80,14 +80,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-google-llm.py
+++ b/examples/transcription/transcription-google-llm.py
@@ -369,6 +369,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -378,11 +382,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/transcription/transcription-google.py
+++ b/examples/transcription/transcription-google.py
@@ -79,14 +79,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-gradium.py
+++ b/examples/transcription/transcription-gradium.py
@@ -77,14 +77,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-mistral.py
+++ b/examples/transcription/transcription-mistral.py
@@ -79,14 +79,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-nvidia.py
+++ b/examples/transcription/transcription-nvidia.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-openai.py
+++ b/examples/transcription/transcription-openai.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-soniox.py
+++ b/examples/transcription/transcription-soniox.py
@@ -75,14 +75,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-speechmatics.py
+++ b/examples/transcription/transcription-speechmatics.py
@@ -90,14 +90,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-together.py
+++ b/examples/transcription/transcription-together.py
@@ -69,14 +69,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-whisper-mlx.py
+++ b/examples/transcription/transcription-whisper-mlx.py
@@ -109,14 +109,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-whisper.py
+++ b/examples/transcription/transcription-whisper.py
@@ -74,14 +74,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transcription/transcription-xai.py
+++ b/examples/transcription/transcription-xai.py
@@ -75,14 +75,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info(f"Client disconnected")
-        await worker.cancel()
-
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
 
     await runner.add_workers(worker)
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await runner.cancel()
+
     await runner.run()
 
 

--- a/examples/transports/transports-daily.py
+++ b/examples/transports/transports-daily.py
@@ -87,6 +87,10 @@ async def main():
             ),
         )
 
+        runner = WorkerRunner()
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
@@ -98,11 +102,8 @@ async def main():
 
         @transport.event_handler("on_participant_left")
         async def on_participant_left(transport, participant, reason):
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner()
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/transports/transports-livekit.py
+++ b/examples/transports/transports-livekit.py
@@ -95,6 +95,10 @@ async def main():
         ),
     )
 
+    runner = WorkerRunner()
+
+    await runner.add_workers(worker)
+
     # Register an event handler so we can play the audio when the
     # participant joins.
     @transport.event_handler("on_first_participant_joined")
@@ -129,9 +133,6 @@ async def main():
             ],
         )
 
-    runner = WorkerRunner()
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/transports/transports-moq.py
+++ b/examples/transports/transports-moq.py
@@ -152,6 +152,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport):
         logger.info("Client subscribed — starting conversation")
@@ -163,7 +167,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_disconnected")
     async def on_disconnected(transport):
         logger.info("Disconnected from MOQ relay")
-        await worker.cancel()
+        await runner.cancel()
 
     @transport.event_handler("on_error")
     async def on_error(transport, message, exception):
@@ -171,10 +175,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 
     # MOQInputTransport.start() auto-connects to the relay when the
     # pipeline starts, so we don't dial transport.connect() here.
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
     try:
-        await runner.add_workers(worker)
         await runner.run()
     finally:
         await transport.disconnect()

--- a/examples/transports/transports-small-webrtc.py
+++ b/examples/transports/transports-small-webrtc.py
@@ -73,6 +73,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -85,11 +89,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/transports/transports-vonage.py
+++ b/examples/transports/transports-vonage.py
@@ -118,6 +118,10 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner()
+
+    await runner.add_workers(worker)
+
     event_handler: Callable[[str], Callable[[Any], Any]] = transport.event_handler
 
     @event_handler("on_client_connected")
@@ -125,9 +129,6 @@ Remember, your responses should be short. Just one or two sentences, usually. Re
         logger.info("Client connected")
         await worker.queue_frames([LLMRunFrame()])
 
-    runner = WorkerRunner()
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-custom-external-turn-strategy.py
+++ b/examples/turn-management/turn-management-custom-external-turn-strategy.py
@@ -207,6 +207,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -219,11 +223,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-detect-user-idle.py
+++ b/examples/turn-management/turn-management-detect-user-idle.py
@@ -175,6 +175,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Set up idle handling with retry logic
     idle_handler = IdleHandler()
 
@@ -205,11 +209,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-filter-incomplete-turns-function-calling.py
+++ b/examples/turn-management/turn-management-filter-incomplete-turns-function-calling.py
@@ -161,6 +161,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -173,7 +177,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @user_aggregator.event_handler("on_user_turn_stopped")
     async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
@@ -187,9 +191,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-filter-incomplete-turns-user-idle.py
+++ b/examples/turn-management/turn-management-filter-incomplete-turns-user-idle.py
@@ -145,6 +145,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -160,7 +164,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @user_aggregator.event_handler("on_user_turn_idle")
     async def on_user_turn_idle(aggregator):
@@ -194,9 +198,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-filter-incomplete-turns.py
+++ b/examples/turn-management/turn-management-filter-incomplete-turns.py
@@ -135,6 +135,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -150,7 +154,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @user_aggregator.event_handler("on_user_turn_stopped")
     async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
@@ -164,9 +168,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         line = f"{timestamp}assistant: {message.content}"
         logger.info(f"Transcript: {line}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-interruption-config.py
+++ b/examples/turn-management/turn-management-interruption-config.py
@@ -109,6 +109,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[TranscriptionLogObserver()],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -121,11 +125,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-smart-turn-local-coreml.py
+++ b/examples/turn-management/turn-management-smart-turn-local-coreml.py
@@ -131,6 +131,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -143,11 +147,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-smart-turn-local.py
+++ b/examples/turn-management/turn-management-smart-turn-local.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[MetricsLogObserver(include_metrics={TurnMetricsData})],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-turn-tracking-observer.py
+++ b/examples/turn-management/turn-management-turn-tracking-observer.py
@@ -130,6 +130,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[latency_observer, startup_observer],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @latency_observer.event_handler("on_first_bot_speech_latency")
     async def on_first_bot_speech_latency(observer, latency_seconds):
         logger.info(f"First bot speech: {latency_seconds:.3f}s after client connected")
@@ -181,11 +185,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-user-assistant-turns.py
+++ b/examples/turn-management/turn-management-user-assistant-turns.py
@@ -169,6 +169,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -181,7 +185,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @user_aggregator.event_handler("on_user_turn_stopped")
     async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
@@ -191,8 +195,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
         await transcript_handler.on_assistant_transcript(message)
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/turn-management/turn-management-user-mute-strategy.py
+++ b/examples/turn-management/turn-management-user-mute-strategy.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -142,7 +146,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @user_aggregator.event_handler("on_user_mute_started")
     async def on_user_mute_started(aggregator):
@@ -152,9 +156,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_user_mute_stopped(aggregator):
         logger.info(f"User mute stopped")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-anthropic.py
+++ b/examples/update-settings/llm/llm-anthropic.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-aws-bedrock.py
+++ b/examples/update-settings/llm/llm-aws-bedrock.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-aws-nova-sonic.py
+++ b/examples/update-settings/llm/llm-aws-nova-sonic.py
@@ -94,6 +94,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -109,11 +113,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-azure-realtime.py
+++ b/examples/update-settings/llm/llm-azure-realtime.py
@@ -92,6 +92,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Azure Realtime emits user-turn frames from server VAD, so
     # on_user_turn_stopped fires at the turn boundary. In realtime mode
     # UserTurnStoppedMessage.content is None (the user transcript isn't
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-azure.py
+++ b/examples/update-settings/llm/llm-azure.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-cerebras.py
+++ b/examples/update-settings/llm/llm-cerebras.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-deepseek.py
+++ b/examples/update-settings/llm/llm-deepseek.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-fireworks.py
+++ b/examples/update-settings/llm/llm-fireworks.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-gemini-live-vertex.py
+++ b/examples/update-settings/llm/llm-gemini-live-vertex.py
@@ -95,6 +95,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-gemini-live.py
+++ b/examples/update-settings/llm/llm-gemini-live.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-google-vertex.py
+++ b/examples/update-settings/llm/llm-google-vertex.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-google.py
+++ b/examples/update-settings/llm/llm-google.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-grok-realtime.py
+++ b/examples/update-settings/llm/llm-grok-realtime.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Grok emits user-turn frames from server VAD, so
     # on_user_turn_stopped fires at the turn boundary. In realtime mode
     # UserTurnStoppedMessage.content is None (the user transcript isn't
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-grok.py
+++ b/examples/update-settings/llm/llm-grok.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-groq.py
+++ b/examples/update-settings/llm/llm-groq.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-mistral.py
+++ b/examples/update-settings/llm/llm-mistral.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-nvidia.py
+++ b/examples/update-settings/llm/llm-nvidia.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-ollama.py
+++ b/examples/update-settings/llm/llm-ollama.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-openai-realtime.py
+++ b/examples/update-settings/llm/llm-openai-realtime.py
@@ -89,6 +89,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # OpenAI Realtime emits user-turn frames from server VAD, so
     # on_user_turn_stopped fires at the turn boundary. In realtime mode
     # UserTurnStoppedMessage.content is None (the user transcript isn't
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-openai-responses-http.py
+++ b/examples/update-settings/llm/llm-openai-responses-http.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-openai-responses.py
+++ b/examples/update-settings/llm/llm-openai-responses.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-openai.py
+++ b/examples/update-settings/llm/llm-openai.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-openrouter.py
+++ b/examples/update-settings/llm/llm-openrouter.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-perplexity.py
+++ b/examples/update-settings/llm/llm-perplexity.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-qwen.py
+++ b/examples/update-settings/llm/llm-qwen.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-sambanova.py
+++ b/examples/update-settings/llm/llm-sambanova.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-sarvam.py
+++ b/examples/update-settings/llm/llm-sarvam.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-together.py
+++ b/examples/update-settings/llm/llm-together.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/llm/llm-ultravox-realtime.py
+++ b/examples/update-settings/llm/llm-ultravox-realtime.py
@@ -108,6 +108,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     # Ultravox doesn't emit user-turn frames, so on_user_turn_stopped
     # won't fire. If you uncomment the local-VAD opt-in above, also
     # uncomment the imports and handler below.
@@ -149,11 +153,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-assemblyai.py
+++ b/examples/update-settings/stt/stt-assemblyai.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -128,11 +132,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-aws-transcribe.py
+++ b/examples/update-settings/stt/stt-aws-transcribe.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-azure.py
+++ b/examples/update-settings/stt/stt-azure.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-cartesia.py
+++ b/examples/update-settings/stt/stt-cartesia.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-deepgram-flux.py
+++ b/examples/update-settings/stt/stt-deepgram-flux.py
@@ -108,6 +108,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -142,11 +146,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-deepgram-sagemaker.py
+++ b/examples/update-settings/stt/stt-deepgram-sagemaker.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -132,11 +136,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-deepgram.py
+++ b/examples/update-settings/stt/stt-deepgram.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -129,11 +133,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-elevenlabs-realtime.py
+++ b/examples/update-settings/stt/stt-elevenlabs-realtime.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-elevenlabs.py
+++ b/examples/update-settings/stt/stt-elevenlabs.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -121,11 +125,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/stt/stt-fal.py
+++ b/examples/update-settings/stt/stt-fal.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-gladia.py
+++ b/examples/update-settings/stt/stt-gladia.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-google.py
+++ b/examples/update-settings/stt/stt-google.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-gradium.py
+++ b/examples/update-settings/stt/stt-gradium.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-groq.py
+++ b/examples/update-settings/stt/stt-groq.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-nvidia-segmented.py
+++ b/examples/update-settings/stt/stt-nvidia-segmented.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-nvidia.py
+++ b/examples/update-settings/stt/stt-nvidia.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-openai-realtime.py
+++ b/examples/update-settings/stt/stt-openai-realtime.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-sarvam.py
+++ b/examples/update-settings/stt/stt-sarvam.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-soniox.py
+++ b/examples/update-settings/stt/stt-soniox.py
@@ -94,6 +94,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-speechmatics.py
+++ b/examples/update-settings/stt/stt-speechmatics.py
@@ -106,6 +106,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -141,11 +145,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-whisper-api.py
+++ b/examples/update-settings/stt/stt-whisper-api.py
@@ -105,6 +105,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -122,11 +126,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-whisper-mlx.py
+++ b/examples/update-settings/stt/stt-whisper-mlx.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -124,11 +128,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/stt/stt-whisper.py
+++ b/examples/update-settings/stt/stt-whisper.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -123,11 +127,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-asyncai-http.py
+++ b/examples/update-settings/tts/tts-asyncai-http.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -121,11 +125,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-asyncai.py
+++ b/examples/update-settings/tts/tts-asyncai.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-aws-polly.py
+++ b/examples/update-settings/tts/tts-aws-polly.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-azure-http.py
+++ b/examples/update-settings/tts/tts-azure-http.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-azure.py
+++ b/examples/update-settings/tts/tts-azure.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-camb.py
+++ b/examples/update-settings/tts/tts-camb.py
@@ -94,6 +94,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-cartesia-http.py
+++ b/examples/update-settings/tts/tts-cartesia-http.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-cartesia.py
+++ b/examples/update-settings/tts/tts-cartesia.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -120,11 +124,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-deepgram-http.py
+++ b/examples/update-settings/tts/tts-deepgram-http.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -127,11 +131,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-deepgram-sagemaker.py
+++ b/examples/update-settings/tts/tts-deepgram-sagemaker.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -124,11 +128,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-deepgram.py
+++ b/examples/update-settings/tts/tts-deepgram.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-elevenlabs-http.py
+++ b/examples/update-settings/tts/tts-elevenlabs-http.py
@@ -106,6 +106,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -123,11 +127,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-elevenlabs.py
+++ b/examples/update-settings/tts/tts-elevenlabs.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -131,11 +135,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-fish.py
+++ b/examples/update-settings/tts/tts-fish.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-gemini.py
+++ b/examples/update-settings/tts/tts-gemini.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -121,11 +125,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-google-http.py
+++ b/examples/update-settings/tts/tts-google-http.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-google-stream.py
+++ b/examples/update-settings/tts/tts-google-stream.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-gradium.py
+++ b/examples/update-settings/tts/tts-gradium.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-groq.py
+++ b/examples/update-settings/tts/tts-groq.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-hume.py
+++ b/examples/update-settings/tts/tts-hume.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-inworld-http.py
+++ b/examples/update-settings/tts/tts-inworld-http.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-inworld.py
+++ b/examples/update-settings/tts/tts-inworld.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-kokoro.py
+++ b/examples/update-settings/tts/tts-kokoro.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-lmnt.py
+++ b/examples/update-settings/tts/tts-lmnt.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-minimax.py
+++ b/examples/update-settings/tts/tts-minimax.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-neuphonic-http.py
+++ b/examples/update-settings/tts/tts-neuphonic-http.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-neuphonic.py
+++ b/examples/update-settings/tts/tts-neuphonic.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-nvidia.py
+++ b/examples/update-settings/tts/tts-nvidia.py
@@ -94,6 +94,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-openai.py
+++ b/examples/update-settings/tts/tts-openai.py
@@ -94,6 +94,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -109,11 +113,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-piper-http.py
+++ b/examples/update-settings/tts/tts-piper-http.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-piper.py
+++ b/examples/update-settings/tts/tts-piper.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-pockettts.py
+++ b/examples/update-settings/tts/tts-pockettts.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-resembleai.py
+++ b/examples/update-settings/tts/tts-resembleai.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-rime-http.py
+++ b/examples/update-settings/tts/tts-rime-http.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-rime.py
+++ b/examples/update-settings/tts/tts-rime.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-sarvam-http.py
+++ b/examples/update-settings/tts/tts-sarvam-http.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-sarvam.py
+++ b/examples/update-settings/tts/tts-sarvam.py
@@ -93,6 +93,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -108,11 +112,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/update-settings/tts/tts-speechmatics.py
+++ b/examples/update-settings/tts/tts-speechmatics.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/update-settings/tts/tts-xtts.py
+++ b/examples/update-settings/tts/tts-xtts.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-heygen-transport.py
+++ b/examples/video-avatar/video-avatar-heygen-transport.py
@@ -94,6 +94,10 @@ async def main():
             ),
         )
 
+        runner = WorkerRunner()
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -109,11 +113,8 @@ async def main():
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner()
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-heygen-video-service.py
+++ b/examples/video-avatar/video-avatar-heygen-video-service.py
@@ -120,6 +120,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -147,11 +151,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-lemonslice-transport.py
+++ b/examples/video-avatar/video-avatar-lemonslice-transport.py
@@ -97,6 +97,10 @@ async def main():
             ),
         )
 
+        runner = WorkerRunner()
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, participant):
             logger.info("Client connected")
@@ -112,7 +116,7 @@ async def main():
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, participant):
             logger.info("Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
         @transport.event_handler("on_avatar_connected")
         async def on_avatar_connected(transport, participant):
@@ -122,9 +126,6 @@ async def main():
         async def on_avatar_disconnected(transport, participant, reason):
             logger.info(f"Avatar disconnected. Reason: {reason}")
 
-        runner = WorkerRunner()
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-simli-video-service.py
+++ b/examples/video-avatar/video-avatar-simli-video-service.py
@@ -110,6 +110,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -119,10 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-tavus-transport.py
+++ b/examples/video-avatar/video-avatar-tavus-transport.py
@@ -92,6 +92,10 @@ async def main():
             ),
         )
 
+        runner = WorkerRunner()
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_connected")
         async def on_connected(transport, data):
             # Extract the room name to build the conversation URL. Share this
@@ -115,11 +119,8 @@ async def main():
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, participant):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner()
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-avatar/video-avatar-tavus-video-service.py
+++ b/examples/video-avatar/video-avatar-tavus-video-service.py
@@ -116,6 +116,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -131,11 +135,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/video-processing/video-processing-custom-video-track.py
+++ b/examples/video-processing/video-processing-custom-video-track.py
@@ -187,6 +187,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -196,8 +200,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Client disconnected")
         await worker.queue_frame(EndFrame())
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/video-processing/video-processing-gstreamer-filesrc.py
+++ b/examples/video-processing/video-processing-gstreamer-filesrc.py
@@ -68,6 +68,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -75,11 +79,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/video-processing/video-processing-local-mirror.py
+++ b/examples/video-processing/video-processing-local-mirror.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     async def run_tk():
         while not worker.has_finished():
             tk_root.update()
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await asyncio.gather(runner.run(), run_tk())
 
 

--- a/examples/video-processing/video-processing-mirror.py
+++ b/examples/video-processing/video-processing-mirror.py
@@ -87,6 +87,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -94,11 +98,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/video-processing/video-processing.py
+++ b/examples/video-processing/video-processing.py
@@ -135,6 +135,10 @@ async def run_bot(pipecat_transport):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=False, force_gc=True)
+
+    await runner.add_workers(worker)
+
     @worker.rtvi.event_handler("on_client_ready")
     async def on_client_ready(rtvi):
         logger.info("Pipecat client ready.")
@@ -158,11 +162,8 @@ async def run_bot(pipecat_transport):
     @pipecat_transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Pipecat Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=False, force_gc=True)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-anthropic.py
+++ b/examples/vision/vision-anthropic.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-aws.py
+++ b/examples/vision/vision-aws.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -127,11 +131,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-gemini-flash.py
+++ b/examples/vision/vision-gemini-flash.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-moondream.py
+++ b/examples/vision/vision-moondream.py
@@ -72,6 +72,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -102,11 +106,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-openai-responses-http.py
+++ b/examples/vision/vision-openai-responses-http.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-openai-responses.py
+++ b/examples/vision/vision-openai-responses.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/vision/vision-openai.py
+++ b/examples/vision/vision-openai.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-aicoustics-vad-only.py
+++ b/examples/voice/voice-aicoustics-vad-only.py
@@ -176,6 +176,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments) -> Non
     pipeline = Pipeline([transport.input(), vad_processor, VADEventLogger()])
     worker = PipelineWorker(pipeline, params=PipelineParams(enable_metrics=False))
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
     await runner.add_workers(worker)
     await runner.run()
 

--- a/examples/voice/voice-aicoustics.py
+++ b/examples/voice/voice-aicoustics.py
@@ -132,6 +132,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -159,11 +163,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-assemblyai-turn-detection.py
+++ b/examples/voice/voice-assemblyai-turn-detection.py
@@ -149,6 +149,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -161,11 +165,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-assemblyai.py
+++ b/examples/voice/voice-assemblyai.py
@@ -107,6 +107,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -122,11 +126,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-asyncai-http.py
+++ b/examples/voice/voice-asyncai-http.py
@@ -105,6 +105,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-asyncai.py
+++ b/examples/voice/voice-asyncai.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-aws-strands.py
+++ b/examples/voice/voice-aws-strands.py
@@ -142,6 +142,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -163,11 +167,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-aws.py
+++ b/examples/voice/voice-aws.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-azure-http.py
+++ b/examples/voice/voice-azure-http.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-azure.py
+++ b/examples/voice/voice-azure.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-camb.py
+++ b/examples/voice/voice-camb.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-cartesia-http.py
+++ b/examples/voice/voice-cartesia-http.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-cartesia-turns.py
+++ b/examples/voice/voice-cartesia-turns.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,7 +115,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @tts.event_handler("on_tts_request")
     async def on_tts_request(tts, context_id: str, text: str):
@@ -128,9 +132,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         """
         logger.debug(f"TTS request: {context_id} - {text}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-cartesia.py
+++ b/examples/voice/voice-cartesia.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -116,7 +120,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @tts.event_handler("on_tts_request")
     async def on_tts_request(tts, context_id: str, text: str):
@@ -133,9 +137,6 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         """
         logger.debug(f"TTS request: {context_id} - {text}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-deepgram-flux-sagemaker.py
+++ b/examples/voice/voice-deepgram-flux-sagemaker.py
@@ -118,6 +118,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -128,15 +132,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @stt.event_handler("on_update")
     async def on_deepgram_flux_update(stt, transcript):
         logger.debug(f"On deepgram flux update: {transcript}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-deepgram-flux.py
+++ b/examples/voice/voice-deepgram-flux.py
@@ -106,6 +106,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -118,15 +122,12 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
     @stt.event_handler("on_update")
     async def on_deepgram_flux_update(stt, transcript):
         logger.debug(f"On deeggram flux update: {transcript}")
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-deepgram-http.py
+++ b/examples/voice/voice-deepgram-http.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-deepgram-sagemaker.py
+++ b/examples/voice/voice-deepgram-sagemaker.py
@@ -115,6 +115,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -127,11 +131,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-deepgram.py
+++ b/examples/voice/voice-deepgram.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-elevenlabs-http.py
+++ b/examples/voice/voice-elevenlabs-http.py
@@ -108,6 +108,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -120,11 +124,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-elevenlabs.py
+++ b/examples/voice/voice-elevenlabs.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-fal.py
+++ b/examples/voice/voice-fal.py
@@ -106,6 +106,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -118,11 +122,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-fish.py
+++ b/examples/voice/voice-fish.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-funasr.py
+++ b/examples/voice/voice-funasr.py
@@ -97,6 +97,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -109,11 +113,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-gladia-vad.py
+++ b/examples/voice/voice-gladia-vad.py
@@ -114,6 +114,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -126,10 +130,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-gladia.py
+++ b/examples/voice/voice-gladia.py
@@ -113,6 +113,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,10 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-google-audio-in.py
+++ b/examples/voice/voice-google-audio-in.py
@@ -268,6 +268,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -280,11 +284,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-google-gemini-tts.py
+++ b/examples/voice/voice-google-gemini-tts.py
@@ -125,6 +125,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -140,11 +144,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-google-http.py
+++ b/examples/voice/voice-google-http.py
@@ -113,6 +113,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-google-image.py
+++ b/examples/voice/voice-google-image.py
@@ -122,6 +122,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -134,11 +138,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-google.py
+++ b/examples/voice/voice-google.py
@@ -113,6 +113,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -125,11 +129,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-gradium.py
+++ b/examples/voice/voice-gradium.py
@@ -105,6 +105,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-groq.py
+++ b/examples/voice/voice-groq.py
@@ -96,6 +96,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -108,11 +112,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-hume.py
+++ b/examples/voice/voice-hume.py
@@ -111,6 +111,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -126,11 +130,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-inworld-http.py
+++ b/examples/voice/voice-inworld-http.py
@@ -111,6 +111,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info("Client connected")
@@ -123,11 +127,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info("Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-inworld.py
+++ b/examples/voice/voice-inworld.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info("Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info("Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-kokoro.py
+++ b/examples/voice/voice-kokoro.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-krisp-viva.py
+++ b/examples/voice/voice-krisp-viva.py
@@ -143,6 +143,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         observers=[MetricsLogObserver(include_metrics={TurnMetricsData})],
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -155,11 +159,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-langchain.py
+++ b/examples/voice/voice-langchain.py
@@ -127,6 +127,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -142,11 +146,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-lmnt.py
+++ b/examples/voice/voice-lmnt.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-minimax.py
+++ b/examples/voice/voice-minimax.py
@@ -107,6 +107,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-mistral.py
+++ b/examples/voice/voice-mistral.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-moonshine.py
+++ b/examples/voice/voice-moonshine.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -114,10 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-neuphonic-http.py
+++ b/examples/voice/voice-neuphonic-http.py
@@ -105,6 +105,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -117,11 +121,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-neuphonic.py
+++ b/examples/voice/voice-neuphonic.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-nvidia-sagemaker.py
+++ b/examples/voice/voice-nvidia-sagemaker.py
@@ -103,6 +103,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -115,11 +119,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-nvidia-segmented.py
+++ b/examples/voice/voice-nvidia-segmented.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-nvidia.py
+++ b/examples/voice/voice-nvidia.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-openai-http.py
+++ b/examples/voice/voice-openai-http.py
@@ -107,6 +107,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-openai-responses-http.py
+++ b/examples/voice/voice-openai-responses-http.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-openai-responses.py
+++ b/examples/voice/voice-openai-responses.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-openai-turn-detection.py
+++ b/examples/voice/voice-openai-turn-detection.py
@@ -126,6 +126,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -138,11 +142,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-openai.py
+++ b/examples/voice/voice-openai.py
@@ -101,6 +101,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-piper.py
+++ b/examples/voice/voice-piper.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-pockettts.py
+++ b/examples/voice/voice-pockettts.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-resemble.py
+++ b/examples/voice/voice-resemble.py
@@ -99,6 +99,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -111,11 +115,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-rime-http.py
+++ b/examples/voice/voice-rime-http.py
@@ -107,6 +107,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-rime.py
+++ b/examples/voice/voice-rime.py
@@ -100,6 +100,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -112,11 +116,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-sarvam-http.py
+++ b/examples/voice/voice-sarvam-http.py
@@ -111,6 +111,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -123,11 +127,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-sarvam-vad.py
+++ b/examples/voice/voice-sarvam-vad.py
@@ -124,6 +124,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -136,11 +140,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-sarvam.py
+++ b/examples/voice/voice-sarvam.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -120,11 +124,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-smallest.py
+++ b/examples/voice/voice-smallest.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -113,11 +117,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-soniox-turn-detection.py
+++ b/examples/voice/voice-soniox-turn-detection.py
@@ -135,6 +135,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -147,11 +151,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-soniox.py
+++ b/examples/voice/voice-soniox.py
@@ -107,6 +107,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -119,11 +123,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-speechmatics-vad.py
+++ b/examples/voice/voice-speechmatics-vad.py
@@ -142,6 +142,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -152,11 +156,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-speechmatics.py
+++ b/examples/voice/voice-speechmatics.py
@@ -129,6 +129,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -139,11 +143,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-together.py
+++ b/examples/voice/voice-together.py
@@ -98,6 +98,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
     )
 
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.add_workers(worker)
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
@@ -110,11 +114,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
         logger.info(f"Client disconnected")
-        await worker.cancel()
+        await runner.cancel()
 
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    await runner.add_workers(worker)
     await runner.run()
 
 

--- a/examples/voice/voice-xai-http.py
+++ b/examples/voice/voice-xai-http.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-xai.py
+++ b/examples/voice/voice-xai.py
@@ -102,6 +102,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -114,11 +118,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/examples/voice/voice-xtts.py
+++ b/examples/voice/voice-xtts.py
@@ -104,6 +104,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         )
 
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
             logger.info(f"Client connected")
@@ -116,11 +120,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         @transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected")
-            await worker.cancel()
+            await runner.cancel()
 
-        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-        await runner.add_workers(worker)
         await runner.run()
 
 

--- a/tests/flows_test_helpers.py
+++ b/tests/flows_test_helpers.py
@@ -1,13 +1,13 @@
 from unittest.mock import AsyncMock, Mock
 
 
-def assert_tts_speak_frames_queued(mock_task, expected_texts):
+def assert_tts_speak_frames_queued(mock_worker, expected_texts):
     """Assert that TTSSpeakFrames with expected texts were queued."""
     from pipecat.frames.frames import TTSSpeakFrame
 
     tts_calls = [
         call
-        for call in mock_task.queue_frame.call_args_list
+        for call in mock_worker.queue_frame.call_args_list
         if isinstance(call[0][0], TTSSpeakFrame)
     ]
     assert len(tts_calls) == len(expected_texts), (
@@ -19,28 +19,28 @@ def assert_tts_speak_frames_queued(mock_task, expected_texts):
         )
 
 
-def get_queued_tts_speak_frames(mock_task):
-    """Return the TTSSpeakFrames queued on the mock task, in order."""
+def get_queued_tts_speak_frames(mock_worker):
+    """Return the TTSSpeakFrames queued on the mock worker, in order."""
     from pipecat.frames.frames import TTSSpeakFrame
 
     return [
         call[0][0]
-        for call in mock_task.queue_frame.call_args_list
+        for call in mock_worker.queue_frame.call_args_list
         if isinstance(call[0][0], TTSSpeakFrame)
     ]
 
 
-def assert_end_frame_queued(mock_task):
+def assert_end_frame_queued(mock_worker):
     """Assert that an EndFrame was queued."""
     from pipecat.frames.frames import EndFrame
 
     end_calls = [
-        call for call in mock_task.queue_frame.call_args_list if isinstance(call[0][0], EndFrame)
+        call for call in mock_worker.queue_frame.call_args_list if isinstance(call[0][0], EndFrame)
     ]
     assert len(end_calls) == 1, "EndFrame not queued"
 
 
-def get_advertised_tools(mock_task):
+def get_advertised_tools(mock_worker):
     """Return the tools from the most recent LLMSetToolsFrame queued (or NOT_GIVEN).
 
     FlowManager advertises a node's tools via an LLMSetToolsFrame; the LLM service
@@ -51,46 +51,46 @@ def get_advertised_tools(mock_task):
 
     set_tools_frames = [
         frame
-        for call in mock_task.queue_frames.call_args_list
+        for call in mock_worker.queue_frames.call_args_list
         for frame in call[0][0]
         if isinstance(frame, LLMSetToolsFrame)
     ]
     return set_tools_frames[-1].tools if set_tools_frames else NOT_GIVEN
 
 
-def get_advertised_tool_handlers(mock_task):
+def get_advertised_tool_handlers(mock_worker):
     """Return {name: handler} from the most recent LLMSetToolsFrame queued."""
     from pipecat.processors.aggregators.llm_context import NOT_GIVEN
 
-    tools = get_advertised_tools(mock_task)
+    tools = get_advertised_tools(mock_worker)
     if tools is NOT_GIVEN:
         return {}
     return {schema.name: schema.handler for schema in tools.standard_tools}
 
 
-def make_mock_task():
-    """Create a mock PipelineTask wired up so that actions don't hang."""
-    mock_task = AsyncMock()
+def make_mock_worker():
+    """Create a mock PipelineWorker wired up so that actions don't hang."""
+    mock_worker = AsyncMock()
 
     # Mock queue_frame method that simulates queued frames reaching all the way downstream.
     # This is necessary for action execution to not hang, waiting.
     async def queue_frame(frame):
-        handler = getattr(mock_task, "on_frame_reached_downstream", None)
+        handler = getattr(mock_worker, "on_frame_reached_downstream", None)
         if handler:
-            await handler(mock_task, frame)
+            await handler(mock_worker, frame)
 
-    mock_task.queue_frame = AsyncMock(side_effect=queue_frame)
+    mock_worker.queue_frame = AsyncMock(side_effect=queue_frame)
 
     # Mock stuff necessary for registering on_frame_reached_downstream handler.
-    mock_task.set_reached_downstream_filter = Mock()
+    mock_worker.set_reached_downstream_filter = Mock()
 
     def mock_event_handler(event_name):
         def decorator(func):
-            setattr(mock_task, event_name, func)
+            setattr(mock_worker, event_name, func)
             return func
 
         return decorator
 
-    mock_task.event_handler = mock_event_handler
+    mock_worker.event_handler = mock_event_handler
 
-    return mock_task
+    return mock_worker

--- a/tests/test_app_resources.py
+++ b/tests/test_app_resources.py
@@ -181,7 +181,7 @@ class TestLLMServiceFunctionCallReadsAppResources(unittest.IsolatedAsyncioTestCa
         self.assertIs(value, resources)
 
 
-class TestPipelineTaskAppResources(unittest.TestCase):
+class TestPipelineWorkerAppResources(unittest.TestCase):
     def test_getter_returns_constructor_value(self):
         resources = _Resources(user_name="John")
         worker = PipelineWorker(Pipeline([]), app_resources=resources)

--- a/tests/test_base_worker.py
+++ b/tests/test_base_worker.py
@@ -93,7 +93,7 @@ def make_stub_pipeline_task(name, *, bridged=None, active=True):
     )
 
 
-class TestPipelineTaskLifecycle(unittest.IsolatedAsyncioTestCase):
+class TestPipelineWorkerLifecycle(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.bus, self.tm = await create_test_bus()
         self.registry = create_test_registry()

--- a/tests/test_flows_actions.py
+++ b/tests/test_flows_actions.py
@@ -31,7 +31,7 @@ from tests.flows_test_helpers import (
     assert_end_frame_queued,
     assert_tts_speak_frames_queued,
     get_queued_tts_speak_frames,
-    make_mock_task,
+    make_mock_worker,
 )
 
 
@@ -65,9 +65,9 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         - Mock PipelineTask for frame queueing
         - ActionManager instance with mocked dependencies
         """
-        self.mock_task = make_mock_task()
+        self.mock_worker = make_mock_worker()
         self.mock_flow_manager = AsyncMock()
-        self.action_manager = ActionManager(self.mock_task, self.mock_flow_manager)
+        self.action_manager = ActionManager(self.mock_worker, self.mock_flow_manager)
 
     async def test_initialization(self):
         """Test ActionManager initialization and default handlers."""
@@ -79,7 +79,7 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         """Test basic TTS action execution."""
         action = {"type": "tts_say", "text": "Hello"}
         await self.action_manager.execute_actions([action])
-        assert_tts_speak_frames_queued(self.mock_task, ["Hello"])
+        assert_tts_speak_frames_queued(self.mock_worker, ["Hello"])
 
     async def test_end_conversation_action(self):
         """Test basic end conversation action."""
@@ -87,7 +87,7 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         await self.action_manager.execute_actions([action])
 
         # Verify EndFrame was queued
-        assert_end_frame_queued(self.mock_task)
+        assert_end_frame_queued(self.mock_worker)
 
     async def test_end_conversation_with_goodbye(self):
         """Test end conversation action with goodbye message."""
@@ -95,10 +95,10 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         await self.action_manager.execute_actions([action])
 
         # Verify TTSSpeakFrame
-        assert_tts_speak_frames_queued(self.mock_task, ["Goodbye!"])
+        assert_tts_speak_frames_queued(self.mock_worker, ["Goodbye!"])
 
         # Verify EndFrame
-        assert_end_frame_queued(self.mock_task)
+        assert_end_frame_queued(self.mock_worker)
 
     async def test_tts_action_append_text_to_context(self):
         """Test that tts_say maps append_text_to_context onto the TTSSpeakFrame."""
@@ -106,26 +106,26 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         await self.action_manager.execute_actions(
             [{"type": "tts_say", "text": "Hello", "append_text_to_context": True}]
         )
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, True)
 
         # Explicitly False
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_worker.queue_frame.reset_mock()
         await self.action_manager.execute_actions(
             [{"type": "tts_say", "text": "Hello", "append_text_to_context": False}]
         )
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, False)
 
         # Omitted: Flows applies its own default of True (and never passes None,
         # so no append_to_context deprecation warning fires).
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_worker.queue_frame.reset_mock()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             await self.action_manager.execute_actions([{"type": "tts_say", "text": "Hello"}])
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, True)
         self.assertEqual(
@@ -140,29 +140,29 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         await self.action_manager.execute_actions(
             [{"type": "end_conversation", "text": "Goodbye!", "append_text_to_context": False}]
         )
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, False)
-        assert_end_frame_queued(self.mock_task)
+        assert_end_frame_queued(self.mock_worker)
 
         # Explicitly True
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_worker.queue_frame.reset_mock()
         await self.action_manager.execute_actions(
             [{"type": "end_conversation", "text": "Goodbye!", "append_text_to_context": True}]
         )
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, True)
 
         # Omitted: Flows applies its own default of True (and never passes None,
         # so no append_to_context deprecation warning fires).
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_worker.queue_frame.reset_mock()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             await self.action_manager.execute_actions(
                 [{"type": "end_conversation", "text": "Goodbye!"}]
             )
-        frames = get_queued_tts_speak_frames(self.mock_task)
+        frames = get_queued_tts_speak_frames(self.mock_worker)
         self.assertEqual(len(frames), 1)
         self.assertIs(frames[0].append_to_context, True)
         self.assertEqual(
@@ -236,7 +236,7 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         await self.action_manager.execute_actions(actions)
 
         # Verify TTS was called twice in correct order
-        assert_tts_speak_frames_queued(self.mock_task, ["First", "Second"])
+        assert_tts_speak_frames_queued(self.mock_worker, ["First", "Second"])
 
     def test_register_invalid_handler(self):
         """Test registering invalid action handlers."""
@@ -254,17 +254,17 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         """Test handling None or empty action lists."""
         # Test None actions
         await self.action_manager.execute_actions(None)
-        self.mock_task.queue_frame.assert_not_called()
+        self.mock_worker.queue_frame.assert_not_called()
 
         # Test empty list
         await self.action_manager.execute_actions([])
-        self.mock_task.queue_frame.assert_not_called()
+        self.mock_worker.queue_frame.assert_not_called()
 
     @patch("loguru.logger.error")
     async def test_action_error_handling(self, mock_logger):
         """Test error handling during action execution."""
-        # Configure task mock to raise an error
-        self.mock_task.queue_frame = AsyncMock(side_effect=Exception("Frame error"))
+        # Configure worker mock to raise an error
+        self.mock_worker.queue_frame = AsyncMock(side_effect=Exception("Frame error"))
 
         action = {"type": "tts_say", "text": "Hello"}
         await self.action_manager.execute_actions([action])
@@ -274,7 +274,7 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
 
     async def test_action_execution_error_handling(self):
         """Test error handling during action execution."""
-        action_manager = ActionManager(self.mock_task, self.mock_flow_manager)
+        action_manager = ActionManager(self.mock_worker, self.mock_flow_manager)
 
         # Test action with missing handler
         with self.assertRaises(ActionError):

--- a/tests/test_flows_context_strategies.py
+++ b/tests/test_flows_context_strategies.py
@@ -42,9 +42,9 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         """Set up test fixtures before each test."""
-        self.mock_task = AsyncMock()
-        self.mock_task.event_handler = Mock()
-        self.mock_task.set_reached_downstream_filter = Mock()
+        self.mock_worker = AsyncMock()
+        self.mock_worker.event_handler = Mock()
+        self.mock_worker.set_reached_downstream_filter = Mock()
 
         # Set up mock LLM with client
         self.mock_llm = OpenAILLMService(api_key="test-key")
@@ -90,7 +90,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         self.mock_llm.run_inference.return_value = mock_summary
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -110,7 +110,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
             self.assertIn("RESET_WITH_SUMMARY is deprecated", str(deprecation_warnings[0].message))
 
         # Second node should NOT trigger a second warning (once-only)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             await flow_manager._set_node("second", self.sample_node)
@@ -121,7 +121,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
     async def test_default_strategy(self):
         """Test default context strategy (APPEND)."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -130,24 +130,24 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Under the default (APPEND) strategy the first node appends, keeping any
         # context already present.
         await flow_manager._set_node("first", self.sample_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesAppendFrame) for f in first_frames))
         self.assertFalse(any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames))
 
         # Reset mock
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Subsequent node should use AppendFrame with default strategy
         await flow_manager._set_node("second", self.sample_node)
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesAppendFrame) for f in second_frames))
 
     async def test_reset_strategy(self):
         """Test RESET strategy behavior."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(strategy=ContextStrategy.RESET),
@@ -156,14 +156,14 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # First node should use UpdateFrame under the RESET strategy
         await flow_manager._set_node("first", self.sample_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames))
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Second node should use UpdateFrame with RESET strategy
         await flow_manager._set_node("second", self.sample_node)
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesUpdateFrame) for f in second_frames))
 
@@ -174,7 +174,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         self.mock_llm.run_inference.return_value = mock_summary
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -186,12 +186,12 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Set nodes and verify summary inclusion
         await flow_manager._set_node("first", self.sample_node)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         await flow_manager._set_node("second", self.sample_node)
 
         # Verify summary was included in context update
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         update_frame = next(f for f in second_frames if isinstance(f, LLMMessagesUpdateFrame))
         self.assertTrue(any(mock_summary in str(m) for m in update_frame.messages))
@@ -199,7 +199,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
     async def test_reset_with_summary_timeout(self):
         """Test RESET_WITH_SUMMARY fallback to APPEND on timeout."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -214,12 +214,12 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Set nodes and verify fallback to APPEND
         await flow_manager._set_node("first", self.sample_node)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         await flow_manager._set_node("second", self.sample_node)
 
         # Verify UpdateFrame was used (APPEND behavior)
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesAppendFrame) for f in second_frames))
 
@@ -229,7 +229,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Test OpenAI format
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=OpenAILLMService(api_key="test-key"),
             context_aggregator=self.mock_context_aggregator,
         )
@@ -238,7 +238,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Test Anthropic format
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=AnthropicLLMService(api_key="test-key"),
             context_aggregator=self.mock_context_aggregator,
         )
@@ -247,7 +247,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Test Gemini format
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=GoogleLLMService(api_key=" "),  # dummy key (GoogleLLMService rejects empty string)
             context_aggregator=self.mock_context_aggregator,
         )
@@ -257,7 +257,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
     async def test_node_level_strategy_override(self):
         """Test that node-level strategy overrides global strategy."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(strategy=ContextStrategy.APPEND),
@@ -272,12 +272,12 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Set nodes and verify strategy override
         await flow_manager._set_node("first", self.sample_node)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         await flow_manager._set_node("second", node_with_strategy)
 
         # Verify UpdateFrame was used (RESET behavior) despite global APPEND
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         self.assertTrue(any(isinstance(f, LLMMessagesUpdateFrame) for f in second_frames))
 
@@ -288,7 +288,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         summary_prompt = "Create a detailed summary"
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -324,7 +324,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         self.mock_llm.run_inference.return_value = mock_summary
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -335,7 +335,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Set nodes to trigger summary generation
         await flow_manager._set_node("first", self.sample_node)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Node with new task messages
         new_node = {
@@ -345,7 +345,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         await flow_manager._set_node("second", new_node)
 
         # Verify context structure
-        update_call = self.mock_task.queue_frames.call_args_list[0]
+        update_call = self.mock_worker.queue_frames.call_args_list[0]
         update_frames = update_call[0][0]
         messages_frame = next(f for f in update_frames if isinstance(f, LLMMessagesUpdateFrame))
 
@@ -361,7 +361,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         self.mock_llm.run_inference.return_value = mock_summary
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(
@@ -378,7 +378,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
             "functions": [],
         }
         await flow_manager._set_node("first", first_node)
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Set second node with role_message — triggers summary + settings update
         second_node = {
@@ -388,7 +388,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         }
         await flow_manager._set_node("second", second_node)
 
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
 
         # Verify LLMUpdateSettingsFrame is present with new system instruction

--- a/tests/test_flows_manager.py
+++ b/tests/test_flows_manager.py
@@ -42,7 +42,7 @@ from tests.flows_test_helpers import (
     assert_tts_speak_frames_queued,
     get_advertised_tool_handlers,
     get_advertised_tools,
-    make_mock_task,
+    make_mock_worker,
 )
 
 
@@ -60,7 +60,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         """Set up test fixtures before each test."""
-        self.mock_task = make_mock_task()
+        self.mock_worker = make_mock_worker()
         self.mock_llm = OpenAILLMService(api_key="test-key")
 
         # Create mock assistant aggregator with public property only
@@ -99,30 +99,30 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         """Test the worker argument and the deprecated task argument."""
         # worker= is the canonical argument
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
-        self.assertIs(flow_manager.worker, self.mock_task)
+        self.assertIs(flow_manager.worker, self.mock_worker)
 
         # task= still works but is deprecated
         with self.assertWarns(DeprecationWarning):
             flow_manager = FlowManager(
-                task=self.mock_task,
+                task=self.mock_worker,
                 llm=self.mock_llm,
                 context_aggregator=self.mock_context_aggregator,
             )
-        self.assertIs(flow_manager.worker, self.mock_task)
+        self.assertIs(flow_manager.worker, self.mock_worker)
 
         # The task property still resolves to the worker, but is deprecated
         with self.assertWarns(DeprecationWarning):
-            self.assertIs(flow_manager.task, self.mock_task)
+            self.assertIs(flow_manager.task, self.mock_worker)
 
         # Passing both is an error
         with self.assertRaises(ValueError):
             FlowManager(
-                worker=self.mock_task,
-                task=self.mock_task,
+                worker=self.mock_worker,
+                task=self.mock_worker,
                 llm=self.mock_llm,
                 context_aggregator=self.mock_context_aggregator,
             )
@@ -141,7 +141,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         # Initialize flow manager
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -171,7 +171,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_node_validation(self):
         """Test node configuration validation."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -193,28 +193,28 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_function_registration(self):
         """Test that a node's functions are advertised with a handler for auto-registration."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
         await flow_manager.initialize()
 
         # Reset mock to clear initialization calls
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Set node with function
         await flow_manager.set_node_from_config(self.sample_node)
 
         # The tool is advertised carrying its handler, which the LLM service
         # registers when it sees the advertised tools.
-        handlers = get_advertised_tool_handlers(self.mock_task)
+        handlers = get_advertised_tool_handlers(self.mock_worker)
         self.assertEqual(set(handlers), {"test_function"})
         self.assertTrue(callable(handlers["test_function"]))
 
     async def test_action_execution(self):
         """Test execution of pre and post actions."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -230,23 +230,23 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         }
 
         # Reset mock to clear initialization calls
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_worker.queue_frame.reset_mock()
 
         # Set node with actions
         await flow_manager.set_node_from_config(node_with_actions)
 
-        assert_tts_speak_frames_queued(self.mock_task, ["Pre action", "Post action"])
+        assert_tts_speak_frames_queued(self.mock_worker, ["Pre action", "Post action"])
 
     async def test_error_handling(self):
         """Test error handling in flow manager.
 
         Verifies:
         1. Cannot set node before initialization
-        2. Initialization fails properly when task queue fails
-        3. Node setting fails when task queue fails
+        2. Initialization fails properly when the worker queue fails
+        3. Node setting fails when the worker queue fails
         """
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -260,7 +260,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(flow_manager._initialized)
 
         # Test node setting error
-        self.mock_task.queue_frames.side_effect = Exception("Queue error")
+        self.mock_worker.queue_frames.side_effect = Exception("Queue error")
         with self.assertRaises(FlowError):
             await flow_manager.set_node_from_config(self.sample_node)
 
@@ -270,7 +270,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_state_management(self):
         """Test state management across nodes."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -281,7 +281,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         flow_manager.state["test_key"] = test_value
 
         # Reset mock to clear initialization calls
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Verify state persists across node transitions
         await flow_manager.set_node_from_config(self.sample_node)
@@ -290,7 +290,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_multiple_function_registration(self):
         """Test registration of multiple functions."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -314,7 +314,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         await flow_manager.set_node_from_config(node_config)
 
         # Verify all functions were advertised (each carrying a handler) and tracked
-        handlers = get_advertised_tool_handlers(self.mock_task)
+        handlers = get_advertised_tool_handlers(self.mock_worker)
         self.assertEqual(set(handlers), {"func_0", "func_1", "func_2"})
         self.assertEqual(len(flow_manager._current_functions), 3)
 
@@ -327,7 +327,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         overrides on both FlowsFunctionSchemas and direct functions.
         """
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -371,7 +371,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # Register the advertised tools the way the LLM service does on inference.
-        self.mock_llm._sync_registered_tool_handlers(get_advertised_tools(self.mock_task))
+        self.mock_llm._sync_registered_tool_handlers(get_advertised_tools(self.mock_worker))
 
         # FlowsFunctionSchema default: Flows' False default survives (not the service's True).
         defaults = self.mock_llm._functions["defaults"]
@@ -398,7 +398,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         See https://github.com/pipecat-ai/pipecat-flows/issues/269.
         """
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -451,7 +451,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # After node B, the advertised ``go`` handler must be node B's, not node A's.
-        latest_go = get_advertised_tool_handlers(self.mock_task)["go"]
+        latest_go = get_advertised_tool_handlers(self.mock_worker)["go"]
 
         async def result_callback(result, *, properties=None):
             pass
@@ -461,7 +461,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="t1",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=result_callback,
         )
@@ -473,7 +473,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_initialize_already_initialized(self):
         """Test initializing an already initialized flow manager."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -487,7 +487,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_register_action(self):
         """Test registering custom actions."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -501,7 +501,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_call_handler_variations(self):
         """Test different handler signature variations."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -609,7 +609,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_transition_func_error_handling(self):
         """Test error handling in transition functions."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -636,7 +636,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="id",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=result_callback,
         )
@@ -646,7 +646,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_node_validation_edge_cases(self):
         """Test edge cases in node validation."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -673,7 +673,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_action_execution_error_handling(self):
         """Test error handling in action execution."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -701,7 +701,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_update_llm_context_error_handling(self):
         """Test error handling in LLM context updates."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -721,7 +721,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_function_declarations_processing(self):
         """Test processing of function declarations format."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -761,7 +761,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_role_message_inheritance(self):
         """Test that role_message is sent as LLMUpdateSettingsFrame."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -782,7 +782,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         # Set first node
         await flow_manager.set_node_from_config(first_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
 
         # Verify LLMUpdateSettingsFrame with system_instruction
@@ -803,11 +803,11 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertLess(settings_idx, append_idx)
 
         # Reset mock and set second node
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         await flow_manager.set_node_from_config(second_node)
 
         # Verify no LLMUpdateSettingsFrame for second node (no role_messages)
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
         settings_frames = [f for f in second_frames if isinstance(f, LLMUpdateSettingsFrame)]
         self.assertEqual(len(settings_frames), 0)
@@ -824,7 +824,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         every node.
         """
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -837,7 +837,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         # Under the default strategy the first node appends.
         await flow_manager.set_node_from_config(test_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]  # Get first call
+        first_call = self.mock_worker.queue_frames.call_args_list[0]  # Get first call
         first_frames = first_call[0][0]
         self.assertTrue(
             any(isinstance(f, LLMMessagesAppendFrame) for f in first_frames),
@@ -849,11 +849,11 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # Reset mock
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
 
         # Subsequent node should also use AppendFrame
         await flow_manager.set_node_from_config(test_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]  # Get first call
+        first_call = self.mock_worker.queue_frames.call_args_list[0]  # Get first call
         second_frames = first_call[0][0]
         self.assertTrue(
             any(isinstance(f, LLMMessagesAppendFrame) for f in second_frames),
@@ -867,7 +867,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_edge_vs_node_function_behavior(self):
         """Test different completion behavior for edge and node functions."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -923,13 +923,13 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         await flow_manager.set_node_from_config(node_config)
 
         # Get the advertised handlers (which the LLM service auto-registers)
-        handlers = get_advertised_tool_handlers(self.mock_task)
+        handlers = get_advertised_tool_handlers(self.mock_worker)
         node_func = handlers["node_function"]
         edge_func_1 = handlers["edge_function_1"]
         edge_func_2 = handlers["edge_function_2"]
 
         # Test node function
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         node_result = None
         node_properties = None
 
@@ -943,7 +943,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="id1",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=node_callback,
         )
@@ -953,7 +953,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(node_properties is None or node_properties.run_llm is not False)
 
         # Test edge function 1
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         edge_result_1 = None
         edge_properties_1 = None
 
@@ -967,7 +967,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="id2",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=edge_callback_1,
         )
@@ -977,7 +977,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(edge_properties_1 is not None and edge_properties_1.run_llm is False)
 
         # Test edge function 2
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         edge_result_2 = None
         edge_properties_2 = None
 
@@ -991,7 +991,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="id3",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=edge_callback_2,
         )
@@ -1003,7 +1003,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_no_response_function_behavior(self):
         """A function returning NO_RESPONSE finishes without responding or transitioning."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1026,11 +1026,11 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             ],
         }
         await flow_manager.set_node_from_config(node_config)
-        handoff_func = get_advertised_tool_handlers(self.mock_task)["handoff_function"]
+        handoff_func = get_advertised_tool_handlers(self.mock_worker)["handoff_function"]
 
         # Nothing should be queued (no context update, no completion) after the
         # node is set up.
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         result = None
         properties = None
 
@@ -1045,7 +1045,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             tool_call_id="id1",
             arguments={},
             llm=None,
-            pipeline_worker=self.mock_task,
+            pipeline_worker=self.mock_worker,
             context=None,
             result_callback=callback,
         )
@@ -1060,20 +1060,20 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         # Unlike an edge function, NO_RESPONSE schedules no transition and
         # writes nothing to the (possibly shared) context.
         self.assertIsNone(flow_manager._pending_transition)
-        self.mock_task.queue_frames.assert_not_called()
+        self.mock_worker.queue_frames.assert_not_called()
 
     @patch("pipecat.flows.manager.LLMRunFrame")
     async def test_completion_timing(self, mock_llm_run_frame):
         """Test that completions occur at the right time."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
         await flow_manager.initialize()
 
         # Test initial node setup
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         mock_llm_run_frame.reset_mock()
 
         await flow_manager.set_node_from_config(
@@ -1085,7 +1085,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         # Should see context update and completion trigger
         # First call is for updating context
-        self.assertTrue(self.mock_task.queue_frames.called)
+        self.assertTrue(self.mock_worker.queue_frames.called)
 
         # Verify that LLM completion was triggered by checking LLMRunFrame instantiation
         mock_llm_run_frame.assert_called_once()
@@ -1096,19 +1096,19 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             "functions": [],
         }
 
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         mock_llm_run_frame.reset_mock()
 
         await flow_manager.set_node_from_config(next_node)
 
         # Should see context update and completion trigger again
-        self.assertTrue(self.mock_task.queue_frames.called)
+        self.assertTrue(self.mock_worker.queue_frames.called)
         mock_llm_run_frame.assert_called_once()
 
     async def test_get_current_context(self):
         """Test getting current conversation context."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1131,7 +1131,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_handler_with_flow_manager(self):
         """Test function handler that receives both args and flow_manager."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1156,7 +1156,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_node_without_functions(self):
         """Test node configuration without functions field."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1176,7 +1176,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         # Verify LLM tools were still set (with empty or placeholder functions)
         tools_frames_call = [
             call
-            for call in self.mock_task.queue_frames.call_args_list
+            for call in self.mock_worker.queue_frames.call_args_list
             if any(isinstance(frame, LLMSetToolsFrame) for frame in call[0][0])
         ]
         self.assertTrue(len(tools_frames_call) > 0, "Should have called LLMSetToolsFrame")
@@ -1184,7 +1184,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_node_with_empty_functions(self):
         """Test node configuration with empty functions list."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1205,7 +1205,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         # Verify LLM tools were still set (with empty or placeholder functions)
         tools_frames_call = [
             call
-            for call in self.mock_task.queue_frames.call_args_list
+            for call in self.mock_worker.queue_frames.call_args_list
             if any(isinstance(frame, LLMSetToolsFrame) for frame in call[0][0])
         ]
         self.assertTrue(len(tools_frames_call) > 0, "Should have called LLMSetToolsFrame")
@@ -1213,7 +1213,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_role_message_singular(self):
         """Test that plain string role_message (singular) works correctly."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1226,7 +1226,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         }
 
         await flow_manager.set_node_from_config(node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
 
         # Verify LLMUpdateSettingsFrame with correct system_instruction
@@ -1246,7 +1246,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         from pipecat.flows.types import ContextStrategy, ContextStrategyConfig
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
             context_strategy=ContextStrategyConfig(strategy=ContextStrategy.RESET),
@@ -1261,7 +1261,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         }
 
         await flow_manager.set_node_from_config(first_node)
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
 
         # Verify first node sends LLMUpdateSettingsFrame
@@ -1272,14 +1272,14 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # Second node with RESET strategy but no role_messages
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         second_node: NodeConfig = {
             "task_messages": [{"role": "developer", "content": "Second task."}],
             "functions": [],
         }
 
         await flow_manager.set_node_from_config(second_node)
-        second_call = self.mock_task.queue_frames.call_args_list[0]
+        second_call = self.mock_worker.queue_frames.call_args_list[0]
         second_frames = second_call[0][0]
 
         # No LLMUpdateSettingsFrame since no role_message — system instruction
@@ -1297,7 +1297,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         import warnings
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1320,7 +1320,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
 
         # Verify the node still works correctly despite the warning —
         # legacy role_messages go into context messages, not LLMUpdateSettingsFrame
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
         settings_frames = [f for f in first_frames if isinstance(f, LLMUpdateSettingsFrame)]
         self.assertEqual(len(settings_frames), 0)
@@ -1333,7 +1333,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # Verify the warning is only emitted once
-        self.mock_task.queue_frames.reset_mock()
+        self.mock_worker.queue_frames.reset_mock()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             await flow_manager.set_node_from_config(node)
@@ -1343,7 +1343,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def test_role_message_and_role_messages_both_specified(self):
         """Test that role_message takes precedence when both are specified."""
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1362,7 +1362,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
                 "Both 'role_message' and 'role_messages' specified; using 'role_message'"
             )
 
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
         settings_frames = [f for f in first_frames if isinstance(f, LLMUpdateSettingsFrame)]
         self.assertEqual(len(settings_frames), 1)
@@ -1373,7 +1373,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         import warnings
 
         flow_manager = FlowManager(
-            worker=self.mock_task,
+            worker=self.mock_worker,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
         )
@@ -1395,7 +1395,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
             self.assertEqual(len(deprecation_warnings), 1)
 
-        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_call = self.mock_worker.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
 
         # Legacy role_messages should NOT produce LLMUpdateSettingsFrame

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -133,7 +133,7 @@ class TestParallelPipeline(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class TestPipelineTask(unittest.IsolatedAsyncioTestCase):
+class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
     async def test_task_single(self):
         pipeline = Pipeline([IdentityFilter()])
         worker = PipelineWorker(pipeline)


### PR DESCRIPTION
## Summary

- Every example creates its `WorkerRunner` and calls `add_workers()` right after constructing the `PipelineWorker`, before registering any transport event handlers
- Disconnect handlers end the session with `runner.cancel()` rather than `worker.cancel()`, which tears down every worker the runner owns
- The `cleanup` skill's example-structure snippet shows the same shape, and no longer references the deprecated `PipelineRunner`

```python
worker = PipelineWorker(pipeline, params=..., idle_timeout_secs=...)

runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)

await runner.add_workers(worker)

@transport.event_handler("on_client_connected")
async def on_client_connected(transport, client):
    await worker.queue_frames([LLMRunFrame()])

@transport.event_handler("on_client_disconnected")
async def on_client_disconnected(transport, client):
    await runner.cancel()

await runner.run()
```

Handlers registered after `add_workers()` are still installed before anything starts: with the runner not yet running, `add_workers()` only attaches the worker to the bus and registry, and nothing starts until `run()`.

## Reviewing

The sweep is mechanical across 375 files. These are the ones that needed a different shape and are worth a closer look:

- `transports/transports-moq.py` keeps `runner.run()` inside its `try/finally`, with `add_workers()` moved out
- `multi-worker/{pgmq,redis}-handoff/main.py` and `remote-proxy-assistant/{main,assistant}.py` have ordering constraints on what `add_workers()` reads
- `getting-started/03a-local-still-frame.py` registers the worker above its local `run_tk` helper
- `flows/multi_worker_handoff.py`, `multi-worker/parallel-debate`, `sensor-controller`, `code-assistant`, and the `ui-worker` bots register several workers in one call

Six `# Run the pipeline` comments no longer described the line below them and are gone, and a comment in `ui-worker/shopping-list/bot.py` that placed the UI worker's registration "at the end" is corrected.