### PR TITLE
Phase 1 of ACP  (Agent Client Protocol) client support

### DIFF
--- a/changelog/acp-client.added.md
+++ b/changelog/acp-client.added.md
@@ -1,15 +1,5 @@
-- Added Agent Client Protocol (ACP) support in `pipecat.services.acp`. `ACPService`
-  runs a coding agent as a subprocess and bridges it to a pipeline: it sends user
-  turns as `session/prompt`, converts the agent's `session/update` stream into ACP
-  frames, and hands agent-initiated callbacks (permission requests, filesystem and
-  terminal methods) to any processor willing to answer them.
+- Added Agent Client Protocol (ACP) support in `pipecat.services.acp`. ACP is the JSON-RPC protocol code editors speak to coding agents (Claude Code, Gemini CLI, Goose); `ACPService` runs one as a subprocess and bridges it to a pipeline, so a bot can drive an agent the way an editor would. It sends each user turn as `session/prompt` and converts the agent's `session/update` stream into ACP frames: agent messages and reasoning, tool calls and their updates, plans, and session and turn boundaries. Event handlers are available for `on_session_started`, `on_turn_started`, `on_turn_ended`, and `on_agent_exited`.
 
-  The package also provides `ACPClient`, a Pipecat-independent JSON-RPC client for
-  the protocol; `ACPUserAggregator`, which collects transcriptions into one prompt
-  per user turn; and `ACPAutoPermission`, which auto-approves the agent's
-  permission requests. `ACPService` offers `on_session_started`, `on_turn_started`,
-  `on_turn_ended`, and `on_agent_exited` event handlers. See `examples/acp/`.
+  Everything the agent asks the client to do (permission requests, filesystem reads and writes, terminal commands) arrives as an `ACPClientRequestFrame` and is answered by pushing an `ACPClientResponseFrame` with the same `request_id`. Requests are broadcast upstream and downstream, so the processor that answers them can sit on either side of the service. `ACPAutoPermission` answers permission requests automatically, for development against a scratch repository.
 
-- Added `ACPLogObserver` (`pipecat.observers.loggers.acp_log_observer`), which logs
-  an ACP agent's full stream (turns, messages, reasoning, tool calls, plans) without
-  speaking any of it.
+  The package also provides `ACPClient`, a Pipecat-independent JSON-RPC client usable from a plain script, and `ACPUserAggregator`, which collects transcriptions into one prompt per user turn. `ACPService` emits no speakable text: turning an agent's tool calls and reasoning into something worth hearing belongs in a renderer downstream of it. `ACPLogObserver` (`pipecat.observers.loggers.acp_log_observer`) logs the agent's full stream without speaking any of it, which is the starting point for writing one. See `examples/acp/`.

--- a/changelog/acp-client.added.md
+++ b/changelog/acp-client.added.md
@@ -1,0 +1,15 @@
+- Added Agent Client Protocol (ACP) support in `pipecat.services.acp`. `ACPService`
+  runs a coding agent as a subprocess and bridges it to a pipeline: it sends user
+  turns as `session/prompt`, converts the agent's `session/update` stream into ACP
+  frames, and hands agent-initiated callbacks (permission requests, filesystem and
+  terminal methods) to any processor willing to answer them.
+
+  The package also provides `ACPClient`, a Pipecat-independent JSON-RPC client for
+  the protocol; `ACPUserAggregator`, which collects transcriptions into one prompt
+  per user turn; and `ACPAutoPermission`, which auto-approves the agent's
+  permission requests. `ACPService` offers `on_session_started`, `on_turn_started`,
+  `on_turn_ended`, and `on_agent_exited` event handlers. See `examples/acp/`.
+
+- Added `ACPLogObserver` (`pipecat.observers.loggers.acp_log_observer`), which logs
+  an ACP agent's full stream (turns, messages, reasoning, tool calls, plans) without
+  speaking any of it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,6 +125,10 @@ Video processing, mirroring, GStreamer, and custom video tracks.
 
 Audio recording, background sounds, and sound effects.
 
+### [`acp/`](./acp/)
+
+Driving a coding agent (Claude Code, Gemini CLI, Goose) over the Agent Client Protocol.
+
 ### [`observability/`](./observability/)
 
 Pipeline monitoring: observers, heartbeats, and Sentry metrics.

--- a/examples/acp/acp-voice-client.py
+++ b/examples/acp/acp-voice-client.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A voice client for a coding agent, over the Agent Client Protocol.
+
+Speech becomes an ACP prompt, the agent's stream becomes ACP frames, and
+``ACPLogObserver`` logs those frames without speaking. The bot stays silent by
+design: deciding what an agent's tool calls and reasoning should sound like is
+the rendering problem, and it belongs in a processor between ``ACPService`` and
+the TTS service.
+
+Set ``ACP_AGENT_COMMAND`` to the agent to run and ``ACP_AGENT_CWD`` to the
+directory it should work in. Permission requests are auto-approved, so point it
+at a scratch repository.
+
+Run it::
+
+    export ACP_AGENT_COMMAND="npx @zed-industries/claude-code-acp"
+    export ACP_AGENT_CWD=/path/to/scratch/repo
+    python examples/acp/acp-voice-client.py
+"""
+
+import os
+import shlex
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.observers.loggers.acp_log_observer import ACPLogObserver
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.acp.aggregator import ACPUserAggregator
+from pipecat.services.acp.permissions import ACPAutoPermission
+from pipecat.services.acp.service import ACPService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+transport_params = {
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        vad_analyzer=SileroVADAnalyzer(),
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        vad_analyzer=SileroVADAnalyzer(),
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    command = shlex.split(os.environ["ACP_AGENT_COMMAND"])
+    cwd = os.environ["ACP_AGENT_CWD"]
+    logger.info(f"Running ACP agent {command} in {cwd}")
+
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+
+    acp = ACPService(command=command, cwd=cwd)
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            stt,
+            ACPUserAggregator(),  # Speech -> ACPPromptFrame
+            ACPAutoPermission(),  # Answers the agent's permission requests
+            acp,  # The agent
+            # A renderer goes here: ACP frames in, speakable text out.
+            transport.output(),
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(enable_metrics=True),
+        observers=[ACPLogObserver()],
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @acp.event_handler("on_agent_exited")
+    async def on_agent_exited(service, returncode):
+        logger.error(f"ACP agent exited with code {returncode}")
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/src/pipecat/observers/loggers/acp_log_observer.py
+++ b/src/pipecat/observers/loggers/acp_log_observer.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""ACP logging observer for Pipecat."""
+
+from loguru import logger
+
+from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.services.acp.renderers import describe
+from pipecat.services.acp.service import ACPService
+
+
+class ACPLogObserver(BaseObserver):
+    """Observer to log an ACP agent's activity to the console.
+
+    Logs one line per ACP frame: session and turn boundaries, agent messages
+    and reasoning, tool calls and their updates, plans, and the agent's requests
+    to the client. Non-ACP frames are ignored.
+
+    Useful while deciding what a renderer should say. It shows the full stream a
+    real agent produces without any of it reaching a TTS service.
+
+    Example::
+
+        worker = PipelineWorker(pipeline, observers=[ACPLogObserver()])
+    """
+
+    async def on_push_frame(self, data: FramePushed):
+        """Log an ACP frame as it is pushed.
+
+        Args:
+            data: The frame push event.
+        """
+        # Every processor the frame passes through pushes it again. Anchoring on
+        # the service logs each frame once, on the hop where it enters or leaves.
+        if not isinstance(data.source, ACPService) and not isinstance(data.destination, ACPService):
+            return
+
+        if summary := describe(data.frame):
+            logger.info(f"ACP | {summary}")

--- a/src/pipecat/services/acp/__init__.py
+++ b/src/pipecat/services/acp/__init__.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Agent Client Protocol support.
+
+The Agent Client Protocol (https://agentclientprotocol.com) is what code editors
+speak to coding agents. :class:`~pipecat.services.acp.service.ACPService` runs an
+agent as a subprocess and bridges it to a Pipecat pipeline, so a bot can drive
+one the way an editor would.
+
+The service is protocol plumbing only. It emits ACP frames and no speakable
+text; see :mod:`pipecat.services.acp.renderers` for the seam where a voice
+client decides what the agent's output should sound like.
+"""
+
+from pipecat.services.acp.aggregator import ACPUserAggregator
+from pipecat.services.acp.client import ACPClient, ACPError
+from pipecat.services.acp.permissions import ACPAutoPermission
+from pipecat.services.acp.renderers import describe
+from pipecat.services.acp.service import ACPService
+
+__all__ = [
+    "ACPAutoPermission",
+    "ACPClient",
+    "ACPError",
+    "ACPService",
+    "ACPUserAggregator",
+    "describe",
+]

--- a/src/pipecat/services/acp/aggregator.py
+++ b/src/pipecat/services/acp/aggregator.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Turns user speech into ACP prompts."""
+
+import asyncio
+
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    Frame,
+    StartFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.acp.frames import ACPPromptFrame
+from pipecat.services.acp.types import text_block
+
+
+class ACPUserAggregator(FrameProcessor):
+    """Collects transcriptions into one prompt per user turn.
+
+    The ACP equivalent of an LLM user aggregator, minus the context: the agent
+    keeps the conversation history, so each turn is sent on its own rather than
+    appended to a message list.
+
+    A turn is closed by a quiet period rather than by
+    ``UserStoppedSpeakingFrame`` directly. Speaking frames are system frames and
+    transcriptions are data frames, so the end of a turn arrives before the
+    words that finish it. Every transcription received after the user stops
+    speaking restarts the timer, and the prompt goes out once they stop coming.
+    """
+
+    def __init__(self, *, aggregation_timeout: float = 0.5, **kwargs):
+        """Initialize the aggregator.
+
+        Args:
+            aggregation_timeout: Seconds of quiet after the user stops speaking
+                before the turn is sent. Raise it for slow transcription,
+                lower it for snappier hand-off.
+            **kwargs: Additional arguments passed to parent.
+        """
+        super().__init__(**kwargs)
+        self._aggregation_timeout = aggregation_timeout
+        self._parts: list[str] = []
+        self._speaking = False
+        self._text_event = asyncio.Event()
+        self._aggregation_task: asyncio.Task | None = None
+
+    async def cleanup(self):
+        """Clean up resources."""
+        await super().cleanup()
+        await self._stop_aggregation_task()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process a frame.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame processing.
+        """
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, StartFrame):
+            self._create_aggregation_task()
+        elif isinstance(frame, UserStartedSpeakingFrame):
+            self._speaking = True
+        elif isinstance(frame, UserStoppedSpeakingFrame):
+            self._speaking = False
+            self._text_event.set()
+        elif isinstance(frame, TranscriptionFrame):
+            if frame.text.strip():
+                self._parts.append(frame.text.strip())
+            if not self._speaking:
+                self._text_event.set()
+        elif isinstance(frame, (EndFrame, CancelFrame)):
+            await self._flush()
+            await self._stop_aggregation_task()
+
+        await self.push_frame(frame, direction)
+
+    def _create_aggregation_task(self):
+        if not self._aggregation_task:
+            self._aggregation_task = self.create_task(self._aggregation_task_handler())
+
+    async def _stop_aggregation_task(self):
+        if self._aggregation_task:
+            await self.cancel_task(self._aggregation_task)
+            self._aggregation_task = None
+
+    async def _aggregation_task_handler(self):
+        """Flush the turn once transcriptions stop arriving."""
+        while True:
+            try:
+                await asyncio.wait_for(self._text_event.wait(), timeout=self._aggregation_timeout)
+                self._text_event.clear()
+            except TimeoutError:
+                if not self._speaking:
+                    await self._flush()
+
+    async def _flush(self):
+        if not self._parts:
+            return
+        text = " ".join(self._parts)
+        self._parts = []
+        await self.push_frame(ACPPromptFrame(blocks=[text_block(text)]))

--- a/src/pipecat/services/acp/client.py
+++ b/src/pipecat/services/acp/client.py
@@ -1,0 +1,406 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A JSON-RPC client for the Agent Client Protocol.
+
+This module has no Pipecat dependencies so it can be driven from a plain script
+while iterating on protocol behavior.
+
+ACP is bidirectional: the client calls the agent to start sessions and send
+prompts, and the agent calls back into the client to request permission, read
+and write files, and run terminal commands. Both directions run over
+newline-delimited JSON on the agent subprocess's stdin and stdout.
+"""
+
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any
+
+from loguru import logger
+
+from pipecat.services.acp.types import (
+    PROTOCOL_VERSION,
+    ClientCapabilities,
+    ContentBlock,
+    InitializeResult,
+    MCPServer,
+    NewSessionResult,
+    StopReason,
+)
+
+TaskFactory = Callable[[Coroutine, str], asyncio.Task]
+"""Creates a tracked task. Defaults to :func:`asyncio.create_task`."""
+
+SessionUpdateHandler = Callable[[dict[str, Any]], Awaitable[None]]
+"""Receives the params of a ``session/update`` notification."""
+
+ClientRequestHandler = Callable[[str, str, dict[str, Any]], Awaitable[dict[str, Any]]]
+"""Answers an agent-initiated request, given its id, method, and params."""
+
+ClosedHandler = Callable[[int | None], Awaitable[None]]
+"""Notified when the agent exits on its own, with its return code."""
+
+
+class ACPError(Exception):
+    """A JSON-RPC error returned by the agent, or raised to become one.
+
+    Parameters:
+        code: JSON-RPC error code.
+        message: Human-readable description.
+        data: Additional error detail.
+    """
+
+    def __init__(self, code: int, message: str, data: Any | None = None):
+        """Initialize the error.
+
+        Args:
+            code: JSON-RPC error code.
+            message: Human-readable description.
+            data: Additional error detail.
+        """
+        super().__init__(f"ACP error {code}: {message}")
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+class ACPClient:
+    """Speaks ACP to an agent subprocess.
+
+    The client owns the subprocess, correlates requests with responses, and
+    dispatches everything the agent initiates to the handlers assigned to
+    :attr:`on_session_update` and :attr:`on_client_request`.
+
+    Example::
+
+        client = ACPClient()
+        client.on_session_update = handle_update
+        await client.start(["npx", "@zed-industries/claude-code-acp"], cwd="/repo")
+        await client.initialize(ClientCapabilities())
+        session_id = await client.new_session("/repo")
+        await client.prompt(session_id, [text_block("what does worker.py do?")])
+    """
+
+    def __init__(
+        self,
+        *,
+        request_timeout: float = 30.0,
+        task_factory: TaskFactory | None = None,
+    ):
+        """Initialize the client.
+
+        Args:
+            request_timeout: Seconds to wait for the agent to answer a request.
+                Does not apply to ``session/prompt``, which is unbounded.
+            task_factory: Creates the read loop and per-request tasks. Pass a
+                processor's ``create_task`` so the pipeline's task manager
+                tracks them.
+        """
+        self._request_timeout = request_timeout
+        self._task_factory: TaskFactory = task_factory or (
+            lambda coro, name: asyncio.create_task(coro, name=name)
+        )
+
+        self._proc: asyncio.subprocess.Process | None = None
+        self._read_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._write_lock = asyncio.Lock()
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._stopping = False
+
+        self.on_session_update: SessionUpdateHandler | None = None
+        self.on_client_request: ClientRequestHandler | None = None
+        self.on_closed: ClosedHandler | None = None
+
+    #
+    # Lifecycle
+    #
+
+    async def start(self, command: list[str], cwd: str, env: dict[str, str] | None = None):
+        """Spawn the agent and begin reading its output.
+
+        Args:
+            command: The agent executable and its arguments.
+            cwd: Working directory for the agent process.
+            env: Extra environment variables, merged over the current
+                environment.
+        """
+        self._stopping = False
+        self._proc = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._read_task = self._task_factory(self._read_loop(), "acp-read")
+        self._stderr_task = self._task_factory(self._stderr_loop(), "acp-stderr")
+        logger.debug(f"ACP agent started: {' '.join(command)} (pid {self._proc.pid})")
+
+    async def stop(self):
+        """Terminate the agent and fail any in-flight requests."""
+        self._stopping = True
+        self._fail_pending("ACP client stopped")
+
+        if self._proc and self._proc.returncode is None:
+            self._proc.terminate()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except TimeoutError:
+                self._proc.kill()
+        self._proc = None
+
+    #
+    # Client to agent
+    #
+
+    async def initialize(self, capabilities: ClientCapabilities) -> InitializeResult:
+        """Negotiate the protocol version and exchange capabilities.
+
+        Args:
+            capabilities: What this client is willing to do for the agent.
+
+        Returns:
+            What the agent supports.
+        """
+        result = await self._request(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "clientCapabilities": capabilities.to_wire(),
+            },
+        )
+        return InitializeResult.model_validate(result)
+
+    async def authenticate(self, method_id: str):
+        """Run one of the agent's authentication methods.
+
+        Args:
+            method_id: The method to run, from ``InitializeResult.auth_methods``.
+        """
+        await self._request("authenticate", {"methodId": method_id})
+
+    async def new_session(
+        self, cwd: str, mcp_servers: list[MCPServer] | None = None
+    ) -> NewSessionResult:
+        """Start a conversation.
+
+        Args:
+            cwd: Working directory the agent should operate in.
+            mcp_servers: MCP servers the agent should connect to.
+
+        Returns:
+            The new session's identifier and initial mode state.
+        """
+        result = await self._request(
+            "session/new",
+            {
+                "cwd": cwd,
+                "mcpServers": [s.to_wire() for s in (mcp_servers or [])],
+            },
+        )
+        return NewSessionResult.model_validate(result)
+
+    async def load_session(
+        self, session_id: str, cwd: str, mcp_servers: list[MCPServer] | None = None
+    ):
+        """Resume a prior session.
+
+        The agent replays the session's history as ``session/update``
+        notifications before this call returns.
+
+        Args:
+            session_id: The session to resume.
+            cwd: Working directory the agent should operate in.
+            mcp_servers: MCP servers the agent should connect to.
+        """
+        await self._request(
+            "session/load",
+            {
+                "sessionId": session_id,
+                "cwd": cwd,
+                "mcpServers": [s.to_wire() for s in (mcp_servers or [])],
+            },
+        )
+
+    async def prompt(self, session_id: str, blocks: list[ContentBlock]) -> StopReason:
+        """Send a user turn and wait for the agent to finish acting on it.
+
+        A turn can run for minutes and can call back into the client several
+        times before it resolves, so this call has no timeout.
+
+        Args:
+            session_id: The session to prompt.
+            blocks: The user turn's content.
+
+        Returns:
+            Why the turn ended.
+        """
+        result = await self._request(
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [b.to_wire() for b in blocks],
+            },
+            timeout=None,
+        )
+        return StopReason(result.get("stopReason", StopReason.END_TURN))
+
+    async def cancel(self, session_id: str):
+        """Interrupt the in-flight turn.
+
+        The pending :meth:`prompt` still resolves, with
+        :attr:`~pipecat.services.acp.types.StopReason.CANCELLED`.
+
+        Args:
+            session_id: The session to interrupt.
+        """
+        await self._notify("session/cancel", {"sessionId": session_id})
+
+    async def set_mode(self, session_id: str, mode_id: str):
+        """Switch the agent's operating mode.
+
+        Args:
+            session_id: The session to change.
+            mode_id: The mode to switch to.
+        """
+        await self._request("session/set_mode", {"sessionId": session_id, "modeId": mode_id})
+
+    #
+    # JSON-RPC plumbing
+    #
+
+    async def _request(
+        self, method: str, params: dict[str, Any], timeout: float | None = -1.0
+    ) -> dict[str, Any]:
+        """Send a request and wait for its response."""
+        if not self._proc:
+            raise ACPError(-32000, "ACP agent is not running")
+
+        self._next_id += 1
+        request_id = self._next_id
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+
+        await self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+
+        # -1.0 means "use the configured default"; None means wait forever.
+        wait_for = self._request_timeout if timeout == -1.0 else timeout
+        try:
+            if wait_for is None:
+                return await future
+            return await asyncio.wait_for(future, timeout=wait_for)
+        finally:
+            self._pending.pop(request_id, None)
+
+    async def _notify(self, method: str, params: dict[str, Any]):
+        """Send a notification, which expects no response."""
+        if not self._proc:
+            return
+        await self._write({"jsonrpc": "2.0", "method": method, "params": params})
+
+    async def _write(self, message: dict[str, Any]):
+        """Write one newline-delimited JSON message to the agent's stdin."""
+        if not self._proc or not self._proc.stdin:
+            raise ACPError(-32000, "ACP agent is not running")
+        data = (json.dumps(message) + "\n").encode()
+        async with self._write_lock:
+            self._proc.stdin.write(data)
+            await self._proc.stdin.drain()
+
+    async def _read_loop(self):
+        """Read messages from the agent until its stdout closes."""
+        assert self._proc and self._proc.stdout
+        while line := await self._proc.stdout.readline():
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(f"ACP: skipping unparseable line: {line[:200]!r}")
+                continue
+            try:
+                await self._dispatch(message)
+            except Exception as e:
+                logger.exception(f"ACP: error dispatching message: {e}")
+
+        # stdout closed: the agent is gone. Anything still waiting on it never
+        # gets an answer, so fail it here rather than letting each caller sit
+        # until its own timeout.
+        returncode = await self._proc.wait() if self._proc else None
+        self._fail_pending(f"ACP agent exited ({returncode})")
+        if not self._stopping and self.on_closed:
+            await self.on_closed(returncode)
+
+    def _fail_pending(self, reason: str):
+        """Fail every request still waiting on the agent."""
+        for future in self._pending.values():
+            if not future.done():
+                future.set_exception(ACPError(-32000, reason))
+        self._pending.clear()
+
+    async def _stderr_loop(self):
+        """Surface the agent's stderr, which is where agents log."""
+        assert self._proc and self._proc.stderr
+        while line := await self._proc.stderr.readline():
+            logger.debug(f"ACP agent: {line.decode(errors='replace').rstrip()}")
+
+    async def _dispatch(self, message: dict[str, Any]):
+        """Route one inbound message to a pending future or a handler."""
+        if "method" not in message:
+            self._resolve(message)
+        elif "id" in message:
+            # An agent-initiated request. Handled in its own task: a permission
+            # request blocks until a human answers, and the read loop has to
+            # keep running so the agent's other traffic still arrives.
+            self._task_factory(self._serve(message), f"acp-serve-{message['id']}")
+        elif self.on_session_update and message["method"] == "session/update":
+            await self.on_session_update(message.get("params", {}))
+        else:
+            logger.debug(f"ACP: ignoring notification {message['method']}")
+
+    def _resolve(self, message: dict[str, Any]):
+        """Complete the future waiting on this response."""
+        future = self._pending.get(message.get("id"))
+        if not future or future.done():
+            return
+        if error := message.get("error"):
+            future.set_exception(
+                ACPError(error.get("code", -32603), error.get("message", ""), error.get("data"))
+            )
+        else:
+            future.set_result(message.get("result") or {})
+
+    async def _serve(self, message: dict[str, Any]):
+        """Answer an agent-initiated request."""
+        request_id = message["id"]
+        method = message["method"]
+        try:
+            if not self.on_client_request:
+                raise ACPError(-32601, f"Method not supported: {method}")
+            result = await self.on_client_request(
+                str(request_id), method, message.get("params", {})
+            )
+            await self._write({"jsonrpc": "2.0", "id": request_id, "result": result})
+        except ACPError as e:
+            await self._write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": e.code, "message": e.message, "data": e.data},
+                }
+            )
+        except Exception as e:
+            logger.exception(f"ACP: error serving {method}: {e}")
+            await self._write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": -32603, "message": str(e)},
+                }
+            )

--- a/src/pipecat/services/acp/frames.py
+++ b/src/pipecat/services/acp/frames.py
@@ -1,0 +1,344 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Frames for the Agent Client Protocol.
+
+Every ACP message that crosses the pipeline boundary has a frame here. The
+mapping is deliberately flat: one frame per ``session/update`` variant, one per
+lifecycle event, and a single request/response pair covering everything the
+agent asks the client to do.
+
+Frame classes are chosen for interruption behavior. Session and turn boundaries
+are control frames, streamed content is data frames, and the request/response
+pair are system frames so a barge-in cannot strand the agent waiting on an
+answer that was dropped from a queue.
+"""
+
+from dataclasses import dataclass, field
+
+from pipecat.frames.frames import ControlFrame, DataFrame, SystemFrame
+from pipecat.services.acp.types import (
+    ACPErrorData,
+    AgentCapabilities,
+    AvailableCommand,
+    ContentBlock,
+    PlanEntry,
+    ReadTextFileParams,
+    RequestPermissionParams,
+    SessionMode,
+    StopReason,
+    TerminalParams,
+    ToolCall,
+    ToolCallUpdate,
+    WriteTextFileParams,
+)
+
+#
+# Session lifecycle
+#
+
+
+@dataclass
+class ACPSessionStartedFrame(ControlFrame):
+    """A session is open and ready for prompts.
+
+    Parameters:
+        session_id: Identifier of the new session.
+        agent_capabilities: What the agent supports.
+        current_mode_id: The mode the agent is operating in.
+        available_modes: Every mode the agent offers.
+        commands: Slash commands the agent exposes.
+    """
+
+    session_id: str = ""
+    agent_capabilities: AgentCapabilities = field(default_factory=AgentCapabilities)
+    current_mode_id: str | None = None
+    available_modes: list[SessionMode] = field(default_factory=list)
+    commands: list[AvailableCommand] = field(default_factory=list)
+
+
+@dataclass
+class ACPSessionEndedFrame(ControlFrame):
+    """The agent process is gone and the session is closed.
+
+    Parameters:
+        session_id: Identifier of the closed session.
+        reason: Why the session ended.
+    """
+
+    session_id: str = ""
+    reason: str | None = None
+
+
+#
+# Turn lifecycle
+#
+
+
+@dataclass
+class ACPTurnStartedFrame(ControlFrame):
+    """A prompt has been sent and the agent is working.
+
+    Parameters:
+        session_id: Session the turn belongs to.
+    """
+
+    session_id: str = ""
+
+
+@dataclass
+class ACPTurnEndedFrame(ControlFrame):
+    """The agent finished acting on a prompt.
+
+    Parameters:
+        session_id: Session the turn belongs to.
+        stop_reason: Why the turn ended.
+    """
+
+    session_id: str = ""
+    stop_reason: StopReason = StopReason.END_TURN
+
+
+#
+# session/update variants
+#
+
+
+@dataclass
+class ACPAgentMessageFrame(DataFrame):
+    """A chunk of the agent's reply to the user.
+
+    Parameters:
+        session_id: Session the chunk belongs to.
+        content: The chunk's content block.
+    """
+
+    session_id: str = ""
+    content: ContentBlock = field(default_factory=lambda: ContentBlock(type="text", text=""))
+
+
+@dataclass
+class ACPAgentThoughtFrame(DataFrame):
+    """A chunk of the agent's reasoning.
+
+    Parameters:
+        session_id: Session the chunk belongs to.
+        content: The chunk's content block.
+    """
+
+    session_id: str = ""
+    content: ContentBlock = field(default_factory=lambda: ContentBlock(type="text", text=""))
+
+
+@dataclass
+class ACPUserMessageFrame(DataFrame):
+    """A user turn echoed back by the agent, during session replay.
+
+    Parameters:
+        session_id: Session the chunk belongs to.
+        content: The chunk's content block.
+    """
+
+    session_id: str = ""
+    content: ContentBlock = field(default_factory=lambda: ContentBlock(type="text", text=""))
+
+
+@dataclass
+class ACPToolCallFrame(DataFrame):
+    """The agent started a tool call.
+
+    Parameters:
+        session_id: Session the call belongs to.
+        tool_call: The call, including its title and kind.
+    """
+
+    session_id: str = ""
+    tool_call: ToolCall = field(default_factory=lambda: ToolCall(tool_call_id=""))
+
+
+@dataclass
+class ACPToolCallUpdateFrame(DataFrame):
+    """A tool call changed status or produced output.
+
+    The update carries only what changed. :attr:`tool_call` is the service's
+    merged view of the call, so a consumer can render the update without having
+    tracked the original.
+
+    Parameters:
+        session_id: Session the call belongs to.
+        update: The fields the agent reported as changed.
+        tool_call: The call with the update already applied.
+    """
+
+    session_id: str = ""
+    update: ToolCallUpdate = field(default_factory=lambda: ToolCallUpdate(tool_call_id=""))
+    tool_call: ToolCall = field(default_factory=lambda: ToolCall(tool_call_id=""))
+
+
+@dataclass
+class ACPPlanFrame(DataFrame):
+    """The agent's plan for the turn, revised as it works.
+
+    Parameters:
+        session_id: Session the plan belongs to.
+        entries: The plan's steps, in order.
+    """
+
+    session_id: str = ""
+    entries: list[PlanEntry] = field(default_factory=list)
+
+
+@dataclass
+class ACPModeUpdatedFrame(ControlFrame):
+    """The agent switched operating mode.
+
+    Parameters:
+        session_id: Session that changed mode.
+        current_mode_id: The mode now in effect.
+    """
+
+    session_id: str = ""
+    current_mode_id: str | None = None
+
+
+@dataclass
+class ACPCommandsUpdatedFrame(ControlFrame):
+    """The agent's available slash commands changed.
+
+    Parameters:
+        session_id: Session whose commands changed.
+        commands: The commands now available.
+    """
+
+    session_id: str = ""
+    commands: list[AvailableCommand] = field(default_factory=list)
+
+
+#
+# Agent-initiated requests
+#
+
+
+@dataclass
+class ACPClientRequestFrame(SystemFrame):
+    """The agent is asking the client to do something and is blocked until it answers.
+
+    The service broadcasts these both upstream and downstream, so a processor
+    that answers them works on either side of the service. Answer by pushing an
+    :class:`ACPClientResponseFrame` carrying the same ``request_id``. An
+    unanswered request fails after the service's request timeout.
+
+    Parameters:
+        request_id: Correlates the request with its response.
+        method: The ACP method the agent called.
+    """
+
+    request_id: str = ""
+    method: str = ""
+
+
+@dataclass
+class ACPPermissionRequestFrame(ACPClientRequestFrame):
+    """The agent needs the user to approve a tool call.
+
+    Parameters:
+        params: The call awaiting approval and the options to choose from.
+    """
+
+    params: RequestPermissionParams | None = None
+
+
+@dataclass
+class ACPReadFileRequestFrame(ACPClientRequestFrame):
+    """The agent wants the client to read a file.
+
+    Only sent when the client advertised the ``fs.readTextFile`` capability.
+
+    Parameters:
+        params: The path and optional line range to read.
+    """
+
+    params: ReadTextFileParams | None = None
+
+
+@dataclass
+class ACPWriteFileRequestFrame(ACPClientRequestFrame):
+    """The agent wants the client to write a file.
+
+    Only sent when the client advertised the ``fs.writeTextFile`` capability.
+
+    Parameters:
+        params: The path and the file's full new contents.
+    """
+
+    params: WriteTextFileParams | None = None
+
+
+@dataclass
+class ACPTerminalRequestFrame(ACPClientRequestFrame):
+    """The agent wants the client to operate a terminal.
+
+    Covers every ``terminal/*`` method; :attr:`~ACPClientRequestFrame.method`
+    says which. Only sent when the client advertised the ``terminal``
+    capability.
+
+    Parameters:
+        params: Parameters of the terminal operation.
+    """
+
+    params: TerminalParams | None = None
+
+
+@dataclass
+class ACPClientResponseFrame(SystemFrame):
+    """An answer to an :class:`ACPClientRequestFrame`.
+
+    Push either ``result`` or ``error``. The service unblocks the agent with
+    whichever is set, preferring ``error``.
+
+    Parameters:
+        request_id: The request being answered.
+        result: The method's result, as camelCase-ready fields.
+        error: A JSON-RPC error to return instead of a result.
+    """
+
+    request_id: str = ""
+    result: dict | None = None
+    error: ACPErrorData | None = None
+
+
+#
+# Pipeline to agent
+#
+
+
+@dataclass
+class ACPPromptFrame(DataFrame):
+    """A user turn to send to the agent.
+
+    Parameters:
+        blocks: The turn's content.
+    """
+
+    blocks: list[ContentBlock] = field(default_factory=list)
+
+
+@dataclass
+class ACPCancelTurnFrame(SystemFrame):
+    """Interrupt the agent's in-flight turn."""
+
+    pass
+
+
+@dataclass
+class ACPSetModeFrame(ControlFrame):
+    """Switch the agent's operating mode.
+
+    Parameters:
+        mode_id: The mode to switch to.
+    """
+
+    mode_id: str = ""

--- a/src/pipecat/services/acp/permissions.py
+++ b/src/pipecat/services/acp/permissions.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Answering the agent's permission requests."""
+
+from loguru import logger
+
+from pipecat.frames.frames import Frame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.acp.frames import ACPClientResponseFrame, ACPPermissionRequestFrame
+from pipecat.services.acp.types import (
+    ACPErrorData,
+    PermissionOptionKind,
+    RequestPermissionResult,
+)
+
+DEFAULT_PREFERENCE = [
+    PermissionOptionKind.ALLOW_ALWAYS,
+    PermissionOptionKind.ALLOW_ONCE,
+]
+"""Option kinds :class:`ACPAutoPermission` will pick, most preferred first."""
+
+
+class ACPAutoPermission(FrameProcessor):
+    """Answers permission requests without asking anyone.
+
+    Useful for development against a scratch repository, and as the reference
+    for what a real answerer does: pick an option id, push an
+    :class:`~pipecat.services.acp.frames.ACPClientResponseFrame` carrying the
+    request id, and let the request frame continue on its way.
+
+    The response is broadcast, so this processor works on either side of the
+    service.
+    """
+
+    def __init__(self, *, preference: list[PermissionOptionKind] | None = None, **kwargs):
+        """Initialize the processor.
+
+        Args:
+            preference: Option kinds to pick, most preferred first. A request
+                offering none of them is answered with an error.
+            **kwargs: Additional arguments passed to parent.
+        """
+        super().__init__(**kwargs)
+        self._preference = preference or DEFAULT_PREFERENCE
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process a frame.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame processing.
+        """
+        await super().process_frame(frame, direction)
+        await self.push_frame(frame, direction)
+
+        if isinstance(frame, ACPPermissionRequestFrame) and frame.params:
+            await self._answer(frame)
+
+    async def _answer(self, frame: ACPPermissionRequestFrame):
+        options = {o.kind: o for o in frame.params.options}
+        chosen = next((options[k] for k in self._preference if k in options), None)
+
+        if not chosen:
+            offered = [o.kind.value for o in frame.params.options]
+            logger.warning(f"{self}: no acceptable permission option in {offered}")
+            response = ACPClientResponseFrame(
+                request_id=frame.request_id,
+                error=ACPErrorData(code=-32000, message="No acceptable permission option"),
+            )
+        else:
+            logger.debug(f"{self}: auto-allowing {frame.params.tool_call.title} ({chosen.kind})")
+            response = ACPClientResponseFrame(
+                request_id=frame.request_id,
+                result=RequestPermissionResult.selected(chosen.option_id).to_wire(),
+            )
+
+        await self.broadcast_frame_instance(response)

--- a/src/pipecat/services/acp/renderers.py
+++ b/src/pipecat/services/acp/renderers.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Turning ACP frames into something a person can hear.
+
+A renderer is a processor downstream of
+:class:`~pipecat.services.acp.service.ACPService` that consumes ACP frames and
+emits whatever the rest of the pipeline should say. ACP's output is written to
+be read: file paths, diffs, token counts, and a reasoning stream that can run
+for thousands of words. Speaking it verbatim does not work, so the renderer is
+where a voice client decides what is worth saying.
+
+:func:`describe` is the smallest possible version, one line per frame with no
+speech at all. :class:`~pipecat.observers.loggers.acp_log_observer.ACPLogObserver`
+logs it, which is a useful starting point: run a bot, watch the whole agent
+stream go by, and decide what a real renderer should do with it.
+"""
+
+from pipecat.frames.frames import Frame
+from pipecat.services.acp.frames import (
+    ACPAgentMessageFrame,
+    ACPAgentThoughtFrame,
+    ACPClientRequestFrame,
+    ACPPlanFrame,
+    ACPSessionStartedFrame,
+    ACPToolCallFrame,
+    ACPToolCallUpdateFrame,
+    ACPTurnEndedFrame,
+    ACPTurnStartedFrame,
+)
+
+
+def describe(frame: Frame) -> str | None:
+    """Summarize an ACP frame in one line.
+
+    Args:
+        frame: The frame to summarize.
+
+    Returns:
+        A one-line description, or None if the frame is not an ACP frame.
+    """
+    if isinstance(frame, ACPSessionStartedFrame):
+        return f"session {frame.session_id} open (mode: {frame.current_mode_id})"
+    if isinstance(frame, ACPTurnStartedFrame):
+        return "turn started"
+    if isinstance(frame, ACPTurnEndedFrame):
+        return f"turn ended ({frame.stop_reason.value})"
+    if isinstance(frame, ACPAgentMessageFrame):
+        return f"message: {frame.content.text or f'<{frame.content.type}>'}"
+    if isinstance(frame, ACPAgentThoughtFrame):
+        return f"thought: {frame.content.text or f'<{frame.content.type}>'}"
+    if isinstance(frame, ACPToolCallFrame):
+        call = frame.tool_call
+        return f"tool {call.kind.value} {call.status.value}: {call.title}"
+    if isinstance(frame, ACPToolCallUpdateFrame):
+        call = frame.tool_call
+        return f"tool {call.kind.value} {call.status.value}: {call.title}"
+    if isinstance(frame, ACPPlanFrame):
+        steps = ", ".join(f"{e.content} [{e.status.value}]" for e in frame.entries)
+        return f"plan: {steps}"
+    if isinstance(frame, ACPClientRequestFrame):
+        return f"agent asked for {frame.method}"
+    return None

--- a/src/pipecat/services/acp/service.py
+++ b/src/pipecat/services/acp/service.py
@@ -1,0 +1,443 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A Pipecat service that drives a coding agent over the Agent Client Protocol.
+
+The service is a protocol bridge and nothing more. It turns
+:class:`~pipecat.services.acp.frames.ACPPromptFrame` into ``session/prompt``,
+turns everything the agent streams back into ACP frames, and hands the agent's
+callbacks to whichever processor is willing to answer them. It emits no text a
+TTS service would speak; converting the agent's output into something worth
+saying is a downstream concern.
+"""
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from pipecat.frames.frames import CancelFrame, EndFrame, Frame, InterruptionFrame, StartFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.acp.client import ACPClient, ACPError
+from pipecat.services.acp.frames import (
+    ACPAgentMessageFrame,
+    ACPAgentThoughtFrame,
+    ACPCancelTurnFrame,
+    ACPClientRequestFrame,
+    ACPClientResponseFrame,
+    ACPCommandsUpdatedFrame,
+    ACPModeUpdatedFrame,
+    ACPPermissionRequestFrame,
+    ACPPlanFrame,
+    ACPPromptFrame,
+    ACPReadFileRequestFrame,
+    ACPSessionEndedFrame,
+    ACPSessionStartedFrame,
+    ACPSetModeFrame,
+    ACPTerminalRequestFrame,
+    ACPToolCallFrame,
+    ACPToolCallUpdateFrame,
+    ACPTurnEndedFrame,
+    ACPTurnStartedFrame,
+    ACPUserMessageFrame,
+    ACPWriteFileRequestFrame,
+)
+from pipecat.services.acp.types import (
+    AvailableCommand,
+    ClientCapabilities,
+    ContentBlock,
+    MCPServer,
+    PlanEntry,
+    ReadTextFileParams,
+    RequestPermissionParams,
+    StopReason,
+    TerminalParams,
+    ToolCall,
+    ToolCallUpdate,
+    WriteTextFileParams,
+)
+from pipecat.services.ai_service import AIService
+from pipecat.services.settings import ServiceSettings
+
+
+def _content_frame(frame_cls):
+    """Build a frame carrying a single content block."""
+    return lambda service, session_id, params: frame_cls(
+        session_id=session_id, content=ContentBlock.model_validate(params["content"])
+    )
+
+
+# Each ``sessionUpdate`` variant and the frame it becomes. Builders take the
+# service so the tool-call ones can read and update its merged view.
+SESSION_UPDATE_FRAMES: dict[str, Callable[["ACPService", str, dict], Frame]] = {
+    "agent_message_chunk": _content_frame(ACPAgentMessageFrame),
+    "agent_thought_chunk": _content_frame(ACPAgentThoughtFrame),
+    "user_message_chunk": _content_frame(ACPUserMessageFrame),
+    "tool_call": lambda service, session_id, params: service._build_tool_call_frame(
+        session_id, params
+    ),
+    "tool_call_update": lambda service, session_id, params: service._build_tool_call_update_frame(
+        session_id, params
+    ),
+    "plan": lambda service, session_id, params: ACPPlanFrame(
+        session_id=session_id,
+        entries=[PlanEntry.model_validate(e) for e in params.get("entries", [])],
+    ),
+    "current_mode_update": lambda service, session_id, params: ACPModeUpdatedFrame(
+        session_id=session_id, current_mode_id=params.get("currentModeId")
+    ),
+    "available_commands_update": lambda service, session_id, params: ACPCommandsUpdatedFrame(
+        session_id=session_id,
+        commands=[AvailableCommand.model_validate(c) for c in params.get("availableCommands", [])],
+    ),
+}
+
+# Each agent-initiated method and the frame that carries it into the pipeline.
+CLIENT_REQUEST_FRAMES: dict[str, tuple[type[ACPClientRequestFrame], type]] = {
+    "session/request_permission": (ACPPermissionRequestFrame, RequestPermissionParams),
+    "fs/read_text_file": (ACPReadFileRequestFrame, ReadTextFileParams),
+    "fs/write_text_file": (ACPWriteFileRequestFrame, WriteTextFileParams),
+    "terminal/create": (ACPTerminalRequestFrame, TerminalParams),
+    "terminal/output": (ACPTerminalRequestFrame, TerminalParams),
+    "terminal/wait_for_exit": (ACPTerminalRequestFrame, TerminalParams),
+    "terminal/kill": (ACPTerminalRequestFrame, TerminalParams),
+    "terminal/release": (ACPTerminalRequestFrame, TerminalParams),
+}
+
+
+class ACPService(AIService):
+    """Runs a coding agent as a subprocess and bridges it to the pipeline.
+
+    The agent owns the conversation history, so the service holds no context and
+    sends only the new user turn on each prompt. What it does hold is the state
+    the protocol requires a client to keep: the session id, the in-flight turn,
+    a merged view of every tool call so partial updates can be rendered, and the
+    futures for agent callbacks awaiting an answer.
+
+    Prompts are serialized. ACP allows one turn at a time per session, so a
+    prompt that arrives while the agent is working is queued rather than
+    dropped.
+
+    Event handlers available:
+
+    - on_session_started: Called with the ``ACPSessionStartedFrame``
+    - on_turn_started: Called with the session id when a prompt is sent
+    - on_turn_ended: Called with the session id and the turn's ``StopReason``
+    - on_agent_exited: Called with the agent's return code when it dies
+
+    Example::
+
+        acp = ACPService(
+            command=["npx", "@zed-industries/claude-code-acp"],
+            cwd="/path/to/repo",
+        )
+    """
+
+    def __init__(
+        self,
+        *,
+        command: list[str],
+        cwd: str,
+        env: dict[str, str] | None = None,
+        mcp_servers: list[MCPServer] | None = None,
+        client_capabilities: ClientCapabilities | None = None,
+        cancel_turn_on_interruption: bool = False,
+        request_timeout: float = 120.0,
+        **kwargs,
+    ):
+        """Initialize the service.
+
+        Args:
+            command: The agent executable and its arguments.
+            cwd: Working directory the agent should operate in.
+            env: Extra environment variables for the agent process.
+            mcp_servers: MCP servers the agent should connect to.
+            client_capabilities: What this client will do on the agent's behalf.
+                Defaults to nothing, which makes agents fall back to touching
+                the filesystem and spawning processes themselves.
+            cancel_turn_on_interruption: Whether a user interruption cancels the
+                agent's turn. Off by default: barge-in during a multi-file edit
+                would leave the working tree half-changed.
+            request_timeout: Seconds to wait for a processor to answer an agent
+                callback before returning an error to the agent.
+            **kwargs: Additional arguments passed to parent.
+        """
+        super().__init__(settings=ServiceSettings(model=None), **kwargs)
+
+        self._command = command
+        self._cwd = cwd
+        self._env = env
+        self._mcp_servers = mcp_servers or []
+        self._client_capabilities = client_capabilities or ClientCapabilities()
+        self._cancel_turn_on_interruption = cancel_turn_on_interruption
+        self._request_timeout = request_timeout
+
+        self._client = ACPClient(task_factory=self.create_task)
+        self._client.on_session_update = self._on_session_update
+        self._client.on_client_request = self._on_client_request
+        self._client.on_closed = self._on_agent_exited
+
+        self._session_id: str | None = None
+        self._session_started_frame: ACPSessionStartedFrame | None = None
+        self._tool_calls: dict[str, ToolCall] = {}
+        self._pending_requests: dict[str, asyncio.Future] = {}
+        self._prompts: asyncio.Queue[list[ContentBlock]] = asyncio.Queue()
+        self._turn_task: asyncio.Task | None = None
+        self._session_closed = False
+
+        self._register_event_handler("on_session_started")
+        self._register_event_handler("on_turn_started")
+        self._register_event_handler("on_turn_ended")
+        self._register_event_handler("on_agent_exited")
+
+    @property
+    def session_id(self) -> str | None:
+        """The current ACP session, or None before the session opens."""
+        return self._session_id
+
+    #
+    # Lifecycle
+    #
+
+    async def start(self, frame: StartFrame):
+        """Spawn the agent, negotiate capabilities, and open a session.
+
+        Args:
+            frame: The start frame.
+        """
+        await super().start(frame)
+
+        try:
+            await self._client.start(self._command, self._cwd, self._env)
+            init = await self._client.initialize(self._client_capabilities)
+            session = await self._client.new_session(self._cwd, self._mcp_servers)
+        except Exception as e:
+            # AIService._start only logs what start() raises, which would leave
+            # the pipeline running against an agent that never came up.
+            await self.push_error(f"Could not start ACP agent {self._command}", e, fatal=True)
+            return
+
+        self._session_id = session.session_id
+
+        modes = session.modes
+        # Held rather than pushed: start() runs before this processor forwards
+        # the StartFrame, and nothing may precede a StartFrame downstream.
+        self._session_started_frame = ACPSessionStartedFrame(
+            session_id=session.session_id,
+            agent_capabilities=init.agent_capabilities,
+            current_mode_id=modes.current_mode_id if modes else None,
+            available_modes=modes.available_modes if modes else [],
+        )
+        self._turn_task = self.create_task(self._turn_loop(), "acp-turns")
+
+    async def stop(self, frame: EndFrame):
+        """Close the session and terminate the agent.
+
+        Args:
+            frame: The end frame.
+        """
+        await super().stop(frame)
+        await self._shutdown("ended")
+
+    async def cancel(self, frame: CancelFrame):
+        """Terminate the agent immediately.
+
+        Args:
+            frame: The cancel frame.
+        """
+        await super().cancel(frame)
+        await self._shutdown("cancelled")
+
+    async def _shutdown(self, reason: str):
+        if self._turn_task:
+            await self.cancel_task(self._turn_task)
+            self._turn_task = None
+        await self._close_session(reason)
+        await self._client.stop()
+
+    async def _close_session(self, reason: str):
+        """Announce the session's end, at most once."""
+        if self._session_closed or not self._session_id:
+            return
+        self._session_closed = True
+        await self.push_frame(ACPSessionEndedFrame(session_id=self._session_id, reason=reason))
+        self._session_id = None
+
+    async def _on_agent_exited(self, returncode: int | None):
+        """Handle the agent process going away on its own.
+
+        Reached when the agent crashes or exits mid-session. The client has
+        already failed everything waiting on it, so the remaining job is to tell
+        the pipeline the session is over and that it cannot recover.
+
+        An agent that dies before the session opens is reported by ``start()``
+        instead, which has the failing call to describe.
+        """
+        if not self._session_id:
+            return
+
+        logger.error(f"{self}: ACP agent exited with code {returncode}")
+        await self._close_session(f"agent exited ({returncode})")
+        await self._call_event_handler("on_agent_exited", returncode)
+        await self.push_error(f"ACP agent exited with code {returncode}", fatal=True)
+
+    #
+    # Frame processing
+    #
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process a frame.
+
+        Args:
+            frame: The frame to process.
+            direction: The direction of frame processing.
+        """
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, InterruptionFrame):
+            if self._cancel_turn_on_interruption:
+                await self._cancel_turn()
+            await self.push_frame(frame, direction)
+        elif isinstance(frame, ACPPromptFrame):
+            await self._prompts.put(frame.blocks)
+        elif isinstance(frame, ACPClientResponseFrame):
+            self._resolve_request(frame)
+        elif isinstance(frame, ACPCancelTurnFrame):
+            await self._cancel_turn()
+        elif isinstance(frame, ACPSetModeFrame):
+            if self._session_id:
+                await self._client.set_mode(self._session_id, frame.mode_id)
+        else:
+            await self.push_frame(frame, direction)
+
+        if isinstance(frame, StartFrame) and self._session_started_frame:
+            started = self._session_started_frame
+            self._session_started_frame = None
+            await self.push_frame(started)
+            await self._call_event_handler("on_session_started", started)
+
+    async def _cancel_turn(self):
+        if self._session_id:
+            await self._client.cancel(self._session_id)
+
+    #
+    # Turns
+    #
+
+    async def _turn_loop(self):
+        """Send queued prompts one at a time, since a session runs one turn."""
+        while True:
+            blocks = await self._prompts.get()
+            # Captured up front: the agent can die mid-turn, which clears
+            # _session_id before the turn is done being reported.
+            session_id = self._session_id
+            if not session_id:
+                continue
+            await self.push_frame(ACPTurnStartedFrame(session_id=session_id))
+            await self._call_event_handler("on_turn_started", session_id)
+            try:
+                stop_reason = await self._client.prompt(session_id, blocks)
+            except ACPError as e:
+                await self.push_error(f"ACP prompt failed: {e.message}", e)
+                stop_reason = StopReason.REFUSAL
+            await self.push_frame(ACPTurnEndedFrame(session_id=session_id, stop_reason=stop_reason))
+            await self._call_event_handler("on_turn_ended", session_id, stop_reason)
+
+    #
+    # Agent to pipeline
+    #
+
+    async def _on_session_update(self, params: dict[str, Any]):
+        """Turn a ``session/update`` notification into a frame."""
+        session_id = params.get("sessionId", self._session_id or "")
+        kind = params.get("sessionUpdate")
+
+        builder = SESSION_UPDATE_FRAMES.get(kind)
+        if not builder:
+            logger.debug(f"{self}: ignoring session update {kind}")
+            return
+
+        await self.push_frame(builder(self, session_id, params))
+
+    def _build_tool_call_frame(self, session_id: str, params: dict) -> ACPToolCallFrame:
+        tool_call = ToolCall.model_validate(params)
+        self._tool_calls[tool_call.tool_call_id] = tool_call
+        return ACPToolCallFrame(session_id=session_id, tool_call=tool_call)
+
+    def _build_tool_call_update_frame(
+        self, session_id: str, params: dict
+    ) -> ACPToolCallUpdateFrame:
+        update = ToolCallUpdate.model_validate(params)
+        return ACPToolCallUpdateFrame(
+            session_id=session_id, update=update, tool_call=self._merge_tool_call(update)
+        )
+
+    def _merge_tool_call(self, update: ToolCallUpdate) -> ToolCall:
+        """Apply an update to the tracked call and return the merged result.
+
+        Updates carry only what changed, so the title announced with the
+        original call is the only place a renderer can learn what finished.
+        """
+        call = self._tool_calls.get(update.tool_call_id) or ToolCall(
+            tool_call_id=update.tool_call_id
+        )
+        changes = update.model_dump(exclude_none=True, exclude={"tool_call_id", "content"})
+        merged = call.model_copy(update=changes)
+        if update.content:
+            merged.content = call.content + update.content
+        self._tool_calls[update.tool_call_id] = merged
+        return merged
+
+    #
+    # Agent callbacks
+    #
+
+    async def _on_client_request(
+        self, request_id: str, method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Ask the pipeline to answer an agent-initiated request."""
+        entry = CLIENT_REQUEST_FRAMES.get(method)
+        if not entry:
+            raise ACPError(-32601, f"Method not supported: {method}")
+        frame_cls, params_cls = entry
+
+        future: asyncio.Future = self.get_event_loop().create_future()
+        self._pending_requests[request_id] = future
+
+        # Broadcast: an answering processor may sit on either side of this
+        # service. A permission answer derived from user speech, for instance,
+        # arrives from upstream.
+        await self.broadcast_frame_instance(
+            frame_cls(
+                request_id=request_id,
+                method=method,
+                params=params_cls.model_validate(params),
+            )
+        )
+
+        try:
+            response: ACPClientResponseFrame = await asyncio.wait_for(
+                future, timeout=self._request_timeout
+            )
+        except TimeoutError:
+            raise ACPError(-32000, f"No processor answered {method} in time")
+        finally:
+            self._pending_requests.pop(request_id, None)
+
+        if response.error:
+            raise ACPError(response.error.code, response.error.message, response.error.data)
+        return response.result or {}
+
+    def _resolve_request(self, frame: ACPClientResponseFrame):
+        """Unblock the agent callback this response answers."""
+        future = self._pending_requests.get(frame.request_id)
+        if not future:
+            logger.debug(f"{self}: no request pending for {frame.request_id}")
+        elif not future.done():
+            # The request was broadcast, so a response may arrive twice; the
+            # second one lands here after the future is already resolved.
+            future.set_result(frame)

--- a/src/pipecat/services/acp/service.py
+++ b/src/pipecat/services/acp/service.py
@@ -54,6 +54,7 @@ from pipecat.services.acp.types import (
     PlanEntry,
     ReadTextFileParams,
     RequestPermissionParams,
+    RequestPermissionResult,
     StopReason,
     TerminalParams,
     ToolCall,
@@ -185,6 +186,7 @@ class ACPService(AIService):
         self._session_started_frame: ACPSessionStartedFrame | None = None
         self._tool_calls: dict[str, ToolCall] = {}
         self._pending_requests: dict[str, asyncio.Future] = {}
+        self._pending_permission_requests: dict[str, asyncio.Future] = {}
         self._prompts: asyncio.Queue[list[ContentBlock]] = asyncio.Queue()
         self._turn_task: asyncio.Task | None = None
         self._session_closed = False
@@ -324,6 +326,18 @@ class ACPService(AIService):
         if self._session_id:
             await self._client.cancel(self._session_id)
 
+        # ACP requires a cancelled result for every permission request still
+        # awaiting a user decision. Without it, an agent can remain blocked on
+        # the request after receiving session/cancel.
+        for request_id, future in list(self._pending_permission_requests.items()):
+            if not future.done():
+                future.set_result(
+                    ACPClientResponseFrame(
+                        request_id=request_id,
+                        result=RequestPermissionResult.cancelled().to_wire(),
+                    )
+                )
+
     #
     # Turns
     #
@@ -354,14 +368,15 @@ class ACPService(AIService):
     async def _on_session_update(self, params: dict[str, Any]):
         """Turn a ``session/update`` notification into a frame."""
         session_id = params.get("sessionId", self._session_id or "")
-        kind = params.get("sessionUpdate")
+        update = params.get("update", {})
+        kind = update.get("sessionUpdate")
 
         builder = SESSION_UPDATE_FRAMES.get(kind)
         if not builder:
             logger.debug(f"{self}: ignoring session update {kind}")
             return
 
-        await self.push_frame(builder(self, session_id, params))
+        await self.push_frame(builder(self, session_id, update))
 
     def _build_tool_call_frame(self, session_id: str, params: dict) -> ACPToolCallFrame:
         tool_call = ToolCall.model_validate(params)
@@ -407,6 +422,8 @@ class ACPService(AIService):
 
         future: asyncio.Future = self.get_event_loop().create_future()
         self._pending_requests[request_id] = future
+        if method == "session/request_permission":
+            self._pending_permission_requests[request_id] = future
 
         # Broadcast: an answering processor may sit on either side of this
         # service. A permission answer derived from user speech, for instance,
@@ -427,6 +444,7 @@ class ACPService(AIService):
             raise ACPError(-32000, f"No processor answered {method} in time")
         finally:
             self._pending_requests.pop(request_id, None)
+            self._pending_permission_requests.pop(request_id, None)
 
         if response.error:
             raise ACPError(response.error.code, response.error.message, response.error.data)

--- a/src/pipecat/services/acp/types.py
+++ b/src/pipecat/services/acp/types.py
@@ -1,0 +1,535 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Wire types for the Agent Client Protocol.
+
+These models mirror the JSON shapes defined by the Agent Client Protocol
+(https://agentclientprotocol.com). The protocol uses camelCase on the wire, so
+every model here declares a camelCase alias generator and accepts either
+spelling on input.
+
+Unknown fields are preserved rather than dropped: agents may send extension
+fields (and ACP reserves ``_meta`` plus underscore-prefixed members for exactly
+that), and a client that discards them cannot pass them on to a renderer.
+"""
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+PROTOCOL_VERSION = 1
+"""The ACP major version this client speaks."""
+
+
+class ACPModel(BaseModel):
+    """Base for every ACP wire model: camelCase aliases, extras preserved."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="allow",
+    )
+
+    def to_wire(self) -> dict[str, Any]:
+        """Serialize to a JSON-RPC-ready dict.
+
+        Returns:
+            The model as camelCase keys with unset fields omitted.
+        """
+        return self.model_dump(by_alias=True, exclude_none=True)
+
+
+#
+# Content
+#
+
+
+class ContentBlock(ACPModel):
+    """A single piece of content in a prompt or an agent message.
+
+    ACP reuses MCP's content block shapes. Which fields are populated depends on
+    ``type``: ``text`` carries ``text``, ``image``/``audio`` carry ``data`` and
+    ``mime_type``, ``resource_link`` carries ``uri``, and ``resource`` carries an
+    embedded ``resource`` object.
+
+    Parameters:
+        type: The block discriminator.
+        text: Text content, for ``text`` blocks.
+        data: Base64 payload, for ``image`` and ``audio`` blocks.
+        mime_type: Media type of ``data``.
+        uri: Target, for ``resource_link`` blocks.
+        name: Human-readable label, for ``resource_link`` blocks.
+        resource: Embedded resource contents, for ``resource`` blocks.
+    """
+
+    type: str
+    text: str | None = None
+    data: str | None = None
+    mime_type: str | None = None
+    uri: str | None = None
+    name: str | None = None
+    resource: dict[str, Any] | None = None
+
+
+def text_block(text: str) -> ContentBlock:
+    """Build a plain text content block.
+
+    Args:
+        text: The text to wrap.
+
+    Returns:
+        A ``text`` content block.
+    """
+    return ContentBlock(type="text", text=text)
+
+
+#
+# Capabilities and initialization
+#
+
+
+class FileSystemCapability(ACPModel):
+    """Filesystem methods the client is willing to serve.
+
+    Parameters:
+        read_text_file: Whether the client serves ``fs/read_text_file``.
+        write_text_file: Whether the client serves ``fs/write_text_file``.
+    """
+
+    read_text_file: bool = False
+    write_text_file: bool = False
+
+
+class ClientCapabilities(ACPModel):
+    """What the client can do on the agent's behalf.
+
+    An agent that sees a capability turned off falls back to doing the work
+    itself, so declaring nothing is always safe.
+
+    Parameters:
+        fs: Filesystem methods the client serves.
+        terminal: Whether the client serves the ``terminal/*`` methods.
+    """
+
+    fs: FileSystemCapability = Field(default_factory=FileSystemCapability)
+    terminal: bool = False
+
+
+class PromptCapabilities(ACPModel):
+    """Content block types the agent accepts in a prompt.
+
+    Parameters:
+        image: Whether image blocks are accepted.
+        audio: Whether audio blocks are accepted.
+        embedded_context: Whether embedded resource blocks are accepted.
+    """
+
+    image: bool = False
+    audio: bool = False
+    embedded_context: bool = False
+
+
+class AgentCapabilities(ACPModel):
+    """What the agent supports.
+
+    Parameters:
+        load_session: Whether ``session/load`` is supported.
+        prompt_capabilities: Content block types accepted in a prompt.
+    """
+
+    load_session: bool = False
+    prompt_capabilities: PromptCapabilities = Field(default_factory=PromptCapabilities)
+
+
+class AuthMethod(ACPModel):
+    """An authentication method the agent offers.
+
+    Parameters:
+        id: Identifier to pass to ``authenticate``.
+        name: Human-readable label.
+        description: Longer explanation of the method.
+    """
+
+    id: str
+    name: str | None = None
+    description: str | None = None
+
+
+class InitializeResult(ACPModel):
+    """The agent's response to ``initialize``.
+
+    Parameters:
+        protocol_version: Major protocol version the agent settled on.
+        agent_capabilities: What the agent supports.
+        auth_methods: Authentication methods the agent offers.
+    """
+
+    protocol_version: int = PROTOCOL_VERSION
+    agent_capabilities: AgentCapabilities = Field(default_factory=AgentCapabilities)
+    auth_methods: list[AuthMethod] = Field(default_factory=list)
+
+
+class MCPServer(ACPModel):
+    """An MCP server the agent should connect to for this session.
+
+    Parameters:
+        name: Label for the server.
+        command: Executable to run.
+        args: Arguments passed to the executable.
+        env: Environment variables for the server process.
+    """
+
+    name: str
+    command: str
+    args: list[str] = Field(default_factory=list)
+    env: list[dict[str, str]] = Field(default_factory=list)
+
+
+#
+# Session state
+#
+
+
+class SessionMode(ACPModel):
+    """An operating mode the agent offers.
+
+    Parameters:
+        id: Identifier to pass to ``session/set_mode``.
+        name: Human-readable label.
+        description: Longer explanation of the mode.
+    """
+
+    id: str
+    name: str | None = None
+    description: str | None = None
+
+
+class SessionModeState(ACPModel):
+    """The agent's current and available modes.
+
+    Parameters:
+        current_mode_id: The mode the agent is operating in.
+        available_modes: Every mode the agent offers.
+    """
+
+    current_mode_id: str | None = None
+    available_modes: list[SessionMode] = Field(default_factory=list)
+
+
+class AvailableCommand(ACPModel):
+    """A slash command the agent exposes.
+
+    Parameters:
+        name: Command name, without a leading slash.
+        description: What the command does.
+        input: Hint describing the command's expected input.
+    """
+
+    name: str
+    description: str | None = None
+    input: dict[str, Any] | None = None
+
+
+class NewSessionResult(ACPModel):
+    """The agent's response to ``session/new``.
+
+    Parameters:
+        session_id: Identifier for the new session.
+        modes: The session's initial mode state, if the agent offers modes.
+    """
+
+    session_id: str
+    modes: SessionModeState | None = None
+
+
+#
+# Plans and tool calls
+#
+
+
+class PlanEntryStatus(StrEnum):
+    """Status of a single plan entry."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class PlanEntry(ACPModel):
+    """One step in the agent's plan.
+
+    Parameters:
+        content: What the step does.
+        priority: Relative importance, as reported by the agent.
+        status: Where the step is in its lifecycle.
+    """
+
+    content: str
+    priority: str | None = None
+    status: PlanEntryStatus = PlanEntryStatus.PENDING
+
+
+class ToolKind(StrEnum):
+    """Broad category of a tool call, used to pick an icon or a phrasing."""
+
+    READ = "read"
+    EDIT = "edit"
+    DELETE = "delete"
+    MOVE = "move"
+    SEARCH = "search"
+    EXECUTE = "execute"
+    THINK = "think"
+    FETCH = "fetch"
+    SWITCH_MODE = "switch_mode"
+    OTHER = "other"
+
+
+class ToolCallStatus(StrEnum):
+    """Where a tool call is in its lifecycle."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ToolCallLocation(ACPModel):
+    """A file the tool call touches.
+
+    Parameters:
+        path: Absolute path to the file.
+        line: Line number of interest within the file.
+    """
+
+    path: str
+    line: int | None = None
+
+
+class ToolCall(ACPModel):
+    """A tool call the agent has started.
+
+    Parameters:
+        tool_call_id: Identifier used by every later update.
+        title: Human-readable description of the call.
+        kind: Broad category of the call.
+        status: Where the call is in its lifecycle.
+        content: Output produced by the call, including diffs.
+        locations: Files the call touches.
+        raw_input: The arguments the agent passed to the tool.
+        raw_output: The raw result the tool returned.
+    """
+
+    tool_call_id: str
+    title: str | None = None
+    kind: ToolKind = ToolKind.OTHER
+    status: ToolCallStatus = ToolCallStatus.PENDING
+    content: list[dict[str, Any]] = Field(default_factory=list)
+    locations: list[ToolCallLocation] = Field(default_factory=list)
+    raw_input: Any | None = None
+    raw_output: Any | None = None
+
+
+class ToolCallUpdate(ACPModel):
+    """A change to a tool call already announced.
+
+    Every field other than ``tool_call_id`` is a delta: absent means unchanged,
+    so a consumer needs the original :class:`ToolCall` to render an update in
+    full.
+
+    Parameters:
+        tool_call_id: Identifier of the call being updated.
+        title: Replacement description, if it changed.
+        kind: Replacement category, if it changed.
+        status: New lifecycle status, if it changed.
+        content: Output produced since the last update.
+        locations: Replacement file list, if it changed.
+        raw_input: Replacement arguments, if they changed.
+        raw_output: The raw result the tool returned.
+    """
+
+    tool_call_id: str
+    title: str | None = None
+    kind: ToolKind | None = None
+    status: ToolCallStatus | None = None
+    content: list[dict[str, Any]] | None = None
+    locations: list[ToolCallLocation] | None = None
+    raw_input: Any | None = None
+    raw_output: Any | None = None
+
+
+#
+# Permission
+#
+
+
+class PermissionOptionKind(StrEnum):
+    """The effect of choosing a permission option."""
+
+    ALLOW_ONCE = "allow_once"
+    ALLOW_ALWAYS = "allow_always"
+    REJECT_ONCE = "reject_once"
+    REJECT_ALWAYS = "reject_always"
+
+
+class PermissionOption(ACPModel):
+    """One choice offered in a permission request.
+
+    Parameters:
+        option_id: Identifier to send back in the response.
+        name: Human-readable label for the choice.
+        kind: The effect of choosing this option.
+    """
+
+    option_id: str
+    name: str | None = None
+    kind: PermissionOptionKind = PermissionOptionKind.ALLOW_ONCE
+
+
+class RequestPermissionParams(ACPModel):
+    """Parameters of a ``session/request_permission`` call.
+
+    Parameters:
+        session_id: Session the request belongs to.
+        tool_call: The call awaiting approval.
+        options: The choices the user may pick from.
+    """
+
+    session_id: str
+    tool_call: ToolCall
+    options: list[PermissionOption] = Field(default_factory=list)
+
+
+class RequestPermissionResult(ACPModel):
+    """The client's answer to a permission request.
+
+    Parameters:
+        outcome: Either ``{"outcome": "selected", "optionId": ...}`` or
+            ``{"outcome": "cancelled"}``.
+    """
+
+    outcome: dict[str, Any]
+
+    @classmethod
+    def selected(cls, option_id: str) -> "RequestPermissionResult":
+        """Build a result selecting an option.
+
+        Args:
+            option_id: The chosen option's identifier.
+
+        Returns:
+            A populated result.
+        """
+        return cls(outcome={"outcome": "selected", "optionId": option_id})
+
+    @classmethod
+    def cancelled(cls) -> "RequestPermissionResult":
+        """Build a result declining to answer.
+
+        Returns:
+            A populated result.
+        """
+        return cls(outcome={"outcome": "cancelled"})
+
+
+#
+# Filesystem and terminal
+#
+
+
+class ReadTextFileParams(ACPModel):
+    """Parameters of an ``fs/read_text_file`` call.
+
+    Parameters:
+        session_id: Session the request belongs to.
+        path: Absolute path to read.
+        line: First line to return, 1-indexed.
+        limit: Maximum number of lines to return.
+    """
+
+    session_id: str
+    path: str
+    line: int | None = None
+    limit: int | None = None
+
+
+class ReadTextFileResult(ACPModel):
+    """The contents returned for an ``fs/read_text_file`` call.
+
+    Parameters:
+        content: The requested text.
+    """
+
+    content: str
+
+
+class WriteTextFileParams(ACPModel):
+    """Parameters of an ``fs/write_text_file`` call.
+
+    Parameters:
+        session_id: Session the request belongs to.
+        path: Absolute path to write.
+        content: The full new contents of the file.
+    """
+
+    session_id: str
+    path: str
+    content: str
+
+
+class TerminalParams(ACPModel):
+    """Parameters of any ``terminal/*`` call.
+
+    The protocol splits these across several methods with overlapping shapes;
+    this model covers all of them, leaving unused fields unset.
+
+    Parameters:
+        session_id: Session the request belongs to.
+        terminal_id: Identifier of an existing terminal.
+        command: Executable to run, for ``terminal/create``.
+        args: Arguments passed to the executable.
+        env: Environment variables for the process.
+        cwd: Working directory for the process.
+        output_byte_limit: Maximum bytes of output to retain.
+    """
+
+    session_id: str
+    terminal_id: str | None = None
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env: list[dict[str, str]] = Field(default_factory=list)
+    cwd: str | None = None
+    output_byte_limit: int | None = None
+
+
+#
+# Turn completion
+#
+
+
+class StopReason(StrEnum):
+    """Why a ``session/prompt`` turn ended."""
+
+    END_TURN = "end_turn"
+    MAX_TOKENS = "max_tokens"
+    MAX_TURN_REQUESTS = "max_turn_requests"
+    REFUSAL = "refusal"
+    CANCELLED = "cancelled"
+
+
+class ACPErrorData(ACPModel):
+    """A JSON-RPC error returned to or by this client.
+
+    Parameters:
+        code: JSON-RPC error code.
+        message: Human-readable description.
+        data: Additional error detail.
+    """
+
+    code: int = -32603
+    message: str = "Internal error"
+    data: Any | None = None

--- a/tests/acp_fake_agent.py
+++ b/tests/acp_fake_agent.py
@@ -1,0 +1,145 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A minimal ACP agent, for testing an ACP client against a real subprocess.
+
+Reads newline-delimited JSON-RPC on stdin and writes it on stdout, the way a
+real agent does. On ``session/prompt`` it streams a thought, a tool call, a
+permission request, and a reply, then ends the turn.
+
+Run it as ``python tests/acp_fake_agent.py``. Pass ``--die-after-session`` to
+exit as soon as a session opens, which simulates an agent crashing mid-session.
+"""
+
+import json
+import sys
+import threading
+
+_write_lock = threading.Lock()
+
+
+def send(message):
+    """Write one message to stdout."""
+    with _write_lock:
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+
+def update(session_id, **params):
+    """Send a session/update notification."""
+    send(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"sessionId": session_id, **params},
+        }
+    )
+
+
+def main():
+    """Serve requests until stdin closes."""
+    next_id = 1000
+    pending = {}
+
+    for line in sys.stdin:
+        message = json.loads(line)
+        method = message.get("method")
+
+        if method is None:
+            # A response to something we asked the client.
+            if callback := pending.pop(message.get("id"), None):
+                callback(message)
+            continue
+
+        if method == "initialize":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {
+                            "loadSession": True,
+                            "promptCapabilities": {"image": False},
+                        },
+                    },
+                }
+            )
+        elif method == "session/new":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "result": {
+                        "sessionId": "test-session",
+                        "modes": {
+                            "currentModeId": "default",
+                            "availableModes": [{"id": "default", "name": "Default"}],
+                        },
+                    },
+                }
+            )
+            if "--die-after-session" in sys.argv:
+                return
+        elif method == "session/prompt":
+            session_id = message["params"]["sessionId"]
+            prompt_id = message["id"]
+
+            update(
+                session_id,
+                sessionUpdate="agent_thought_chunk",
+                content={"type": "text", "text": "thinking"},
+            )
+            update(
+                session_id,
+                sessionUpdate="tool_call",
+                toolCallId="call-1",
+                title="Read worker.py",
+                kind="read",
+                status="pending",
+            )
+
+            next_id += 1
+            request_id = next_id
+
+            def finish(_response, session_id=session_id, prompt_id=prompt_id):
+                update(
+                    session_id,
+                    sessionUpdate="tool_call_update",
+                    toolCallId="call-1",
+                    status="completed",
+                )
+                update(
+                    session_id,
+                    sessionUpdate="agent_message_chunk",
+                    content={"type": "text", "text": "done"},
+                )
+                send({"jsonrpc": "2.0", "id": prompt_id, "result": {"stopReason": "end_turn"}})
+
+            pending[request_id] = finish
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "session/request_permission",
+                    "params": {
+                        "sessionId": session_id,
+                        "toolCall": {"toolCallId": "call-1", "title": "Read worker.py"},
+                        "options": [
+                            {"optionId": "yes", "name": "Allow", "kind": "allow_once"},
+                            {"optionId": "no", "name": "Reject", "kind": "reject_once"},
+                        ],
+                    },
+                }
+            )
+        elif method == "session/cancel":
+            pass
+        elif "id" in message:
+            send({"jsonrpc": "2.0", "id": message["id"], "result": {}})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/acp_fake_agent.py
+++ b/tests/acp_fake_agent.py
@@ -34,7 +34,7 @@ def update(session_id, **params):
         {
             "jsonrpc": "2.0",
             "method": "session/update",
-            "params": {"sessionId": session_id, **params},
+            "params": {"sessionId": session_id, "update": params},
         }
     )
 
@@ -106,6 +106,11 @@ def main():
             request_id = next_id
 
             def finish(_response, session_id=session_id, prompt_id=prompt_id):
+                if "--expect-cancelled-permission" in sys.argv:
+                    outcome = _response.get("result", {}).get("outcome", {}).get("outcome")
+                    stop_reason = "cancelled" if outcome == "cancelled" else "refusal"
+                    send({"jsonrpc": "2.0", "id": prompt_id, "result": {"stopReason": stop_reason}})
+                    return
                 update(
                     session_id,
                     sessionUpdate="tool_call_update",

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,0 +1,237 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Agent Client Protocol support."""
+
+import os
+import sys
+import unittest
+
+from pipecat.frames.frames import (
+    CancelFrame,
+    ErrorFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.services.acp.aggregator import ACPUserAggregator
+from pipecat.services.acp.client import ACPClient
+from pipecat.services.acp.frames import (
+    ACPAgentMessageFrame,
+    ACPAgentThoughtFrame,
+    ACPClientResponseFrame,
+    ACPPermissionRequestFrame,
+    ACPPromptFrame,
+    ACPSessionEndedFrame,
+    ACPSessionStartedFrame,
+    ACPToolCallFrame,
+    ACPToolCallUpdateFrame,
+    ACPTurnEndedFrame,
+    ACPTurnStartedFrame,
+)
+from pipecat.services.acp.permissions import ACPAutoPermission
+from pipecat.services.acp.service import ACPService
+from pipecat.services.acp.types import (
+    ClientCapabilities,
+    StopReason,
+    ToolCall,
+    ToolCallStatus,
+    ToolCallUpdate,
+    text_block,
+)
+from pipecat.tests.utils import SleepFrame, run_test
+
+FAKE_AGENT = [sys.executable, os.path.join(os.path.dirname(__file__), "acp_fake_agent.py")]
+
+
+class TestACPClient(unittest.IsolatedAsyncioTestCase):
+    """The protocol client, driven against a real agent subprocess."""
+
+    async def test_initialize_and_new_session(self):
+        client = ACPClient()
+        await client.start(FAKE_AGENT, cwd=os.getcwd())
+        try:
+            init = await client.initialize(ClientCapabilities())
+            self.assertEqual(init.protocol_version, 1)
+            self.assertTrue(init.agent_capabilities.load_session)
+
+            session = await client.new_session(os.getcwd())
+            self.assertEqual(session.session_id, "test-session")
+            self.assertEqual(session.modes.current_mode_id, "default")
+        finally:
+            await client.stop()
+
+    async def test_prompt_streams_updates_and_serves_requests(self):
+        updates = []
+        client = ACPClient()
+        client.on_session_update = lambda params: _collect(updates, params)
+        client.on_client_request = _allow_permission
+
+        await client.start(FAKE_AGENT, cwd=os.getcwd())
+        try:
+            await client.initialize(ClientCapabilities())
+            session = await client.new_session(os.getcwd())
+            stop_reason = await client.prompt(session.session_id, [text_block("hello")])
+        finally:
+            await client.stop()
+
+        self.assertEqual(stop_reason, StopReason.END_TURN)
+        kinds = [u["sessionUpdate"] for u in updates]
+        self.assertEqual(
+            kinds,
+            [
+                "agent_thought_chunk",
+                "tool_call",
+                "tool_call_update",
+                "agent_message_chunk",
+            ],
+        )
+
+
+async def _collect(sink, params):
+    sink.append(params)
+
+
+async def _allow_permission(request_id, method, params):
+    assert method == "session/request_permission"
+    return {"outcome": {"outcome": "selected", "optionId": "yes"}}
+
+
+class TestACPUserAggregator(unittest.IsolatedAsyncioTestCase):
+    """Transcriptions collected into one prompt per turn."""
+
+    async def test_emits_one_prompt_per_turn(self):
+        """Transcriptions arriving after the turn ends still make the prompt."""
+        aggregator = ACPUserAggregator(aggregation_timeout=0.1)
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            TranscriptionFrame(text="what does", user_id="u", timestamp=""),
+            UserStoppedSpeakingFrame(),
+            TranscriptionFrame(text="worker.py do", user_id="u", timestamp=""),
+            SleepFrame(sleep=0.3),
+        ]
+        expected_down_frames = [
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            TranscriptionFrame,
+            TranscriptionFrame,
+            ACPPromptFrame,
+        ]
+
+        received_down, _ = await run_test(
+            aggregator,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        prompt = received_down[-1]
+        self.assertEqual(prompt.blocks[0].text, "what does worker.py do")
+
+    async def test_silent_turn_emits_no_prompt(self):
+        aggregator = ACPUserAggregator(aggregation_timeout=0.1)
+        await run_test(
+            aggregator,
+            frames_to_send=[
+                UserStartedSpeakingFrame(),
+                UserStoppedSpeakingFrame(),
+                SleepFrame(sleep=0.3),
+            ],
+            expected_down_frames=[UserStartedSpeakingFrame, UserStoppedSpeakingFrame],
+        )
+
+
+class TestACPService(unittest.IsolatedAsyncioTestCase):
+    """The service, bridging a real agent subprocess to frames."""
+
+    async def test_prompt_produces_acp_frames(self):
+        pipeline = Pipeline([ACPService(command=FAKE_AGENT, cwd=os.getcwd()), ACPAutoPermission()])
+
+        frames_to_send = [
+            ACPPromptFrame(blocks=[text_block("hello")]),
+            SleepFrame(sleep=1.0),
+        ]
+        expected_down_frames = [
+            ACPSessionStartedFrame,
+            ACPTurnStartedFrame,
+            ACPAgentThoughtFrame,
+            ACPToolCallFrame,
+            ACPPermissionRequestFrame,
+            ACPClientResponseFrame,
+            ACPToolCallUpdateFrame,
+            ACPAgentMessageFrame,
+            ACPTurnEndedFrame,
+            ACPSessionEndedFrame,
+        ]
+
+        received_down, _ = await run_test(
+            pipeline,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+        )
+
+        turn_ended = next(f for f in received_down if isinstance(f, ACPTurnEndedFrame))
+        self.assertEqual(turn_ended.stop_reason, StopReason.END_TURN)
+
+        # The update omits the title; the service merges it from the original call.
+        update = next(f for f in received_down if isinstance(f, ACPToolCallUpdateFrame))
+        self.assertEqual(update.tool_call.title, "Read worker.py")
+        self.assertEqual(update.tool_call.status, ToolCallStatus.COMPLETED)
+
+    async def test_tool_call_update_carries_merged_call(self):
+        """An update omits the title, so the service supplies it from the original."""
+        service = ACPService(command=FAKE_AGENT, cwd=os.getcwd())
+        service._tool_calls["call-1"] = ToolCall(
+            tool_call_id="call-1", title="Read worker.py", status=ToolCallStatus.PENDING
+        )
+
+        merged = service._merge_tool_call(
+            ToolCallUpdate(tool_call_id="call-1", status=ToolCallStatus.COMPLETED)
+        )
+
+        self.assertEqual(merged.title, "Read worker.py")
+        self.assertEqual(merged.status, ToolCallStatus.COMPLETED)
+
+    async def test_agent_exit_ends_session_and_errors(self):
+        """A dead agent has to surface, not hang until a timeout."""
+        service = ACPService(command=FAKE_AGENT + ["--die-after-session"], cwd=os.getcwd())
+
+        received_down, received_up = await run_test(
+            service,
+            frames_to_send=[SleepFrame(sleep=0.5)],
+            expected_down_frames=[ACPSessionStartedFrame, ACPSessionEndedFrame, CancelFrame],
+            expected_up_frames=[ErrorFrame],
+        )
+
+        self.assertTrue(received_up[0].fatal)
+        self.assertIn("exited", received_down[1].reason)
+
+    async def test_failed_spawn_pushes_fatal_error(self):
+        service = ACPService(command=["definitely-not-a-real-binary"], cwd=os.getcwd())
+
+        _, received_up = await run_test(
+            service,
+            frames_to_send=[SleepFrame(sleep=0.2)],
+            expected_up_frames=[ErrorFrame],
+        )
+
+        self.assertTrue(received_up[0].fatal)
+
+    async def test_tool_call_update_appends_content(self):
+        service = ACPService(command=FAKE_AGENT, cwd=os.getcwd())
+        service._tool_calls["call-1"] = ToolCall(
+            tool_call_id="call-1", content=[{"type": "content", "text": "first"}]
+        )
+
+        merged = service._merge_tool_call(
+            ToolCallUpdate(tool_call_id="call-1", content=[{"type": "content", "text": "second"}])
+        )
+
+        self.assertEqual(len(merged.content), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -23,6 +23,7 @@ from pipecat.services.acp.client import ACPClient
 from pipecat.services.acp.frames import (
     ACPAgentMessageFrame,
     ACPAgentThoughtFrame,
+    ACPCancelTurnFrame,
     ACPClientResponseFrame,
     ACPPermissionRequestFrame,
     ACPPromptFrame,
@@ -80,7 +81,7 @@ class TestACPClient(unittest.IsolatedAsyncioTestCase):
             await client.stop()
 
         self.assertEqual(stop_reason, StopReason.END_TURN)
-        kinds = [u["sessionUpdate"] for u in updates]
+        kinds = [u["update"]["sessionUpdate"] for u in updates]
         self.assertEqual(
             kinds,
             [
@@ -208,6 +209,34 @@ class TestACPService(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(received_up[0].fatal)
         self.assertIn("exited", received_down[1].reason)
+
+    async def test_cancel_turn_cancels_pending_permission(self):
+        """Cancellation must unblock an agent waiting on a permission decision."""
+        service = ACPService(
+            command=FAKE_AGENT + ["--expect-cancelled-permission"], cwd=os.getcwd()
+        )
+
+        received_down, _ = await run_test(
+            service,
+            frames_to_send=[
+                ACPPromptFrame(blocks=[text_block("hello")]),
+                SleepFrame(sleep=0.1),
+                ACPCancelTurnFrame(),
+                SleepFrame(sleep=0.3),
+            ],
+            expected_down_frames=[
+                ACPSessionStartedFrame,
+                ACPTurnStartedFrame,
+                ACPAgentThoughtFrame,
+                ACPToolCallFrame,
+                ACPPermissionRequestFrame,
+                ACPTurnEndedFrame,
+                ACPSessionEndedFrame,
+            ],
+        )
+
+        turn_ended = next(f for f in received_down if isinstance(f, ACPTurnEndedFrame))
+        self.assertEqual(turn_ended.stop_reason, StopReason.CANCELLED)
 
     async def test_failed_spawn_pushes_fatal_error(self):
         service = ACPService(command=["definitely-not-a-real-binary"], cwd=os.getcwd())


### PR DESCRIPTION
This is the first part of a multi-step process to add ACP support to Pipecat. 

[Agent Client Protocol](https://agentclientprotocol.com) is what code editors speak to coding agents: JSON-RPC over stdio, with the editor spawning the agent as a subprocess. Zed uses it for Claude Code, Gemini CLI, and Goose. It sits on the other side of an agent from MCP, connecting the agent up to a user interface rather than down to tools.

This adds `pipecat.services.acp`, so a Pipecat bot can drive one of those agents the way an editor would.

```
src/pipecat/services/acp/
  types.py        Pydantic wire models
  client.py       ACPClient: subprocess, JSON-RPC, correlation. No Pipecat imports.
  frames.py       19 frame types
  service.py      ACPService(AIService)
  aggregator.py   ACPUserAggregator: speech -> ACPPromptFrame
  permissions.py  ACPAutoPermission: auto-approve stub
  renderers.py    describe(): one line per ACP frame
src/pipecat/observers/loggers/acp_log_observer.py
examples/acp/acp-voice-client.py
```

`ACPService` sends each user turn as `session/prompt`, converts the agent's `session/update` stream into frames, and hands the agent's callbacks to whichever processor is willing to answer them.

## Scope: this is plumbing only

This is the protocol layer, so we're specifically _not_ solving three problems right now:

**How a voice loop answers approvals and questions.** When an agent hits `session/request_permission`, it blocks until a human decides. We sort of have a mechanism for this in UIAgent as prior art, but that doesn't just drop in to ACP.

**What the agent should sound like.** ACP's output is written to be read: file paths, diffs, token counts, and a reasoning stream that runs to thousands of words. `ACPService` emits no `TextFrame` and nothing a TTS service will speak, so a pipeline built from this is silent by design. `describe()` in `renderers.py` is the smallest possible renderer, one line per frame, and `ACPLogObserver` logs it. Mark and I have discussed a few possibilities here, but we're not solving this yet.

**Any actual agents.** Claude Code, Codex, Hermes, and other agent frameworks will likely exist as subclasses eventually.

## Design notes

**The agent owns the conversation.** ACP replays history from the `sessionId`, so the service holds no `LLMContext` and sends only the new user turn. It subclasses `AIService` rather than `LLMService` for that reason.

**One mechanism for every agent callback.** Permission, `fs/read_text_file`, `fs/write_text_file`, and the five `terminal/*` methods are all "the agent asks the client something and blocks." They share one request/response frame pair, correlated by `request_id`, following the `FunctionCallInProgressFrame`/`FunctionCallResultFrame` precedent. Requests are broadcast upstream and downstream, so an answering processor works on either side of the service. A permission answer derived from user speech arrives from upstream; a UI-driven one arrives from downstream.

**Interruption does not cancel the agent by default.** Barge-in during a multi-file edit would leave the working tree half-changed, so `InterruptionFrame` stops downstream playback and the agent keeps working. `cancel_turn_on_interruption=True` opts into the aggressive behavior.

**A dead agent is fatal.** When the agent's stdout closes, the client reaps the return code and fails everything waiting on it, rather than letting each caller sit until its own timeout. The service ends the session, fires `on_agent_exited`, and pushes a fatal error. A failure during spawn or handshake reports separately, since `AIService._start` would otherwise only log it.

**Turn-end can't trigger on `UserStoppedSpeakingFrame`.** That's a system frame and transcriptions are data frames, so it arrives before the words that finish the turn. `ACPUserAggregator` debounces instead, following the `DTMFAggregator` pattern: one long-lived task, an event poked by each transcription, flush after a quiet period.

## Testing

`tests/acp_fake_agent.py` is a working ACP agent in ~145 lines of stdlib Python. It serves `initialize` and `session/new`, then on `session/prompt` streams a thought and a tool call, sends a permission request, and finishes the turn only after the client answers. Tests spawn it as a real subprocess, so the full path is exercised, including the agent-blocked-on-client callback.

Nine tests cover the client handshake and prompt stream, the aggregator (including a transcription arriving after the turn ends), the end-to-end frame sequence with the permission round trip, tool-call merging, mid-session agent death, and a failed spawn. Full suite passes at 3604.

## Notes From a Human At The End

I put this in a PR because it felt like the right place to talk about some of the philosophical ideas around whether we even want this, and it's easier to have those conversations about something concrete rather than abstract. I suspect that if we _do_ want this, we'll want to stack a few more PRs on top of this before we consider merging any of them.