### PR TITLE
fix(turns): defer LLMRunFrame until an in-flight user turn finalizes

### DIFF
--- a/changelog/5283.fixed.md
+++ b/changelog/5283.fixed.md
@@ -1,0 +1,6 @@
+- Fixed `LLMRunFrame` (and `LLMMessagesAppendFrame` / `LLMMessagesUpdateFrame`
+  / `LLMMessagesTransformFrame` with `run_llm=True`) triggering a duplicate
+  generation when received while a user turn is in flight — e.g. a flows node
+  transition with `respond_immediately` generating and speaking its opening
+  message twice. The run is now deferred until the turn finalizes and fires
+  exactly once.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -717,6 +717,15 @@ class LLMUserAggregator(LLMContextAggregator):
         # surfaces the full turn transcript even when several
         # inferences fire before finalization.
         self._full_user_turn_aggregation: str | None = None
+        # Set by `_maybe_run_llm` when a "run the LLM now" frame (LLMRunFrame,
+        # or a messages append/update/transform frame with run_llm=True)
+        # arrives while a user turn is active (e.g. a flows node transition
+        # mid-turn). Pushing immediately would race the turn's own
+        # finalization against the same context, generating twice.
+        # `push_aggregation` clears this the next time the turn itself runs
+        # inference; if the turn finalizes without ever doing so,
+        # `_resolve_pending_llm_run` fires it then.
+        self._pending_llm_run = False
 
         self._user_turn_controller = UserTurnController(
             user_turn_strategies=user_turn_strategies,
@@ -877,6 +886,9 @@ class LLMUserAggregator(LLMContextAggregator):
             cast(LLMContextMessage, {"role": self.role, "content": aggregation})
         )
         await self.push_context_frame()
+        # This push already ran inference against the current context, so it
+        # satisfies any run parked mid-turn by `_maybe_run_llm`.
+        self._pending_llm_run = False
 
         message = UserTurnMessageAddedMessage(
             content=aggregation, timestamp=self._user_turn_start_timestamp
@@ -1141,6 +1153,11 @@ class LLMUserAggregator(LLMContextAggregator):
         # looks like: no audio arriving, no turn finishing, the user idle. They
         # stop here, while what they hold (the VAD analyzer, the turn
         # strategies) may be shared and is released in cleanup() instead.
+        #
+        # A run parked by `_maybe_run_llm` goes the same way, dropped rather
+        # than fired: the session is over, so there's nothing left to run it
+        # against.
+        self._pending_llm_run = False
         await self._cancel_realtime_handoff_flush_task()
         if self._vad_controller:
             await self._vad_controller.stop()
@@ -1193,21 +1210,35 @@ class LLMUserAggregator(LLMContextAggregator):
         return should_mute_frame
 
     async def _handle_llm_run(self, frame: LLMRunFrame):
-        await self.push_context_frame()
+        await self._maybe_run_llm()
 
     async def _handle_llm_messages_append(self, frame: LLMMessagesAppendFrame):
         self.add_messages(frame.messages)
         if frame.run_llm:
-            await self.push_context_frame()
+            await self._maybe_run_llm()
 
     async def _handle_llm_messages_update(self, frame: LLMMessagesUpdateFrame):
         self.set_messages(frame.messages)
         if frame.run_llm:
-            await self.push_context_frame()
+            await self._maybe_run_llm()
 
     async def _handle_llm_messages_transform(self, frame: LLMMessagesTransformFrame):
         self.transform_messages(frame.transform)
         if frame.run_llm:
+            await self._maybe_run_llm()
+
+    async def _maybe_run_llm(self):
+        """Push a context frame now, or park it if a user turn is in flight.
+
+        Shared by every "run the LLM now" frame handler (`LLMRunFrame` and
+        the ``run_llm=True`` variants of the messages append/update/transform
+        frames). Pushing immediately while a turn is open would race the
+        turn's own finalization against the same context, generating twice,
+        so the run is parked instead -- see `_pending_llm_run`.
+        """
+        if self._user_turn_start_timestamp:
+            self._pending_llm_run = True
+        else:
             await self.push_context_frame()
 
     async def _handle_transcription(self, frame: TranscriptionFrame):
@@ -1348,10 +1379,15 @@ class LLMUserAggregator(LLMContextAggregator):
             # effective end-of-turn signal, and the user message is
             # written then. Content is None here; subscribers wanting
             # the finalized text use on_user_turn_message_added instead.
+            # A parked LLMRunFrame is unaffected by that deferral: nothing
+            # else in realtime mode runs inference off turn-stop, so resolve
+            # it here rather than leaving it stranded until a handoff flush
+            # that may never come (e.g. no local transcript ever arrives).
             message = UserTurnStoppedMessage(
                 content=None, timestamp=self._user_turn_start_timestamp
             )
             await self._call_event_handler("on_user_turn_stopped", strategy, message)
+            await self._resolve_pending_llm_run()
             return
 
         await self._maybe_emit_user_turn_stopped(strategy)
@@ -1401,6 +1437,23 @@ class LLMUserAggregator(LLMContextAggregator):
             )
             await self._call_event_handler("on_user_turn_stopped", strategy, message)
             self._user_turn_start_timestamp = ""
+
+        await self._resolve_pending_llm_run(on_session_end=on_session_end)
+
+    async def _resolve_pending_llm_run(self, *, on_session_end: bool = False):
+        """Fire or drop a run parked mid-turn by `_maybe_run_llm`.
+
+        Called wherever a user turn finalizes. `push_aggregation` clears
+        `_pending_llm_run` whenever the turn itself already ran inference,
+        so reaching here with it still set means nothing did -- fire it now.
+        On session end there's nothing left to run it for, so drop it
+        instead.
+        """
+        if not self._pending_llm_run:
+            return
+        self._pending_llm_run = False
+        if not on_session_end:
+            await self.push_context_frame()
 
 
 class LLMAssistantAggregator(LLMContextAggregator):

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1058,6 +1058,347 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
         user_messages = [m for m in context.get_messages() if m.get("role") == "user"]
         self.assertEqual([m["content"] for m in user_messages], ["I'm thinking", "about pizza"])
 
+    async def test_llm_run_while_turn_in_flight_does_not_double_generate(self):
+        """An LLMRunFrame arriving mid-turn (e.g. a flows node transition) must
+        not race the turn's own finalization into a second generation.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            # User turn opens and produces a transcript.
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            # While the turn is still open, something (flows' _set_node)
+            # queues an LLMRunFrame.
+            LLMRunFrame(),
+            SleepFrame(),
+            # The user's turn now finalizes on its own.
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+        user_messages = [m for m in context.get_messages() if m.get("role") == "user"]
+        self.assertEqual([m["content"] for m in user_messages], ["Hello!"])
+
+    async def test_llm_run_with_no_active_turn_pushes_immediately(self):
+        """An LLMRunFrame arriving after a turn has already finalized behaves
+        exactly as it does with no turn strategies at all: an immediate push.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            VADUserStoppedSpeakingFrame(),
+            # Let the turn fully finalize before the run arrives.
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+            LLMRunFrame(),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        # One generation from the turn finalizing, one from the LLMRunFrame
+        # that arrived afterward -- both legitimate, independent runs.
+        self.assertEqual(len(context_frames), 2)
+
+    async def test_llm_run_while_turn_in_flight_resolved_by_stop_timeout_watchdog(self):
+        """A parked LLMRunFrame still fires exactly once when the turn is
+        finalized by the stop-timeout watchdog rather than a stop strategy.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            # Default strategies need a transcript to finalize on their own,
+            # so with none, only the stop-timeout watchdog will end this turn.
+            VADUserStartedSpeakingFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(),
+            LLMRunFrame(),
+            SleepFrame(sleep=USER_TURN_STOP_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+    async def test_llm_run_while_turn_in_flight_discarded_on_session_end(self):
+        """A parked LLMRunFrame is dropped, not fired, if the session ends
+        before the turn it was waiting on ever finalizes.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(context)
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            # The turn is open with no transcript when the run is queued.
+            LLMRunFrame(),
+            SleepFrame(),
+            # run_test sends an EndFrame next, ending the session while the
+            # turn -- and the parked run -- are still open.
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 0)
+
+    async def test_llm_run_while_turn_in_flight_does_not_double_generate_realtime_mode(self):
+        """Realtime mode's turn-stop path never calls push_aggregation itself
+        (the local transcript is normally flushed later, on the assistant
+        response starting), so a parked run has to be resolved directly at
+        turn-stop rather than riding along with it.
+
+        A transcript still sitting in the aggregation buffer at session end
+        is flushed independently -- an unrelated, pre-existing mechanism
+        that also produces an LLMContextFrame. That's not a second firing of
+        the parked run: it must resolve exactly once, at turn-stop, before
+        the trailing transcript is committed.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+            _realtime_service_mode=True,
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        # LLMContextFrame wraps a reference to the live context, not a
+        # snapshot, so inspecting frames after the fact would only ever show
+        # the final state. Snapshot the messages at each push instead.
+        push_snapshots = []
+        original_push_context_frame = user_aggregator.push_context_frame
+
+        async def _tracking_push_context_frame(*args, **kwargs):
+            push_snapshots.append(list(context.get_messages()))
+            await original_push_context_frame(*args, **kwargs)
+
+        user_aggregator.push_context_frame = _tracking_push_context_frame
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            LLMRunFrame(),
+            SleepFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+        ]
+        await run_test(pipeline, frames_to_send=frames_to_send)
+
+        self.assertEqual(len(push_snapshots), 2)
+
+        def has_user_message(messages):
+            return any(m.get("content") == "Hello!" for m in messages)
+
+        # The parked run resolves at turn-stop, before the trailing
+        # transcript is committed to context.
+        self.assertFalse(has_user_message(push_snapshots[0]))
+        # The session-end flush is what commits the trailing transcript --
+        # a second, independent push, not a repeat of the first.
+        self.assertTrue(has_user_message(push_snapshots[1]))
+
+    async def test_llm_run_while_turn_in_flight_realtime_mode_watchdog_no_transcript(self):
+        """A parked run still fires exactly once in realtime mode when the
+        turn ends via the stop-timeout watchdog with no local transcript --
+        the case where nothing ever calls push_aggregation for this turn.
+
+        Uses an explicit stop strategy with a speech timeout longer than the
+        watchdog, so the watchdog is guaranteed to be what finalizes the
+        turn (rather than the default strategy, which runs real turn-analysis
+        inference and isn't deterministic on timing).
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=10.0)],
+                ),
+                user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+            ),
+            _realtime_service_mode=True,
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(),
+            LLMRunFrame(),
+            SleepFrame(sleep=USER_TURN_STOP_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+    async def test_llm_messages_append_run_while_turn_in_flight_does_not_double_generate(self):
+        """LLMMessagesAppendFrame(run_llm=True) carries the same "run now"
+        semantics as LLMRunFrame, so it must defer the run the same way --
+        but the message append itself still happens immediately.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            LLMMessagesAppendFrame(
+                messages=[{"role": "user", "content": "Appended!"}],
+                run_llm=True,
+            ),
+            SleepFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+        # The append landed immediately -- ahead of the turn's own message,
+        # which is written only once the turn finalizes.
+        contents = [m["content"] for m in context.get_messages()]
+        self.assertEqual(contents, ["Appended!", "Hello!"])
+
+    async def test_llm_messages_update_run_while_turn_in_flight_does_not_double_generate(self):
+        """LLMMessagesUpdateFrame(run_llm=True) mid-turn defers the run but
+        still replaces the context immediately.
+        """
+        context = LLMContext()
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            LLMMessagesUpdateFrame(
+                messages=[{"role": "system", "content": "Updated!"}],
+                run_llm=True,
+            ),
+            SleepFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+        # The update landed immediately -- ahead of the turn's own message,
+        # which is appended only once the turn finalizes.
+        contents = [(m["role"], m["content"]) for m in context.get_messages()]
+        self.assertEqual(contents, [("system", "Updated!"), ("user", "Hello!")])
+
+    async def test_llm_messages_transform_run_while_turn_in_flight_does_not_double_generate(self):
+        """LLMMessagesTransformFrame(run_llm=True) mid-turn defers the run
+        but still transforms the context immediately.
+        """
+        context = LLMContext()
+        context.set_messages([{"role": "system", "content": "hello"}])
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    stop=[
+                        SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=TRANSCRIPTION_TIMEOUT)
+                    ],
+                ),
+            ),
+        )
+
+        pipeline = Pipeline([user_aggregator])
+
+        def uppercase_content(messages):
+            return [{"role": m["role"], "content": m["content"].upper()} for m in messages]
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="Hello!", user_id="", timestamp="now"),
+            SleepFrame(),
+            LLMMessagesTransformFrame(transform=uppercase_content, run_llm=True),
+            SleepFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=TRANSCRIPTION_TIMEOUT + 0.1),
+        ]
+        received_down, _ = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        context_frames = [f for f in received_down if isinstance(f, LLMContextFrame)]
+        self.assertEqual(len(context_frames), 1)
+
+        # The transform landed immediately -- ahead of the turn's own
+        # message, which is appended only once the turn finalizes.
+        contents = [(m["role"], m["content"]) for m in context.get_messages()]
+        self.assertEqual(contents, [("system", "HELLO"), ("user", "Hello!")])
+
 
 class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
     async def test_empty(self):


### PR DESCRIPTION
Fixes #5091.

## The bug

Flows' `FlowManager._set_node` queues an `LLMRunFrame` on every node transition when `respond_immediately` is set (the default), with no idea whether a user turn is open. `LLMUserAggregator._handle_llm_run` pushed a context frame unconditionally, so when a function-call handler transitions the node while the user's turn is still in flight, the run fires mid-turn and the turn's own finalization triggers a second generation — the node's opening message gets generated and spoken twice.

## The fix

In the aggregator, not `_set_node`. The aggregator already owns the turn state, and it's the single funnel every "run the LLM now" producer goes through — so guarding here covers flows and anything else that pushes these frames, and doesn't touch the `NO_RESPONSE`/inactive-worker handling #4995 added to the same `_set_node` path.

`_maybe_run_llm` now parks the run when a user turn is open instead of pushing immediately (no turn open: unchanged, pushes right away). The parked run resolves exactly once when the turn finalizes:

- Normal stop-strategy and stop-timeout watchdog paths fire it at turn stop.
- If the turn's own finalization already ran inference, that satisfies the parked run — `push_aggregation` clears it, so no double fire.
- Realtime mode resolves it on its own turn-stop branch (nothing else runs inference off turn stop there; the transcript commit is decoupled).
- Session end (`EndFrame`/`CancelFrame`) drops it rather than firing into a shutting-down pipeline.

The same guard applies to `LLMMessagesAppendFrame`/`LLMMessagesUpdateFrame`/`LLMMessagesTransformFrame` with `run_llm=True`, which had the identical double-generation. The message mutation itself still happens immediately — only the run defers.

## Tests

Nine new tests, the behavior-changing ones red without the fix: single generation for a mid-turn `LLMRunFrame` (cascade and realtime modes, including the watchdog path with no transcript), unchanged immediate push with no turn open, session-end drop, and one each for append/update/transform showing single generation with the mutation still applied. Full aggregator suite (96) and flows suite (76) green, ruff clean.
