### PR TITLE
Enforce a curated set of ruff's bugbear rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,18 +231,43 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
+    "B", # Likely bugs and design problems
     "D", # Docstring rules
     "F", # Pyflakes
     "I", # Import rules
     "UP", # Modern Python
 ]
 ignore = [
+    # Bugbear rules that do not fit this codebase.
+    #
+    # Base classes leave optional hooks empty so subclasses override only what
+    # they need. Marking them abstract, as B027 wants, would instead force every
+    # subclass to implement them, and BaseObject is a shared-behaviour base
+    # rather than an interface, so it has no abstract methods to declare.
+    "B024",
+    "B027",
+    #
+    # Bugbear rules worth adopting, each on its own once someone takes the
+    # sweep. Every entry below is a deferral, not a rejection: drop the line and
+    # fix what it reports.
+    "B007", # unused loop control variable — 23 sites, cosmetic
+    "B009", # getattr with a constant attribute — cosmetic
+    "B010", # setattr with a constant attribute — cosmetic
+    "B011", # `assert False` — cosmetic
+    "B904", # `raise ... from` — 48 sites, better tracebacks, no behaviour change
+    "B905", # `zip(strict=)` — 18 sites, each needs its own length-invariant call
+    #
     "D105",  # Missing docstring in magic methods (__str__, __repr__, etc.)
     # Unused imports are selected in .pre-commit-config.yaml instead, so they are
     # only stripped at commit time, not mid-development. A `--extend-select` on the
     # command line overrides this entry, so the hook still reports and fixes them.
     "F401",
 ]
+
+[tool.ruff.lint.flake8-bugbear]
+# Typer reads a CLI parameter's configuration from its default, so calling these
+# in a default argument is the documented idiom rather than a shared-state bug.
+extend-immutable-calls = ["typer.Argument", "typer.Option"]
 
 [tool.ruff.lint.per-file-ignores]
 # Skip docstring checks for non-source code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,9 +251,6 @@ ignore = [
     # sweep. Every entry below is a deferral, not a rejection: drop the line and
     # fix what it reports.
     "B007", # unused loop control variable — 23 sites, cosmetic
-    "B009", # getattr with a constant attribute — cosmetic
-    "B010", # setattr with a constant attribute — cosmetic
-    "B011", # `assert False` — cosmetic
     "B904", # `raise ... from` — 48 sites, better tracebacks, no behaviour change
     "B905", # `zip(strict=)` — 18 sites, each needs its own length-invariant call
     #

--- a/scripts/deprecations/scan.py
+++ b/scripts/deprecations/scan.py
@@ -305,7 +305,7 @@ def scan_source(src_root: Path, *, exclude: frozenset[str] = DEFAULT_EXCLUDE) ->
         for version, body, param in iter_directives(ast.get_docstring(tree) or ""):
             scan.directives.append(Directive(relpath, "<module>", param, version, body))
 
-        def visit(node, prefix: str, parent_is_class: bool) -> None:
+        def visit(node, prefix: str, parent_is_class: bool, relpath: str = relpath) -> None:
             for child in ast.iter_child_nodes(node):
                 if isinstance(child, ast.Assign):
                     for target in child.targets:

--- a/src/pipecat/observers/loggers/debug_log_observer.py
+++ b/src/pipecat/observers/loggers/debug_log_observer.py
@@ -135,7 +135,7 @@ class DebugLogObserver(BaseObserver):
         elif isinstance(value, (bytes, bytearray)):
             return f"{len(value)} bytes"
         elif hasattr(value, "get_messages_for_logging") and callable(
-            getattr(value, "get_messages_for_logging")
+            value.get_messages_for_logging
         ):
             # Special case for OpenAI context
             return f"{value.__class__.__name__} with messages: {value.get_messages_for_logging()}"

--- a/src/pipecat/pipeline/job_decorator.py
+++ b/src/pipecat/pipeline/job_decorator.py
@@ -57,7 +57,7 @@ def _collect_job_handlers(obj) -> dict[str, Callable]:
                 continue
             seen.add(attr_name)
             if callable(val) and getattr(val, "is_job_handler", False):
-                job_name: str = getattr(val, "job_name")
+                job_name: str = val.job_name
                 if job_name in handlers:
                     existing = handlers[job_name].__name__
                     raise ValueError(

--- a/src/pipecat/runner/utils.py
+++ b/src/pipecat/runner/utils.py
@@ -288,7 +288,8 @@ async def parse_telephony_websocket(websocket: "WebSocket"):
         # Only successful parses are cached; the raising paths stay retryable.
         # setattr (not attribute assignment) since WebSocket has no such declared
         # field; mirrors the getattr-based read above.
-        setattr(websocket, "_pipecat_parsed_telephony", result)
+        # setattr: the attribute is ours to stash, not part of WebSocket's type.
+        setattr(websocket, "_pipecat_parsed_telephony", result)  # noqa: B010
         return result
 
     except Exception as e:

--- a/src/pipecat/serializers/protobuf.py
+++ b/src/pipecat/serializers/protobuf.py
@@ -156,10 +156,10 @@ class ProtobufFrameSerializer(FrameSerializer):
 
         # Set special fields
         if id:
-            setattr(instance, "id", id)
+            instance.id = id
         if name:
-            setattr(instance, "name", name)
+            instance.name = name
         if pts:
-            setattr(instance, "pts", pts)
+            instance.pts = pts
 
         return instance

--- a/src/pipecat/services/nvidia/tts.py
+++ b/src/pipecat/services/nvidia/tts.py
@@ -734,7 +734,9 @@ class NvidiaTTSService(TTSService):
 
                     base_req = self._build_base_request()
 
-                    def request_gen():
+                    # Bound as defaults because the body runs when the stub iterates
+                    # the generator, by which point the loop may have moved on.
+                    def request_gen(base_req=base_req, chunk=chunk):
                         base_req.text = chunk
                         yield base_req
 

--- a/src/pipecat/services/speechmatics/stt.py
+++ b/src/pipecat/services/speechmatics/stt.py
@@ -1234,7 +1234,9 @@ class SpeechmaticsSTTService(STTService):
                     message = f"`{old}` is deprecated, use `InputParams.{new}`"
                 else:
                     message = f"`{old}` is deprecated and not used"
-                warnings.warn(message, DeprecationWarning)
+                # 3 frames out of this nested helper is the caller constructing
+                # the service, which is the code that has to change.
+                warnings.warn(message, DeprecationWarning, stacklevel=3)
 
         # List of deprecated arguments and their new location
         deprecated_args = [

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -170,7 +170,7 @@ class TTSService(AIService):
         # TTS output sample rate
         sample_rate: int | None = None,
         # Types of text aggregations that should not be spoken.
-        skip_aggregator_types: list[str] | None = [],
+        skip_aggregator_types: list[str] | None = None,
         # A list of callables to transform text before just before sending it to TTS.
         # Each callable takes the aggregated text and its type, and returns the transformed text.
         # To register, provide a list of tuples of (aggregation_type | '*', transform_function).

--- a/src/pipecat/transports/heygen/transport.py
+++ b/src/pipecat/transports/heygen/transport.py
@@ -327,7 +327,7 @@ class HeyGenTransport(BaseTransport):
         self,
         session: aiohttp.ClientSession,
         api_key: str,
-        params: HeyGenParams = HeyGenParams(),
+        params: HeyGenParams | None = None,
         input_name: str | None = None,
         output_name: str | None = None,
         session_request: LiveAvatarNewSessionRequest | NewSessionRequest | None = None,
@@ -351,6 +351,7 @@ class HeyGenTransport(BaseTransport):
             The transport will automatically join the same virtual room as the HeyGen Avatar
             and user through the HeyGenClient, which handles session initialization via HeyGenApi.
         """
+        params = params or HeyGenParams()
         super().__init__(input_name=input_name, output_name=output_name)
         self._params = params
         self._client = HeyGenClient(

--- a/src/pipecat/transports/lemonslice/transport.py
+++ b/src/pipecat/transports/lemonslice/transport.py
@@ -134,7 +134,7 @@ class LemonSliceTransportClient:
         self,
         *,
         bot_name: str,
-        params: LemonSliceParams = LemonSliceParams(),
+        params: LemonSliceParams | None = None,
         callbacks: LemonSliceCallbacks,
         api_key: str,
         session_request: LemonSliceNewSessionRequest | None = None,
@@ -150,6 +150,7 @@ class LemonSliceTransportClient:
             session_request: Session creation parameters.
             session: The aiohttp session for making async HTTP requests.
         """
+        params = params or LemonSliceParams()
         self._bot_name = bot_name
         self._api = LemonSliceApi(api_key, session)
         if session_request is None:
@@ -749,7 +750,7 @@ class LemonSliceTransport(BaseTransport):
         session: aiohttp.ClientSession,
         api_key: str,
         session_request: LemonSliceNewSessionRequest | None = None,
-        params: LemonSliceParams = LemonSliceParams(),
+        params: LemonSliceParams | None = None,
         input_name: str | None = None,
         output_name: str | None = None,
     ):
@@ -765,6 +766,7 @@ class LemonSliceTransport(BaseTransport):
             input_name: Optional name for the input transport.
             output_name: Optional name for the output transport.
         """
+        params = params or LemonSliceParams()
         super().__init__(input_name=input_name, output_name=output_name)
         self._params = params
 

--- a/src/pipecat/transports/tavus/transport.py
+++ b/src/pipecat/transports/tavus/transport.py
@@ -187,7 +187,7 @@ class TavusTransportClient:
         self,
         *,
         bot_name: str,
-        params: TavusParams = TavusParams(),
+        params: TavusParams | None = None,
         callbacks: TavusCallbacks,
         api_key: str,
         replica_id: str,
@@ -208,6 +208,7 @@ class TavusTransportClient:
                 `conversation.echo` app message API.
             session: The aiohttp session for making async HTTP requests.
         """
+        params = params or TavusParams()
         self._bot_name = bot_name
         self._api = TavusApi(api_key, session)
         self._replica_id = replica_id
@@ -891,7 +892,7 @@ class TavusTransport(BaseTransport):
         api_key: str,
         replica_id: str,
         persona_id: str = "pipecat0",
-        params: TavusParams = TavusParams(),
+        params: TavusParams | None = None,
         input_name: str | None = None,
         output_name: str | None = None,
     ):
@@ -910,6 +911,7 @@ class TavusTransport(BaseTransport):
             input_name: Optional name for the input transport.
             output_name: Optional name for the output transport.
         """
+        params = params or TavusParams()
         super().__init__(input_name=input_name, output_name=output_name)
         self._params = params
 

--- a/src/pipecat/transports/websocket/client.py
+++ b/src/pipecat/transports/websocket/client.py
@@ -178,8 +178,7 @@ class WebsocketClientSession:
                 result = True
         except Exception as e:
             logger.error(f"{self} exception sending data: {e.__class__.__name__} ({e})")
-        finally:
-            return result
+        return result
 
     @property
     def is_connected(self) -> bool:

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -93,8 +93,6 @@ SENTENCE_ENDING_PUNCTUATION: frozenset[str] = frozenset(
         "؛",  # Arabic semicolon
         "۔",  # Urdu full stop
         "؏",  # Arabic sign misra (classical texts)
-        # Thai
-        "।",  # Thai uses Devanagari-style punctuation in some contexts
         # Myanmar/Burmese
         "၊",  # Myanmar sign little section
         "။",  # Myanmar sign section
@@ -103,7 +101,6 @@ SENTENCE_ENDING_PUNCTUATION: frozenset[str] = frozenset(
         "៕",  # Khmer sign bariyoosan
         # Lao
         "໌",  # Lao cancellation mark (used as period)
-        "༎",  # Tibetan mark delimiter tsheg bstar (also used in Lao contexts)
         # Tibetan
         "།",  # Tibetan mark intersyllabic tsheg
         "༎",  # Tibetan mark delimiter tsheg bstar

--- a/src/pipecat/utils/tracing/service_attributes.py
+++ b/src/pipecat/utils/tracing/service_attributes.py
@@ -441,7 +441,7 @@ def add_openai_realtime_span_attributes(
             if isinstance(tool, dict) and "name" in tool:
                 tool_names.append(tool["name"])
             elif hasattr(tool, "name"):
-                tool_names.append(getattr(tool, "name"))
+                tool_names.append(getattr(tool, "name"))  # noqa: B009
             elif isinstance(tool, dict) and "function" in tool and "name" in tool["function"]:
                 tool_names.append(tool["function"]["name"])
 
@@ -456,7 +456,10 @@ def add_openai_realtime_span_attributes(
         if function_calls:
             call = function_calls[0]
             if hasattr(call, "name"):
-                span.set_attribute("function_calls.first_name", getattr(call, "name"))
+                span.set_attribute(
+                    "function_calls.first_name",
+                    getattr(call, "name"),  # noqa: B009
+                )
             elif isinstance(call, dict) and "name" in call:
                 span.set_attribute("function_calls.first_name", call["name"])
 

--- a/src/pipecat/utils/tracing/service_decorators.py
+++ b/src/pipecat/utils/tracing/service_decorators.py
@@ -465,7 +465,7 @@ def traced_tts(func: Callable | None = None, *, name: str | None = None) -> Call
                 await original_setup(self, setup)
                 install_audio_context_patches(self)
 
-            setattr(patched_setup, "__tts_tracing_setup_wrapped__", True)
+            setattr(patched_setup, "__tts_tracing_setup_wrapped__", True)  # noqa: B010
             owner.setup = patched_setup
 
         def attach_run_tts_attributes(service, text, args, kwargs):
@@ -784,7 +784,7 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                     except Exception as e:
                         logging.warning(f"Error in STT post-push tracing: {e}")
 
-            setattr(patched_push_frame, "__stt_tracing_push_frame_wrapped__", True)
+            setattr(patched_push_frame, "__stt_tracing_push_frame_wrapped__", True)  # noqa: B010
             owner.push_frame = patched_push_frame
 
         def patch_stop_ttfb_metrics(owner):
@@ -829,7 +829,7 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                 except Exception as e:
                     logging.warning(f"Error in STT stop_ttfb_metrics tracing: {e}")
 
-            setattr(patched_stop, "__stt_tracing_stop_ttfb_wrapped__", True)
+            setattr(patched_stop, "__stt_tracing_stop_ttfb_wrapped__", True)  # noqa: B010
             owner.stop_ttfb_metrics = patched_stop
 
         def patch_start_stt_usage_metrics(owner):
@@ -866,7 +866,7 @@ def traced_stt(func: Callable | None = None, *, name: str | None = None) -> Call
                 except Exception as e:
                     logging.warning(f"Error in STT usage tracing: {e}")
 
-            setattr(patched_start, "__stt_tracing_usage_wrapped__", True)
+            setattr(patched_start, "__stt_tracing_usage_wrapped__", True)  # noqa: B010
             owner.start_stt_usage_metrics = patched_start
 
         class _TracedSTTDescriptor:

--- a/tests/test_app_resources.py
+++ b/tests/test_app_resources.py
@@ -294,7 +294,7 @@ class TestFrameProcessorPipelineTaskAccess(unittest.IsolatedAsyncioTestCase):
 
     def test_pipeline_task_raises_when_not_set_up(self):
         recorder = _RecordingProcessor()
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "pipeline worker is still not set"):
             _ = recorder.pipeline_worker
 
 

--- a/tests/test_direct_functions.py
+++ b/tests/test_direct_functions.py
@@ -188,19 +188,19 @@ class TestDirectFunction(unittest.TestCase):
         def my_function_non_async(params: FunctionCallParams):
             return {"status": "success"}, None
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "must be async"):
             DirectFunctionWrapper(function=my_function_non_async)
 
         async def my_function_missing_params():
             return {"status": "success"}, None
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "must have at least one parameter"):
             DirectFunctionWrapper(my_function_missing_params)
 
         async def my_function_misplaced_params(foo: str, params: FunctionCallParams):
             return {"status": "success"}, None
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "first parameter must be named"):
             DirectFunctionWrapper(my_function_misplaced_params)
 
     def test_invoke_calls_function_with_args_and_params_object(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -542,7 +542,7 @@ class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
         except TimeoutError:
             assert True
         else:
-            assert False
+            raise AssertionError("worker.run() returned instead of running until cancelled")
 
     async def test_idle_task_heartbeats(self):
         identity = IdentityFilter()


### PR DESCRIPTION
## Summary

- Selects ruff's `B` (bugbear) rules, which flag likely bugs the pyflakes rules do not
- Ignores the ones that do not pay their way here, each with a reason, so the deferrals stay visible rather than silently absent
- Resolves the 33 findings that remain — 26 fixed, 7 documented as intentional: **19 files, +64/-31**

Stacked on #5289, which touches the same `select`/`ignore` block. Retarget to `main` once that merges.

## Why a curated set

Enabling all of `B` reports 136 findings — 123 once Typer's idiom is allowed and B027 is off — and I went through every one. The ratio does not hold up: most are cosmetic or behaviour-preserving, and every genuine defect sits in what is left after the ignores. The two largest deferrals are `B904` (48 sites, exception chaining, no behaviour change) and `B905` (18 sites, each needing its own length-invariant judgement, where `strict=True` risks raising on a path that works today).

The ignore list separates the two kinds of decision. `B024` and `B027` are wrong for this codebase and stay off. The rest are deferrals: delete a line, fix what it reports.

## What it caught

**`WebsocketClientTransport.send` swallowed cancellation.** It returned from a `finally` block, which discards the in-flight exception. `except Exception` does not catch `CancelledError`, but the `finally` did, so cancelling a task blocked in `send` returned `False` instead of cancelling. Python 3.14 warns about the construct.

**Four transports shared one params object.** `params: TavusParams = TavusParams()` evaluates once, so every caller that omitted the argument got the same instance — and it is not read-only: `enable_audio_in_stream_on_start` assigns to `self._params.audio_in_stream_on_start`, so one transport could change another's configuration.

**The sentence-terminator set claimed coverage it did not have.** It listed the Devanagari danda a second time under Thai and the Tibetan nyis shad a second time under Lao. Being a set, it dropped both, so the entries only made those scripts look supported. Thai has no terminating punctuation to list at all, and this does not change how any text is split — it removes a claim, not a behaviour.

**A deprecation warning pointed at itself.** The Speechmatics warn site omitted `stacklevel`, so it reported its own frame instead of the construction the user has to change.

Also: a gRPC request generator and the deprecation scanner's recursive `visit` captured loop variables instead of binding them, and four tests asserted only that *some* `Exception` escaped.

## One thing worth a look

`B009`/`B010` rewrite `getattr(x, "name")` into `x.name`. Seven call sites use those functions *deliberately*, to step around the type checker — stamping a marker attribute on a wrapped function, stashing pipecat state on a FastAPI `WebSocket`, reading `name` off a value pyright narrowed to `dict`. Applying the rewrite there makes `pyright` fail with 7 errors, so those sites keep the call and carry a `noqa` saying why. The rule still catches the five places where the name really was just a constant.

## Reviewing this

| Commit | |
| --- | --- |
| Enforce a curated set of the bugbear rules | the config and the reasoning |
| Stop sharing state the bugbear rules flag | transports, TTS default, two closures |
| **Fix the defects the bugbear rules surfaced** | **the three above — worth your time** |
| Assert on the message in tests that expect a bare Exception | test tightening |
| Enforce the constant-attribute and assert-False rules too | the getattr/setattr pass |

## Testing

- `uv run ruff check` and `ruff format --diff` pass against the committed tree
- `uv run pyright`: 0 errors
- `uv run pytest`: 4026 passed, 29 skipped
