### PR TITLE
fix(elevenlabs): drop stale partial transcripts re-sent by the realtime STT server

### DIFF
--- a/changelog/5281.fixed.md
+++ b/changelog/5281.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `ElevenLabsRealtimeSTTService` opening phantom user turns from stale
+  `partial_transcript` messages the server re-sends (identical repeats,
+  post-commit echoes, silence-cadence refreshes). Stale partials are now
+  deduplicated; the dedup state is scoped to the current turn and cleared when
+  VAD detects a new turn start.

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -32,6 +32,7 @@ from pipecat.frames.frames import (
     InterimTranscriptionFrame,
     StartFrame,
     TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
@@ -607,6 +608,17 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         self._connected_event = asyncio.Event()
         self._connected_event.set()
 
+        # ElevenLabs Scribe v2 realtime occasionally re-sends a partial_transcript
+        # that carries no new information: an identical repeat of the last partial,
+        # or an echo of text that was just committed. Track both so
+        # _on_partial_transcript can drop the repeats instead of opening a phantom
+        # user turn downstream. Scoped to the current turn: process_frame clears
+        # both markers on VADUserStartedSpeakingFrame, since a repeat utterance in
+        # a later turn is real audio, not a re-send. A repeat so soft VAD never
+        # detects it stays suppressed until a differing partial arrives.
+        self._last_partial_text: str | None = None
+        self._last_committed_text: str | None = None
+
     def can_generate_metrics(self) -> bool:
         """Check if the service can generate processing metrics.
 
@@ -654,7 +666,15 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         """
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, VADUserStoppedSpeakingFrame):
+        if isinstance(frame, VADUserStartedSpeakingFrame):
+            # A VAD-detected turn start is driven by real audio energy, which
+            # the server's phantom partial re-sends can't produce. Clearing
+            # the dedup markers here lets a genuine repeat utterance (e.g. a
+            # second "yes") pass through in the new turn, while stale echoes
+            # arriving during silence stay suppressed.
+            self._last_partial_text = None
+            self._last_committed_text = None
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
             # Send commit when user stops speaking (manual commit mode)
             if self._commit_strategy == CommitStrategy.MANUAL:
                 if self._websocket and self._websocket.state is State.OPEN:
@@ -707,6 +727,8 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
     async def _connect(self):
         """Establish WebSocket connection to ElevenLabs Realtime STT."""
         self._connected_event.clear()
+        self._last_partial_text = None
+        self._last_committed_text = None
         try:
             await self._connect_websocket()
 
@@ -902,6 +924,14 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         if not text:
             return
 
+        # Drop repeats of the last partial and echoes of text that was just
+        # committed -- both are stale re-sends with no new information, and
+        # pushing them would open a phantom user turn downstream.
+        if text == self._last_partial_text or text == self._last_committed_text:
+            return
+        self._last_committed_text = None
+        self._last_partial_text = text
+
         # Get language if provided
         language = data.get("language_code")
 
@@ -939,6 +969,9 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         text = data.get("text", "").strip()
         if not text:
             return
+
+        self._last_committed_text = text
+        self._last_partial_text = None
 
         # Get language if provided
         language = data.get("language_code")
@@ -986,6 +1019,9 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
         text = data.get("text", "").strip()
         if not text:
             return
+
+        self._last_committed_text = text
+        self._last_partial_text = None
 
         # Get language if provided
         language = data.get("language_code")

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -10,7 +10,12 @@ import aiohttp
 import pytest
 from aiohttp import web
 
-from pipecat.frames.frames import TranscriptionFrame
+from pipecat.frames.frames import (
+    InterimTranscriptionFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.elevenlabs.stt import (
     CommitStrategy,
     ElevenLabsRealtimeSTTService,
@@ -33,6 +38,28 @@ TIMESTAMPED_COMMITTED_MESSAGE = {
     "words": [{"text": "Hello.", "start": 0.0, "end": 0.5, "type": "word"}],
 }
 
+INTERIM_TEXT = "Hello. How's your day going?"
+
+PARTIAL_MESSAGE = {
+    "message_type": "partial_transcript",
+    "text": INTERIM_TEXT,
+}
+
+COMMITTED_TRANSCRIPT_MESSAGE = {
+    "message_type": "committed_transcript",
+    "text": INTERIM_TEXT,
+}
+
+GROWN_PARTIAL_MESSAGE = {
+    "message_type": "partial_transcript",
+    "text": "Hello. How's your day going? Good so far.",
+}
+
+NEW_PARTIAL_MESSAGE = {
+    "message_type": "partial_transcript",
+    "text": "Good.",
+}
+
 
 def _capture_transcriptions(service: ElevenLabsRealtimeSTTService) -> list[TranscriptionFrame]:
     """Collect the TranscriptionFrames a service pushes."""
@@ -40,6 +67,18 @@ def _capture_transcriptions(service: ElevenLabsRealtimeSTTService) -> list[Trans
 
     async def push_frame(frame, direction=None):
         if isinstance(frame, TranscriptionFrame):
+            captured.append(frame)
+
+    service.push_frame = push_frame
+    return captured
+
+
+def _capture_interims(service: ElevenLabsRealtimeSTTService) -> list[InterimTranscriptionFrame]:
+    """Collect the InterimTranscriptionFrames a service pushes."""
+    captured: list[InterimTranscriptionFrame] = []
+
+    async def push_frame(frame, direction=None):
+        if isinstance(frame, InterimTranscriptionFrame):
             captured.append(frame)
 
     service.push_frame = push_frame
@@ -257,3 +296,118 @@ async def test_elevenlabs_realtime_plain_committed_emitted_without_options():
     assert len(captured) == 1
     assert captured[0].text == COMMITTED_TEXT
     assert captured[0].language is None
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_repeated_partial_is_suppressed():
+    """An identical repeat of the last partial carries no new information."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(PARTIAL_MESSAGE)
+
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_post_commit_echo_partial_is_suppressed():
+    """The server echoes just-committed text as a stale partial shortly after commit."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(COMMITTED_TRANSCRIPT_MESSAGE)
+    await service._process_response(PARTIAL_MESSAGE)
+
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_new_partial_after_commit_is_emitted():
+    """Genuinely new text after a commit is a new user turn and must pass through."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(COMMITTED_TRANSCRIPT_MESSAGE)
+    await service._process_response(NEW_PARTIAL_MESSAGE)
+
+    assert [f.text for f in captured] == [INTERIM_TEXT, NEW_PARTIAL_MESSAGE["text"]]
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_changed_partial_text_is_emitted():
+    """Partial progression within a turn (text grows/changes) must pass through."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(GROWN_PARTIAL_MESSAGE)
+
+    assert [f.text for f in captured] == [INTERIM_TEXT, GROWN_PARTIAL_MESSAGE["text"]]
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_partial_state_resets_on_reconnect(monkeypatch):
+    """A reconnect must not carry stale partial/committed text into the new session."""
+
+    async def fake_websocket_connect(url, *, additional_headers, **kwargs):
+        return object()
+
+    monkeypatch.setattr(
+        "pipecat.services.websocket_service.websocket_connect",
+        fake_websocket_connect,
+    )
+
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    service._audio_format = audio_format_from_sample_rate(16000)
+    service.create_task = lambda coro, name=None: coro.close()
+
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(COMMITTED_TRANSCRIPT_MESSAGE)
+    assert len(captured) == 1
+
+    await service._connect()
+
+    # The same text arrives fresh in the new session and must not be
+    # suppressed as a stale echo from the previous one.
+    await service._process_response(PARTIAL_MESSAGE)
+
+    assert len(captured) == 2
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_genuine_repeat_after_vad_start_is_emitted():
+    """A VAD-detected turn start clears the markers, so a real repeat utterance fires."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    # Turn 1: user says "Hello. How's your day going?"
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(COMMITTED_TRANSCRIPT_MESSAGE)
+
+    # Turn 2 begins: VAD detects real speech, not a phantom re-send.
+    await service.process_frame(VADUserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+
+    # The user genuinely says the same thing again.
+    await service._process_response(PARTIAL_MESSAGE)
+
+    assert [f.text for f in captured] == [INTERIM_TEXT, INTERIM_TEXT]
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_realtime_post_commit_echo_without_vad_start_still_suppressed():
+    """Without a VAD-detected turn start, the post-commit echo is still a stale re-send."""
+    service = ElevenLabsRealtimeSTTService(api_key="test-key", sample_rate=16000)
+    captured = _capture_interims(service)
+
+    await service._process_response(PARTIAL_MESSAGE)
+    await service._process_response(COMMITTED_TRANSCRIPT_MESSAGE)
+
+    # No VADUserStartedSpeakingFrame here -- this is the phantom post-commit echo.
+    await service._process_response(PARTIAL_MESSAGE)
+
+    assert len(captured) == 1


### PR DESCRIPTION
Fixes #5197.

## The bug

The Scribe v2 realtime server re-sends stale `partial_transcript` messages: identical repeats of the last partial, echoes of text it just committed, and ~1s refreshes during silence (the server-side behavior ElevenLabs acknowledged back in July). `ElevenLabsRealtimeSTTService` pushed an `InterimTranscriptionFrame` for every one of them, and with `TranscriptionUserTurnStartStrategy`'s default `use_interim=True` each re-send can open a phantom user turn — the bot gets interrupted while nobody's talking.

## The fix

Track the last partial text and the last committed text, and drop any partial matching either. Genuinely new text clears the committed marker before pushing. Both committed-transcript handlers set the committed marker, and `_connect` resets everything so nothing leaks across reconnects.

The markers are turn-scoped: `process_frame` clears them on `VADUserStartedSpeakingFrame`. VAD start needs real audio energy, which a server re-send can't fake, so stale echoes during silence stay dead while a user who genuinely repeats themselves ("yes" ... "yes") in a new turn still gets their interim through. One edge accepted: a repeat so quiet VAD never fires stays suppressed until the text changes — the final `TranscriptionFrame` comes through regardless, since the committed handlers don't consult the markers.

## Tests

Seven new tests in `tests/test_elevenlabs_stt.py`; the suppression and turn-scoping ones fail without the fix:

- identical repeated partial suppressed
- post-commit echo suppressed
- new partial after commit passes through
- changed partial text passes through
- genuine repeat after a VAD turn start passes through
- post-commit echo with no intervening VAD start still suppressed
- markers reset on reconnect

Full file 15 tests green, ruff clean.
