### PR TITLE
fix(elevenlabs): defer close_context until the first audio chunk arrives

### DIFF
--- a/changelog/5282.fixed.md
+++ b/changelog/5282.fixed.md
@@ -1,0 +1,6 @@
+- Fixed `ElevenLabsTTSService` silently dropping an entire utterance when the
+  server processed `close_context` before registering the turn's text. The
+  end-of-turn close is now deferred until the context's first audio chunk
+  arrives (or until the local audio-context timeout, so server-side contexts
+  are never leaked), and function-call-only turns no longer send a stray
+  `close_context`.

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -439,6 +439,21 @@ class ElevenLabsTTSService(ElevenLabsTTSBase):
         # which contexts are safe to target.
         self._context_init_sent: set[str] = set()
 
+        # Contexts that have received their first audio chunk. Once audio is
+        # streaming, the server orders isFinal after the last byte, so closing
+        # is safe.
+        self._contexts_with_first_audio: set[str] = set()
+
+        # Contexts whose end-of-turn close was deferred because no audio had
+        # arrived yet -- closing then would let isFinal overtake the first
+        # audio chunk and drop the whole utterance. The close is sent once the
+        # first chunk arrives (see _receive_messages), or on interruption. A
+        # context that never produces any audio gets its close sent once the
+        # local audio-context queue times out waiting for audio (see
+        # on_audio_context_completed), so the server-side context is never
+        # left open indefinitely.
+        self._contexts_pending_close: set[str] = set()
+
     def _set_voice_settings(self):
         return build_elevenlabs_voice_settings(self._settings)
 
@@ -481,6 +496,8 @@ class ElevenLabsTTSService(ElevenLabsTTSBase):
 
     def _clear_connection_state(self):
         self._context_init_sent.clear()
+        self._contexts_with_first_audio.clear()
+        self._contexts_pending_close.clear()
 
     async def _close_context(self, context_id: str):
         # ElevenLabs requires that Pipecat explicitly closes contexts to free
@@ -504,16 +521,41 @@ class ElevenLabsTTSService(ElevenLabsTTSBase):
         super()._reset_alignment_state(context_id)
         self._alignment_started_context_ids.discard(context_id)
         self._context_init_sent.discard(context_id)
+        self._contexts_with_first_audio.discard(context_id)
+        self._contexts_pending_close.discard(context_id)
+
+    async def on_audio_context_completed(self, context_id: str):
+        """Send any deferred close, then reset state after the audio has played.
+
+        The local audio context queue also reaches completion when it times
+        out waiting for audio (``stop_frame_timeout_s``, e.g. slow synthesis
+        under load) rather than via a server isFinal ack. If a close was
+        deferred for this context and never got sent (no audio ever arrived
+        to trigger it), send it now so the server-side context isn't leaked.
+        """
+        if context_id in self._contexts_pending_close:
+            await self._close_context(context_id)
+        await super().on_audio_context_completed(context_id)
 
     async def on_turn_context_completed(self):
         """Close the server-side context at end of turn.
 
-        Sends close_context so isFinal arrives immediately after the last audio byte.
+        When audio is already streaming, closing now is safe: the server
+        orders isFinal after the last audio byte. But when synthesis is still
+        buffered (no audio yet), an immediate close lets isFinal overtake the
+        first chunk and drop the whole utterance, so the close is deferred
+        until the first chunk arrives (see _receive_messages). Turns that
+        never sent any text (function-call-only turns) never opened a
+        context, so nothing is closed.
         """
         context_id = self._turn_context_id
         await super().on_turn_context_completed()
-        if context_id:
+        if not context_id or not self.audio_context_available(context_id):
+            return
+        if context_id in self._contexts_with_first_audio:
             await self._close_context(context_id)
+        else:
+            self._contexts_pending_close.add(context_id)
 
     async def _receive_messages(self):
         """Handle incoming WebSocket messages from ElevenLabs."""
@@ -537,6 +579,11 @@ class ElevenLabsTTSService(ElevenLabsTTSBase):
                 audio = base64.b64decode(msg["audio"])
                 frame = TTSAudioRawFrame(audio, self.sample_rate, 1, context_id=received_ctx_id)
                 await self.append_to_audio_context(received_ctx_id, frame)
+                if received_ctx_id and received_ctx_id not in self._contexts_with_first_audio:
+                    self._contexts_with_first_audio.add(received_ctx_id)
+                    if received_ctx_id in self._contexts_pending_close:
+                        self._contexts_pending_close.discard(received_ctx_id)
+                        await self._close_context(received_ctx_id)
 
             raw_alignment = _select_alignment(
                 msg,

--- a/tests/test_elevenlabs_tts_close_context.py
+++ b/tests/test_elevenlabs_tts_close_context.py
@@ -1,0 +1,250 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for ElevenLabsTTSService end-of-turn close_context race handling.
+
+When ElevenLabs synthesis is slow, closing the context at end of turn lets the
+server's `isFinal` ack overtake the first audio chunk and drop the whole
+utterance. These tests pin the deferral behavior that avoids that: the close
+is held until the first audio chunk arrives, and turns that never open a
+context (function-call-only turns) send no close at all.
+"""
+
+import base64
+import json
+
+import pytest
+from websockets.protocol import State
+
+from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
+
+
+class _FakeWebSocket:
+    """Stand-in for the ElevenLabs websocket: records sends, replays messages."""
+
+    def __init__(self, messages: list[str] | None = None):
+        self.state = State.OPEN
+        self.sent: list[dict] = []
+        self._messages = messages or []
+
+    async def send(self, data: str):
+        self.sent.append(json.loads(data))
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for message in self._messages:
+            yield message
+
+
+def _make_service(**kwargs) -> ElevenLabsTTSService:
+    return ElevenLabsTTSService(
+        api_key="test-key",
+        settings=ElevenLabsTTSService.Settings(voice="test-voice"),
+        **kwargs,
+    )
+
+
+def _audio_message(context_id: str) -> str:
+    audio = base64.b64encode(b"\x00\x01" * 32).decode()
+    return json.dumps({"audio": audio, "contextId": context_id})
+
+
+def _close_messages(ws: _FakeWebSocket) -> list[dict]:
+    return [m for m in ws.sent if m.get("close_context") is True]
+
+
+@pytest.mark.asyncio
+async def test_close_deferred_when_no_audio_yet():
+    """End of turn with no audio yet defers the close instead of sending it."""
+    service = _make_service()
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+
+    assert _close_messages(ws) == []
+    assert "ctx-1" in service._contexts_pending_close
+
+
+@pytest.mark.asyncio
+async def test_close_immediate_when_audio_already_streaming():
+    """End of turn after audio has started closes immediately (unchanged path)."""
+    service = _make_service()
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+    service._contexts_with_first_audio.add("ctx-1")
+
+    await service.on_turn_context_completed()
+
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+    assert "ctx-1" not in service._contexts_pending_close
+
+
+@pytest.mark.asyncio
+async def test_no_close_sent_for_function_call_only_turn():
+    """A turn that never sends text never opens a context, so no close is sent."""
+    service = _make_service()
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    # No create_audio_context call: text never reached run_tts for this turn.
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+
+    assert ws.sent == []
+    assert "ctx-1" not in service._contexts_pending_close
+
+
+@pytest.mark.asyncio
+async def test_deferred_close_sent_on_first_audio_chunk():
+    """The deferred close fires once the first audio chunk arrives."""
+    service = _make_service()
+    ws = _FakeWebSocket([_audio_message("ctx-1")])
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+    assert "ctx-1" in service._contexts_pending_close
+    assert _close_messages(ws) == []
+
+    await service._receive_messages()
+
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+    assert "ctx-1" not in service._contexts_pending_close
+    assert "ctx-1" in service._contexts_with_first_audio
+
+
+@pytest.mark.asyncio
+async def test_interruption_clears_pending_close():
+    """A barge-in drops deferred state so a late chunk can't resurrect the context."""
+    service = _make_service()
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._contexts_pending_close.add("ctx-1")
+
+    await service.on_audio_context_interrupted("ctx-1")
+
+    assert "ctx-1" not in service._contexts_pending_close
+    assert "ctx-1" not in service._contexts_with_first_audio
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_deferred_close_state():
+    """Disconnecting drops any lingering per-context tracking so it can't leak."""
+    service = _make_service()
+    service._websocket = None
+    service._contexts_pending_close.add("ctx-1")
+    service._contexts_with_first_audio.add("ctx-1")
+
+    await service._disconnect_websocket()
+
+    assert service._contexts_pending_close == set()
+    assert service._contexts_with_first_audio == set()
+
+
+# ---------------------------------------------------------------------------
+# Local stop_frame_timeout_s idle timeout vs. deferred close
+#
+# A context's local audio queue can also reach completion by timing out
+# (TTSService._handle_audio_context, e.g. slow synthesis under load) rather
+# than via a server isFinal ack. If a close was deferred at turn end and no
+# audio ever arrived to trigger it, the timeout path must still send it, or
+# the server-side context leaks indefinitely.
+# ---------------------------------------------------------------------------
+
+
+async def _run_local_timeout(service: ElevenLabsTTSService, context_id: str):
+    """Drive the real base-class idle-timeout path for a context.
+
+    Mirrors the relevant part of TTSService._audio_context_task_handler: run
+    the real _handle_audio_context (which times out on an empty queue after
+    stop_frame_timeout_s) and then the real on_audio_context_completed, in
+    the same order the base class uses.
+    """
+    await service._handle_audio_context(context_id)
+    del service._audio_contexts[context_id]
+    await service.on_audio_context_completed(context_id=context_id)
+
+
+@pytest.mark.asyncio
+async def test_local_timeout_sends_deferred_close_exactly_once():
+    """No audio within stop_frame_timeout_s still gets its close sent, via completion."""
+    service = _make_service(stop_frame_timeout_s=0.05)
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+    assert "ctx-1" in service._contexts_pending_close
+    assert _close_messages(ws) == []
+
+    await _run_local_timeout(service, "ctx-1")
+
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+    assert "ctx-1" not in service._contexts_pending_close
+    assert "ctx-1" not in service._contexts_with_first_audio
+
+
+@pytest.mark.asyncio
+async def test_completion_after_first_audio_close_sends_no_second_close():
+    """A context closed via the first-audio path doesn't get a second close on completion."""
+    service = _make_service(stop_frame_timeout_s=0.05)
+    ws = _FakeWebSocket([_audio_message("ctx-1")])
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+    await service._receive_messages()
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+
+    # The queue reaches completion normally (e.g. the server's isFinal ack
+    # drained it) rather than via the idle timeout -- either way,
+    # on_audio_context_completed must not re-close an already-closed context.
+    del service._audio_contexts["ctx-1"]
+    await service.on_audio_context_completed(context_id="ctx-1")
+
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+
+
+@pytest.mark.asyncio
+async def test_late_audio_after_timeout_close_is_dropped_not_resurrected():
+    """Audio arriving after the timeout-triggered close is dropped, not recreated.
+
+    _turn_context_id is already None by the time a context reaches
+    _contexts_pending_close (on_turn_context_completed resets it before
+    deferring), so append_to_audio_context's recreate-on-append branch can
+    never match a pending-close context: late audio for it is silently
+    dropped rather than resurrecting a context we've already told the server
+    to close.
+    """
+    service = _make_service(stop_frame_timeout_s=0.05)
+    ws = _FakeWebSocket()
+    service._websocket = ws
+    await service.create_audio_context("ctx-1")
+    service._turn_context_id = "ctx-1"
+
+    await service.on_turn_context_completed()
+    assert service._turn_context_id is None
+
+    await _run_local_timeout(service, "ctx-1")
+    assert _close_messages(ws) == [{"context_id": "ctx-1", "close_context": True}]
+
+    # Late audio for the now-closed context arrives on the wire.
+    service._websocket = _FakeWebSocket([_audio_message("ctx-1")])
+    await service._receive_messages()
+
+    assert "ctx-1" not in service._audio_contexts
+    assert _close_messages(service._websocket) == []


### PR DESCRIPTION
Fixes #5271. Same defect as #4681, which had production telemetry (~2.5% of peak-hour calls) and ElevenLabs engineers confirming the server-side race before it got closed as not-planned.

## The bug

`on_turn_context_completed` sends `close_context` the instant the turn's text has gone out. Under load, ElevenLabs can process the close before it has registered that text for synthesis, and it honors the close immediately: `isFinal` comes back with zero audio chunks. The utterance is silently dropped, and since no audio means no `BotStartedSpeakingFrame`, the pipeline sits paused until the silent context completes at `stop_frame_timeout_s` (3s default) and `_maybe_resume_frame_processing()` lifts it. This came in with the refactor that moved the close from after-playback to turn-end (d146a7f8e).

## The fix

Defer the close until the context has actually produced audio — once the first chunk is streaming, the server reliably orders `isFinal` after the last byte, so closing is safe. Same approach as #5118 took for Inworld, but self-contained in `elevenlabs/tts.py`: no base-class changes, so the two PRs don't collide. ElevenLabs doesn't need the `_can_recreate_audio_context` hook — every context that defers its close has already had `_turn_context_id` reset in the same call, so the recreate-on-append branch can't resurrect it (there's a test pinning that).

Concretely:

- Turn end with audio already streaming: close immediately (unchanged behavior).
- Turn end with no audio yet: mark the close pending; `_receive_messages` sends it when the first chunk arrives.
- No audio ever arrives: when the local audio-context queue times out (`stop_frame_timeout_s`), `on_audio_context_completed` sends the pending close before resetting state, so the server-side context is never leaked.
- Function-call-only turns (no text sent, no context opened): nothing is closed, which also fixes the stray bare `close_context` flagged in #4681.
- Interruption and disconnect clear the tracking state.

## Tests

New file `tests/test_elevenlabs_tts_close_context.py`, nine tests, the behavior-changing ones red without the fix: deferred close when no audio yet, immediate close when streaming, deferred close fires on first chunk, exactly one close via the timeout path, no second close after completion, nothing sent for function-call-only turns, late audio after a timeout close is dropped rather than resurrected, and interruption/disconnect state cleanup. 49 ElevenLabs tests green overall, ruff clean.

