### PR TITLE
fix(turns): rearm idle timer after interruptions

### DIFF
--- a/src/pipecat/turns/user_idle_controller.py
+++ b/src/pipecat/turns/user_idle_controller.py
@@ -88,7 +88,7 @@ class UserIdleController(BaseObject):
             self._user_idle_timeout = frame.timeout
             if self._user_idle_timeout <= 0:
                 await self._cancel_idle_timer()
-            elif self._waiting_for_user:
+            elif self._waiting_for_user and not self._user_turn_in_progress:
                 # Apply the new timeout now: restart a running timer with the
                 # new duration, or arm one if idle detection was previously
                 # disabled.
@@ -110,12 +110,12 @@ class UserIdleController(BaseObject):
             # BotStoppedSpeaking when pushing a TTSSpeakFrame in the
             # on_function_calls_started event handler, so the counter guard
             # prevents the timer from starting while a function call is in progress.
-            if not self._user_turn_in_progress and self._function_calls_in_progress == 0:
-                # Track the waiting-for-user window even when the timeout is
-                # currently <= 0 (no timer), so a later timeout update can arm
-                # the timer without waiting for the next bot turn.
+            if self._function_calls_in_progress == 0:
+                # Remember that the bot stopped even if the user is still
+                # speaking, and arm the timer when the user turn ends.
                 self._waiting_for_user = True
-                await self._start_idle_timer()
+                if not self._user_turn_in_progress:
+                    await self._start_idle_timer()
         elif isinstance(frame, BotStartedSpeakingFrame):
             self._waiting_for_user = False
             await self._cancel_idle_timer()
@@ -125,6 +125,8 @@ class UserIdleController(BaseObject):
             await self._cancel_idle_timer()
         elif isinstance(frame, UserStoppedSpeakingFrame):
             self._user_turn_in_progress = False
+            if self._waiting_for_user:
+                await self._start_idle_timer()
         elif isinstance(frame, FunctionCallsStartedFrame):
             self._waiting_for_user = False
             self._function_calls_in_progress += len(frame.function_calls)

--- a/tests/test_user_idle_controller.py
+++ b/tests/test_user_idle_controller.py
@@ -134,6 +134,28 @@ class TestUserIdleController(unittest.IsolatedAsyncioTestCase):
 
         await controller.cleanup()
 
+    async def test_idle_after_interrupted_user_turn_stops(self):
+        """Test that idle fires after an interrupting user turn stops."""
+        controller = UserIdleController(user_idle_timeout=USER_IDLE_TIMEOUT)
+        await controller.setup(self.task_manager)
+
+        idle_triggered = False
+
+        @controller.event_handler("on_user_turn_idle")
+        async def on_user_turn_idle(controller):
+            nonlocal idle_triggered
+            idle_triggered = True
+
+        await controller.process_frame(UserStartedSpeakingFrame())
+        await controller.process_frame(BotStoppedSpeakingFrame())
+        await controller.process_frame(UserStoppedSpeakingFrame())
+
+        await asyncio.sleep(USER_IDLE_TIMEOUT + 0.1)
+
+        self.assertTrue(idle_triggered)
+
+        await controller.cleanup()
+
     async def test_idle_cycle(self):
         """Test that idle fires, then can fire again after another bot speaking cycle."""
         controller = UserIdleController(user_idle_timeout=USER_IDLE_TIMEOUT)


### PR DESCRIPTION
## What changed

- Preserve the existing waiting-for-user state when the bot stops during a user interruption.
- Start the idle timer when that user turn ends.
- Prevent timeout updates from arming the timer while the user is still speaking.
- Add a regression test for `UserStartedSpeakingFrame -> BotStoppedSpeakingFrame -> UserStoppedSpeakingFrame`.

## Why

When a user-turn detector interrupts the bot but produces no transcript, `BotStoppedSpeakingFrame` arrives while the user turn is active. The controller suppresses the timer at that point. `UserStoppedSpeakingFrame` then clears the user-turn flag but does not restart the timer, so idle detection can remain disabled for the rest of the call.

The fix uses the controller's existing `_waiting_for_user` state. It adds no new state and does not synthesize frames.

## Validation

- Regression test failed before the implementation change and passed afterward.
- `uv run pytest -q tests/test_user_idle_controller.py` — 20 passed.
- Ruff lint passed.
- Ruff format check passed.