### PR TITLE
fix(utils): honor every configured tag pair in parse_start_end_tags

### DIFF
--- a/changelog/5336.fixed.md
+++ b/changelog/5336.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the skip-tags aggregator only honoring the first configured tag pair: content inside a tag from a later pair was split at sentence boundaries (or leaked chunk by chunk in TOKEN mode) whenever an earlier pair was absent from the text.

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -237,7 +237,9 @@ def parse_start_end_tags(
         start_tag_count = text[current_tag_index:].count(start_tag)
         end_tag_count = text[current_tag_index:].count(end_tag)
         if start_tag_count == 0 and end_tag_count == 0:
-            return (None, current_tag_index)
+            # This tag pair does not appear in the text; keep scanning the
+            # remaining pairs before deciding nothing is open.
+            continue
         elif start_tag_count > end_tag_count:
             return ((start_tag, end_tag), len(text))
         elif start_tag_count == end_tag_count:

--- a/tests/test_skip_tags_aggregator.py
+++ b/tests/test_skip_tags_aggregator.py
@@ -252,5 +252,52 @@ class TestSkipTagsAggregatorTokenMode(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(texts, ["<spell>abc</spell>", "<spell>def</spell>", " done"])
 
 
+class TestSkipTagsAggregatorMultiplePairs(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.aggregator = SkipTagsAggregator([("<spell>", "</spell>"), ("<think>", "</think>")])
+
+    async def test_sentence_content_inside_later_tag_not_split(self):
+        """Content inside a tag from a later pair is not split at sentence boundaries.
+
+        Regression: with more than one registered tag pair, the scan returned
+        as soon as the first pair did not appear in the text, so a tag from a
+        later pair was never detected and its content was split at sentence
+        boundaries (or leaked chunk by chunk in TOKEN mode).
+        """
+        results = []
+        for chunk in ["Please spell ", "<think>foo. bar. baz</think>", " now."]:
+            async for agg in self.aggregator.aggregate(chunk):
+                results.append(agg)
+
+        # Nothing is emitted while inside <think>: sentence detection stays
+        # suspended until the closing tag arrives.
+        self.assertEqual(len(results), 0)
+
+        flush = await self.aggregator.flush()
+        self.assertEqual(flush.text, "Please spell <think>foo. bar. baz</think> now.")
+        self.assertEqual(self.aggregator.text.text, "")
+
+    async def test_token_content_inside_later_tag_buffered(self):
+        """In TOKEN mode, a tag from a later pair buffers its content like a first pair would."""
+        from pipecat.utils.text.base_text_aggregator import AggregationType
+
+        aggregator = SkipTagsAggregator(
+            [("<spell>", "</spell>"), ("<think>", "</think>")],
+            aggregation_type=AggregationType.TOKEN,
+        )
+
+        results = []
+        async for agg in aggregator.aggregate("<think>hidden text"):
+            results.append(agg)
+        # Still inside the tag: nothing is emitted.
+        self.assertEqual(len(results), 0)
+
+        async for agg in aggregator.aggregate("</think> and more"):
+            results.append(agg)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "<think>hidden text</think> and more")
+        self.assertEqual(results[0].type, "token")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -277,6 +277,22 @@ class TestStartEndTags(unittest.IsolatedAsyncioTestCase):
             41,
         )
 
+    async def test_later_pair_detected_when_first_is_absent(self):
+        # Regression: the loop over the tag pairs used to return as soon as one
+        # pair did not appear in the text, so a tag from a later pair was never
+        # detected when an earlier pair was absent.
+        tags = [("<spell>", "</spell>"), ("<think>", "</think>")]
+
+        text = "Please think <think>about this"
+        assert parse_start_end_tags(text, tags, None, 0) == (
+            ("<think>", "</think>"),
+            len(text),
+        )
+
+        # A fully balanced later pair is consumed just like a first pair would be.
+        text = "Let me <think>think</think> now"
+        assert parse_start_end_tags(text, tags, None, 0) == (None, len(text))
+
 
 class TestLongestTrailingPartialMatch(unittest.IsolatedAsyncioTestCase):
     async def test_empty_and_no_match(self):


### PR DESCRIPTION
## What this does

`parse_start_end_tags()` (used by `SkipTagsAggregator`, which backs the expressive TTS text aggregation for Cartesia and Rime) only ever honored the **first** configured tag pair. The loop over the tag pairs returned as soon as one pair did not appear in the text, so any tag registered after the first absent pair was never detected:

- in SENTENCE mode, content inside the later tag was split at sentence boundaries (`<think>foo. bar. baz</think>` emitted as `foo.` / `bar.` while the tag was still open);
- in TOKEN mode, the tagged content leaked chunk by chunk instead of being buffered until the closing tag.

The loop now scans every configured pair before giving up; behavior for a single tag pair (or a fully balanced pair) is unchanged.

## How to test

- `pytest tests/test_skip_tags_aggregator.py tests/test_utils_string.py` - added regression tests: content inside a later tag pair is no longer split in SENTENCE mode, is buffered in TOKEN mode, and `parse_start_end_tags` detects a later pair when an earlier one is absent.
- `ruff check` and `ruff format --check` pass on the changed files.
