### PR TITLE
Hold on to background tasks, and enforce the rules that catch them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,13 +231,28 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
+    "ASYNC", # Blocking calls and other misuse inside async functions
     "B", # Likely bugs and design problems
     "D", # Docstring rules
     "F", # Pyflakes
     "I", # Import rules
+    "RUF006", # asyncio tasks nothing holds a reference to
     "UP", # Modern Python
 ]
 ignore = [
+    # Async rules that do not fit this codebase.
+    #
+    # ASYNC109 objects to a `timeout` parameter on an async function, which is
+    # how cancellation is spelled throughout pipecat's own API, and ASYNC240
+    # prescribes trio.Path or anyio.path for filesystem work; pipecat runs on
+    # asyncio, and the calls it flags are in CLI and startup paths.
+    "ASYNC109",
+    "ASYNC240",
+    #
+    # ASYNC110 is a deferral: its one site polls a queue in the audio output
+    # path, and swapping it for an Event means restructuring a real-time loop.
+    "ASYNC110",
+    #
     # Bugbear rules that do not fit this codebase.
     #
     # Base classes leave optional hooks empty so subclasses override only what
@@ -267,10 +282,13 @@ ignore = [
 extend-immutable-calls = ["typer.Argument", "typer.Option"]
 
 [tool.ruff.lint.per-file-ignores]
-# Skip docstring checks for non-source code
-"examples/**/*.py" = ["D"]
-"tests/**/*.py" = ["D"]
-"scripts/**/*.py" = ["D"]
+# Skip docstring checks for non-source code. ASYNC230 and RUF006 are enforced in
+# the framework, where a blocked event loop stalls a live session and a collected
+# task drops one, and left off the demo and test code around it: both findings
+# there want a per-site rewrite that would bury what the file is teaching.
+"examples/**/*.py" = ["D", "ASYNC230", "RUF006"]
+"tests/**/*.py" = ["D", "ASYNC230", "RUF006"]
+"scripts/**/*.py" = ["D", "ASYNC230", "RUF006"]
 "docs/**/*.py" = ["D"]
 # Skip D104 (missing docstring in public package) for __init__.py files
 "**/__init__.py" = ["D104"]

--- a/src/pipecat/runner/run.py
+++ b/src/pipecat/runner/run.py
@@ -195,6 +195,19 @@ Import this to add custom routes from other packages before calling
         main()
 """
 
+# Bot sessions started from a request handler outlive the response, and the event
+# loop only holds a weak reference to a task, so one that nothing else references
+# can be collected while it is still running.
+_bot_sessions: set[asyncio.Task] = set()
+
+
+def _start_bot_session(coro) -> asyncio.Task:
+    """Run a bot in the background, holding a reference until it finishes."""
+    task = asyncio.create_task(coro)
+    _bot_sessions.add(task)
+    task.add_done_callback(_bot_sessions.discard)
+    return task
+
 
 def _is_module_available(module: str) -> bool:
     """Check whether a module can be imported without importing it.
@@ -773,7 +786,7 @@ def _setup_unified_start_route(
                 runner_args = RunnerArguments(body=body, session_id=session_id)
 
             runner_args.cli_args = args
-            asyncio.create_task(bot_module.bot(runner_args))
+            _start_bot_session(bot_module.bot(runner_args))
             return result
 
         elif transport in TELEPHONY_TRANSPORTS:
@@ -825,7 +838,7 @@ def _setup_unified_start_route(
             )
             runner_args.cli_args = args
 
-            asyncio.create_task(bot_module.bot(runner_args))
+            _start_bot_session(bot_module.bot(runner_args))
             try:
                 await asyncio.wait_for(ready_event.wait(), timeout=15.0)
             except TimeoutError:
@@ -1197,7 +1210,7 @@ def _setup_daily_routes(app: FastAPI, args: argparse.Namespace):
                 room_url=room_url, token=token, session_id=str(uuid.uuid4())
             )
             runner_args.cli_args = args
-            asyncio.create_task(bot_module.bot(runner_args))
+            _start_bot_session(bot_module.bot(runner_args))
             return RedirectResponse(room_url)
 
     if args.dialin:
@@ -1305,7 +1318,7 @@ def _setup_daily_routes(app: FastAPI, args: argparse.Namespace):
             )
             runner_args.cli_args = args
 
-            asyncio.create_task(bot_module.bot(runner_args))
+            _start_bot_session(bot_module.bot(runner_args))
 
             # Return response matching Pipecat Cloud format
             return {

--- a/src/pipecat/services/google/gemini_live/file_api.py
+++ b/src/pipecat/services/google/gemini_live/file_api.py
@@ -14,6 +14,7 @@ this API can be referenced in Gemini generative model calls.
 import mimetypes
 from typing import Any
 
+import aiofiles
 import aiohttp
 from loguru import logger
 
@@ -62,8 +63,8 @@ class GeminiFileAPI:
                 mime_type = "application/octet-stream"
 
             # Read the file
-            with open(file_path, "rb") as f:
-                file_data = f.read()
+            async with aiofiles.open(file_path, "rb") as f:
+                file_data = await f.read()
 
             # Create the metadata payload
             metadata = {}

--- a/src/pipecat/transports/smallwebrtc/connection.py
+++ b/src/pipecat/transports/smallwebrtc/connection.py
@@ -143,6 +143,7 @@ class SmallWebRTCTrack:
         self._enabled = True
         self._last_recv_time: float = 0.0
         self._idle_task: asyncio.Task | None = None
+        self._renegotiation_task: asyncio.Task | None = None
         self._idle_timeout: float = 2.0  # seconds before discarding old frames
 
     def set_enabled(self, enabled: bool) -> None:
@@ -466,8 +467,13 @@ class SmallWebRTCConnection(BaseObject):
         async def delayed_task():
             await asyncio.sleep(2)
             self._renegotiation_in_progress = False
+            # A renegotiation arriving inside the two seconds replaces this task.
+            if self._renegotiation_task is asyncio.current_task():
+                self._renegotiation_task = None
 
-        asyncio.create_task(delayed_task())
+        # Held on self so the task cannot be collected before it clears the flag,
+        # which would leave renegotiation blocked for the rest of the session.
+        self._renegotiation_task = asyncio.create_task(delayed_task())
 
     def force_transceivers_to_send_recv(self):
         """Force all transceivers to bidirectional send/receive mode."""


### PR DESCRIPTION
## Summary

- Selects ruff's `ASYNC` rules and `RUF006`, which catch work that blocks the event loop and tasks nothing holds a reference to
- Fixes the six findings in the framework: **4 files, +46/-11**

Stacked on #5292, which touches the same `select`/`ignore` block. Retarget to `main` once that merges.

## What it caught

**The runner dropped every bot session.** All four transport paths started the bot as `asyncio.create_task(bot_module.bot(runner_args))` and returned. The event loop holds only a weak reference to a task, so a task nothing else references can be collected while it is still running — asyncio's own docs say to keep one. Here the discarded task *is the whole session*. Bots now start through a helper that holds the task in a module-level set until it completes.

**A dropped timer could wedge renegotiation.** `SmallWebRTCConnection` cleared `_renegotiation_in_progress` from a two-second timer it discarded. Lose that task and the flag stays set for the rest of the session, blocking every later renegotiation. It is now held on the connection, which is what that class already does for its other three tasks.

**A file upload blocked the event loop.** The Gemini File API client read the file with a blocking `open` inside an async function, stalling everything else for the length of the read. It now uses `aiofiles`, already a dependency.

This also turns `AGENTS.md`'s "always use `self.create_task(...)` instead of raw `asyncio.create_task()`" into something the linter enforces rather than something review has to catch. The runner is not a `FrameProcessor`, so it cannot use `self.create_task` and keeps its own reference instead.

## Scoping

Both rules are enforced in `src` and off for `examples`, `tests` and `scripts`, which trip them 24 more times. The hazard is real there too, but each finding wants its own rewrite — a module-level task holder, a file read moved to `aiofiles` — and that is noise in a file whose job is to show how something works. Worth a follow-up for `examples/`, since a reader copying the pattern inherits it.

Three `ASYNC` rules stay off, each with a reason in the config: `ASYNC109` objects to the `timeout` parameter that is how cancellation is spelled throughout pipecat's API, `ASYNC240` prescribes trio or anyio for filesystem work in an asyncio codebase, and `ASYNC110` is a deferral whose one site polls the audio output queue, where an `Event` means restructuring a real-time loop.

## Testing

- `uv run ruff check` and `ruff format --diff` pass against the committed tree
- `uv run pyright`: 0 errors
- `uv run pytest`: 4026 passed, 29 skipped