### PR TITLE
fix(rime): migrate Arcana settings to Coda

### DIFF
--- a/changelog/5279.changed.md
+++ b/changelog/5279.changed.md
@@ -1,0 +1,1 @@
+- Rime TTS services apply Coda model settings across WebSocket and HTTP requests, and the examples use Luna for cross-model voice continuity.

--- a/changelog/5279.changed.md
+++ b/changelog/5279.changed.md
@@ -1,1 +1,1 @@
-- Rime TTS services default to Coda and forward Coda-compatible model settings across WebSocket and HTTP requests. The examples use Luna for cross-model voice continuity.
+- ⚠️ Removed Arcana model support from Rime TTS services before Rime's cloud cutoff on August 15, 2026 at 12:00 UTC. Set `model="coda"` when you upgrade. Rime examples use Luna for cross-model voice continuity.

--- a/changelog/5279.changed.md
+++ b/changelog/5279.changed.md
@@ -1,1 +1,1 @@
-- Rime TTS services apply Coda model settings across WebSocket and HTTP requests, and the examples use Luna for cross-model voice continuity.
+- Rime TTS services default to Coda and forward Coda-compatible model settings across WebSocket and HTTP requests. The examples use Luna for cross-model voice continuity.

--- a/examples/voice/voice-rime-http.py
+++ b/examples/voice/voice-rime-http.py
@@ -67,9 +67,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
             api_key=os.getenv("RIME_API_KEY", ""),
             settings=RimeHttpTTSService.Settings(
                 voice="luna",
-                model="arcana",
+                model="coda",
             ),
-            model="arcana",
             aiohttp_session=session,
         )
 

--- a/examples/voice/voice-rime.py
+++ b/examples/voice/voice-rime.py
@@ -63,6 +63,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         api_key=os.getenv("RIME_API_KEY", ""),
         settings=RimeTTSService.Settings(
             voice="luna",
+            model="coda",
         ),
     )
 

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -75,10 +75,10 @@ class RimeTTSSettings(TTSSettings):
         noTextNormalization: Whether to disable text normalization (mistv2 only).
         saveOovs: Whether to save out-of-vocabulary words (mistv2 only).
         inlineSpeedAlpha: Inline speed control markup.
-        repetition_penalty: Token repetition penalty (arcana only, 1.0-2.0).
-        temperature: Sampling temperature (arcana only, 0.0-1.0).
-        top_p: Cumulative probability threshold (arcana only, 0.0-1.0).
-        timeScaleFactor: Audio playback speed factor (arcana, mistv3, and coda only).
+        repetition_penalty: Token repetition penalty (coda only, 1.0-2.0).
+        temperature: Sampling temperature (coda only, 0.0-1.0).
+        top_p: Cumulative probability threshold (coda only, 0.0-1.0).
+        timeScaleFactor: Audio playback speed factor (coda only).
             Values above 1.0 slow down the audio; values below 1.0 speed it up.
     """
 
@@ -143,9 +143,9 @@ class RimeTTSService(WebsocketTTSService):
             language: Language for synthesis. Defaults to English.
             segment: Text segmentation mode ("immediate", "bySentence", "never").
             speed_alpha: Speech speed multiplier.
-            repetition_penalty: Token repetition penalty (arcana only).
-            temperature: Sampling temperature (arcana only).
-            top_p: Cumulative probability threshold (arcana only).
+            repetition_penalty: Token repetition penalty (coda only).
+            temperature: Sampling temperature (coda only).
+            top_p: Cumulative probability threshold (coda only).
             reduce_latency: Whether to reduce latency at potential quality cost (mistv2 only).
             pause_between_brackets: Whether to add pauses between bracketed content (mistv2 only).
             phonemize_between_brackets: Whether to phonemize bracketed content (mistv2 only).
@@ -156,7 +156,7 @@ class RimeTTSService(WebsocketTTSService):
         language: Language | None = Language.EN
         segment: str | None = None
         speed_alpha: float | None = None
-        # Arcana params
+        # Coda params
         repetition_penalty: float | None = None
         temperature: float | None = None
         top_p: float | None = None
@@ -224,7 +224,7 @@ class RimeTTSService(WebsocketTTSService):
             segment=None,
             inlineSpeedAlpha=None,
             speedAlpha=None,
-            # Arcana params
+            # Coda sampling params
             repetition_penalty=None,
             temperature=None,
             top_p=None,
@@ -234,7 +234,7 @@ class RimeTTSService(WebsocketTTSService):
             phonemizeBetweenBrackets=None,
             noTextNormalization=None,
             saveOovs=None,
-            # Shared with arcana, mistv3, and coda
+            # Coda audio params
             timeScaleFactor=None,
         )
 
@@ -253,7 +253,7 @@ class RimeTTSService(WebsocketTTSService):
                 default_settings.language = params.language
                 default_settings.segment = params.segment
                 default_settings.speedAlpha = params.speed_alpha
-                # Arcana params
+                # Coda sampling params
                 default_settings.repetition_penalty = params.repetition_penalty
                 default_settings.temperature = params.temperature
                 default_settings.top_p = params.top_p
@@ -343,16 +343,13 @@ class RimeTTSService(WebsocketTTSService):
         if self._settings.speedAlpha is not None:
             params["speedAlpha"] = self._settings.speedAlpha
 
-        if self._settings.model == "arcana":
+        if self._settings.model == "coda":
             if self._settings.repetition_penalty is not None:
                 params["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:
                 params["temperature"] = self._settings.temperature
             if self._settings.top_p is not None:
                 params["top_p"] = self._settings.top_p
-            if self._settings.timeScaleFactor is not None:
-                params["timeScaleFactor"] = self._settings.timeScaleFactor
-        elif self._settings.model == "coda":
             if self._settings.timeScaleFactor is not None:
                 params["timeScaleFactor"] = self._settings.timeScaleFactor
         else:  # mistv2/mist
@@ -841,16 +838,13 @@ class RimeHttpTTSService(TTSService):
         if self._settings.inlineSpeedAlpha is not None:
             payload["inlineSpeedAlpha"] = self._settings.inlineSpeedAlpha
 
-        if self._settings.model == "arcana":
+        if self._settings.model == "coda":
             if self._settings.repetition_penalty is not None:
                 payload["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:
                 payload["temperature"] = self._settings.temperature
             if self._settings.top_p is not None:
                 payload["top_p"] = self._settings.top_p
-            if self._settings.timeScaleFactor is not None:
-                payload["timeScaleFactor"] = self._settings.timeScaleFactor
-        elif self._settings.model == "coda":
             if self._settings.timeScaleFactor is not None:
                 payload["timeScaleFactor"] = self._settings.timeScaleFactor
         else:  # mistv2/mist
@@ -860,13 +854,6 @@ class RimeHttpTTSService(TTSService):
                 payload["pauseBetweenBrackets"] = self._settings.pauseBetweenBrackets
             if self._settings.phonemizeBetweenBrackets is not None:
                 payload["phonemizeBetweenBrackets"] = self._settings.phonemizeBetweenBrackets
-
-        # Arcana does not support PCM audio
-        if payload["modelId"] == "arcana":
-            headers["Accept"] = "audio/wav"
-            need_to_strip_wav_header = True
-        else:
-            need_to_strip_wav_header = False
 
         try:
             async with self._session.post(
@@ -883,7 +870,7 @@ class RimeHttpTTSService(TTSService):
 
                 async for frame in self._stream_audio_frames_from_iterator(
                     response.content.iter_chunked(CHUNK_SIZE),
-                    strip_wav_header=need_to_strip_wav_header,
+                    strip_wav_header=False,
                     context_id=context_id,
                 ):
                     await self.stop_ttfb_metrics()
@@ -1000,7 +987,7 @@ class RimeNonJsonTTSService(InterruptibleTTSService):
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
             voice=None,
-            model="arcana",
+            model="coda",
             language=None,
             segment=None,
             repetition_penalty=None,
@@ -1170,7 +1157,7 @@ class RimeNonJsonTTSService(InterruptibleTTSService):
         """Process incoming WebSocket messages (raw audio bytes)."""
         async for message in self._get_websocket():
             try:
-                # Rime Arcana sends raw audio bytes directly (not JSON)
+                # Rime sends raw audio bytes directly.
                 if isinstance(message, bytes):
                     await self.stop_ttfb_metrics()
 

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -75,12 +75,10 @@ class RimeTTSSettings(TTSSettings):
         noTextNormalization: Whether to disable text normalization (mistv2 only).
         saveOovs: Whether to save out-of-vocabulary words (mistv2 only).
         inlineSpeedAlpha: Inline speed control markup.
-        repetition_penalty: Token repetition penalty forwarded with Arcana and Coda requests
-            (1.0-2.0).
-        temperature: Sampling temperature forwarded with Arcana and Coda requests (0.0-1.0).
-        top_p: Cumulative probability threshold forwarded with Arcana and Coda requests
-            (0.0-1.0).
-        timeScaleFactor: Audio playback speed factor for Arcana and Coda requests.
+        repetition_penalty: Token repetition penalty for Coda requests (1.0-2.0).
+        temperature: Sampling temperature for Coda requests (0.0-1.0).
+        top_p: Cumulative probability threshold for Coda requests (0.0-1.0).
+        timeScaleFactor: Audio playback speed factor for Coda requests.
             Values above 1.0 slow down the audio; values below 1.0 speed it up.
     """
 
@@ -145,9 +143,9 @@ class RimeTTSService(WebsocketTTSService):
             language: Language for synthesis. Defaults to English.
             segment: Text segmentation mode ("immediate", "bySentence", "never").
             speed_alpha: Speech speed multiplier.
-            repetition_penalty: Token repetition penalty forwarded with Arcana and Coda requests.
-            temperature: Sampling temperature forwarded with Arcana and Coda requests.
-            top_p: Cumulative probability threshold forwarded with Arcana and Coda requests.
+            repetition_penalty: Token repetition penalty for Coda requests.
+            temperature: Sampling temperature for Coda requests.
+            top_p: Cumulative probability threshold for Coda requests.
             reduce_latency: Whether to reduce latency at potential quality cost (mistv2 only).
             pause_between_brackets: Whether to add pauses between bracketed content (mistv2 only).
             phonemize_between_brackets: Whether to phonemize bracketed content (mistv2 only).
@@ -341,7 +339,7 @@ class RimeTTSService(WebsocketTTSService):
         if self._settings.speedAlpha is not None:
             params["speedAlpha"] = self._settings.speedAlpha
 
-        if self._settings.model in ("arcana", "coda"):
+        if self._settings.model == "coda":
             if self._settings.repetition_penalty is not None:
                 params["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:
@@ -836,7 +834,7 @@ class RimeHttpTTSService(TTSService):
         if self._settings.inlineSpeedAlpha is not None:
             payload["inlineSpeedAlpha"] = self._settings.inlineSpeedAlpha
 
-        if self._settings.model in ("arcana", "coda"):
+        if self._settings.model == "coda":
             if self._settings.repetition_penalty is not None:
                 payload["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -75,10 +75,12 @@ class RimeTTSSettings(TTSSettings):
         noTextNormalization: Whether to disable text normalization (mistv2 only).
         saveOovs: Whether to save out-of-vocabulary words (mistv2 only).
         inlineSpeedAlpha: Inline speed control markup.
-        repetition_penalty: Token repetition penalty (coda only, 1.0-2.0).
-        temperature: Sampling temperature (coda only, 0.0-1.0).
-        top_p: Cumulative probability threshold (coda only, 0.0-1.0).
-        timeScaleFactor: Audio playback speed factor (coda only).
+        repetition_penalty: Token repetition penalty forwarded with Arcana and Coda requests
+            (1.0-2.0).
+        temperature: Sampling temperature forwarded with Arcana and Coda requests (0.0-1.0).
+        top_p: Cumulative probability threshold forwarded with Arcana and Coda requests
+            (0.0-1.0).
+        timeScaleFactor: Audio playback speed factor for Arcana and Coda requests.
             Values above 1.0 slow down the audio; values below 1.0 speed it up.
     """
 
@@ -143,9 +145,9 @@ class RimeTTSService(WebsocketTTSService):
             language: Language for synthesis. Defaults to English.
             segment: Text segmentation mode ("immediate", "bySentence", "never").
             speed_alpha: Speech speed multiplier.
-            repetition_penalty: Token repetition penalty (coda only).
-            temperature: Sampling temperature (coda only).
-            top_p: Cumulative probability threshold (coda only).
+            repetition_penalty: Token repetition penalty forwarded with Arcana and Coda requests.
+            temperature: Sampling temperature forwarded with Arcana and Coda requests.
+            top_p: Cumulative probability threshold forwarded with Arcana and Coda requests.
             reduce_latency: Whether to reduce latency at potential quality cost (mistv2 only).
             pause_between_brackets: Whether to add pauses between bracketed content (mistv2 only).
             phonemize_between_brackets: Whether to phonemize bracketed content (mistv2 only).
@@ -156,7 +158,6 @@ class RimeTTSService(WebsocketTTSService):
         language: Language | None = Language.EN
         segment: str | None = None
         speed_alpha: float | None = None
-        # Coda params
         repetition_penalty: float | None = None
         temperature: float | None = None
         top_p: float | None = None
@@ -224,7 +225,6 @@ class RimeTTSService(WebsocketTTSService):
             segment=None,
             inlineSpeedAlpha=None,
             speedAlpha=None,
-            # Coda sampling params
             repetition_penalty=None,
             temperature=None,
             top_p=None,
@@ -234,7 +234,6 @@ class RimeTTSService(WebsocketTTSService):
             phonemizeBetweenBrackets=None,
             noTextNormalization=None,
             saveOovs=None,
-            # Coda audio params
             timeScaleFactor=None,
         )
 
@@ -253,7 +252,6 @@ class RimeTTSService(WebsocketTTSService):
                 default_settings.language = params.language
                 default_settings.segment = params.segment
                 default_settings.speedAlpha = params.speed_alpha
-                # Coda sampling params
                 default_settings.repetition_penalty = params.repetition_penalty
                 default_settings.temperature = params.temperature
                 default_settings.top_p = params.top_p
@@ -343,7 +341,7 @@ class RimeTTSService(WebsocketTTSService):
         if self._settings.speedAlpha is not None:
             params["speedAlpha"] = self._settings.speedAlpha
 
-        if self._settings.model == "coda":
+        if self._settings.model in ("arcana", "coda"):
             if self._settings.repetition_penalty is not None:
                 params["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:
@@ -838,7 +836,7 @@ class RimeHttpTTSService(TTSService):
         if self._settings.inlineSpeedAlpha is not None:
             payload["inlineSpeedAlpha"] = self._settings.inlineSpeedAlpha
 
-        if self._settings.model == "coda":
+        if self._settings.model in ("arcana", "coda"):
             if self._settings.repetition_penalty is not None:
                 payload["repetition_penalty"] = self._settings.repetition_penalty
             if self._settings.temperature is not None:

--- a/tests/test_rime_tts.py
+++ b/tests/test_rime_tts.py
@@ -4,7 +4,13 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-from pipecat.services.rime.tts import RimeTTSService
+import pytest
+
+from pipecat.services.rime.tts import (
+    RimeHttpTTSService,
+    RimeNonJsonTTSService,
+    RimeTTSService,
+)
 
 
 def _service() -> RimeTTSService:
@@ -59,3 +65,84 @@ def test_context_switch_drops_stale_remainder():
     # A new context must not inherit the old context's dangling byte.
     assert service._sample_aligned_audio("new", b"\x0a\x0b") == b"\x0a\x0b"
     assert service._audio_remainder == b""
+
+
+def test_coda_sampling_params_are_included_in_websocket_params():
+    service = RimeTTSService(
+        api_key="test-api-key",
+        settings=RimeTTSService.Settings(
+            model="coda",
+            voice="luna",
+            repetition_penalty=1.1,
+            temperature=0.5,
+            top_p=0.9,
+            timeScaleFactor=1.2,
+        ),
+    )
+
+    params = service._build_ws_params()
+
+    assert params["modelId"] == "coda"
+    assert params["speaker"] == "luna"
+    assert params["repetition_penalty"] == 1.1
+    assert params["temperature"] == 0.5
+    assert params["top_p"] == 0.9
+    assert params["timeScaleFactor"] == 1.2
+
+
+def test_non_json_service_defaults_to_coda_without_a_voice():
+    with pytest.warns(DeprecationWarning, match="RimeNonJsonTTSService"):
+        service = RimeNonJsonTTSService(api_key="test-api-key")
+
+    assert service._settings.model == "coda"
+    assert service._settings.voice is None
+    assert service._url == "wss://users.rime.ai/ws"
+
+
+class _ErrorResponse:
+    status = 400
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class _CapturingSession:
+    def __init__(self):
+        self.payload = None
+        self.headers = None
+
+    def post(self, url, *, json, headers):
+        self.payload = json
+        self.headers = headers
+        return _ErrorResponse()
+
+
+@pytest.mark.asyncio
+async def test_coda_sampling_params_are_included_in_http_payload():
+    session = _CapturingSession()
+    service = RimeHttpTTSService(
+        api_key="test-api-key",
+        aiohttp_session=session,
+        sample_rate=24000,
+        settings=RimeHttpTTSService.Settings(
+            model="coda",
+            voice="luna",
+            repetition_penalty=1.1,
+            temperature=0.5,
+            top_p=0.9,
+            timeScaleFactor=1.2,
+        ),
+    )
+
+    _ = [frame async for frame in service.run_tts("Hello", "context")]
+
+    assert session.payload["modelId"] == "coda"
+    assert session.payload["speaker"] == "luna"
+    assert session.payload["repetition_penalty"] == 1.1
+    assert session.payload["temperature"] == 0.5
+    assert session.payload["top_p"] == 0.9
+    assert session.payload["timeScaleFactor"] == 1.2
+    assert session.headers["Accept"] == "audio/pcm"

--- a/tests/test_rime_tts.py
+++ b/tests/test_rime_tts.py
@@ -67,12 +67,11 @@ def test_context_switch_drops_stale_remainder():
     assert service._audio_remainder == b""
 
 
-@pytest.mark.parametrize("model", ["arcana", "coda"])
-def test_sampling_params_are_included_in_websocket_params(model: str):
+def test_coda_sampling_params_are_included_in_websocket_params():
     service = RimeTTSService(
         api_key="test-api-key",
         settings=RimeTTSService.Settings(
-            model=model,
+            model="coda",
             voice="luna",
             repetition_penalty=1.1,
             temperature=0.5,
@@ -83,7 +82,7 @@ def test_sampling_params_are_included_in_websocket_params(model: str):
 
     params = service._build_ws_params()
 
-    assert params["modelId"] == model
+    assert params["modelId"] == "coda"
     assert params["speaker"] == "luna"
     assert params["repetition_penalty"] == 1.1
     assert params["temperature"] == 0.5
@@ -122,15 +121,14 @@ class _CapturingSession:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model", ["arcana", "coda"])
-async def test_sampling_params_are_included_in_http_payload(model: str):
+async def test_coda_sampling_params_are_included_in_http_payload():
     session = _CapturingSession()
     service = RimeHttpTTSService(
         api_key="test-api-key",
         aiohttp_session=session,
         sample_rate=24000,
         settings=RimeHttpTTSService.Settings(
-            model=model,
+            model="coda",
             voice="luna",
             repetition_penalty=1.1,
             temperature=0.5,
@@ -141,7 +139,7 @@ async def test_sampling_params_are_included_in_http_payload(model: str):
 
     _ = [frame async for frame in service.run_tts("Hello", "context")]
 
-    assert session.payload["modelId"] == model
+    assert session.payload["modelId"] == "coda"
     assert session.payload["speaker"] == "luna"
     assert session.payload["repetition_penalty"] == 1.1
     assert session.payload["temperature"] == 0.5

--- a/tests/test_rime_tts.py
+++ b/tests/test_rime_tts.py
@@ -67,11 +67,12 @@ def test_context_switch_drops_stale_remainder():
     assert service._audio_remainder == b""
 
 
-def test_coda_sampling_params_are_included_in_websocket_params():
+@pytest.mark.parametrize("model", ["arcana", "coda"])
+def test_sampling_params_are_included_in_websocket_params(model: str):
     service = RimeTTSService(
         api_key="test-api-key",
         settings=RimeTTSService.Settings(
-            model="coda",
+            model=model,
             voice="luna",
             repetition_penalty=1.1,
             temperature=0.5,
@@ -82,7 +83,7 @@ def test_coda_sampling_params_are_included_in_websocket_params():
 
     params = service._build_ws_params()
 
-    assert params["modelId"] == "coda"
+    assert params["modelId"] == model
     assert params["speaker"] == "luna"
     assert params["repetition_penalty"] == 1.1
     assert params["temperature"] == 0.5
@@ -121,14 +122,15 @@ class _CapturingSession:
 
 
 @pytest.mark.asyncio
-async def test_coda_sampling_params_are_included_in_http_payload():
+@pytest.mark.parametrize("model", ["arcana", "coda"])
+async def test_sampling_params_are_included_in_http_payload(model: str):
     session = _CapturingSession()
     service = RimeHttpTTSService(
         api_key="test-api-key",
         aiohttp_session=session,
         sample_rate=24000,
         settings=RimeHttpTTSService.Settings(
-            model="coda",
+            model=model,
             voice="luna",
             repetition_penalty=1.1,
             temperature=0.5,
@@ -139,7 +141,7 @@ async def test_coda_sampling_params_are_included_in_http_payload():
 
     _ = [frame async for frame in service.run_tts("Hello", "context")]
 
-    assert session.payload["modelId"] == "coda"
+    assert session.payload["modelId"] == model
     assert session.payload["speaker"] == "luna"
     assert session.payload["repetition_penalty"] == 1.1
     assert session.payload["temperature"] == 0.5


### PR DESCRIPTION
## Summary
- migrate Rime TTS model-specific settings and the legacy non-JSON model default to Coda
- keep the legacy service voice unset
- use Luna in the examples because Pipecat already used it and Rime supports it on both Arcana and Coda
- send supported Coda sampling settings through the WebSocket and HTTP services
- add focused tests for the Coda request settings