### PR TITLE
Add a pcm_to_wav helper to pipecat.audio.utils

### DIFF
--- a/changelog/5284.added.md
+++ b/changelog/5284.added.md
@@ -1,0 +1,2 @@
+- Added `pcm_to_wav()` to `pipecat.audio.utils`, wrapping raw s16le PCM (what
+  `AudioBufferProcessor` emits from its audio event handlers) in a WAV container.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -12,6 +12,8 @@ various audio formats used in Pipecat pipelines.
 """
 
 import audioop
+import io
+import wave
 
 import loudness
 import numpy as np
@@ -104,6 +106,30 @@ def interleave_stereo_audio(left_audio: bytes, right_audio: bytes) -> bytes:
     stereo = np.column_stack((left, right))
 
     return stereo.astype(np.int16).tobytes()
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+    """Wrap raw PCM audio in a WAV container.
+
+    The PCM data is expected to be signed 16-bit little-endian samples, which
+    is what Pipecat pipelines carry (e.g. what ``AudioBufferProcessor`` emits
+    from its audio event handlers).
+
+    Args:
+        pcm: Raw PCM audio data (16-bit signed integers).
+        sample_rate: Sample rate of the audio in Hz.
+        num_channels: Number of interleaved channels in the PCM data.
+
+    Returns:
+        A complete in-memory WAV file as bytes.
+    """
+    with io.BytesIO() as buffer:
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(num_channels)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(pcm)
+        return buffer.getvalue()
 
 
 def normalize_value(value, min_value, max_value):

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import io
+import unittest
+import wave
+
+from pipecat.audio.utils import pcm_to_wav
+
+
+class TestPcmToWav(unittest.TestCase):
+    def _read_wav(self, data: bytes):
+        with wave.open(io.BytesIO(data), "rb") as wav_file:
+            return (
+                wav_file.getnchannels(),
+                wav_file.getsampwidth(),
+                wav_file.getframerate(),
+                wav_file.readframes(wav_file.getnframes()),
+            )
+
+    def test_mono(self):
+        pcm = b"\x01\x00" * 1600  # 0.1s of a constant sample at 16kHz
+        wav = pcm_to_wav(pcm, 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 1)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, pcm)
+
+    def test_stereo(self):
+        pcm = b"\x01\x00\x02\x00" * 2400  # 0.1s of interleaved stereo at 24kHz
+        wav = pcm_to_wav(pcm, 24000, num_channels=2)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 2)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 24000)
+        self.assertEqual(frames, pcm)
+
+    def test_empty(self):
+        wav = pcm_to_wav(b"", 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `pcm_to_wav(pcm, sample_rate, num_channels=1)` to `pipecat.audio.utils`, wrapping raw s16le PCM in a WAV container.

## Why

Every example that persists or uploads audio from `AudioBufferProcessor` hand-rolls the same `wave.open` block, including the `pipecat init` server template (`src/pipecat/cli/templates/server/_macros/event_handlers.jinja2`). `audio/utils.py` already holds the other PCM helpers (mix, interleave, ulaw/alaw), so this gives the WAV wrap a home next to them.

Extracted from the Langfuse call-recording example (pipecat-ai/pipecat-examples#240), where it is one of three pieces of generic glue the example carries because core lacks them.

## Test plan

- New `tests/test_audio_utils.py`: mono, stereo, and empty PCM round-trip through `wave.open` with the expected channels, width, rate, and frames.
- `uv run pytest tests/test_audio_utils.py` → 3 passed.