### PR TITLE
test(utils): wait for the pipeline to start before pushing frames

### DIFF
--- a/changelog/5313.fixed.md
+++ b/changelog/5313.fixed.md
@@ -1,0 +1,1 @@
+- Fixed intermittent failures in tests written with `run_test()`. Frames were sent after a fixed 10ms delay, so a pipeline that took longer than that to start would drop them; `run_test()` now waits for the pipeline to be ready before sending. A new `start_timeout` argument (1 second by default) raises `TimeoutError` if the pipeline never starts.

--- a/src/pipecat/tests/utils.py
+++ b/src/pipecat/tests/utils.py
@@ -132,6 +132,7 @@ async def run_test(
     observers: list[BaseObserver] | None = None,
     pipeline_params: PipelineParams | None = None,
     send_end_frame: bool = True,
+    start_timeout: float = 1.0,
 ) -> tuple[Sequence[Frame], Sequence[Frame]]:
     """Run a test pipeline with the specified processor and validate frame flow.
 
@@ -152,12 +153,15 @@ async def run_test(
         observers: Optional list of observers to attach to the pipeline.
         pipeline_params: Optional pipeline parameters.
         send_end_frame: Whether to send an EndFrame at the end of the test.
+        start_timeout: How long to wait, in seconds, for the pipeline to start
+            before giving up.
 
     Returns:
         Tuple containing (downstream_frames, upstream_frames) that were received.
 
     Raises:
         AssertionError: If the received frames don't match the expected frame types.
+        TimeoutError: If the pipeline doesn't start within ``start_timeout``.
     """
     observers = observers or []
     pipeline_params = pipeline_params or PipelineParams()
@@ -185,9 +189,16 @@ async def run_test(
         params=pipeline_params,
     )
 
+    pipeline_started = asyncio.Event()
+
+    @worker.event_handler("on_pipeline_started")
+    async def _on_pipeline_started(worker, frame):
+        pipeline_started.set()
+
     async def push_frames():
-        # Just give a little head start to the runner.
-        await asyncio.sleep(0.01)
+        # Processors drop frames that arrive before StartFrame, and upstream
+        # frames enter at the sink, which StartFrame reaches last.
+        await asyncio.wait_for(pipeline_started.wait(), timeout=start_timeout)
         for frame in frames_to_send:
             if isinstance(frame, SleepFrame):
                 await asyncio.sleep(frame.sleep)


### PR DESCRIPTION
tl;dr

Fix for flaky tests in CI. There used to be a 0.01 sec sleep, which worked locally but was flaky in CI. Now, moving to an event instead with a 1.0 sec timout.

## Summary

- `run_test()` waits for the pipeline to be ready before pushing frames, rather than pushing after a fixed 10ms delay that a slow start can outrun. Processors drop frames received before `StartFrame`, and upstream frames enter at the sink — the last processor `StartFrame` reaches — so those frames were silently lost.
- The wait is on the worker's `on_pipeline_started` event, which fires when `StartFrame` reaches the end of the pipeline: the same condition the worker itself waits on before pushing anything.
- A new `start_timeout` argument (1 second) raises `TimeoutError` if the pipeline never starts, so a stuck pipeline fails instead of hanging.
- All 266 `run_test` call sites shared the race; upstream senders are the worst case, since the sink receives `StartFrame` last.

It surfaced as `TestLLMAssistantAggregator::test_llm_messages_append` failing in the Coverage job of an unrelated PR, 7ms from passing:

```
11.267  PipelineWorker#48: Waiting for StartFrame#107 to reach the end of the pipeline...
11.268  PipelineWorker#48::Sink Trying to process LLMMessagesAppendFrame#2 but StartFrame not received yet
11.274  PipelineWorker#48: StartFrame#107 reached the end of the pipeline, pipeline is now ready.
```

The dropped frame left the context empty, so the test's `context.messages[0]` raised `IndexError`. Coverage tracing inflates per-frame processing time, which is why it showed up in that job.

## Testing

- `uv run pytest` — 4086 passed, 29 skipped.
- To exercise the race directly: pass a processor that sleeps 300ms on `StartFrame`, and send a frame with `frames_to_send_direction=FrameDirection.UPSTREAM`. The frame reaches the processor on this branch; on `main` it is dropped with `Trying to process ... but StartFrame not received yet`.

On the `start_timeout` default: pipeline start measured across 292 `run_test` calls is 4.0ms median, 10.3ms p95, 55.8ms p99, 109.5ms max under coverage instrumentation, and effectively identical without it. 1 second leaves ~9x headroom over the slowest observed start while still failing fast. It is never reached on a healthy pipeline — the wait ends when the event fires.
