### PR TITLE
Default GroqLLMService to openai/gpt-oss-120b

### DIFF
--- a/changelog/5338.changed.md
+++ b/changelog/5338.changed.md
@@ -1,0 +1,1 @@
+- `GroqLLMService` now defaults to `openai/gpt-oss-120b`. The previous default, `llama-3.3-70b-versatile`, is being retired by Groq. Pass `settings=GroqLLMService.Settings(model=...)` to choose a different model.

--- a/src/pipecat/services/groq/llm.py
+++ b/src/pipecat/services/groq/llm.py
@@ -45,7 +45,7 @@ class GroqLLMService(OpenAILLMService):
         Args:
             api_key: The API key for accessing Groq's API.
             base_url: The base URL for Groq API. Defaults to "https://api.groq.com/openai/v1".
-            model: The model identifier to use. Defaults to "llama-3.3-70b-versatile".
+            model: The model identifier to use. Defaults to "openai/gpt-oss-120b".
 
                 .. deprecated:: 0.0.105
                     Use ``settings=GroqLLMService.Settings(model=...)`` instead.
@@ -56,7 +56,7 @@ class GroqLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="llama-3.3-70b-versatile")
+        default_settings = self.Settings(model="openai/gpt-oss-120b")
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:


### PR DESCRIPTION
## Summary

- `GroqLLMService` defaults to `openai/gpt-oss-120b`, replacing `llama-3.3-70b-versatile`, which Groq is retiring.
- Applications that pass an explicit model — via `settings=GroqLLMService.Settings(model=...)` or the deprecated `model=` argument — are unaffected. Applications relying on the default will now run against a different model.