### PR TITLE
Add TurnAudioCollector for attributing turn audio to turns

### DIFF
--- a/changelog/5327.added.md
+++ b/changelog/5327.added.md
@@ -1,0 +1,7 @@
+- Added `TurnAudioCollector` in `pipecat.audio.turn_audio`, which files an `AudioBufferProcessor`'s turn audio under the turn each clip belongs to. It handles the two cases that make this more than reading the current turn number: a turn holds as many clips as there were runs of speech, and a barge-in reports the bot's cut-off audio after the next turn has already started. Each turn's runs are kept separate, with `TurnAudio.user` and `TurnAudio.bot` joining them.
+
+      collector = TurnAudioCollector()
+      collector.attach(audio_buffer, worker.turn_tracking_observer)
+
+      for turn in collector.turns():
+          save(turn.number, turn.user, turn.bot, collector.sample_rate)

--- a/changelog/5327.added.md
+++ b/changelog/5327.added.md
@@ -1,7 +1,1 @@
-- Added `TurnAudioCollector` in `pipecat.audio.turn_audio`, which files an `AudioBufferProcessor`'s turn audio under the turn each clip belongs to. It handles the two cases that make this more than reading the current turn number: a turn holds as many clips as there were runs of speech, and a barge-in reports the bot's cut-off audio after the next turn has already started. Each turn's runs are kept separate, with `TurnAudio.user` and `TurnAudio.bot` joining them.
-
-      collector = TurnAudioCollector()
-      collector.attach(audio_buffer, worker.turn_tracking_observer)
-
-      for turn in collector.turns():
-          save(turn.number, turn.user, turn.bot, collector.sample_rate)
+- Added `TurnAudioCollector` in `pipecat.audio.turn_audio`, which collects an `AudioBufferProcessor`'s turn audio by turn. It handles the two cases that otherwise attach a clip to the wrong turn: a turn holds as many clips as there were runs of speech, and a barge-in reports the bot's cut-off audio after the next turn has started.

--- a/src/pipecat/audio/turn_audio.py
+++ b/src/pipecat/audio/turn_audio.py
@@ -1,0 +1,150 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Collect a conversation's audio, filed under the turn each clip belongs to.
+
+:class:`~pipecat.processors.audio.audio_buffer_processor.AudioBufferProcessor`
+reports turn audio a run of speech at a time, and
+:class:`~pipecat.observers.turn_tracking_observer.TurnTrackingObserver` numbers
+the turns. Lining the two up takes more than reading the current turn number when
+a clip arrives, and both hazards are silent — the audio still arrives, just
+attached to the wrong turn:
+
+- **A turn holds several runs of speech.** The audio events fire every time a
+  speaker stops, while a turn ends only once the other side takes over. A user
+  who pauses mid-thought, or a bot resuming after a function call, reports more
+  than once for one turn.
+- **A barge-in reports the bot's audio late.** Interrupting the bot ends its turn
+  and starts the next one, and only then does the cut-off audio arrive, by which
+  point the tracker has moved on. ``on_turn_ended`` flags the interruption
+  first, which is what puts the clip back on the turn it was spoken in.
+
+Runs are kept separate so callers that need the pauses between them can have
+them; :attr:`TurnAudio.user` and :attr:`TurnAudio.bot` join them for callers that
+don't.
+"""
+
+from dataclasses import dataclass, field
+
+from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
+from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+
+
+@dataclass
+class TurnAudio:
+    """One turn's audio, as raw mono PCM.
+
+    Parameters:
+        number: The turn this audio belongs to.
+        user_runs: Each run of user speech during the turn, in order.
+        bot_runs: Each run of bot speech during the turn, in order.
+    """
+
+    number: int
+    user_runs: list[bytes] = field(default_factory=list)
+    bot_runs: list[bytes] = field(default_factory=list)
+
+    @property
+    def user(self) -> bytes:
+        """The turn's user speech, runs joined without the pauses between them."""
+        return b"".join(self.user_runs)
+
+    @property
+    def bot(self) -> bytes:
+        """The turn's bot speech, runs joined without the pauses between them."""
+        return b"".join(self.bot_runs)
+
+
+class TurnAudioCollector:
+    """Collects an audio buffer processor's turn audio, by turn.
+
+    Audio is retained in memory for the life of the collector, so a collector is
+    scoped to one conversation.
+
+    Example::
+
+        audio_buffer = AudioBufferProcessor(enable_turn_audio=True)
+        # ...place audio_buffer in the pipeline...
+
+        collector = TurnAudioCollector()
+        collector.attach(audio_buffer, worker.turn_tracking_observer)
+
+        # Once the conversation is over:
+        for turn in collector.turns():
+            save(turn.number, turn.user, turn.bot, collector.sample_rate)
+    """
+
+    def __init__(self):
+        """Initialize the collector."""
+        self._turns: dict[int, TurnAudio] = {}
+        self._sample_rate: int | None = None
+        self._turn_number = 0
+        self._interrupted_turn: int | None = None
+
+    @property
+    def sample_rate(self) -> int | None:
+        """Sample rate of the collected audio, or None until some arrives."""
+        return self._sample_rate
+
+    def attach(
+        self, audio_buffer: AudioBufferProcessor, turn_tracker: TurnTrackingObserver
+    ) -> None:
+        """Start collecting.
+
+        Args:
+            audio_buffer: The pipeline's audio buffer processor. It must be
+                constructed with ``enable_turn_audio=True``, which is what makes
+                it report turn audio at all.
+            turn_tracker: The turn tracking observer for the same pipeline, e.g.
+                a pipeline worker's ``turn_tracking_observer``. It owns turn
+                numbering and reports what an interruption does to a turn.
+        """
+
+        @turn_tracker.event_handler("on_turn_started")
+        async def on_turn_started(tracker, turn_number: int):
+            self._turn_number = turn_number
+
+        @turn_tracker.event_handler("on_turn_ended")
+        async def on_turn_ended(tracker, turn_number: int, duration: float, was_interrupted: bool):
+            # A turn ends as interrupted only when the bot was speaking, and the
+            # barge-in that ends it starts the next turn before the cut-off audio
+            # is reported.
+            if was_interrupted:
+                self._interrupted_turn = turn_number
+
+        @audio_buffer.event_handler("on_user_turn_audio_data")
+        async def on_user_turn_audio_data(buffer, audio, sample_rate, num_channels):
+            self._store(bytes(audio), sample_rate, user=True)
+
+        @audio_buffer.event_handler("on_bot_turn_audio_data")
+        async def on_bot_turn_audio_data(buffer, audio, sample_rate, num_channels):
+            self._store(bytes(audio), sample_rate, user=False)
+
+    def turns(self) -> list[TurnAudio]:
+        """Every turn that produced audio, in turn order."""
+        return [self._turns[number] for number in sorted(self._turns)]
+
+    def turn_numbers(self) -> list[int]:
+        """The numbers of the turns that produced audio, in order."""
+        return sorted(self._turns)
+
+    def _store(self, audio: bytes, sample_rate: int, *, user: bool) -> None:
+        # Turn 1 opens with the pipeline, so audio only goes unfiled when it
+        # arrives before the tracker has announced any turn at all.
+        if not audio or not self._turn_number:
+            return
+        self._sample_rate = sample_rate
+
+        turn_number = self._turn_number
+        if not user and self._interrupted_turn == self._turn_number - 1:
+            # Only the turn that just ended can still have audio in flight.
+            # Anything older ended without the bot speaking, e.g. at shutdown.
+            turn_number = self._interrupted_turn
+            self._interrupted_turn = None
+
+        turn = self._turns.setdefault(turn_number, TurnAudio(number=turn_number))
+        runs = turn.user_runs if user else turn.bot_runs
+        runs.append(audio)

--- a/src/pipecat/observers/turn_tracking_observer.py
+++ b/src/pipecat/observers/turn_tracking_observer.py
@@ -41,6 +41,17 @@ class TurnTrackingObserver(BaseObserver):
 
       - The user starts speaking again
       - A timeout period elapses with no more bot speech
+
+    Events:
+
+    - on_turn_started: Triggered when a turn starts, providing the turn number
+    - on_turn_ended: Triggered when a turn ends, providing the turn number, the turn's
+      duration in seconds, and whether it was interrupted
+
+    A turn counts as interrupted only when the user spoke over the bot. That distinction
+    matters to anything correlating data to turns: an interruption ends one turn and starts the
+    next in the same moment, so whatever the bot was in the middle of arrives once the tracker
+    has already moved on.
     """
 
     def __init__(self, max_frames=100, turn_end_timeout_secs=2.5, **kwargs):

--- a/src/pipecat/processors/audio/audio_buffer_processor.py
+++ b/src/pipecat/processors/audio/audio_buffer_processor.py
@@ -42,10 +42,16 @@ class AudioBufferProcessor(FrameProcessor):
 
     - on_audio_data: Triggered when buffer_size is reached, providing merged audio
     - on_track_audio_data: Triggered when buffer_size is reached, providing separate tracks
-    - on_user_turn_audio_data: Triggered when user turn has ended, providing that user turn's audio
-    - on_bot_turn_audio_data: Triggered when bot turn has ended, providing that bot turn's audio
+    - on_user_turn_audio_data: Triggered when the user stops speaking, providing that speech
+    - on_bot_turn_audio_data: Triggered when the bot stops speaking, providing that speech
     - on_recording_started: Triggered when recording starts (state transitions to active)
     - on_recording_stopped: Triggered after recording stops and the final audio has been emitted
+
+    The turn audio events report one run of speech rather than a whole turn. They fire every
+    time a speaker stops, while a turn ends only once the other side takes over, so a single
+    turn can report several times; and on a barge-in the bot's final run is reported after the
+    next turn has already started. :class:`~pipecat.audio.turn_audio.TurnAudioCollector`
+    accounts for both when collecting this audio by turn.
 
     Audio handling:
 

--- a/tests/test_turn_audio.py
+++ b/tests/test_turn_audio.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import unittest
+
+from pipecat.audio.turn_audio import TurnAudio, TurnAudioCollector
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    Frame,
+    InputAudioRawFrame,
+    OutputAudioRawFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
+from pipecat.pipeline.worker import PipelineParams
+from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
+from pipecat.tests.utils import SleepFrame, run_test
+
+SAMPLE_RATE = 16000
+
+# 0.1s of mono audio. Every run of speech below is one chunk long unless it says
+# otherwise, so run lengths are comparable by counting chunks.
+CHUNK = b"\x11\x00" * 1600
+
+
+def user_audio() -> Frame:
+    return InputAudioRawFrame(audio=CHUNK, sample_rate=SAMPLE_RATE, num_channels=1)
+
+
+def bot_audio() -> Frame:
+    return OutputAudioRawFrame(audio=CHUNK, sample_rate=SAMPLE_RATE, num_channels=1)
+
+
+def user_speaks() -> list[Frame]:
+    """One run of user speech, with the pauses a real mic would produce."""
+    return [
+        UserStartedSpeakingFrame(),
+        SleepFrame(sleep=0.05),
+        user_audio(),
+        SleepFrame(sleep=0.05),
+        UserStoppedSpeakingFrame(),
+        SleepFrame(sleep=0.2),
+    ]
+
+
+def bot_speaks() -> list[Frame]:
+    """One run of bot speech.
+
+    Bot audio is a DataFrame and queues, while the speaking frames are
+    SystemFrames that skip the queue, so the audio needs time to drain before
+    BotStoppedSpeakingFrame or it would be reported after its own run ended.
+    """
+    return [
+        BotStartedSpeakingFrame(),
+        SleepFrame(sleep=0.05),
+        bot_audio(),
+        SleepFrame(sleep=0.1),
+        BotStoppedSpeakingFrame(),
+        SleepFrame(sleep=0.2),
+    ]
+
+
+class TestTurnAudioCollector(unittest.IsolatedAsyncioTestCase):
+    async def _collect(self, frames: list[Frame]) -> TurnAudioCollector:
+        """Run frames through a recording processor and return the collector."""
+        processor = AudioBufferProcessor(
+            sample_rate=SAMPLE_RATE,
+            num_channels=1,
+            enable_turn_audio=True,
+            auto_start_recording=True,
+        )
+        turn_tracker = TurnTrackingObserver()
+        collector = TurnAudioCollector()
+        collector.attach(processor, turn_tracker)
+
+        await run_test(
+            processor,
+            frames_to_send=frames,
+            observers=[turn_tracker],
+            pipeline_params=PipelineParams(
+                audio_in_sample_rate=SAMPLE_RATE, audio_out_sample_rate=SAMPLE_RATE
+            ),
+        )
+        return collector
+
+    async def test_collects_nothing_without_audio(self):
+        collector = await self._collect([SleepFrame(sleep=0.1)])
+        self.assertEqual(collector.turns(), [])
+        self.assertIsNone(collector.sample_rate)
+
+    async def test_files_a_turn_under_its_number(self):
+        collector = await self._collect([*user_speaks(), *bot_speaks()])
+
+        # Turn 1 opens with the pipeline, so the first exchange lands there.
+        self.assertEqual(collector.turn_numbers(), [1])
+        turn = collector.turns()[0]
+        self.assertEqual(turn.number, 1)
+        self.assertEqual(turn.user, CHUNK)
+        self.assertEqual(turn.bot, CHUNK)
+        self.assertEqual(collector.sample_rate, SAMPLE_RATE)
+
+    async def test_numbers_successive_turns(self):
+        collector = await self._collect(
+            [*user_speaks(), *bot_speaks(), *user_speaks(), *bot_speaks()]
+        )
+
+        self.assertEqual(collector.turn_numbers(), [1, 2])
+        for turn in collector.turns():
+            self.assertEqual(turn.user, CHUNK, f"turn {turn.number} user audio")
+            self.assertEqual(turn.bot, CHUNK, f"turn {turn.number} bot audio")
+
+    async def test_keeps_each_run_of_speech_in_a_turn(self):
+        # The user pauses mid-thought before the bot has replied, so both runs
+        # belong to the same turn.
+        collector = await self._collect([*user_speaks(), *user_speaks(), *bot_speaks()])
+
+        self.assertEqual(collector.turn_numbers(), [1])
+        turn = collector.turns()[0]
+        self.assertEqual(turn.user_runs, [CHUNK, CHUNK])
+        self.assertEqual(turn.user, CHUNK * 2)
+
+    async def test_keeps_each_run_of_bot_speech_in_a_turn(self):
+        # A bot that resumes after a function call reports twice for one turn.
+        collector = await self._collect([*user_speaks(), *bot_speaks(), *bot_speaks()])
+
+        self.assertEqual(collector.turn_numbers(), [1])
+        turn = collector.turns()[0]
+        self.assertEqual(turn.bot_runs, [CHUNK, CHUNK])
+        self.assertEqual(turn.bot, CHUNK * 2)
+
+    async def test_files_barged_in_bot_audio_under_the_interrupted_turn(self):
+        # The user barges in while the bot is speaking. That ends turn 1 and
+        # starts turn 2, and only then is the bot's cut-off audio reported.
+        collector = await self._collect(
+            [
+                *user_speaks(),
+                BotStartedSpeakingFrame(),
+                SleepFrame(sleep=0.05),
+                bot_audio(),
+                SleepFrame(sleep=0.1),
+                UserStartedSpeakingFrame(),
+                SleepFrame(sleep=0.05),
+                BotStoppedSpeakingFrame(),
+                SleepFrame(sleep=0.05),
+                user_audio(),
+                SleepFrame(sleep=0.05),
+                UserStoppedSpeakingFrame(),
+                SleepFrame(sleep=0.2),
+                *bot_speaks(),
+            ]
+        )
+
+        self.assertEqual(collector.turn_numbers(), [1, 2])
+        interrupted, replied = collector.turns()
+
+        # The interrupted turn keeps the audio it was cut off in the middle of.
+        self.assertEqual(interrupted.number, 1)
+        self.assertEqual(interrupted.user, CHUNK)
+        self.assertEqual(interrupted.bot, CHUNK)
+
+        # The turn that interrupted keeps only its own.
+        self.assertEqual(replied.number, 2)
+        self.assertEqual(replied.user, CHUNK)
+        self.assertEqual(replied.bot, CHUNK)
+
+
+class TestTurnAudio(unittest.TestCase):
+    def test_joins_runs(self):
+        turn = TurnAudio(number=3, user_runs=[b"ab", b"cd"], bot_runs=[b"ef"])
+        self.assertEqual(turn.user, b"abcd")
+        self.assertEqual(turn.bot, b"ef")
+
+    def test_empty_turn(self):
+        turn = TurnAudio(number=1)
+        self.assertEqual(turn.user, b"")
+        self.assertEqual(turn.bot, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `TurnAudioCollector` in `pipecat.audio.turn_audio`, which files an `AudioBufferProcessor`'s turn audio under the turn each clip belongs to.
- Corrects the `AudioBufferProcessor` and `TurnTrackingObserver` docstrings, which described the turn audio events as reporting a whole turn.

Pairing the audio buffer processor with the turn tracker takes more than reading the current turn number when a clip arrives, and both of the cases that make it harder fail silently — the audio still arrives, just attached to the wrong turn:

- **A turn holds several runs of speech.** The audio events fire every time a speaker stops, while a turn ends only once the other side takes over. A user who pauses mid-thought, or a bot resuming after a function call, reports more than once for one turn.
- **A barge-in reports the bot's audio late.** Interrupting the bot ends its turn and starts the next one, and only then does the cut-off audio arrive. Attributing it to the current turn puts it on the turn that did the interrupting.

```python
collector = TurnAudioCollector()
collector.attach(audio_buffer, worker.turn_tracking_observer)

# Once the conversation is over:
for turn in collector.turns():
    save(turn.number, turn.user, turn.bot, collector.sample_rate)
```

Each turn keeps its runs of speech separate, in `TurnAudio.user_runs` and `TurnAudio.bot_runs`, so callers that want the pauses between them can have them. `TurnAudio.user` and `TurnAudio.bot` join them for callers that don't.

## Docstrings

`on_user_turn_audio_data` and `on_bot_turn_audio_data` were documented as "Triggered when user turn has ended, providing that user turn's audio," which is wrong on both counts and sets up exactly the expectation that leads to the bugs above. They now say what the events report, with a note covering the two cases. `TurnTrackingObserver` had no `Events:` section at all, so `on_turn_ended`'s `was_interrupted` argument — the thing that makes correct attribution possible — was undocumented.

## Testing

- `uv run pytest tests/test_turn_audio.py` — 8 tests covering turn numbering, several runs of speech per turn on both sides, and a barge-in.
- The barge-in test is a real regression test: reverting the collector to the naive "read the current turn number" version fails it and leaves the other 7 passing.
- Full suite: 4236 passing. The four `test_krisp_viva_*` failures are order-dependent and fail at the branch point too.