### PR TITLE
Attach call recordings to Langfuse traces

### DIFF
--- a/changelog/5285.added.2.md
+++ b/changelog/5285.added.2.md
@@ -1,0 +1,5 @@
+- Added `AudioBufferProcessor.set_turn_tracker()`. Attach the pipeline's
+  `TurnTrackingObserver` and the `on_user_turn_audio_data` /
+  `on_bot_turn_audio_data` events report the tracker's turn number for each
+  clip, so turn audio can be matched to its turn (turn spans in tracing,
+  per-turn evals, storage keys) without hand-rolled counting.

--- a/changelog/5285.added.3.md
+++ b/changelog/5285.added.3.md
@@ -1,0 +1,2 @@
+- Added `pcm_to_wav()` to `pipecat.audio.utils`, wrapping raw s16le PCM (what
+  `AudioBufferProcessor` emits from its audio event handlers) in a WAV container.

--- a/changelog/5285.added.md
+++ b/changelog/5285.added.md
@@ -1,0 +1,5 @@
+- Added `AudioBufferProcessor.set_turn_tracker()`. Attach the pipeline's
+  `TurnTrackingObserver` and the `on_user_turn_audio_data` /
+  `on_bot_turn_audio_data` events report the tracker's turn number for each
+  clip, so turn audio can be matched to its turn (turn spans in tracing,
+  per-turn evals, storage keys) without hand-rolled counting.

--- a/changelog/5285.added.md
+++ b/changelog/5285.added.md
@@ -1,5 +1,6 @@
-- Added `AudioBufferProcessor.set_turn_tracker()`. Attach the pipeline's
-  `TurnTrackingObserver` and the `on_user_turn_audio_data` /
-  `on_bot_turn_audio_data` events report the tracker's turn number for each
-  clip, so turn audio can be matched to its turn (turn spans in tracing,
-  per-turn evals, storage keys) without hand-rolled counting.
+- Added `LangfuseRecordingUploader` in `pipecat.utils.tracing.langfuse`. It captures
+  audio from an `AudioBufferProcessor` and, after the pipeline shuts down, uploads it
+  through the Langfuse media API and links it to the conversation's trace: the whole call
+  (stereo, user left / bot right) playable from the trace root, and each turn's user and
+  bot audio on that turn's `turn` span as its `input` and `output`. Uses only aiohttp; no
+  `langfuse` package dependency.

--- a/changelog/5285.changed.md
+++ b/changelog/5285.changed.md
@@ -1,0 +1,4 @@
+- BREAKING: `AudioBufferProcessor`'s `on_user_turn_audio_data` and
+  `on_bot_turn_audio_data` events now pass a trailing `turn_number` argument
+  (0 when no turn tracker is attached). Existing handlers for these two events
+  need the parameter added to their signature.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -12,6 +12,8 @@ various audio formats used in Pipecat pipelines.
 """
 
 import audioop
+import io
+import wave
 
 import loudness
 import numpy as np
@@ -104,6 +106,30 @@ def interleave_stereo_audio(left_audio: bytes, right_audio: bytes) -> bytes:
     stereo = np.column_stack((left, right))
 
     return stereo.astype(np.int16).tobytes()
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+    """Wrap raw PCM audio in a WAV container.
+
+    The PCM data is expected to be signed 16-bit little-endian samples, which
+    is what Pipecat pipelines carry (e.g. what ``AudioBufferProcessor`` emits
+    from its audio event handlers).
+
+    Args:
+        pcm: Raw PCM audio data (16-bit signed integers).
+        sample_rate: Sample rate of the audio in Hz.
+        num_channels: Number of interleaved channels in the PCM data.
+
+    Returns:
+        A complete in-memory WAV file as bytes.
+    """
+    with io.BytesIO() as buffer:
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(num_channels)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(pcm)
+        return buffer.getvalue()
 
 
 def normalize_value(value, min_value, max_value):

--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -42,8 +42,10 @@ class AudioBufferProcessor(FrameProcessor):
 
     - on_audio_data: Triggered when buffer_size is reached, providing merged audio
     - on_track_audio_data: Triggered when buffer_size is reached, providing separate tracks
-    - on_user_turn_audio_data: Triggered when user turn has ended, providing that user turn's audio
-    - on_bot_turn_audio_data: Triggered when bot turn has ended, providing that bot turn's audio
+    - on_user_turn_audio_data: Triggered when user turn has ended, providing that user turn's
+      audio and its turn number (see :meth:`set_turn_tracker`)
+    - on_bot_turn_audio_data: Triggered when bot turn has ended, providing that bot turn's
+      audio and its turn number (see :meth:`set_turn_tracker`)
     - on_recording_started: Triggered when recording starts (state transitions to active)
     - on_recording_stopped: Triggered after recording stops and the final audio has been emitted
 
@@ -94,6 +96,7 @@ class AudioBufferProcessor(FrameProcessor):
         self._bot_speaking = False
         self._user_turn_audio_buffer = bytearray()
         self._bot_turn_audio_buffer = bytearray()
+        self._turn_number = 0
 
         self._recording = False
 
@@ -154,6 +157,27 @@ class AudioBufferProcessor(FrameProcessor):
             )
         else:
             return b""
+
+    def set_turn_tracker(self, turn_tracker):
+        """Number turn audio events with the tracker's turn numbers.
+
+        The pipeline is usually built before the object that owns the turn
+        tracker (e.g. the pipeline worker), so the tracker is attached after
+        construction rather than passed to it.
+
+        Args:
+            turn_tracker: A ``TurnTrackingObserver``, e.g. the pipeline
+                worker's ``turn_tracking_observer``. When set, the
+                ``on_user_turn_audio_data`` and ``on_bot_turn_audio_data``
+                events report the turn number the audio belongs to, so a clip
+                can be matched to that turn elsewhere (turn spans in tracing,
+                per-turn evals, storage keys). Without a tracker the turn
+                number is always 0.
+        """
+
+        @turn_tracker.event_handler("on_turn_started")
+        async def on_turn_started(tracker, turn_number: int):
+            self._turn_number = turn_number
 
     async def start_recording(self):
         """Start recording audio from both user and bot.
@@ -359,12 +383,20 @@ class AudioBufferProcessor(FrameProcessor):
         # _process_recording so it is always up-to-date here.
         if isinstance(frame, UserStoppedSpeakingFrame):
             await self._call_event_handler(
-                "on_user_turn_audio_data", self._user_turn_audio_buffer, self.sample_rate, 1
+                "on_user_turn_audio_data",
+                self._user_turn_audio_buffer,
+                self.sample_rate,
+                1,
+                self._turn_number,
             )
             self._user_turn_audio_buffer = bytearray()
         elif isinstance(frame, BotStoppedSpeakingFrame):
             await self._call_event_handler(
-                "on_bot_turn_audio_data", self._bot_turn_audio_buffer, self.sample_rate, 1
+                "on_bot_turn_audio_data",
+                self._bot_turn_audio_buffer,
+                self.sample_rate,
+                1,
+                self._turn_number,
             )
             self._bot_turn_audio_buffer = bytearray()
 

--- a/src/pipecat/utils/tracing/langfuse.py
+++ b/src/pipecat/utils/tracing/langfuse.py
@@ -1,0 +1,466 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Attach conversation audio to a Langfuse trace.
+
+Pipecat sends spans to Langfuse over OTLP, but Langfuse media does not travel over OTLP.
+Audio is uploaded out of band through the media REST API and linked to a trace, or to a
+single observation inside it, by id. Langfuse renders a player from that link alone, so
+nothing has to be written into the span payload and no span has to still be open.
+
+That gives two levels of playback:
+
+- The whole call, linked to the trace, playable from the trace root.
+- Each turn, linked to that turn's ``turn`` span. The user's speech lands on the span's
+  ``input`` and the bot's reply on its ``output``, so clicking a turn plays just that turn.
+
+Because linking is by id, all uploading happens after the pipeline has shut down. Turn span
+ids stay available through ``TurnTraceObserver.get_turn_context()``, which retains them for
+the life of the observer.
+
+The media API is called directly over aiohttp. The ``langfuse`` Python package is not used:
+its full client starts a second OpenTelemetry tracer provider, which conflicts with
+Pipecat's ``setup_tracing()``, and its ``LangfuseMedia`` class only uploads media embedded
+in spans the Langfuse SDK itself created, and these spans come from Pipecat.
+
+Example::
+
+    audiobuffer = AudioBufferProcessor(num_channels=2, buffer_size=0, enable_turn_audio=True)
+    uploader = LangfuseRecordingUploader.from_env()
+    if uploader:
+        uploader.attach(audiobuffer, turn_tracker=worker.turn_tracking_observer)
+
+    # In on_client_disconnected, while the pipeline still runs:
+    await uploader.stop_and_collect(audiobuffer, worker)
+
+    # After the runner returns:
+    await uploader.upload(worker)
+
+See https://langfuse.com/docs/observability/features/multi-modality
+"""
+
+import asyncio
+import base64
+import hashlib
+import os
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
+
+import aiohttp
+from loguru import logger
+
+from pipecat.audio.utils import pcm_to_wav
+
+if TYPE_CHECKING:
+    from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+
+# AudioBufferProcessor emits raw signed 16-bit little-endian PCM.
+SAMPLE_WIDTH_BYTES = 2
+
+# Stereo 24kHz s16 is roughly 350MB/hour, so cap the whole-call recording well below what
+# Langfuse would accept and truncate loudly rather than exhausting the container.
+DEFAULT_MAX_BYTES = 100 * 1024 * 1024
+
+# How long to wait after the recording stops for the final on_audio_data event. Pipecat
+# dispatches async event handlers as fire-and-forget tasks, so the audio arrives on a
+# different task than the one that stopped the recording.
+DEFAULT_FLUSH_TIMEOUT_S = 5.0
+
+# Turn clips are uploaded one per turn per speaker, and every upload costs two calls against
+# Langfuse's general API rate limit (30/min on Hobby, 100/min on Core). Cap how many turns
+# get clips so a long call degrades to "the first N turns have audio" instead of a wall of
+# 429s. The whole-call recording is always uploaded first.
+DEFAULT_MAX_TURN_CLIPS = 40
+
+# Uploads run a couple at a time. Higher concurrency just hits the rate limit sooner.
+UPLOAD_CONCURRENCY = 2
+
+
+class LangfuseRecordingUploader:
+    """Uploads Pipecat call audio to Langfuse and links it to the trace and its turns."""
+
+    def __init__(
+        self,
+        host: str,
+        public_key: str,
+        secret_key: str,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        max_turn_clips: int = DEFAULT_MAX_TURN_CLIPS,
+        flush_timeout_s: float = DEFAULT_FLUSH_TIMEOUT_S,
+    ):
+        """Initialize the uploader.
+
+        Args:
+            host: Langfuse base URL, e.g. ``https://cloud.langfuse.com``.
+            public_key: Langfuse public key, used as the HTTP Basic username.
+            secret_key: Langfuse secret key, used as the HTTP Basic password.
+            max_bytes: Truncate the whole-call recording beyond this many bytes of PCM.
+            max_turn_clips: Upload per-turn audio for at most this many turns.
+            flush_timeout_s: How long to wait for the final audio event after stopping.
+        """
+        self._host = host.rstrip("/")
+        # Built by hand so the presigned storage PUT can stay auth-free: session-level
+        # auth would leak onto it, and aiohttp's per-request auth= is deprecated.
+        credentials = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+        self._auth_headers = {"Authorization": f"Basic {credentials}"}
+        self._max_bytes = max_bytes
+        self._max_turn_clips = max_turn_clips
+        self._flush_timeout_s = flush_timeout_s
+
+        # Whole-call recording.
+        self._pcm = bytearray()
+        self._sample_rate: int | None = None
+        self._num_channels: int | None = None
+        self._truncated = False
+        self._audio_ready = asyncio.Event()
+
+        # Per-turn clips: {turn_number: {"input": pcm, "output": pcm}}.
+        self._turn_clips: dict[int, dict[str, bytes]] = {}
+        self._turn_sample_rate: int | None = None
+
+        # Captured while the pipeline is still running, see stop_and_collect().
+        self._trace_id: str | None = None
+
+    @classmethod
+    def from_env(cls, **kwargs) -> Optional["LangfuseRecordingUploader"]:
+        """Build an uploader from ``LANGFUSE_*`` env vars, or None if they are not all set.
+
+        Reads ``LANGFUSE_PUBLIC_KEY``, ``LANGFUSE_SECRET_KEY``, and ``LANGFUSE_HOST``
+        (defaulting to Langfuse Cloud). Also warns when the media host and the OTLP
+        endpoint point at different Langfuse regions, because that split sends the audio
+        to a different project than the trace with no error anywhere.
+
+        Args:
+            **kwargs: Additional arguments passed to the constructor.
+        """
+        host = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+        public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+        secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+
+        if not public_key or not secret_key:
+            logger.info(
+                "Langfuse recording disabled: set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY "
+                "to attach call audio to traces"
+            )
+            return None
+
+        _warn_on_region_mismatch(host)
+
+        return cls(host=host, public_key=public_key, secret_key=secret_key, **kwargs)
+
+    def attach(self, audio_buffer: "AudioBufferProcessor", turn_tracker=None) -> None:
+        """Capture audio from the processor.
+
+        Construct the processor with ``num_channels=2`` for a stereo whole-call recording
+        (user left, bot right), and ``enable_turn_audio=True`` to also get per-turn clips.
+
+        Args:
+            audio_buffer: The pipeline's ``AudioBufferProcessor``.
+            turn_tracker: The worker's ``turn_tracking_observer``. Attached to the
+                processor with ``set_turn_tracker()`` so clips arrive numbered and can be
+                matched to their turn spans. Without it, only the whole-call recording is
+                uploaded.
+        """
+
+        @audio_buffer.event_handler("on_audio_data")
+        async def on_audio_data(buffer, audio: bytes, sample_rate: int, num_channels: int):
+            if num_channels != 2:
+                logger.warning(
+                    f"Langfuse recording: num_channels={num_channels}; use num_channels=2 "
+                    "for a stereo (user left / bot right) recording that preserves barge-in"
+                )
+
+            self._sample_rate = sample_rate
+            self._num_channels = num_channels
+
+            remaining = self._max_bytes - len(self._pcm)
+            if remaining <= 0:
+                self._truncated = True
+            elif len(audio) > remaining:
+                self._pcm.extend(audio[:remaining])
+                self._truncated = True
+            else:
+                self._pcm.extend(audio)
+
+            self._audio_ready.set()
+
+        if turn_tracker is None:
+            logger.debug("Langfuse recording: no turn tracker, per-turn audio disabled")
+            return
+
+        audio_buffer.set_turn_tracker(turn_tracker)
+
+        # Turn audio arrives mono, one buffer per speaker per turn. The user's clip is the
+        # turn's input and the bot's is its output, which is how they are filed in Langfuse.
+        @audio_buffer.event_handler("on_user_turn_audio_data")
+        async def on_user_turn_audio_data(buffer, audio, sample_rate, num_channels, turn_number):
+            self._store_turn_clip("input", bytes(audio), sample_rate, turn_number)
+
+        @audio_buffer.event_handler("on_bot_turn_audio_data")
+        async def on_bot_turn_audio_data(buffer, audio, sample_rate, num_channels, turn_number):
+            self._store_turn_clip("output", bytes(audio), sample_rate, turn_number)
+
+    def _store_turn_clip(self, field: str, audio: bytes, sample_rate: int, turn_number: int):
+        if not audio or not turn_number:
+            return
+        self._turn_sample_rate = sample_rate
+        self._turn_clips.setdefault(turn_number, {})[field] = audio
+
+    async def stop_and_collect(self, audio_buffer: "AudioBufferProcessor", worker=None) -> None:
+        """Stop recording and wait for the final audio event.
+
+        Call this while the pipeline is still running, before cancelling the worker. The
+        upload itself can happen later.
+
+        Args:
+            audio_buffer: The pipeline's ``AudioBufferProcessor``.
+            worker: The ``PipelineWorker``. Passing it lets the trace id be read while the
+                spans are still open, which is the most reliable moment to do it.
+        """
+        if worker is not None:
+            self._trace_id = self._resolve_trace_id(getattr(worker, "turn_trace_observer", None))
+
+        try:
+            await audio_buffer.stop_recording()
+            await asyncio.wait_for(self._audio_ready.wait(), timeout=self._flush_timeout_s)
+        except TimeoutError:
+            logger.warning(
+                f"Langfuse recording: no audio within {self._flush_timeout_s}s of stopping"
+            )
+        except Exception as e:
+            logger.warning(f"Langfuse recording: could not collect audio: {e}")
+
+    async def upload(self, worker) -> None:
+        """Upload the recording and per-turn clips, and link them to the trace.
+
+        Safe to call after the pipeline has shut down. Never raises: a recording that fails
+        to upload must not turn into a failed call.
+
+        Args:
+            worker: The ``PipelineWorker`` that ran the conversation.
+        """
+        try:
+            await self._upload(worker)
+        except Exception as e:
+            logger.warning(f"Langfuse recording: upload failed, continuing without audio: {e}")
+
+    async def _upload(self, worker) -> None:
+        trace_observer = getattr(worker, "turn_trace_observer", None)
+        if trace_observer is None:
+            logger.debug("Langfuse recording: tracing is off, skipping upload")
+            return
+
+        trace_id = self._trace_id or self._resolve_trace_id(trace_observer)
+        if not trace_id:
+            logger.warning("Langfuse recording: no trace id available, skipping upload")
+            return
+
+        async with aiohttp.ClientSession() as session:
+            semaphore = asyncio.Semaphore(UPLOAD_CONCURRENCY)
+            uploads = [self._upload_full_recording(session, semaphore, trace_id)]
+            uploads += self._turn_uploads(session, semaphore, trace_id, trace_observer)
+            results = await asyncio.gather(*uploads, return_exceptions=True)
+
+        attached = sum(1 for r in results if r is True)
+        logger.info(
+            f"Langfuse recording: attached {attached}/{len(results)} clips to trace {trace_id}"
+        )
+
+    def _resolve_trace_id(self, trace_observer) -> str | None:
+        """Find the trace id, preferring public observer API.
+
+        Tries, in order: any recorded turn's context (retained for the life of the
+        observer, so this works long after the spans close), the live turn context, and
+        finally the conversation span (public as ``conversation_span`` from
+        pipecat-ai/pipecat#5272 onward, private before that).
+        """
+        if trace_observer is None:
+            return None
+
+        for turn_number in range(1, max(max(self._turn_clips, default=0), 10) + 1):
+            context = trace_observer.get_turn_context(turn_number)
+            if context is not None:
+                return format(context.trace_id, "032x")
+
+        context = trace_observer.get_current_turn_context()
+        if context is not None:
+            return format(context.trace_id, "032x")
+
+        span = getattr(trace_observer, "conversation_span", None) or getattr(
+            trace_observer, "_conversation_span", None
+        )
+        if span is not None:
+            return format(span.get_span_context().trace_id, "032x")
+        return None
+
+    async def _upload_full_recording(self, session, semaphore, trace_id: str) -> bool:
+        if not self._pcm or not self._sample_rate:
+            logger.warning("Langfuse recording: recording was empty, nothing to upload")
+            return False
+
+        if self._truncated:
+            logger.warning(
+                f"Langfuse recording: truncated at {self._max_bytes} bytes of PCM; "
+                "the uploaded audio is shorter than the call"
+            )
+
+        num_channels = self._num_channels or 1
+        wav = await asyncio.to_thread(pcm_to_wav, bytes(self._pcm), self._sample_rate, num_channels)
+        async with semaphore:
+            media_id = await self._upload_one(session, wav, trace_id, None, "output")
+        if media_id:
+            duration = len(self._pcm) / (self._sample_rate * SAMPLE_WIDTH_BYTES * num_channels)
+            logger.info(
+                f"Langfuse recording: whole call attached "
+                f"(mediaId={media_id}, {duration:.1f}s, trace {trace_id})"
+            )
+        return bool(media_id)
+
+    def _turn_uploads(self, session, semaphore, trace_id: str, trace_observer) -> list:
+        uploads = []
+        dropped = 0
+        for turn_number, clips in sorted(self._turn_clips.items()):
+            context = trace_observer.get_turn_context(turn_number)
+            if context is None:
+                continue
+            if len(uploads) >= self._max_turn_clips * 2:
+                dropped += len(clips)
+                continue
+            observation_id = format(context.span_id, "016x")
+            for field, pcm in clips.items():
+                uploads.append(
+                    self._upload_turn_clip(
+                        session, semaphore, trace_id, observation_id, field, pcm, turn_number
+                    )
+                )
+        if dropped:
+            logger.warning(
+                f"Langfuse recording: skipped {dropped} turn clips past the "
+                f"max_turn_clips={self._max_turn_clips} cap to stay under the API rate limit"
+            )
+        return uploads
+
+    async def _upload_turn_clip(
+        self, session, semaphore, trace_id, observation_id, field, pcm, turn_number
+    ) -> bool:
+        # Turn audio is always mono, one speaker per clip.
+        wav = await asyncio.to_thread(pcm_to_wav, pcm, self._turn_sample_rate or 24000, 1)
+        async with semaphore:
+            media_id = await self._upload_one(session, wav, trace_id, observation_id, field)
+        if media_id:
+            logger.debug(
+                f"Langfuse recording: turn {turn_number} {field} attached (mediaId={media_id})"
+            )
+        return bool(media_id)
+
+    async def _upload_one(
+        self,
+        session: aiohttp.ClientSession,
+        wav: bytes,
+        trace_id: str,
+        observation_id: str | None,
+        field: str,
+    ) -> str | None:
+        """Run Langfuse's three-call media upload. Returns the mediaId, or None."""
+        # Langfuse validates a base64 SHA-256 digest, not hex.
+        digest = base64.b64encode(hashlib.sha256(wav).digest()).decode()
+
+        body = {
+            "traceId": trace_id,
+            "contentType": "audio/wav",
+            "contentLength": len(wav),
+            "sha256Hash": digest,
+            "field": field,
+        }
+        if observation_id:
+            body["observationId"] = observation_id
+
+        payload = await self._post_media(session, body)
+        if payload is None:
+            return None
+
+        media_id = payload["mediaId"]
+        upload_url = payload.get("uploadUrl")
+
+        # The media API is content addressed. Identical bytes return the same mediaId with a
+        # null uploadUrl, already linked, so there is nothing left to upload.
+        if not upload_url:
+            return media_id
+
+        started_at = time.monotonic()
+        async with session.put(
+            upload_url,
+            data=wav,
+            headers={"Content-Type": "audio/wav", "x-amz-checksum-sha256": digest},
+        ) as response:
+            upload_status = response.status
+            if upload_status >= 400:
+                logger.warning(
+                    f"Langfuse recording: upload failed ({upload_status}): {await response.text()}"
+                )
+                return None
+        upload_ms = int((time.monotonic() - started_at) * 1000)
+
+        # Reporting success is what lets a later upload of identical bytes short circuit.
+        async with session.patch(
+            f"{self._host}/api/public/media/{media_id}",
+            json={
+                "uploadedAt": datetime.now(UTC).isoformat(),
+                "uploadHttpStatus": upload_status,
+                "uploadTimeMs": upload_ms,
+            },
+            headers=self._auth_headers,
+        ) as response:
+            if response.status >= 400:
+                logger.warning(f"Langfuse recording: could not confirm upload ({response.status})")
+
+        return media_id
+
+    async def _post_media(self, session: aiohttp.ClientSession, body: dict) -> dict | None:
+        """Request an upload URL, retrying once if we are rate limited."""
+        for attempt in (1, 2):
+            async with session.post(
+                f"{self._host}/api/public/media", json=body, headers=self._auth_headers
+            ) as response:
+                if response.status == 429 and attempt == 1:
+                    delay = float(response.headers.get("Retry-After", 2))
+                    logger.warning(
+                        f"Langfuse recording: rate limited, retrying in {delay:.0f}s. "
+                        "Lower max_turn_clips if this keeps happening."
+                    )
+                    await asyncio.sleep(min(delay, 10))
+                    continue
+                if response.status >= 400:
+                    logger.warning(
+                        f"Langfuse recording: media request failed ({response.status}): "
+                        f"{await response.text()}"
+                    )
+                    return None
+                return await response.json()
+        return None
+
+
+def _warn_on_region_mismatch(host: str) -> None:
+    """Warn when the media host and the OTLP endpoint point at different Langfuse regions.
+
+    Spans and media travel over two different URLs. If they disagree, the audio lands in a
+    different project than the trace and no player appears, with no error anywhere.
+    """
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return
+
+    media_host = urlparse(host).netloc
+    otlp_host = urlparse(endpoint).netloc
+    if media_host and otlp_host and media_host != otlp_host:
+        logger.warning(
+            f"Langfuse recording: LANGFUSE_HOST ({media_host}) and "
+            f"OTEL_EXPORTER_OTLP_ENDPOINT ({otlp_host}) are different hosts. The recording "
+            "will upload to a different project than the trace, so no audio player will "
+            "appear. Point both at the same region."
+        )

--- a/src/pipecat/utils/tracing/langfuse.py
+++ b/src/pipecat/utils/tracing/langfuse.py
@@ -225,15 +225,24 @@ class LangfuseRecordingUploader:
         if worker is not None:
             self._trace_id = self._resolve_trace_id(getattr(worker, "turn_trace_observer", None))
 
+        flush_event = asyncio.Event()
+
+        async def _on_stop_flush(_, audio: bytes, sample_rate: int, num_channels: int) -> None:
+            flush_event.set()
+
+        audio_buffer.add_event_handler("on_audio_data", _on_stop_flush)
         try:
             await audio_buffer.stop_recording()
-            await asyncio.wait_for(self._audio_ready.wait(), timeout=self._flush_timeout_s)
+            await asyncio.wait_for(flush_event.wait(), timeout=self._flush_timeout_s)
         except TimeoutError:
-            logger.warning(
-                f"Langfuse recording: no audio within {self._flush_timeout_s}s of stopping"
-            )
+            if not self._pcm:
+                logger.warning(
+                    f"Langfuse recording: no audio within {self._flush_timeout_s}s of stopping"
+                )
         except Exception as e:
             logger.warning(f"Langfuse recording: could not collect audio: {e}")
+        finally:
+            audio_buffer.remove_event_handler("on_audio_data", _on_stop_flush)
 
     async def upload(self, worker) -> None:
         """Upload the recording and per-turn clips, and link them to the trace.

--- a/src/pipecat/utils/tracing/langfuse.py
+++ b/src/pipecat/utils/tracing/langfuse.py
@@ -272,12 +272,12 @@ class LangfuseRecordingUploader:
         )
 
     def _resolve_trace_id(self, trace_observer) -> str | None:
-        """Find the trace id, preferring public observer API.
+        """Find the trace id.
 
         Tries, in order: any recorded turn's context (retained for the life of the
         observer, so this works long after the spans close), the live turn context, and
-        finally the conversation span (public as ``conversation_span`` from
-        pipecat-ai/pipecat#5272 onward, private before that).
+        finally the observer's conversation span. Turn 1 starts with the conversation,
+        so the last resort only matters when tracing is on but no turn ever started.
         """
         if trace_observer is None:
             return None
@@ -291,9 +291,7 @@ class LangfuseRecordingUploader:
         if context is not None:
             return format(context.trace_id, "032x")
 
-        span = getattr(trace_observer, "conversation_span", None) or getattr(
-            trace_observer, "_conversation_span", None
-        )
+        span = getattr(trace_observer, "_conversation_span", None)
         if span is not None:
             return format(span.get_span_context().trace_id, "032x")
         return None

--- a/tests/test_audio_buffer_processor.py
+++ b/tests/test_audio_buffer_processor.py
@@ -23,6 +23,8 @@ from pipecat.frames.frames import (
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
+from pipecat.observers.base_observer import FramePushed
+from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.tests.utils import run_test
@@ -37,7 +39,11 @@ class _PassthroughResampler:
 
 
 async def _make_processor(
-    *, buffer_size: int = 0, start: bool = True, auto_start: bool = False
+    *,
+    buffer_size: int = 0,
+    start: bool = True,
+    auto_start: bool = False,
+    enable_turn_audio: bool = False,
 ) -> AudioBufferProcessor:
     """Create a processor ready to record.
 
@@ -53,6 +59,7 @@ async def _make_processor(
         num_channels=2,
         buffer_size=buffer_size,
         auto_start_recording=auto_start,
+        enable_turn_audio=enable_turn_audio,
     )
     processor._input_resampler = _PassthroughResampler()
     processor._output_resampler = _PassthroughResampler()
@@ -1001,6 +1008,94 @@ class TestRecordingLifecycleEvents(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0.05)
         self.assertEqual(len(stopped), 0)
         await p.cleanup()
+
+
+class TestTurnAudioTurnNumbers(unittest.IsolatedAsyncioTestCase):
+    """Tests for turn numbers on the turn audio events.
+
+    With a turn tracker attached (set_turn_tracker), on_user_turn_audio_data and
+    on_bot_turn_audio_data report the tracker's turn number, so a clip can be
+    matched to its turn elsewhere. Without one, the turn number is always 0.
+    """
+
+    async def _drive_tracker(self, tracker, frame):
+        """Push a frame through the tracker and let its event tasks run."""
+        await tracker.on_push_frame(
+            FramePushed(
+                source=None,  # type: ignore[arg-type]
+                destination=None,  # type: ignore[arg-type]
+                frame=frame,
+                direction=FrameDirection.DOWNSTREAM,
+                timestamp=0,
+            )
+        )
+        await asyncio.sleep(0.01)
+
+    async def _speak_user(self, p):
+        await p.process_frame(UserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        await p.process_frame(
+            InputAudioRawFrame(
+                audio=struct.pack("<hh", 1000, -1000), sample_rate=16000, num_channels=1
+            ),
+            FrameDirection.DOWNSTREAM,
+        )
+        await p.process_frame(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        await asyncio.sleep(0.01)
+
+    async def test_turn_number_is_zero_without_tracker(self):
+        p = await _make_processor(enable_turn_audio=True)
+
+        turns = []
+        p.add_event_handler(
+            "on_user_turn_audio_data",
+            lambda _, audio, sample_rate, num_channels, turn_number: turns.append(turn_number),
+        )
+
+        await self._speak_user(p)
+        self.assertEqual(turns, [0])
+        await p.cleanup()
+
+    async def test_turn_numbers_follow_tracker(self):
+        p = await _make_processor(enable_turn_audio=True)
+        tracker = TurnTrackingObserver()
+        p.set_turn_tracker(tracker)
+
+        user_turns = []
+        bot_turns = []
+        p.add_event_handler(
+            "on_user_turn_audio_data",
+            lambda _, audio, sample_rate, num_channels, turn_number: user_turns.append(turn_number),
+        )
+        p.add_event_handler(
+            "on_bot_turn_audio_data",
+            lambda _, audio, sample_rate, num_channels, turn_number: bot_turns.append(turn_number),
+        )
+
+        # Turn 1 starts when the pipeline starts.
+        await self._drive_tracker(tracker, StartFrame())
+        await self._speak_user(p)
+
+        # Bot reply, still turn 1.
+        await p.process_frame(BotStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        await p.process_frame(
+            OutputAudioRawFrame(
+                audio=struct.pack("<hh", 500, -500), sample_rate=16000, num_channels=1
+            ),
+            FrameDirection.DOWNSTREAM,
+        )
+        await p.process_frame(BotStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        await asyncio.sleep(0.01)
+
+        # The user speaking again after the bot's reply starts turn 2.
+        await self._drive_tracker(tracker, BotStartedSpeakingFrame())
+        await self._drive_tracker(tracker, BotStoppedSpeakingFrame())
+        await self._drive_tracker(tracker, UserStartedSpeakingFrame())
+        await self._speak_user(p)
+
+        self.assertEqual(user_turns, [1, 2])
+        self.assertEqual(bot_turns, [1])
+        await p.cleanup()
+        await tracker.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import io
+import unittest
+import wave
+
+from pipecat.audio.utils import pcm_to_wav
+
+
+class TestPcmToWav(unittest.TestCase):
+    def _read_wav(self, data: bytes):
+        with wave.open(io.BytesIO(data), "rb") as wav_file:
+            return (
+                wav_file.getnchannels(),
+                wav_file.getsampwidth(),
+                wav_file.getframerate(),
+                wav_file.readframes(wav_file.getnframes()),
+            )
+
+    def test_mono(self):
+        pcm = b"\x01\x00" * 1600  # 0.1s of a constant sample at 16kHz
+        wav = pcm_to_wav(pcm, 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 1)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, pcm)
+
+    def test_stereo(self):
+        pcm = b"\x01\x00\x02\x00" * 2400  # 0.1s of interleaved stereo at 24kHz
+        wav = pcm_to_wav(pcm, 24000, num_channels=2)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 2)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 24000)
+        self.assertEqual(frames, pcm)
+
+    def test_empty(self):
+        wav = pcm_to_wav(b"", 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_langfuse_uploader.py
+++ b/tests/test_langfuse_uploader.py
@@ -1,0 +1,208 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from pipecat.utils.tracing.langfuse import LangfuseRecordingUploader
+
+TRACE_ID = int("ab" * 16, 16)
+
+
+class _FakeTurnContext:
+    def __init__(self, trace_id: int, span_id: int):
+        self.trace_id = trace_id
+        self.span_id = span_id
+
+
+class _FakeTraceObserver:
+    """Stands in for TurnTraceObserver: turn contexts for known turns, nothing else."""
+
+    def __init__(self, turns: dict[int, int]):
+        self._turns = {n: _FakeTurnContext(TRACE_ID, span_id) for n, span_id in turns.items()}
+
+    def get_turn_context(self, turn_number: int):
+        return self._turns.get(turn_number)
+
+    def get_current_turn_context(self):
+        return None
+
+
+class _FakeLangfuse:
+    """A local Langfuse media API: records requests, serves presigned upload URLs."""
+
+    def __init__(self):
+        self.posts = []
+        self.puts = []
+        self.patches = []
+        self.dedup = False
+        self._counter = 0
+
+        app = web.Application()
+        app.router.add_post("/api/public/media", self._post_media)
+        app.router.add_put("/storage/{media_id}", self._put_storage)
+        app.router.add_patch("/api/public/media/{media_id}", self._patch_media)
+        self.server = TestServer(app)
+
+    async def __aenter__(self):
+        await self.server.start_server()
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.server.close()
+
+    @property
+    def host(self) -> str:
+        return str(self.server.make_url("")).rstrip("/")
+
+    async def _post_media(self, request: web.Request) -> web.Response:
+        body = await request.json()
+        self.posts.append({"auth": request.headers.get("Authorization"), **body})
+        self._counter += 1
+        media_id = f"media-{self._counter}"
+        upload_url = None if self.dedup else str(self.server.make_url(f"/storage/{media_id}"))
+        return web.json_response({"mediaId": media_id, "uploadUrl": upload_url})
+
+    async def _put_storage(self, request: web.Request) -> web.Response:
+        self.puts.append(
+            {
+                "media_id": request.match_info["media_id"],
+                "auth": request.headers.get("Authorization"),
+                "checksum": request.headers.get("x-amz-checksum-sha256"),
+                "content_type": request.headers.get("Content-Type"),
+                "size": len(await request.read()),
+            }
+        )
+        return web.Response()
+
+    async def _patch_media(self, request: web.Request) -> web.Response:
+        body = await request.json()
+        self.patches.append({"media_id": request.match_info["media_id"], **body})
+        return web.Response()
+
+
+def _make_uploader(host: str) -> LangfuseRecordingUploader:
+    uploader = LangfuseRecordingUploader(host=host, public_key="pk-test", secret_key="sk-test")
+    # Preload collected audio, as if attach()/stop_and_collect() already ran.
+    uploader._pcm = bytearray(b"\x01\x00" * 3200)  # 0.1s stereo at 16kHz
+    uploader._sample_rate = 16000
+    uploader._num_channels = 2
+    uploader._turn_clips = {
+        1: {"input": b"\x02\x00" * 800, "output": b"\x03\x00" * 800},
+        2: {"input": b"\x04\x00" * 800},
+    }
+    uploader._turn_sample_rate = 16000
+    return uploader
+
+
+class TestLangfuseRecordingUploader(unittest.IsolatedAsyncioTestCase):
+    async def test_uploads_whole_call_and_turn_clips(self):
+        async with _FakeLangfuse() as langfuse:
+            uploader = _make_uploader(langfuse.host)
+            observer = _FakeTraceObserver({1: 0x1111, 2: 0x2222})
+            worker = SimpleNamespace(turn_trace_observer=observer)
+
+            await uploader.upload(worker)
+
+        # Whole call + turn 1 input/output + turn 2 input.
+        self.assertEqual(len(langfuse.posts), 4)
+        self.assertEqual(len(langfuse.puts), 4)
+        self.assertEqual(len(langfuse.patches), 4)
+
+        trace_hex = format(TRACE_ID, "032x")
+        for post in langfuse.posts:
+            self.assertEqual(post["traceId"], trace_hex)
+            self.assertEqual(post["contentType"], "audio/wav")
+            self.assertTrue(post["auth"].startswith("Basic "))
+
+        whole_call = [p for p in langfuse.posts if "observationId" not in p]
+        self.assertEqual(len(whole_call), 1)
+        self.assertEqual(whole_call[0]["field"], "output")
+
+        turn_posts = [p for p in langfuse.posts if "observationId" in p]
+        self.assertEqual(
+            sorted((p["observationId"], p["field"]) for p in turn_posts),
+            [
+                (format(0x1111, "016x"), "input"),
+                (format(0x1111, "016x"), "output"),
+                (format(0x2222, "016x"), "input"),
+            ],
+        )
+
+        # The presigned PUT carries the checksum but no Langfuse auth.
+        for put in langfuse.puts:
+            self.assertIsNone(put["auth"])
+            self.assertTrue(put["checksum"])
+            self.assertEqual(put["content_type"], "audio/wav")
+
+        for patch_body in langfuse.patches:
+            self.assertEqual(patch_body["uploadHttpStatus"], 200)
+            self.assertIn("uploadedAt", patch_body)
+
+    async def test_dedup_skips_put_and_patch(self):
+        async with _FakeLangfuse() as langfuse:
+            langfuse.dedup = True
+            uploader = _make_uploader(langfuse.host)
+            observer = _FakeTraceObserver({1: 0x1111, 2: 0x2222})
+            worker = SimpleNamespace(turn_trace_observer=observer)
+
+            await uploader.upload(worker)
+
+        # A null uploadUrl means the content is already stored and linked.
+        self.assertEqual(len(langfuse.posts), 4)
+        self.assertEqual(len(langfuse.puts), 0)
+        self.assertEqual(len(langfuse.patches), 0)
+
+    async def test_turn_without_span_is_skipped(self):
+        async with _FakeLangfuse() as langfuse:
+            uploader = _make_uploader(langfuse.host)
+            # Only turn 1 has a span; turn 2's clip has nowhere to link.
+            observer = _FakeTraceObserver({1: 0x1111})
+            worker = SimpleNamespace(turn_trace_observer=observer)
+
+            await uploader.upload(worker)
+
+        self.assertEqual(len(langfuse.posts), 3)  # whole call + turn 1 input/output
+
+    async def test_no_trace_id_skips_upload(self):
+        async with _FakeLangfuse() as langfuse:
+            uploader = _make_uploader(langfuse.host)
+            worker = SimpleNamespace(turn_trace_observer=_FakeTraceObserver({}))
+
+            await uploader.upload(worker)
+
+        self.assertEqual(len(langfuse.posts), 0)
+
+    async def test_upload_never_raises(self):
+        # Point at a closed port; upload() must swallow the connection error.
+        uploader = _make_uploader("http://127.0.0.1:1")
+        worker = SimpleNamespace(turn_trace_observer=_FakeTraceObserver({1: 0x1111}))
+        await uploader.upload(worker)
+
+
+class TestFromEnv(unittest.TestCase):
+    def test_returns_none_without_keys(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertIsNone(LangfuseRecordingUploader.from_env())
+
+    def test_builds_uploader_with_keys(self):
+        env = {
+            "LANGFUSE_PUBLIC_KEY": "pk-test",
+            "LANGFUSE_SECRET_KEY": "sk-test",
+            "LANGFUSE_HOST": "https://cloud.langfuse.com/",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            uploader = LangfuseRecordingUploader.from_env()
+        self.assertIsNotNone(uploader)
+        self.assertEqual(uploader._host, "https://cloud.langfuse.com")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Brings the Langfuse call-recording integration into core as `pipecat.utils.tracing.langfuse.LangfuseRecordingUploader`, together with the two primitives it stands on:

- `LangfuseRecordingUploader`: captures audio from an `AudioBufferProcessor` and, after the pipeline has shut down, uploads it through the Langfuse media API and links it to the conversation's trace by id. Two levels of playback: the whole call (stereo, user left / bot right) on the trace root, and each turn's user/bot audio on that turn's `turn` span as its `input`/`output`.
- `AudioBufferProcessor.set_turn_tracker()`: attach the pipeline's `TurnTrackingObserver` and `on_user_turn_audio_data` / `on_bot_turn_audio_data` report the tracker's turn number for each clip. The tracker is the source of truth for turn numbering (it owns interruption and timeout semantics), so the processor takes the number from it instead of keeping a parallel counter that could drift.
- `pcm_to_wav()` in `pipecat.audio.utils`, next to the other PCM helpers. Every example that persists audio hand-rolls this, including the `pipecat init` server template.

## Why

This integration has lived as a 469-line copy-paste file in pipecat-examples (pipecat-ai/pipecat-examples#240). That is a bad distribution mechanism: users copy it and it rots in their repos when the media API or pipecat internals change. Most of the file is generic Pipecat glue (audio collection, turn correlation, trace-id resolution) that core can do better than any example, and `processors/metrics/sentry.py` already set the precedent for a vendor observability integration in core. With this PR the example collapses to a few lines: `from_env()`, `attach()`, `stop_and_collect()`, `upload()`.


## Breaking change

`on_user_turn_audio_data` and `on_bot_turn_audio_data` gain a trailing positional `turn_number` argument (0 when no tracker is attached). Event handlers are called with exact positional args, so existing handlers for these two events need the parameter added. These events are recent and niche; flagging for discussion whether a documented break or new event names is preferred.

## Test plan

- Verified end to end against Langfuse Cloud: a 9-turn, 3-minute audio eval through pipecat-ai/pipecat-examples#240 (running this branch) attached 17/17 clips, and the players render on the trace root and turn spans in the UI.

