### PR TITLE
fix: prevent inline TTS markup from causing spoken text to be dropped

### DIFF
--- a/changelog/5324.fixed.2.md
+++ b/changelog/5324.fixed.2.md
@@ -1,0 +1,1 @@
+- Fixed markup going missing from a turn's spoken text when no word follows it. A tag occupies its own segment and no word-timestamp event ever names one, so a tag closing an utterance — or sitting between the last word and its period — was left out of the text the turn reports.

--- a/changelog/5324.fixed.md
+++ b/changelog/5324.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a word-timestamp token failing to match a tagged span the provider punctuated more than the source text did — Cartesia reports `1234.` for `<spell>1234</spell>` followed by a line break — which cost the sentence every word after the tag.

--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -512,7 +512,10 @@ class TextSegmentMap:
            boundary (see :meth:`_literal_hop`'s ``require_word_boundary``).
         3. Markup-stripped on both sides: for a provider that wraps the word
            token in tags absent from ``tts_text`` (or vice versa). Recomputed
-           fresh each call -- no persisted tag state.
+           fresh each call -- no persisted tag state. As in 1 and 2, the word's
+           own trailing punctuation is also tried removed: a provider may end a
+           tagged span with punctuation the source text left to a following line
+           break.
 
         Strategies 1 and 2 yield :attr:`_HopKind.PLACED` (word fits inside this
         segment) or :attr:`_HopKind.CROSSES` (the segment's remaining text is
@@ -562,10 +565,14 @@ class TextSegmentMap:
             return hop
 
         # Strategy 3: markup-stripped match.
+        haystack = strip_markup(stripped)
         clean_word = strip_markup(remaining_word)
-        if clean_word and strip_markup(stripped).startswith(clean_word):
-            raw_len = _raw_len_for_clean_chars(stripped, len(clean_word))
-            return _Hop(_HopKind.PLACED, seg_chars=lead_ws + raw_len)
+        trimmed_word = strip_trailing_punctuation(clean_word)
+        clean_words = (clean_word,) if trimmed_word == clean_word else (clean_word, trimmed_word)
+        for candidate in clean_words:
+            if candidate and haystack.startswith(candidate):
+                raw_len = _raw_len_for_clean_chars(stripped, len(candidate))
+                return _Hop(_HopKind.PLACED, seg_chars=lead_ws + raw_len)
 
         # Nothing spoken left here: drain so the word can try the next segment.
         if not normalize(segment_remaining):

--- a/src/pipecat/utils/context/word_completion_tracker.py
+++ b/src/pipecat/utils/context/word_completion_tracker.py
@@ -253,7 +253,14 @@ class WordCompletionTracker:
         if self._llm_text is not None:
             self._attribute_llm_consumed(word, prev_llm_pos)
 
-        return self.is_complete
+        complete = self.is_complete
+        if complete:
+            # Everything speakable has been spoken, so whatever is left is text no
+            # word will ever arrive for -- a tag closing the frame, or one sitting
+            # between the last word and its punctuation. It belongs to this frame,
+            # so the cursor takes it rather than leaving it out of the turn.
+            self._user_facing_pos = len(self._user_facing_text)
+        return complete
 
     def _attribute_llm_consumed(self, word: str, prev_llm_pos: int) -> None:
         """Set ``_llm_consumed`` to the llm_text span the just-advanced word maps to.

--- a/tests/test_text_segment_map.py
+++ b/tests/test_text_segment_map.py
@@ -489,5 +489,30 @@ class TestClassifyHopCaseFoldRequiresWordBoundary(unittest.TestCase):
         self.assertTrue(smap.word_belongs_current_segment("database"))
 
 
+class TestWordCarriesItsOwnPunctuation(unittest.TestCase):
+    """A provider may punctuate a tagged span more than the source text does."""
+
+    def test_hop_matches_a_word_whose_punctuation_the_span_lacks(self):
+        """Cartesia reports "1234." for "<spell>1234</spell>\\n\\nHow ...", turning the
+        line break into a sentence ending. The literal and folded strategies already
+        retry with the word's trailing punctuation removed; the markup-stripped one
+        has to as well, or the word matches nothing.
+        """
+        remaining = "<spell>1234</spell>\n\nHow can I help you today?"
+        hop = TextSegmentMap._classify_hop(remaining, "1234.")
+        self.assertEqual(hop.kind, _HopKind.PLACED)
+        self.assertEqual(remaining[: hop.seg_chars], "<spell>1234")
+
+    def test_sentence_tracks_through_the_extra_punctuation(self):
+        text = "I love to count <spell>1234</spell>\n\nHow can I help you today?"
+        smap = TextSegmentMap(text, text)
+        for word in ["I", "love", "to", "count", "1234.", "How", "can", "I", "help", "you"]:
+            smap.advance_word(word)
+            self.assertIsNone(smap.last_overflow, f"{word!r} should not overflow")
+        smap.advance_word("today?")
+        self.assertTrue(smap.is_complete)
+        self.assertEqual(smap.user_facing_pos, len(text))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_word_completion_tracker.py
+++ b/tests/test_word_completion_tracker.py
@@ -2560,5 +2560,66 @@ class TestWordCompletionTrackerAccentFolding(unittest.TestCase):
         self.assertTrue(tracker.add_word_and_check_complete(self.TTS_WORDS[-1]))
 
 
+class TestTextNoWordArrivesFor(unittest.TestCase):
+    """Markup occupies a segment of its own and no word-timestamp event names one,
+    so once everything speakable has been spoken the frame takes what is left --
+    otherwise a tag ending a frame is missing from the turn for good.
+    """
+
+    def test_tag_closing_the_frame_is_included(self):
+        text = 'Hello there <break time="1s"/>'
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        for word in ["Hello", "there"]:
+            tracker.add_word_and_check_complete(word)
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), text)
+        self.assertEqual(tracker.get_remaining_user_facing_text(), "")
+
+    def test_tag_between_the_last_word_and_its_period_is_included(self):
+        text = 'Hello there <break time="1s"/>.'
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        for word in ["Hello", "there."]:
+            tracker.add_word_and_check_complete(word)
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), text)
+
+    def test_tag_mid_frame_is_included(self):
+        text = "Hello <break/> there"
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        for word in ["Hello", "there"]:
+            tracker.add_word_and_check_complete(word)
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), text)
+
+    def test_a_word_still_to_come_holds_the_cursor(self):
+        """The frame only takes the rest once it is genuinely finished."""
+        text = 'Hello <break time="1s"/> there'
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        self.assertFalse(tracker.add_word_and_check_complete("Hello"))
+        self.assertNotEqual(tracker.get_accumulated_user_facing_text(), text)
+
+    def test_a_token_running_into_the_next_frame_still_splits(self):
+        """Taking the rest of the frame happens on completion, which is also when a
+        straddling token is split, so the two must not interfere: the frame keeps
+        its own part and the next frame still receives the remainder.
+        """
+        text = "Say <break/> ABC"
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        tracker.add_word_and_check_complete("Say")
+        self.assertTrue(tracker.add_word_and_check_complete("ABCNext"))
+        self.assertEqual(tracker.get_word_for_frame(), "ABC")
+        self.assertEqual(tracker.get_overflow_word(), "Next")
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), text)
+
+    def test_punctuation_the_text_sets_off_still_waits_for_its_token(self):
+        """French "va ?" is reported as its own token, so the frame is not finished
+        until it lands and must not sweep the mark up early.
+        """
+        text = "Comment ça va ?"
+        tracker = WordCompletionTracker(text, llm_text=text, user_facing_text=text)
+        for word in ["Comment", "ça", "va"]:
+            self.assertFalse(tracker.add_word_and_check_complete(word))
+        self.assertNotIn("?", tracker.get_accumulated_user_facing_text())
+        self.assertTrue(tracker.add_word_and_check_complete("?"))
+        self.assertEqual(tracker.get_accumulated_user_facing_text(), text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rebased onto #5331 and cut down to what that PR doesn't cover.

Dropped from the original version of this PR, per @filipi87's review:
- stripping tags from user-facing text — tags stay, as #5331 does it
- the Cartesia word-token change — #5331 has its own

Two failures remain on #5331. Both lose spoken text from the turn.

**A word whose trailing punctuation the tagged span lacks.** Cartesia reports `1234.` for `<spell>1234</spell>` followed by a line break, turning the break into a sentence ending. The markup-stripped matching strategy only tried the word as-is, so it matched nothing and the sentence lost every word after the tag. It now also tries it with trailing punctuation removed, as the literal and case-folded strategies already do.

```
transcript 'I love to count'
expected   'I love to count <spell>1234</spell>\n\nHow can I help you today?'
```

**Markup no word ever arrives for.** A tag occupies its own segment and no word-timestamp event names one, so a tag closing an utterance — or sitting between the last word and its period — was never reached. Once a frame has heard everything speakable it now takes what is left. Punctuation the text sets off with whitespace still waits for the token that names it, so the French `"va ?"` is unaffected.

```
transcript 'Hello there'                     expected 'Hello there <break time="1s"/>'
transcript 'Hello there How are you today?'  expected 'Hello there <break time="1s"/>. How are you today?'
```

19 added lines across two files. Four new tests, each confirmed failing against #5331 without the change.