### PR TITLE
feat(evals): add stop_on_failure to scenarios

### DIFF
--- a/changelog/5317.added.md
+++ b/changelog/5317.added.md
@@ -1,0 +1,5 @@
+- Added a `stop_on_failure` field to eval scenarios. It defaults to `true`, the
+  existing behavior, where the first turn with a failed assertion ends the
+  scenario. Set it to `false` for a scenario whose turns are scored
+  independently — a benchmark reporting a per-turn pass rate needs every turn
+  driven, not just the ones before the first miss.

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -45,6 +45,10 @@ enumerate every event the bot emits). The ``within_ms`` budget for each
 expectation is measured from the most recent ``send-text`` / ``raw-audio`` / ``dtmf`` send
 (default 60s when omitted).
 
+A turn with a failed assertion ends the scenario, since the conversation is in
+an unknown state from there on. A scenario that scores each turn independently
+sets ``stop_on_failure: false`` to have every turn driven and reported.
+
 An ``llm_response`` with a content check (``text_contains`` / ``eval:``)
 aggregates: the harness accumulates the text of successive response segments
 within the turn and re-checks on each one, so an interim filler ("Let me check
@@ -512,12 +516,18 @@ class EvalSession:
                     turn_failures = await self._run_turn(turn, turn_idx)
                     failures.extend(turn_failures)
                     if turn_failures:
-                        # Fail fast: a failed turn leaves the conversation in an
-                        # unknown state, so running the rest just burns another
-                        # timeout per turn (e.g. a broken greeting turn shouldn't
-                        # cost the full budget here and again on the question).
-                        self._debug(f"turn {turn_idx} failed; stopping scenario (fail-fast)")
-                        break
+                        # By default a failed turn ends the scenario: it leaves the
+                        # conversation in an unknown state, so running the rest just
+                        # burns another timeout per turn (e.g. a broken greeting turn
+                        # shouldn't cost the full budget here and again on the
+                        # question). A scenario whose turns are scored independently
+                        # sets stop_on_failure: false and drives all of them.
+                        if self._scenario.stop_on_failure:
+                            self._debug(
+                                f"turn {turn_idx} failed; stopping scenario (stop_on_failure)"
+                            )
+                            break
+                        self._debug(f"turn {turn_idx} failed; continuing (stop_on_failure: false)")
         except Exception as e:
             # An unexpected harness-side error (a sub-pipeline failing to start
             # under load, a judge/transcriber raising mid-turn, ...) would

--- a/src/pipecat/evals/scenario.py
+++ b/src/pipecat/evals/scenario.py
@@ -112,6 +112,18 @@ Top-level optional fields:
     context: LLM messages the bot's context should start from. When given, the
             harness sends them before driving turns (replacing the bot's
             context); omit to leave the bot's own context untouched.
+    stop_on_failure:
+            whether the first failed turn ends the scenario (default true).
+            A failure leaves the conversation in an unknown state, so the
+            remaining turns usually just burn a timeout each. Set it false for a
+            scenario that scores every turn independently — a benchmark that
+            reports a per-turn pass rate needs all of its turns driven, not just
+            the ones before the first miss::
+
+                stop_on_failure: false
+
+            Give those turns an explicit ``within_ms``: with the 60s default, a
+            silent bot costs one full budget per remaining turn.
     user:   how user turns are delivered::
 
                 user:
@@ -389,6 +401,14 @@ class EvalScenario:
             default to avoid that between scenarios; set True to exercise the
             bot's disconnect path. Independent of ``--stop-bot``, which tears the
             bot down via ``eval-cancel`` regardless of the handler.
+        stop_on_failure: Whether the first failed turn ends the scenario
+            (default True). A failed turn leaves the conversation in an unknown
+            state, so continuing usually costs one timeout per remaining turn.
+            Set False for a scenario whose turns are scored independently, where
+            the turns after a failure are still worth driving. This governs
+            turn-to-turn progression only: within a turn, an expectation that
+            times out still ends that turn's matching, because a turn's
+            expectations share one deadline anchored at the send.
         source_path: Path the scenario was loaded from, for error messages.
     """
 
@@ -400,6 +420,7 @@ class EvalScenario:
     transcriber: dict | None = None
     user_audio: dict | None = None
     trigger_disconnect: bool = False
+    stop_on_failure: bool = True
     source_path: Path | None = None
 
     @classmethod
@@ -475,6 +496,7 @@ class EvalScenario:
             transcriber=transcriber,
             user_audio=user_audio,
             trigger_disconnect=bool(data.get("trigger_disconnect", False)),
+            stop_on_failure=bool(data.get("stop_on_failure", True)),
             source_path=path,
         )
 

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -800,6 +800,62 @@ class TestEvalsHarnessIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result.failures), 1)
         self.assertIn("does not contain", result.failures[0].reason)
 
+    def _two_turn_first_fails(self, *, stop_on_failure: bool) -> EvalScenario:
+        """A scenario whose first turn fails on content and whose second passes."""
+        self.server.on_text(
+            "first",
+            _rtvi("bot-llm-started"),
+            _rtvi("bot-llm-text", {"text": "Paris"}),
+            _rtvi("bot-llm-stopped"),
+        )
+        self.server.on_text(
+            "second",
+            _rtvi("bot-llm-started"),
+            _rtvi("bot-llm-text", {"text": "Berlin"}),
+            _rtvi("bot-llm-stopped"),
+        )
+        return EvalScenario(
+            name="stop",
+            bot_audio=False,
+            stop_on_failure=stop_on_failure,
+            turns=[
+                EvalTurn(
+                    user="first",
+                    expect=[
+                        EvalExpectation(event="llm_response", within_ms=300, text_contains="London")
+                    ],
+                ),
+                EvalTurn(
+                    user="second",
+                    expect=[
+                        EvalExpectation(
+                            event="llm_response", within_ms=2000, text_contains="Berlin"
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def _sent_texts(self) -> list[str]:
+        return [m["data"]["content"] for m in self.server.received if m.get("type") == "send-text"]
+
+    async def test_failed_turn_stops_scenario_by_default(self):
+        scenario = self._two_turn_first_fails(stop_on_failure=True)
+        result = await EvalSession.from_scenario(scenario, self.server.url).run()
+        self.assertFalse(result.passed)
+        # Only turn 0 is reported, and turn 1 is never sent.
+        self.assertEqual([f.turn_index for f in result.failures], [0])
+        self.assertEqual(self._sent_texts(), ["first"])
+
+    async def test_stop_on_failure_false_drives_remaining_turns(self):
+        scenario = self._two_turn_first_fails(stop_on_failure=False)
+        result = await EvalSession.from_scenario(scenario, self.server.url).run()
+        # The run still fails, but every turn was driven and the passing turn
+        # after the failure adds no failure of its own.
+        self.assertFalse(result.passed)
+        self.assertEqual([f.turn_index for f in result.failures], [0])
+        self.assertEqual(self._sent_texts(), ["first", "second"])
+
     async def test_missing_event_times_out(self):
         scenario = EvalScenario(
             name="never",

--- a/tests/test_evals_scenario.py
+++ b/tests/test_evals_scenario.py
@@ -573,6 +573,22 @@ class TestEvalsScenarioParser(unittest.TestCase):
         self.assertEqual(s.judge, {"service": "ollama", "model": "llama3:latest"})
         self.assertEqual(s.user_audio, {"service": "kokoro", "voice": "af_heart"})
 
+    def test_stop_on_failure_defaults_true(self):
+        s = EvalScenario.load(
+            _write("name: a\nturns: [{user: hi, expect: [{event: llm_response}]}]\n")
+        )
+        self.assertTrue(s.stop_on_failure)
+
+    def test_stop_on_failure_false(self):
+        s = EvalScenario.load(
+            _write(
+                "name: a\n"
+                "stop_on_failure: false\n"
+                "turns: [{user: hi, expect: [{event: llm_response}]}]\n"
+            )
+        )
+        self.assertFalse(s.stop_on_failure)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Added a `stop_on_failure` scenario field so a scenario can keep driving turns after one fails.
- It defaults to `true`, the existing fail-fast behavior — right for a regression test, where the conversation is in an unknown state after a failure and the remaining turns each burn a timeout.
- Set it to `false` for a benchmark that scores every turn independently and reports a per-turn pass rate, where aborting discards every later observation. Failures accumulate either way, so a run's pass/fail result is unchanged.

`stop_on_failure` governs turn-to-turn progression only. Within a turn, an expectation that times out still ends that turn's matching, because a turn's expectations share one deadline anchored at the send. A scenario setting it to `false` wants an explicit `within_ms` on its turns: with the 60s default, a silent bot costs one full budget per remaining turn.

## Testing

```
uv run pytest tests/test_evals_harness.py tests/test_evals_scenario.py
```

Covers the default stop, `stop_on_failure: false` driving the turns after a failure, and scenario parsing of the new field.