### PR TITLE
Let VoicemailDetector gates pass WorkerFrame frames when closed

### DIFF
--- a/changelog/5330.fixed.md
+++ b/changelog/5330.fixed.md
@@ -1,0 +1,1 @@
+- The VoicemailDetector gates now pass `WorkerFrame` frames through when closed, so the documented `on_voicemail_detected` handler can end the call: the `EndWorkerFrame` it pushes upstream previously fell into a closed gate and was silently dropped, leaving the call open. `CancelWorkerFrame` already passed, so the detector could be cancelled but never ended gracefully.

--- a/src/pipecat/extensions/voicemail/voicemail_detector.py
+++ b/src/pipecat/extensions/voicemail/voicemail_detector.py
@@ -33,6 +33,7 @@ from pipecat.frames.frames import (
     TTSTextFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    WorkerFrame,
 )
 from pipecat.pipeline.parallel_pipeline import ParallelPipeline
 from pipecat.processors.aggregators.llm_context import LLMContext, LLMContextMessage
@@ -102,7 +103,7 @@ class NotifierGate(FrameProcessor):
             await self.push_frame(frame, direction)
         elif isinstance(
             frame,
-            (SystemFrame, EndFrame, StopFrame),
+            (SystemFrame, WorkerFrame, EndFrame, StopFrame),
         ):
             await self.push_frame(frame, direction)
 
@@ -178,7 +179,7 @@ class ClassifierGate(NotifierGate):
             # to push.
             if not self._conversation_detected:
                 await self.push_frame(frame, direction)
-        elif isinstance(frame, (SystemFrame, EndFrame, StopFrame)):
+        elif isinstance(frame, (SystemFrame, WorkerFrame, EndFrame, StopFrame)):
             # Always allow system frames through
             # This includes the UserStartedSpeakingFrame and UserStoppedSpeakingFrame
             # which are used to detect voicemail timing.

--- a/tests/test_voicemail_detector.py
+++ b/tests/test_voicemail_detector.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Regression tests for VoicemailDetector frame gating.
+
+Once a VOICEMAIL verdict lands, the detector's gates close. An EndWorkerFrame
+pushed from the documented on_voicemail_detected handler (or from anywhere
+downstream of the detector) has to make it past those gates, or the handler
+cannot end the call.
+"""
+
+import unittest
+from typing import Any
+
+from pipecat.extensions.voicemail.voicemail_detector import VoicemailDetector
+from pipecat.frames.frames import (
+    EndWorkerFrame,
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMTextFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.tests.utils import SleepFrame, run_test
+
+
+class _PassthroughLLM(FrameProcessor):
+    """Stands in for the classifier LLM.
+
+    The verdict is injected as the exact frame sequence a streaming LLM emits
+    (LLMFullResponseStartFrame / LLMTextFrame / LLMFullResponseEndFrame), so
+    ClassificationProcessor runs its real code path and no network is needed.
+    """
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        await self.push_frame(frame, direction)
+
+
+class _MainPipelineProcessor(FrameProcessor):
+    """Stands in for whatever sits downstream of the detector in a real app.
+
+    The only property that matters is its position: downstream of the detector,
+    so an upstream push has to cross the whole detector.
+    """
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        await self.push_frame(frame, direction)
+
+
+def _verdict_frames(verdict: str) -> list[Any]:
+    return [
+        LLMFullResponseStartFrame(),
+        LLMTextFrame(verdict),
+        LLMFullResponseEndFrame(),
+        SleepFrame(1.0),  # outlasts voicemail_response_delay
+    ]
+
+
+def _detector() -> VoicemailDetector:
+    return VoicemailDetector(
+        llm=_PassthroughLLM(),  # type: ignore[arg-type]
+        voicemail_response_delay=0.3,
+    )
+
+
+class TestVoicemailDetector(unittest.IsolatedAsyncioTestCase):
+    async def test_docs_handler_end_frame_escapes_the_detector(self):
+        """The documented on_voicemail_detected handler can end the call.
+
+        The handler pushes EndWorkerFrame upstream from the classification
+        processor, so it has to pass the closed ClassifierGate.
+        """
+        detector = _detector()
+
+        @detector.event_handler("on_voicemail_detected")
+        async def _on_voicemail(processor: FrameProcessor):
+            await processor.push_frame(
+                EndWorkerFrame(reason="Voicemail detected."),
+                FrameDirection.UPSTREAM,
+            )
+
+        _down, up = await run_test(detector, frames_to_send=_verdict_frames("VOICEMAIL"))
+
+        assert any(isinstance(frame, EndWorkerFrame) for frame in up), (
+            "the EndWorkerFrame pushed by the documented handler never escaped the detector"
+        )
+
+    async def test_end_frame_from_main_pipeline_after_voicemail(self):
+        """An upstream EndWorkerFrame from after the detector still gets out.
+
+        Both gates close on a VOICEMAIL verdict, so this exercises the
+        conversation branch gate as well as the classifier gate.
+        """
+        detector = _detector()
+        ender = _MainPipelineProcessor()
+
+        @detector.event_handler("on_voicemail_detected")
+        async def _on_voicemail(_processor: FrameProcessor):
+            await ender.push_frame(
+                EndWorkerFrame(reason="Voicemail detected."),
+                FrameDirection.UPSTREAM,
+            )
+
+        _down, up = await run_test(
+            Pipeline([detector, ender]),
+            frames_to_send=_verdict_frames("VOICEMAIL"),
+        )
+
+        assert any(isinstance(frame, EndWorkerFrame) for frame in up), (
+            "the EndWorkerFrame never made it past the closed gates"
+        )
+
+    async def test_end_frame_from_main_pipeline_after_conversation(self):
+        """A CONVERSATION verdict leaves the upstream path open, as before."""
+        detector = _detector()
+        ender = _MainPipelineProcessor()
+
+        @detector.event_handler("on_conversation_detected")
+        async def _on_conversation(_processor: FrameProcessor):
+            await ender.push_frame(
+                EndWorkerFrame(reason="Conversation detected."),
+                FrameDirection.UPSTREAM,
+            )
+
+        _down, up = await run_test(
+            Pipeline([detector, ender]),
+            frames_to_send=_verdict_frames("CONVERSATION"),
+        )
+
+        assert any(isinstance(frame, EndWorkerFrame) for frame in up), (
+            "the conversation branch did not let the frame out"
+        )


### PR DESCRIPTION
Fixes #5330

The documented `on_voicemail_detected` handler pushes an `EndWorkerFrame` upstream to end the call, but once a VOICEMAIL verdict lands the detector's gates are closed and only admit `SystemFrame`, `EndFrame` and `StopFrame`. `EndWorkerFrame` is a `WorkerFrame`, so it was silently dropped and the pipeline kept running — the call sat open, muted, until something else tore it down.

`CancelWorkerFrame` already made it through because `WorkerSystemFrame` extends `SystemFrame`; the detector could be cancelled but never ended gracefully. This adds `WorkerFrame` to the closed-state allowlist in `NotifierGate` and `ClassifierGate`. `ConversationGate` inherits from `NotifierGate`, so the base fix covers all three gates.

Tests: new `tests/test_voicemail_detector.py` drives the detector with a passthrough classifier and a VOICEMAIL verdict, then asserts the `EndWorkerFrame` from the documented handler escapes (and the same for a push from a processor downstream of the detector). The CONVERSATION path is pinned too, so it doesn't silently regress. Changelog fragment added as `changelog/5330.fixed.md`.

Verified locally: `pytest tests/test_voicemail_detector.py` (3 passed), `ruff check` and `ruff format --check` clean on the changed files.
