### PR TITLE
Add a pcm_to_wav helper and use it across core

### DIFF
--- a/changelog/5326.added.md
+++ b/changelog/5326.added.md
@@ -1,0 +1,1 @@
+- Added `pcm_to_wav()` to `pipecat.audio.utils`, which wraps raw 16-bit PCM in a WAV container and returns the file as bytes. It takes PCM in the forms Pipecat pipelines carry it — `bytes`, `bytearray`, or `memoryview` — so audio from an `AudioBufferProcessor` event handler can be written or uploaded directly.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -12,6 +12,8 @@ various audio formats used in Pipecat pipelines.
 """
 
 import audioop
+import io
+import wave
 
 import loudness
 import numpy as np
@@ -104,6 +106,30 @@ def interleave_stereo_audio(left_audio: bytes, right_audio: bytes) -> bytes:
     stereo = np.column_stack((left, right))
 
     return stereo.astype(np.int16).tobytes()
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+    """Wrap raw PCM audio in a WAV container.
+
+    The PCM data is expected to be signed 16-bit little-endian samples, which
+    is what Pipecat pipelines carry (e.g. what ``AudioBufferProcessor`` emits
+    from its audio event handlers).
+
+    Args:
+        pcm: Raw PCM audio data (16-bit signed integers).
+        sample_rate: Sample rate of the audio in Hz.
+        num_channels: Number of interleaved channels in the PCM data.
+
+    Returns:
+        A complete in-memory WAV file as bytes.
+    """
+    with io.BytesIO() as buffer:
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(num_channels)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(pcm)
+        return buffer.getvalue()
 
 
 def normalize_value(value, min_value, max_value):

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -108,12 +108,19 @@ def interleave_stereo_audio(left_audio: bytes, right_audio: bytes) -> bytes:
     return stereo.astype(np.int16).tobytes()
 
 
-def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+def pcm_to_wav(
+    pcm: bytes | bytearray | memoryview, sample_rate: int, num_channels: int = 1
+) -> bytes:
     """Wrap raw PCM audio in a WAV container.
 
     The PCM data is expected to be signed 16-bit little-endian samples, which
     is what Pipecat pipelines carry (e.g. what ``AudioBufferProcessor`` emits
     from its audio event handlers).
+
+    Trailing bytes that don't complete a frame are dropped. Without this the
+    WAV header would report a frame count that excludes them while the data
+    chunk still carries them, so readers would disagree about the length and a
+    stereo stream truncated mid-frame would swap channels.
 
     Args:
         pcm: Raw PCM audio data (16-bit signed integers).
@@ -123,6 +130,11 @@ def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
     Returns:
         A complete in-memory WAV file as bytes.
     """
+    block_align = 2 * num_channels
+    remainder = len(pcm) % block_align
+    if remainder:
+        pcm = pcm[: len(pcm) - remainder]
+
     with io.BytesIO() as buffer:
         with wave.open(buffer, "wb") as wav_file:
             wav_file.setnchannels(num_channels)

--- a/src/pipecat/evals/speech.py
+++ b/src/pipecat/evals/speech.py
@@ -27,7 +27,6 @@ mapping (dispatch + a ``user_audio.factory`` escape hatch) and wraps it;
 rate.
 """
 
-import asyncio
 import hashlib
 import importlib
 import os
@@ -38,6 +37,7 @@ from typing import cast
 
 from loguru import logger
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.evals.services import cartesia_service, kokoro_service
 from pipecat.services.tts_service import TTSService
 from pipecat.services.websocket_service import WebsocketService
@@ -350,8 +350,4 @@ class EvalSpeech:
     @staticmethod
     def _write_wav(path: Path, pcm: bytes, sample_rate: int) -> None:
         """Write mono 16-bit PCM to a WAV file."""
-        with wave.open(str(path), "wb") as wf:
-            wf.setnchannels(1)
-            wf.setsampwidth(2)
-            wf.setframerate(sample_rate)
-            wf.writeframes(pcm)
+        path.write_bytes(pcm_to_wav(pcm, sample_rate))

--- a/src/pipecat/evals/transport.py
+++ b/src/pipecat/evals/transport.py
@@ -45,7 +45,6 @@ sequential eval connections.
 
 import asyncio
 import io
-import wave
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
@@ -54,6 +53,7 @@ import aiofiles
 from loguru import logger
 from PIL import Image
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -111,17 +111,12 @@ async def _write_wav(path: str, audio: bytes, sample_rate: int, num_channels: in
     Encodes the WAV in memory, then writes it to disk without blocking the event
     loop.
     """
-    buffer = io.BytesIO()
-    with wave.open(buffer, "wb") as wf:
-        wf.setnchannels(num_channels)
-        wf.setsampwidth(2)
-        wf.setframerate(sample_rate)
-        wf.writeframes(audio)
+    wav = pcm_to_wav(audio, sample_rate, num_channels)
 
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     async with aiofiles.open(p, "wb") as f:
-        await f.write(buffer.getvalue())
+        await f.write(wav)
     logger.info(f"Eval recording saved: {p} ({len(audio)} bytes)")
 
 

--- a/src/pipecat/processors/aggregators/llm_context.py
+++ b/src/pipecat/processors/aggregators/llm_context.py
@@ -18,7 +18,6 @@ import asyncio
 import base64
 import copy
 import io
-import wave
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast, overload
@@ -29,6 +28,7 @@ from PIL import Image
 from pipecat.adapters.schemas.direct_function import DirectFunction
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import AudioRawFrame
 
 # The sentinel is part of LLMContext's public surface — tools and tool_choice
@@ -191,15 +191,8 @@ class LLMContext:
 
             data = b"".join(frame.audio for frame in audio_frames)
 
-            with io.BytesIO() as buffer:
-                with wave.open(buffer, "wb") as wf:
-                    wf.setsampwidth(2)
-                    wf.setnchannels(num_channels)
-                    wf.setframerate(sample_rate)
-                    wf.writeframes(data)
-
-                encoded_audio = base64.b64encode(buffer.getvalue()).decode("utf-8")
-            return encoded_audio
+            wav = pcm_to_wav(data, sample_rate, num_channels)
+            return base64.b64encode(wav).decode("utf-8")
 
         encoded_audio = await asyncio.to_thread(encode_audio)
 

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -7,10 +7,8 @@
 """Base classes for Speech-to-Text services with continuous and segmented processing."""
 
 import asyncio
-import io
 import time
 import warnings
-import wave
 from abc import abstractmethod
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -18,6 +16,7 @@ from typing import Any
 from loguru import logger
 from websockets.protocol import State
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import (
     AudioRawFrame,
     CancelFrame,
@@ -879,15 +878,7 @@ class SegmentedSTTService(STTService):
         await self.emit_stt_usage_metrics()
 
         if self.wants_wav_segments:
-            content = io.BytesIO()
-            wav = wave.open(content, "wb")
-            wav.setsampwidth(2)
-            wav.setnchannels(1)
-            wav.setframerate(self.sample_rate)
-            wav.writeframes(self._audio_buffer)
-            wav.close()
-            content.seek(0)
-            audio = content.read()
+            audio = pcm_to_wav(self._audio_buffer, self.sample_rate)
         else:
             # Local models read the buffer as raw 16-bit PCM; wrapping it in a
             # WAV container would make them misread the 44-byte header as audio.

--- a/src/pipecat/transports/websocket/client.py
+++ b/src/pipecat/transports/websocket/client.py
@@ -12,9 +12,7 @@ frame serialization, and connection management.
 """
 
 import asyncio
-import io
 import time
-import wave
 from collections.abc import Awaitable, Callable
 
 import websockets
@@ -22,6 +20,7 @@ from loguru import logger
 from pydantic.main import BaseModel
 from websockets.asyncio.client import connect as websocket_connect
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -436,18 +435,11 @@ class WebsocketClientOutputTransport(BaseOutputTransport):
         )
 
         if self._params.add_wav_header:
-            with io.BytesIO() as buffer:
-                with wave.open(buffer, "wb") as wf:
-                    wf.setsampwidth(2)
-                    wf.setnchannels(frame.num_channels)
-                    wf.setframerate(frame.sample_rate)
-                    wf.writeframes(frame.audio)
-                wav_frame = OutputAudioRawFrame(
-                    buffer.getvalue(),
-                    sample_rate=frame.sample_rate,
-                    num_channels=frame.num_channels,
-                )
-                frame = wav_frame
+            frame = OutputAudioRawFrame(
+                pcm_to_wav(frame.audio, frame.sample_rate, frame.num_channels),
+                sample_rate=frame.sample_rate,
+                num_channels=frame.num_channels,
+            )
 
         await self._write_frame(frame)
 

--- a/src/pipecat/transports/websocket/fastapi.py
+++ b/src/pipecat/transports/websocket/fastapi.py
@@ -12,15 +12,14 @@ with configurable session timeouts and WAV header generation.
 """
 
 import asyncio
-import io
 import time
 import typing
-import wave
 from collections.abc import Awaitable, Callable
 
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import (
     CancelFrame,
     ClientConnectedFrame,
@@ -535,18 +534,11 @@ class FastAPIWebsocketOutputTransport(BaseOutputTransport):
         )
 
         if self._params.add_wav_header:
-            with io.BytesIO() as buffer:
-                with wave.open(buffer, "wb") as wf:
-                    wf.setsampwidth(2)
-                    wf.setnchannels(frame.num_channels)
-                    wf.setframerate(frame.sample_rate)
-                    wf.writeframes(frame.audio)
-                wav_frame = OutputAudioRawFrame(
-                    buffer.getvalue(),
-                    sample_rate=frame.sample_rate,
-                    num_channels=frame.num_channels,
-                )
-                frame = wav_frame
+            frame = OutputAudioRawFrame(
+                pcm_to_wav(frame.audio, frame.sample_rate, frame.num_channels),
+                sample_rate=frame.sample_rate,
+                num_channels=frame.num_channels,
+            )
 
         await self._write_frame(frame)
 

--- a/src/pipecat/transports/websocket/server.py
+++ b/src/pipecat/transports/websocket/server.py
@@ -12,9 +12,7 @@ handling, and frame serialization.
 """
 
 import asyncio
-import io
 import time
-import wave
 from collections.abc import Awaitable, Callable
 from typing import cast
 
@@ -25,6 +23,7 @@ from websockets.asyncio.server import serve as websocket_serve
 from websockets.protocol import State
 from websockets.typing import Origin
 
+from pipecat.audio.utils import pcm_to_wav
 from pipecat.frames.frames import (
     CancelFrame,
     ClientConnectedFrame,
@@ -460,18 +459,11 @@ class SingleClientWebsocketServerOutputTransport(BaseOutputTransport):
         )
 
         if self._params.add_wav_header:
-            with io.BytesIO() as buffer:
-                with wave.open(buffer, "wb") as wf:
-                    wf.setsampwidth(2)
-                    wf.setnchannels(frame.num_channels)
-                    wf.setframerate(frame.sample_rate)
-                    wf.writeframes(frame.audio)
-                wav_frame = OutputAudioRawFrame(
-                    buffer.getvalue(),
-                    sample_rate=frame.sample_rate,
-                    num_channels=frame.num_channels,
-                )
-                frame = wav_frame
+            frame = OutputAudioRawFrame(
+                pcm_to_wav(frame.audio, frame.sample_rate, frame.num_channels),
+                sample_rate=frame.sample_rate,
+                num_channels=frame.num_channels,
+            )
 
         await self._write_frame(frame)
 

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import io
+import unittest
+import wave
+
+from pipecat.audio.utils import pcm_to_wav
+
+
+class TestPcmToWav(unittest.TestCase):
+    def _read_wav(self, data: bytes):
+        with wave.open(io.BytesIO(data), "rb") as wav_file:
+            return (
+                wav_file.getnchannels(),
+                wav_file.getsampwidth(),
+                wav_file.getframerate(),
+                wav_file.readframes(wav_file.getnframes()),
+            )
+
+    def test_mono(self):
+        pcm = b"\x01\x00" * 1600  # 0.1s of a constant sample at 16kHz
+        wav = pcm_to_wav(pcm, 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 1)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, pcm)
+
+    def test_stereo(self):
+        pcm = b"\x01\x00\x02\x00" * 2400  # 0.1s of interleaved stereo at 24kHz
+        wav = pcm_to_wav(pcm, 24000, num_channels=2)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 2)
+        self.assertEqual(sample_width, 2)
+        self.assertEqual(sample_rate, 24000)
+        self.assertEqual(frames, pcm)
+
+    def test_empty(self):
+        wav = pcm_to_wav(b"", 16000)
+        num_channels, sample_width, sample_rate, frames = self._read_wav(wav)
+        self.assertEqual(sample_rate, 16000)
+        self.assertEqual(frames, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -45,6 +45,19 @@ class TestPcmToWav(unittest.TestCase):
         self.assertEqual(sample_rate, 16000)
         self.assertEqual(frames, b"")
 
+    def test_bytearray(self):
+        pcm = bytearray(b"\x01\x00" * 1600)
+        wav = pcm_to_wav(pcm, 16000)
+        _, _, _, frames = self._read_wav(wav)
+        self.assertEqual(frames, bytes(pcm))
+
+    def test_drops_partial_trailing_frame(self):
+        pcm = b"\x01\x00\x02\x00" * 100 + b"\x03\x00"  # stereo plus a lone sample
+        wav = pcm_to_wav(pcm, 24000, num_channels=2)
+        num_channels, _, _, frames = self._read_wav(wav)
+        self.assertEqual(num_channels, 2)
+        self.assertEqual(frames, pcm[:-2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `pcm_to_wav()` to `pipecat.audio.utils`, which wraps raw 16-bit PCM in a WAV container and returns the file as bytes.
- It accepts `bytes`, `bytearray`, or `memoryview`, because audio reaches it as a `bytearray` in practice — `SegmentedSTTService` accumulates one, and `AudioBufferProcessor` hands one to its turn-audio events.
- It drops trailing bytes that don't complete a frame. `wave` writes those into the data chunk without counting them in the header, which leaves readers disagreeing about the length and swaps channels on a stereo stream truncated mid-frame.
- Replaces the hand-rolled `wave` boilerplate in the three websocket transports, `SegmentedSTTService`, `LLMContext.create_audio_message()`, and the two eval helpers. That removes ~55 lines and drops the `io`/`wave` imports from five modules.

Two WAV-writing spots stay as they are: `local_smart_turn_v3.py` (debug-only path, writes from a numpy array) and `audio/dtmf/utils.py` (a WAV read, not a write).

The conversions have no user-visible effect — the helper emits the same bytes as the code it replaces. The helper commit is cherry-picked from #5285.

## Testing

- `uv run pytest tests/test_audio_utils.py` covers mono, stereo, empty, `bytearray` input, and a partial trailing frame.
- Byte-identical output confirmed against the replaced inline code across mono, stereo, empty, and unaligned-length inputs.
- Full suite: 4228 passing. The four `test_krisp_viva_*` failures are order-dependent and fail at the branch point too.