### PR TITLE
fix(metrics): end TTFB at the model's first output

### DIFF
--- a/changelog/5319.fixed.md
+++ b/changelog/5319.fixed.md
@@ -1,0 +1,3 @@
+- Fixed TTFB being measured inconsistently across LLM services, so the values were not comparable between them. TTFB now represents the time to the first byte of the model's streamed response for every LLM service. `AnthropicLLMService` and `AWSBedrockLLMService` stopped measuring as soon as the stream was created, before reading any event, so their TTFB reflected connection setup rather than the model's response; `GoogleLLMService` stopped on the first chunk, which can carry usage metadata and no model output. Reasoning is part of the response, so a thinking model's TTFB ends at its first reasoning token.
+
+TTFB values for these models may be increased.

--- a/src/pipecat/processors/metrics/frame_processor_metrics.py
+++ b/src/pipecat/processors/metrics/frame_processor_metrics.py
@@ -117,6 +117,16 @@ class FrameProcessorMetrics(BaseObject):
     async def stop_ttfb_metrics(self, *, end_time: float | None = None):
         """Stop TTFB measurement and generate metrics frame.
 
+        TTFB ends at the first output the service produces, of any kind —
+        including content a caller never sees, such as an LLM's reasoning. Events
+        that merely acknowledge the request (an HTTP response head, a stream-open
+        or keepalive event) carry no output and must not stop it, or TTFB
+        measures connection setup rather than the service's response.
+
+        Only the first call per measurement takes effect, so services can call
+        this from every branch that handles output rather than tracking which
+        arrived first.
+
         Args:
             end_time: Optional timestamp to use as the end time. If None, uses
                 the current time.

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -434,8 +434,6 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
 
             response = await self._create_message_stream(self._client.beta.messages.create, params)
 
-            await self.stop_ttfb_metrics()
-
             # Function calling
             tool_use_block = None
             json_accumulator = ""
@@ -443,6 +441,11 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
             function_calls = []
             async for event in response:
                 # Aggregate streaming content, create frames, trigger events
+
+                # The events that open the stream (message_start, ping) carry no
+                # model output, so TTFB ends at the first content block.
+                if event.type in ("content_block_start", "content_block_delta"):
+                    await self.stop_ttfb_metrics()
 
                 if event.type == "content_block_delta":
                     if hasattr(event.delta, "text"):

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -539,8 +539,6 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
                 # Call AWS Bedrock with streaming
                 response = await self._create_converse_stream(client, request_params)
 
-                await self.stop_ttfb_metrics()
-
                 # Process the streaming response. Bedrock emits each tool call as
                 # its own content block, identified by contentBlockIndex, so we key
                 # accumulators by index to capture parallel tool calls instead of
@@ -551,6 +549,11 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
                 function_calls = []
 
                 async for event in response["stream"]:
+                    # The events that open the stream (messageStart) carry no
+                    # model output, so TTFB ends at the first content block.
+                    if "contentBlockStart" in event or "contentBlockDelta" in event:
+                        await self.stop_ttfb_metrics()
+
                     # Handle text content
                     if "contentBlockDelta" in event:
                         block = event["contentBlockDelta"]

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -611,8 +611,6 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
 
             function_calls = []
             async for chunk in self._stream_response(context):
-                # Stop TTFB metrics after the first chunk
-                await self.stop_ttfb_metrics()
                 # Gemini may send usage_metadata in multiple chunks with varying behavior:
                 # - Sometimes a single chunk, sometimes multiple chunks
                 # - Token counts may be cumulative (growing) or may change between chunks
@@ -628,6 +626,10 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
 
                 if not chunk.candidates:
                     continue
+
+                # A leading chunk can carry usage metadata and no candidates, so
+                # TTFB ends at the first chunk that holds model output.
+                await self.stop_ttfb_metrics()
 
                 for candidate in chunk.candidates:
                     if candidate.content and candidate.content.parts:

--- a/tests/test_llm_ttfb_normalization.py
+++ b/tests/test_llm_ttfb_normalization.py
@@ -1,0 +1,169 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests that LLM services end TTFB at the model's first output.
+
+TTFB is comparable across services only when they all stop it on the same thing:
+the first output the model produces, rather than an earlier event that merely
+acknowledges the request. These tests pin that boundary for the services whose
+streams open with such an event.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from google.genai.types import (
+    Candidate,
+    Content,
+    GenerateContentResponse,
+    GenerateContentResponseUsageMetadata,
+    Part,
+)
+
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.services.anthropic.llm import AnthropicLLMService
+from pipecat.services.google.llm import GoogleLLMService
+
+
+async def _stop_index(service, patch_stream, chunks) -> int | None:
+    """Stream canned chunks and report which one ended TTFB.
+
+    Returns:
+        Index of the chunk being processed when TTFB stopped, or None if it
+        never stopped.
+    """
+    state = {"index": -1, "stopped_at": None}
+
+    async def fake_stop_ttfb(**kwargs):
+        if state["stopped_at"] is None:
+            state["stopped_at"] = state["index"]
+
+    async def generator():
+        for index, chunk in enumerate(chunks):
+            state["index"] = index
+            yield chunk
+
+    async def capture_frame(frame, direction=None):
+        pass
+
+    with (
+        patch.object(service, "push_frame", capture_frame),
+        patch.object(service, "stop_ttfb_metrics", fake_stop_ttfb),
+        patch_stream(service, generator),
+    ):
+        await service._process_context(LLMContext())
+
+    return state["stopped_at"]
+
+
+# -- Google -----------------------------------------------------------------
+
+
+def _google_patch_stream(service, generator):
+    """Patch GoogleLLMService's stream with a canned chunk generator."""
+
+    async def fake_stream(context):
+        return generator()
+
+    return patch.object(service, "_stream_content", fake_stream)
+
+
+def _google_usage_chunk() -> GenerateContentResponse:
+    """A chunk carrying only usage metadata, with no candidates."""
+    return GenerateContentResponse(
+        candidates=None,
+        usage_metadata=GenerateContentResponseUsageMetadata(prompt_token_count=10),
+    )
+
+
+def _google_text_chunk(text: str) -> GenerateContentResponse:
+    """A chunk carrying model output."""
+    return GenerateContentResponse(
+        candidates=[Candidate(content=Content(role="model", parts=[Part(text=text)]))]
+    )
+
+
+@pytest.mark.asyncio
+async def test_google_usage_only_chunk_does_not_stop_ttfb():
+    service = GoogleLLMService(api_key="test-key")
+    stopped_at = await _stop_index(
+        service,
+        _google_patch_stream,
+        [_google_usage_chunk(), _google_text_chunk("Hello")],
+    )
+    assert stopped_at == 1
+
+
+@pytest.mark.asyncio
+async def test_google_stops_ttfb_on_first_output_chunk():
+    service = GoogleLLMService(api_key="test-key")
+    stopped_at = await _stop_index(
+        service,
+        _google_patch_stream,
+        [_google_text_chunk("Hello")],
+    )
+    assert stopped_at == 0
+
+
+# -- Anthropic --------------------------------------------------------------
+
+
+def _anthropic_patch_stream(service, generator):
+    """Patch AnthropicLLMService's stream with a canned event generator."""
+
+    async def fake_stream(api_call, params):
+        return generator()
+
+    return patch.object(service, "_create_message_stream", fake_stream)
+
+
+def _message_start() -> SimpleNamespace:
+    """The event opening an Anthropic stream, which carries no model output."""
+    return SimpleNamespace(type="message_start")
+
+
+def _content_block_start(block_type: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="content_block_start", content_block=SimpleNamespace(type=block_type)
+    )
+
+
+def _text_delta(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(text=text))
+
+
+def _thinking_delta(thinking: str) -> SimpleNamespace:
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(thinking=thinking))
+
+
+@pytest.mark.asyncio
+async def test_anthropic_message_start_does_not_stop_ttfb():
+    service = AnthropicLLMService(api_key="test-key")
+    stopped_at = await _stop_index(
+        service,
+        _anthropic_patch_stream,
+        [_message_start(), _content_block_start("text"), _text_delta("Hello")],
+    )
+    assert stopped_at == 1
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stops_ttfb_on_thinking_before_any_answer_text():
+    """Reasoning is output, so it ends TTFB just as answer text would."""
+    service = AnthropicLLMService(api_key="test-key")
+    stopped_at = await _stop_index(
+        service,
+        _anthropic_patch_stream,
+        [
+            _message_start(),
+            _content_block_start("thinking"),
+            _thinking_delta("Considering..."),
+            _content_block_start("text"),
+            _text_delta("Hello"),
+        ],
+    )
+    assert stopped_at == 1


### PR DESCRIPTION
## Summary

- `AnthropicLLMService`, `AWSBedrockLLMService`, and `GoogleLLMService` stop TTFB at the first stream event holding model output, so the measurement means the same thing across LLM services and can be compared between them.
- Reasoning counts as output — a thinking model's TTFB ends at its first reasoning token, not at its first answer token.
- The rule lives in the `stop_ttfb_metrics` docstring, giving new services a contract to follow rather than a pattern to guess at.

| Service | Stopped TTFB at | Now stops at |
| --- | --- | --- |
| `AnthropicLLMService` | stream creation, before reading any event | first `content_block_start` / `content_block_delta` |
| `AWSBedrockLLMService` | stream creation, before reading any event | first `contentBlockStart` / `contentBlockDelta` |
| `GoogleLLMService` | first chunk, which can carry usage metadata alone | first chunk holding candidates |

Services already stopping on model output are untouched: `OpenAILLMService` and `SambaNovaLLMService` (both behind their empty-choices guards) and `OpenAIResponsesLLMService` (`response.created` already does not stop it). Ultravox is left alone as a realtime speech-to-speech service, where the first audio *is* its output.

## Breaking Changes

- Anthropic and AWS Bedrock report **higher TTFB**, having previously reported something closer to connection-setup time. Dashboards and alert thresholds tracking TTFB for these services will see a step change. No API changes.

## Testing

```
uv run pytest tests/test_llm_ttfb_normalization.py
```

Full suite passes at 4167. The four `test_krisp_viva_*` failures and the `test_langchain.py` collection error (`langsmith` cannot export `RunTree`) also occur on unmodified `main` and are unrelated to this branch.

## Follow-up

Groundwork for a TTFAT (time to first *answer* token) metric that measures to the first user-visible answer token and excludes reasoning. TTFAT minus TTFB is meaningful only once TTFB means the same thing everywhere.