### PR TITLE
fix(turns): dispatch on_user_turn_stop_timeout synchronously so handlers see turn state

### DIFF
--- a/changelog/5280.fixed.md
+++ b/changelog/5280.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `on_user_turn_stop_timeout` handlers on `LLMUserAggregator` and
+  `UserTurnProcessor` observing already-drained turn state (e.g. an empty
+  `aggregation_string()` for a turn that produced a real transcript). The event
+  now dispatches synchronously, before the turn is force-stopped, so handlers
+  must execute fast.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -575,7 +575,9 @@ class LLMUserAggregator(LLMContextAggregator):
 
     - on_user_turn_started: Called when the user turn starts
     - on_user_turn_stopped: Called when the user turn ends
-    - on_user_turn_stop_timeout: Called when no user turn stop strategy triggers
+    - on_user_turn_stop_timeout: Called when no user turn stop strategy triggers.
+      Runs synchronously, before the turn is force-stopped, so handlers can read
+      the aggregation; handlers must execute fast.
     - on_user_turn_idle: Called when the user has been idle for the configured timeout
     - on_user_turn_message_added: Called when a user message is written to context.
       In realtime mode (``realtime_service_mode=True``) the write is
@@ -650,7 +652,9 @@ class LLMUserAggregator(LLMContextAggregator):
 
         self._register_event_handler("on_user_turn_started")
         self._register_event_handler("on_user_turn_stopped")
-        self._register_event_handler("on_user_turn_stop_timeout")
+        # Synchronous so handlers read the aggregation before the force-stop
+        # that follows this event drains it.
+        self._register_event_handler("on_user_turn_stop_timeout", sync=True)
         self._register_event_handler("on_user_turn_idle")
         self._register_event_handler("on_user_turn_inference_triggered")
         self._register_event_handler("on_user_turn_message_added")

--- a/src/pipecat/turns/user_turn_processor.py
+++ b/src/pipecat/turns/user_turn_processor.py
@@ -43,6 +43,8 @@ class UserTurnProcessor(FrameProcessor):
       finalization on the LLM's verdict.
     - on_user_turn_stopped: Emitted when a user turn is semantically final.
     - on_user_turn_stop_timeout: Emitted if no stop strategy triggers before timeout.
+      Runs synchronously, before the turn is force-stopped, so handlers can read
+      per-turn state; handlers must execute fast.
     - on_user_turn_idle: Emitted when the user has been idle for the configured timeout.
 
     Example::
@@ -93,7 +95,9 @@ class UserTurnProcessor(FrameProcessor):
 
         self._register_event_handler("on_user_turn_started")
         self._register_event_handler("on_user_turn_stopped")
-        self._register_event_handler("on_user_turn_stop_timeout")
+        # Synchronous so handlers read strategy state before the force-stop
+        # that follows this event resets it.
+        self._register_event_handler("on_user_turn_stop_timeout", sync=True)
         self._register_event_handler("on_user_turn_idle")
         self._register_event_handler("on_user_turn_inference_triggered")
 

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -620,6 +620,55 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stop_message.content, "Hello!")
         self.assertFalse(timeout)
 
+    async def test_user_turn_stop_timeout_handler_sees_aggregation(self):
+        """The timeout handler reads the aggregation before the force-stop drains it."""
+        context = LLMContext()
+
+        # No stop strategies, so only the stop-timeout watchdog can end the turn.
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    start=[VADUserTurnStartStrategy()],
+                    stop=[],
+                ),
+                user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+            ),
+        )
+
+        aggregation_at_timeout = None
+        stop_strategy = "unset"
+        stop_message = None
+
+        @user_aggregator.event_handler("on_user_turn_stop_timeout")
+        async def on_user_turn_stop_timeout(aggregator):
+            nonlocal aggregation_at_timeout
+            aggregation_at_timeout = aggregator.aggregation_string()
+
+        @user_aggregator.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(aggregator, strategy, message):
+            nonlocal stop_strategy, stop_message
+            stop_strategy = strategy
+            stop_message = message
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=USER_TURN_STOP_TIMEOUT + 0.1),
+        ]
+        await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+        )
+
+        # The watchdog force-stopped the turn (no strategy) with the real transcript.
+        self.assertIsNone(stop_strategy)
+        self.assertEqual(stop_message.content, "Hello!")
+        self.assertEqual(aggregation_at_timeout, "Hello!")
+
     async def test_user_mute_strategies(self):
         context = LLMContext()
 

--- a/tests/test_user_turn_processor.py
+++ b/tests/test_user_turn_processor.py
@@ -23,7 +23,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMUserAggregatorParams,
 )
 from pipecat.tests.utils import SleepFrame, run_test
-from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+from pipecat.turns.user_stop import BaseUserTurnStopStrategy, SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_processor import UserTurnProcessor
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies, UserTurnStrategies
 
@@ -118,6 +118,59 @@ class TestUserTurnProcessor(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(should_start)
         self.assertTrue(should_stop)
         self.assertTrue(timeout)
+
+    async def test_user_turn_stop_timeout_handler_sees_strategy_state(self):
+        """The timeout handler reads per-turn strategy state before the force-stop resets it."""
+
+        class BufferingStopStrategy(BaseUserTurnStopStrategy):
+            """Buffers the last transcript and clears it when the turn ends.
+
+            Never triggers a stop itself, so only the stop-timeout watchdog
+            can end the turn.
+            """
+
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.buffered_text = None
+
+            async def process_frame(self, frame):
+                if isinstance(frame, TranscriptionFrame):
+                    self.buffered_text = frame.text
+                return None
+
+            async def handle_user_turn_stopped(self):
+                await super().handle_user_turn_stopped()
+                self.buffered_text = None
+
+        strategy = BufferingStopStrategy()
+
+        user_turn_processor = UserTurnProcessor(
+            user_turn_strategies=UserTurnStrategies(stop=[strategy]),
+            user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+        )
+
+        seen_at_timeout = "unset"
+
+        @user_turn_processor.event_handler("on_user_turn_stop_timeout")
+        async def on_user_turn_stop_timeout(processor):
+            nonlocal seen_at_timeout
+            seen_at_timeout = strategy.buffered_text
+
+        pipeline = Pipeline([user_turn_processor])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=USER_TURN_STOP_TIMEOUT + 0.1),
+        ]
+        await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+        )
+
+        self.assertEqual(seen_at_timeout, "Hello!")
+        self.assertIsNone(strategy.buffered_text)
 
     async def test_user_turn_stop_timeout_transcription(self):
         user_turn_processor = UserTurnProcessor(


### PR DESCRIPTION
Fixes #4848.

## The bug

`LLMUserAggregator` registers `on_user_turn_stop_timeout` as a regular (async) event, so the user's handler is scheduled as a fire-and-forget task. The watchdog path in `UserTurnController._user_turn_stop_timeout_task_handler` then goes straight on to `_trigger_user_turn_stop(None, ...)`, which drains the aggregation before that task ever runs. So a handler doing the documented thing, reading `aggregation_string()` to decide if the turn was empty, sees `""` for a turn that produced a full transcript (which then arrives intact in `on_user_turn_stopped`). The issue's "no transcript" apology double-fire comes straight from that.

## The fix

Register the event with `sync=True`, matching what `UserTurnController` already does for its own `on_user_turn_stop_timeout` registration. The handler now runs, and finishes, before the force-stop drains the buffer.

`UserTurnProcessor` had the identical race: its stop-timeout event was also async-dispatched while `_trigger_user_turn_stop` synchronously calls `handle_user_turn_stopped()` on every stop strategy right after, resetting whatever per-turn state a strategy buffers (the same pattern `TurnAnalyzerUserTurnStopStrategy` uses for `self._text`). Same one-line fix there.

A tradeoff to point out: the handler now runs inline before the force-stop, so a slow handler delays the stop. Sync events are supposed to be fast anyway, and both docstrings now say so on this event. Seemed better than the alternative, where the event can't do the thing its own example shows.

## Tests

Two new regression tests, both red without the fix:

- `test_user_turn_stop_timeout_handler_sees_aggregation`: watchdog force-stops a turn with a real transcript; the timeout handler's `aggregation_string()` must equal it.
- `test_user_turn_stop_timeout_handler_sees_strategy_state` (processor): a buffering stop strategy's per-turn state must still be readable in the timeout handler.

Full turn-related suites pass (123 tests across the aggregator, controller, and processor files), ruff clean.
