### PR TITLE
fix(inworld): configure interruption text fallback

### DIFF
--- a/changelog/5310.changed.md
+++ b/changelog/5310.changed.md
@@ -1,0 +1,1 @@
+Added an `InworldTTSService` option to suppress full-text fallback when speech is interrupted before timestamps are received.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -613,6 +613,7 @@ class InworldTTSService(WebsocketTTSService):
         aggregate_sentences: bool | None = None,
         text_aggregation_mode: TextAggregationMode | None = None,
         append_trailing_space: bool = True,
+        push_full_text_on_interruption_without_timestamps: bool = True,
         **kwargs: Any,
     ):
         """Initialize the Inworld WebSocket TTS service.
@@ -656,6 +657,8 @@ class InworldTTSService(WebsocketTTSService):
 
             text_aggregation_mode: How to aggregate text before synthesis.
             append_trailing_space: Whether to append a trailing space to text before sending to TTS.
+            push_full_text_on_interruption_without_timestamps: Whether to push the full text
+                when interrupted before any timestamps are received. Defaults to True.
             **kwargs: Additional arguments passed to the parent class.
         """
         # Derive auto_mode from aggregate_sentences if not explicitly set
@@ -752,6 +755,9 @@ class InworldTTSService(WebsocketTTSService):
         self._auto_mode = auto_mode
         self._apply_text_normalization = apply_text_normalization
         self._timestamp_transport_strategy = timestamp_transport_strategy
+        self._push_full_text_on_interruption_without_timestamps = (
+            push_full_text_on_interruption_without_timestamps
+        )
 
     def can_generate_metrics(self) -> bool:
         """Check if this service can generate processing metrics.
@@ -871,17 +877,16 @@ class InworldTTSService(WebsocketTTSService):
 
     async def on_audio_context_interrupted(self, context_id: str):
         """Callback invoked when an audio context has been interrupted."""
-        await self._maybe_push_fallback_text(context_id)
+        await self._maybe_push_fallback_text(context_id, is_interruption=True)
         await self._close_context(context_id)
         await super().on_audio_context_interrupted(context_id)
 
-    async def _maybe_push_fallback_text(self, context_id: str):
+    async def _maybe_push_fallback_text(self, context_id: str, *, is_interruption: bool = False):
         """Push the full text as fallback when no timestamps were received.
 
-        so that the LLM conversation context still reflects what the agent spoke.
-        Without timestamps, the full text is always committed — even on
-        interruption — since there is no timing information to determine which
-        portion was actually spoken.
+        This keeps the LLM conversation context aligned with completed speech.
+        Interrupted speech follows the configured fallback policy because no
+        timing information is available to determine which portion was spoken.
         """
         if not context_id:
             return
@@ -889,6 +894,8 @@ class InworldTTSService(WebsocketTTSService):
         text = self._context_texts.pop(context_id, "").strip()
         self._contexts_with_timestamps.discard(context_id)
         if had_timestamps or not text:
+            return
+        if is_interruption and not self._push_full_text_on_interruption_without_timestamps:
             return
         logger.debug(f"{self}: No timestamps for context {context_id}, pushing fallback: [{text}]")
         fallback = TTSTextFrame(text, aggregated_by=AggregationType.SENTENCE)

--- a/tests/test_inworld_tts_fallback.py
+++ b/tests/test_inworld_tts_fallback.py
@@ -1,0 +1,89 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for Inworld WebSocket TTS fallback text handling."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.frames.frames import TTSTextFrame
+from pipecat.services.inworld.tts import InworldTTSService
+from pipecat.services.tts_service import TTSService
+
+
+def _service(*, push_on_interruption: bool = True) -> InworldTTSService:
+    service = InworldTTSService(
+        api_key="test-key",
+        push_full_text_on_interruption_without_timestamps=push_on_interruption,
+    )
+    service.push_frame = AsyncMock()
+    return service
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_pushes_fallback_when_interruption_fallback_is_disabled():
+    """Normal completion should always preserve text when timestamps are unavailable."""
+    service = _service(push_on_interruption=False)
+    service._context_texts["context-1"] = "Hello world "
+
+    await service._maybe_push_fallback_text("context-1")
+
+    service.push_frame.assert_awaited_once()
+    frame = service.push_frame.await_args.args[0]
+    assert isinstance(frame, TTSTextFrame)
+    assert frame.text == "Hello world"
+    assert frame.context_id == "context-1"
+
+
+@pytest.mark.asyncio
+async def test_interruption_pushes_fallback_by_default():
+    """The default should retain the existing full-text interruption behavior."""
+    service = _service()
+    service._context_texts["context-1"] = "Hello world"
+
+    await service._maybe_push_fallback_text("context-1", is_interruption=True)
+
+    service.push_frame.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_interruption_can_suppress_fallback_and_consumes_context_state():
+    """Suppressed interruption text must not be emitted by a late contextClosed event."""
+    service = _service(push_on_interruption=False)
+    service._context_texts["context-1"] = "Hello world"
+
+    await service._maybe_push_fallback_text("context-1", is_interruption=True)
+    await service._maybe_push_fallback_text("context-1")
+
+    service.push_frame.assert_not_awaited()
+    assert "context-1" not in service._context_texts
+
+
+@pytest.mark.asyncio
+async def test_timestamped_interruption_does_not_push_full_text():
+    """Timestamp-confirmed text should remain authoritative during interruption."""
+    service = _service()
+    service._context_texts["context-1"] = "Hello world"
+    service._contexts_with_timestamps.add("context-1")
+
+    await service._maybe_push_fallback_text("context-1", is_interruption=True)
+
+    service.push_frame.assert_not_awaited()
+    assert "context-1" not in service._contexts_with_timestamps
+
+
+@pytest.mark.asyncio
+async def test_audio_interruption_marks_fallback_as_interrupted():
+    """The interruption callback should apply the configurable fallback policy."""
+    service = _service()
+    service._maybe_push_fallback_text = AsyncMock()
+    service._close_context = AsyncMock()
+
+    with patch.object(TTSService, "on_audio_context_interrupted", new=AsyncMock()):
+        await service.on_audio_context_interrupted("context-1")
+
+    service._maybe_push_fallback_text.assert_awaited_once_with("context-1", is_interruption=True)


### PR DESCRIPTION
## Summary

- add a backward-compatible option to suppress full-text fallback when an Inworld WebSocket TTS context is interrupted before timestamps arrive
- keep normal completion fallback unchanged and preserve timestamp-confirmed interruption behavior
- consume interrupted context state even when fallback is suppressed so a later `contextClosed` event cannot emit stale text

## Tests

- `uv run pytest tests/test_inworld_tts_fallback.py tests/test_inworld_tts_language.py -q`
- `uv run ruff check src/pipecat/services/inworld/tts.py tests/test_inworld_tts_fallback.py`
- `uv run ruff format --check src/pipecat/services/inworld/tts.py tests/test_inworld_tts_fallback.py`

Fixes #5303