### PR TITLE
fix(observers): cancel stale end-of-turn timer when a new turn starts

### DIFF
--- a/changelog/5286.fixed.md
+++ b/changelog/5286.fixed.md
@@ -1,0 +1,4 @@
+- Fixed a `TurnTrackingObserver` race where bot speech played while no turn was
+  active (e.g. a user-idle check-in) armed the end-of-turn timer, and a user
+  turn starting within the timeout window was then ended by that stale timer —
+  before the bot reply, with a tiny or negative reported duration.

--- a/src/pipecat/observers/turn_tracking_observer.py
+++ b/src/pipecat/observers/turn_tracking_observer.py
@@ -142,7 +142,10 @@ class TurnTrackingObserver(BaseObserver):
             await self._end_turn(data, was_interrupted=False)
             await self._start_turn(data)
         elif not self._is_turn_active:
-            # Start a new turn after previous one ended
+            # Start a new turn after previous one ended. Bot speech that played
+            # while no turn was active (e.g. an idle check-in) may have armed
+            # the end-turn timer; cancel it so it cannot end this new turn.
+            self._cancel_turn_end_timer()
             await self._start_turn(data)
         else:
             # User is speaking within the same turn (before bot has responded)

--- a/tests/test_turn_tracking_observer.py
+++ b/tests/test_turn_tracking_observer.py
@@ -441,6 +441,5 @@ class TestTurnTrackingObserver(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(turn_durations[2], 0.3)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_turn_tracking_observer.py
+++ b/tests/test_turn_tracking_observer.py
@@ -364,6 +364,83 @@ class TestTurnTrackingObserver(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(turn_events, expected_events)
         self.assertEqual(turn_observer._turn_count, 1)
 
+    async def test_stale_timer_from_unowned_bot_speech_does_not_end_new_turn(self):
+        """A pending end-turn timer must not end a turn that starts afterwards.
+
+        Bot speech that plays while no turn is active (e.g. an idle check-in)
+        arms the end-turn timer on BotStoppedSpeakingFrame. If the user starts
+        speaking within the timeout window, the new turn must survive that
+        stale timer and stay open until its own bot reply completes.
+        """
+        turn_observer = TurnTrackingObserver(turn_end_timeout_secs=0.2)
+        processor = IdentityFilter()
+
+        turn_events = []
+        turn_durations = {}
+
+        @turn_observer.event_handler("on_turn_started")
+        async def on_turn_started(observer, turn_number):
+            turn_events.append(f"Turn {turn_number} started")
+
+        @turn_observer.event_handler("on_turn_ended")
+        async def on_turn_ended(observer, turn_number, duration, was_interrupted):
+            turn_events.append(f"Turn {turn_number} ended (interrupted: {was_interrupted})")
+            turn_durations[turn_number] = duration
+
+        frames_to_send = [
+            # Turn 1: normal exchange, then let it end via timeout
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+            BotStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.4),  # > 0.2s: turn 1 ends, no turn active
+            # Un-owned bot speech (idle check-in) — arms the end-turn timer
+            BotStartedSpeakingFrame(),
+            BotStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.1),  # < 0.2s: timer still pending
+            # User answers inside the timeout window — turn 2 starts
+            UserStartedSpeakingFrame(),
+            SleepFrame(sleep=0.4),  # stale timer would fire here without the fix
+            UserStoppedSpeakingFrame(),
+            # The bot reply arrives after the stale window
+            BotStartedSpeakingFrame(),
+            BotStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.4),  # turn 2 ends via its own timeout
+        ]
+
+        expected_down_frames = [
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+            BotStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+            BotStoppedSpeakingFrame,
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            BotStartedSpeakingFrame,
+            BotStoppedSpeakingFrame,
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[turn_observer],
+        )
+
+        expected_events = [
+            "Turn 1 started",
+            "Turn 1 ended (interrupted: False)",
+            "Turn 2 started",
+            "Turn 2 ended (interrupted: False)",
+        ]
+        self.assertEqual(turn_events, expected_events)
+        # Without the fix the stale timer ends turn 2 before its bot reply,
+        # using the timestamp captured when the timer was armed — which
+        # precedes the turn start, producing a tiny/negative duration.
+        self.assertGreater(turn_durations[2], 0.3)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

`TurnTrackingObserver` arms an end-of-turn timer whenever the bot stops speaking. In `_handle_user_started_speaking`, two of the three turn-starting branches cancel any pending timer first — but the `not self._is_turn_active` branch does not. When bot speech plays while **no turn is active** (a user-idle check-in like "Are you still there?", or a bot utterance that resumes after the turn already timed out), its `BotStoppedSpeakingFrame` arms the timer, and if the user starts speaking within `turn_end_timeout_secs`, the stale timer fires and ends the freshly started turn — typically before the bot's reply begins.

Downstream effects: `on_turn_ended` fires with a tiny (often **negative**) duration — the timer's `FramePushed` timestamp predates the turn start — and with turn tracing enabled the reply's spans land outside every turn span, so per-turn metrics silently lose those turns. It also chains: each orphaned reply's own BotStopped arms the next stale timer, so a wait-loop conversation loses consecutive turns until the user pauses longer than the timeout.

Observed in production on a real call: four consecutive turns' spans each ended at exactly *previous BotStopped + 2.500s* (the default timeout) with the replies unattributed.

## Fix

Cancel the pending end-turn timer in the `not self._is_turn_active` branch before starting the new turn — the same cancellation the interruption and post-bot-speech branches already perform. A pending timer at turn start is stale by definition.

## Test

`test_stale_timer_from_unowned_bot_speech_does_not_end_new_turn`: turn 1 ends via timeout, un-owned bot speech arms the timer, the user starts speaking inside the window, and the reply arrives after the stale window. Without the fix the new turn is ended by the stale timer (duration ~0/negative); with it the turn survives to its own legitimate timeout close. Fails on `main`, passes with this change; existing tests unaffected (7 passed).

## Checklist
- [x] Ran tests: `pytest tests/test_turn_tracking_observer.py` — 7 passed (new test fails without the fix)
- [x] Changelog fragment added (follow-up commit with the PR number)
