### PR TITLE
fix: markup in TTS word timestamps silently drops transcript text

### DIFF
--- a/changelog/5322.fixed.md
+++ b/changelog/5322.fixed.md
@@ -1,0 +1,10 @@
+- Fixed markup in TTS word timestamps silently dropping text from the transcript.
+  A segment holding markup is transformed, so its cursors are held until the whole
+  segment completes — one unmatchable word loses every word of the sentence,
+  including those before the tag. Two causes: `TextSegmentMap._classify_hop` stalled
+  on a control tag the provider consumes without speaking (`<break/>`, `<speed/>`,
+  `<emotion/>`), because the word after it arrives without the whitespace that
+  trailed the tag; and `CartesiaTTSService` stripped tags off returned words,
+  rewriting `<spell>0364</spell>,` into a token present in neither the TTS nor the
+  original text. Cartesia reports timestamps against the transcript as sent, so
+  tagged spans now pass through unchanged.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -8,7 +8,6 @@
 
 import base64
 import json
-import re
 import warnings
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
@@ -454,20 +453,16 @@ class CartesiaTTSService(WebsocketTTSService):
         base_lang = language.split("-")[0].lower()
         return base_lang in {"zh", "ja"}
 
-    _CARTESIA_TAG_RE = re.compile(r"</?(?:spell|emotion|break|volume|speed)\b[^>]*>", re.IGNORECASE)
-
-    def _strip_cartesia_tags(self, text: str) -> str:
-        text = self._CARTESIA_TAG_RE.sub(" ", text)
-        text = re.sub(r"\s+", " ", text)
-        return text.strip()
-
     def _normalize_word_timestamps(
         self, words: list[str], starts: list[float]
     ) -> list[tuple[str, float]]:
         """Normalize raw word timestamps from Cartesia before further processing.
 
-        Strips Cartesia SSML tags (spell, emotion, break, volume, speed) from each word
-        and drops entries that become empty after stripping.
+        Words keep any SSML markup Cartesia returns on them. Cartesia reports timestamps
+        against the transcript as sent, so a tagged span comes back as one token carrying
+        its tags (e.g. `<spell>0364</spell>,`), and that is exactly the form the word
+        tracker matches against `tts_text`. Stripping the tags here would rewrite the token
+        into something present in neither text, stalling the segment.
 
         For Chinese and Japanese, Cartesia groups related characters in the same timestamp
         message.
@@ -491,18 +486,13 @@ class CartesiaTTSService(WebsocketTTSService):
             # For Chinese/Japanese, combine all characters in this message into one word
             # using the first character's start time.
             if words and starts:
-                combined_word = "".join(self._strip_cartesia_tags(w) for w in words)
+                combined_word = "".join(words)
                 first_start = starts[0]
                 return [(combined_word, first_start)] if combined_word else []
             else:
                 return []
         else:
-            result = []
-            for word, start in zip(words, starts):
-                cleaned = self._strip_cartesia_tags(word)
-                if cleaned:
-                    result.append((cleaned, start))
-            return result
+            return [(word, start) for word, start in zip(words, starts) if word]
 
     def _word_timestamps_include_inter_frame_spaces(self) -> bool:
         """Whether timestamp text should be treated as carrying its own spacing."""

--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -488,10 +488,16 @@ class TextSegmentMap:
         if hop is not None:
             return hop
 
-        # Strategy 3: markup-stripped match.
+        # Strategy 3: markup-stripped match. Whitespace left behind by a stripped tag is
+        # skipped: an unspoken directive (e.g. `<break time="80ms"/> thank`) leaves the
+        # cleaned text starting with the space that followed the tag, which no provider
+        # repeats in its word token. The skipped whitespace is counted back in so the raw
+        # offset still lands just past the matched word.
         clean_word = strip_markup(remaining_word)
-        if clean_word and strip_markup(stripped).startswith(clean_word):
-            raw_len = _raw_len_for_clean_chars(stripped, len(clean_word))
+        clean_segment = strip_markup(stripped)
+        clean_lead_ws = len(clean_segment) - len(clean_segment.lstrip())
+        if clean_word and clean_segment[clean_lead_ws:].startswith(clean_word):
+            raw_len = _raw_len_for_clean_chars(stripped, clean_lead_ws + len(clean_word))
             return _Hop(_HopKind.PLACED, seg_chars=lead_ws + raw_len)
 
         # Nothing spoken left here: drain so the word can try the next segment.

--- a/tests/test_cartesia_tts.py
+++ b/tests/test_cartesia_tts.py
@@ -49,6 +49,25 @@ def _concatenate_processed_timestamps(
     return concatenate_aggregated_text(text_parts)
 
 
+def test_cartesia_word_timestamps_keep_markup():
+    # Cartesia reports timestamps against the transcript as sent, so a tagged span comes back
+    # as one token carrying its tags. That is the form the word tracker matches against
+    # tts_text; rewriting it here would stall the segment and drop its text.
+    assert _process_word_timestamps(
+        words=["ending", "in", "<spell>0364</spell>,", "or"],
+        starts=[0.1, 0.2, 0.3, 0.4],
+        language="en",
+    ) == [("ending", 0.1), ("in", 0.2), ("<spell>0364</spell>,", 0.3), ("or", 0.4)]
+
+
+def test_cartesia_word_timestamps_drop_empty_tokens():
+    assert _process_word_timestamps(
+        words=["hi", "", "there"],
+        starts=[0.1, 0.2, 0.3],
+        language="en",
+    ) == [("hi", 0.1), ("there", 0.3)]
+
+
 def test_cartesia_chinese_word_timestamps_join_without_spaces():
     assert _process_word_timestamps(
         words=["你", "好", "。"],

--- a/tests/test_text_segment_map.py
+++ b/tests/test_text_segment_map.py
@@ -491,3 +491,50 @@ class TestClassifyHopCaseFoldRequiresWordBoundary(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTextSegmentMapUnspokenControlTag(unittest.TestCase):
+    """A control tag the provider consumes without speaking (e.g. Cartesia's
+    <break time="..."/>, <speed ratio="..."/>, <emotion value="..."/>) emits no
+    word-timestamp of its own, so nothing ever consumes its characters. The word
+    that follows arrives without the whitespace that trailed the tag, so the
+    markup-stripped match has to skip that whitespace or the segment stalls on the
+    tag and every word of it is lost.
+    """
+
+    def _consume(self, text: str, words: list[str]) -> tuple[str | None, str]:
+        """Feed words in order; return the first word that did not match and the text covered."""
+        smap = TextSegmentMap(text, text)
+        for word in words:
+            if not smap.word_belongs_current_segment(word):
+                return word, text[: smap.user_facing_pos]
+            smap.advance_word(word)
+        return None, text[: smap.user_facing_pos]
+
+    def test_mid_sentence_break_tag_does_not_stall(self):
+        text = 'Hi,<break time="80ms"/> thank you for calling.'
+        stalled, covered = self._consume(text, ["Hi,", "thank", "you", "for", "calling."])
+        self.assertIsNone(stalled)
+        self.assertEqual(covered, text)
+
+    def test_leading_speed_tag_does_not_stall(self):
+        text = '<speed ratio="0.9"/> That is really kind of you.'
+        stalled, covered = self._consume(text, ["That", "is", "really", "kind", "of", "you."])
+        self.assertIsNone(stalled)
+        self.assertEqual(covered, text)
+
+    def test_inter_sentence_emotion_tag_does_not_stall(self):
+        text = 'That is kind. <emotion value="happy"/> Who is it for?'
+        stalled, covered = self._consume(text, ["That", "is", "kind.", "Who", "is", "it", "for?"])
+        self.assertIsNone(stalled)
+        self.assertEqual(covered, text)
+
+    def test_spoken_tagged_span_still_matches_verbatim(self):
+        # The provider returns a spell span as one token carrying its tags; that path must
+        # keep working alongside the unspoken-tag skip.
+        text = "Your code is <spell>0364</spell>, got it?"
+        stalled, covered = self._consume(
+            text, ["Your", "code", "is", "<spell>0364</spell>,", "got", "it?"]
+        )
+        self.assertIsNone(stalled)
+        self.assertEqual(covered, text)


### PR DESCRIPTION
Two bugs that both end in the same place: a sentence containing SSML markup disappears from the transcript while the caller hears it fine. A segment holding markup is transformed, and a transformed segment's cursors are held until it completes — so a single unmatchable word costs every word of the sentence, including the ones before the tag.

Found in production on Cartesia voice agents: ~2.9k dropped bot turns over 4 days, one agent losing text on 33% of its turns.

**1. `_classify_hop` stalls on unspoken control tags** (`text_segment_map.py`)

`<break/>`, `<speed/>`, `<emotion/>` are directives — the provider consumes them and emits no word timestamp, so nothing consumes their characters in `tts_text`. The next word arrives without the whitespace that trailed the tag, so the markup-stripped match compared `"thank"` against `" thank you for calling."` and failed on the leading space. Fix skips that whitespace and counts it back into the raw offset.

Affects any provider whose text carries markup that isn't spoken, not just Cartesia.

**2. `CartesiaTTSService` strips tags off returned words** (`cartesia/tts.py`)

Cartesia reports timestamps against the transcript as sent, so a tagged span returns as one token carrying its tags — the exact form the tracker matches against `tts_text`. Stripping rewrote `<spell>0364</spell>,` to `0364 ,`, present in neither text. Removed the stripping (and the now-unused helper).

## Reproduction

```python
text = 'Hi,<break time="80ms"/> thank you for calling.'
smap = TextSegmentMap(text, text)
for w in ["Hi,", "thank", "you", "for", "calling."]:
    if smap.word_belongs_current_segment(w):
        smap.advance_word(w)
print(repr(text[: smap.user_facing_pos]))   # before: ''   after: the full sentence
```

Same shape for `<speed ratio="0.9"/>` leading a sentence, `<emotion value="happy"/>` between sentences, and `<spell>0364</spell>` mid-sentence.

## Testing

`pytest tests/test_text_segment_map.py tests/test_cartesia_tts.py tests/test_word_completion_tracker.py tests/test_aggregated_frame_sequencer.py` — 392 passed.

Full suite: 3016 passed, 14 failed, 22 collection errors — all pre-existing on `main` at this commit (missing optional extras: aws, google, langchain, piper, tavus), verified by re-running the same files with these changes stashed.

Added 4 segment-map cases (mid-sentence break, leading speed, inter-sentence emotion, and a spoken spell span to hold the existing path) plus 2 Cartesia cases (markup preserved, empty tokens dropped).

Also confirmed end-to-end against live sonic-3.5: word timestamps reconstruct the input byte-exactly in both single-shot and chunked/continued-context mode, and the tagged sentence now survives into the transcript where it previously vanished.