### PR TITLE
fix(openai): accumulate streamed tool calls by index

### DIFF
--- a/changelog/5342.fixed.md
+++ b/changelog/5342.fixed.md
@@ -1,0 +1,1 @@
+- Fixed OpenAI-compatible streamed tool calls whose first delta uses a non-zero index.

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -72,6 +72,13 @@ class OpenAILLMSettings(LLMSettings):
     )
 
 
+@dataclass
+class _StreamedToolCall:
+    function_name: str = ""
+    arguments: str = ""
+    tool_call_id: str = ""
+
+
 class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
     """Base class for all services that use the AsyncOpenAI client.
 
@@ -430,13 +437,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
 
     @traced_llm
     async def _process_context(self, context: LLMContext):
-        functions_list = []
-        arguments_list = []
-        tool_id_list = []
-        func_idx = 0
-        function_name = ""
-        arguments = ""
-        tool_call_id = ""
+        streamed_tool_calls: dict[int, _StreamedToolCall] = {}
 
         await self.start_ttfb_metrics()
 
@@ -514,21 +515,17 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                         # the response is done, we package up all the arguments and the function name and
                         # yield a frame containing the function name and the arguments.
 
-                        tool_call = chunk.choices[0].delta.tool_calls[0]
-                        if tool_call.index != func_idx:
-                            functions_list.append(function_name)
-                            arguments_list.append(arguments or "{}")
-                            tool_id_list.append(tool_call_id)
-                            function_name = ""
-                            arguments = ""
-                            tool_call_id = ""
-                            func_idx += 1
-                        if tool_call.function and tool_call.function.name:
-                            function_name += tool_call.function.name
-                            tool_call_id = tool_call.id
-                        if tool_call.function and tool_call.function.arguments:
-                            # Keep iterating through the response to collect all the argument fragments
-                            arguments += tool_call.function.arguments
+                        for tool_call in chunk.choices[0].delta.tool_calls:
+                            elem = streamed_tool_calls.setdefault(
+                                tool_call.index, _StreamedToolCall()
+                            )
+                            if tool_call.id:
+                                elem.tool_call_id = tool_call.id
+                            if tool_call.function and tool_call.function.name:
+                                elem.function_name += tool_call.function.name
+                            if tool_call.function and tool_call.function.arguments:
+                                # Keep iterating through the response to collect all argument fragments.
+                                elem.arguments += tool_call.function.arguments
                     elif chunk.choices[0].delta.content:
                         await self._push_llm_text(chunk.choices[0].delta.content)
 
@@ -551,17 +548,19 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
         # a registered handler. If so, run the registered callback, save the result to
         # the context, and re-prompt to get a chat answer. If we don't have a registered
         # handler, raise an exception.
-        if function_name:
-            # added to the list as last function name and arguments not added to the list
-            functions_list.append(function_name)
-            arguments_list.append(arguments or "{}")
-            tool_id_list.append(tool_call_id)
-
+        if streamed_tool_calls:
             function_calls = []
 
-            for function_name, arguments, tool_id in zip(
-                functions_list, arguments_list, tool_id_list
-            ):
+            for _, tool_call in sorted(streamed_tool_calls.items()):
+                if not tool_call.tool_call_id or not tool_call.function_name:
+                    logger.warning(
+                        f"{self}: skipping tool call with empty id/name "
+                        f"function_name={tool_call.function_name!r} "
+                        f"tool_call_id={tool_call.tool_call_id!r}"
+                    )
+                    continue
+
+                arguments = tool_call.arguments or "{}"
                 try:
                     arguments = json.loads(arguments)
                 except json.JSONDecodeError:
@@ -570,13 +569,14 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                 function_calls.append(
                     FunctionCallFromLLM(
                         context=context,
-                        tool_call_id=tool_id,
-                        function_name=function_name,
+                        tool_call_id=tool_call.tool_call_id,
+                        function_name=tool_call.function_name,
                         arguments=arguments,
                     )
                 )
 
-            await self.run_function_calls(function_calls)
+            if function_calls:
+                await self.run_function_calls(function_calls)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames for LLM completion requests.

--- a/tests/test_openai_llm_timeout.py
+++ b/tests/test_openai_llm_timeout.py
@@ -6,6 +6,7 @@
 
 """Unit tests for OpenAI LLM error handling."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -296,6 +297,60 @@ async def test_openai_llm_async_iterator_closed_on_stream_end():
         assert iterator_aclosed, "Async iterator should be explicitly closed"
         # Verify the stream was also closed (releases HTTP resources)
         assert stream_closed, "Stream should be closed to release HTTP resources"
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_streamed_tool_call_index_can_start_after_zero():
+    """Tool-call indexes may be sparse when a provider streams non-tool output first."""
+    with patch.object(OpenAILLMService, "create_client"):
+        service = OpenAILLMService(settings=OpenAILLMService.Settings(model="gpt-4"))
+        service._client = AsyncMock()
+
+        class MockAsyncStream:
+            def __init__(self, chunks):
+                self._chunks = chunks
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._chunks:
+                    raise StopAsyncIteration()
+                return self._chunks.pop(0)
+
+            async def close(self):
+                pass
+
+        def tool_chunk(index, *, tool_call_id=None, name=None, arguments=None):
+            function = SimpleNamespace(name=name, arguments=arguments)
+            tool_call = SimpleNamespace(index=index, id=tool_call_id, function=function)
+            delta = SimpleNamespace(tool_calls=[tool_call], content=None)
+            choice = SimpleNamespace(delta=delta)
+            return SimpleNamespace(usage=None, model=None, choices=[choice])
+
+        mock_stream = MockAsyncStream(
+            [
+                tool_chunk(1, tool_call_id="call_weather", name="get_weather", arguments=""),
+                tool_chunk(1, arguments='{"city": "San Francisco"}'),
+            ]
+        )
+
+        service.get_chat_completions = AsyncMock(return_value=mock_stream)
+        service.start_ttfb_metrics = AsyncMock()
+        service.stop_ttfb_metrics = AsyncMock()
+        service.start_llm_usage_metrics = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        context = LLMContext(messages=[{"role": "user", "content": "weather?"}])
+
+        await service._process_context(context)
+
+        service.run_function_calls.assert_called_once()
+        function_calls = service.run_function_calls.call_args.args[0]
+        assert len(function_calls) == 1
+        assert function_calls[0].tool_call_id == "call_weather"
+        assert function_calls[0].function_name == "get_weather"
+        assert function_calls[0].arguments == {"city": "San Francisco"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Fixes #4987.

OpenAI-compatible streaming responses can emit the first tool-call delta with an index greater than zero, for example when non-tool output precedes the function call. The previous accumulator assumed dense indexes starting at zero, which could flush an empty phantom tool call before the real one.

This PR accumulates streamed tool-call fields by `tool_call.index`, skips malformed calls with empty id/name, and adds a regression test for a first tool call arriving at index 1.

Tests:

- `/tmp/pipecat-pr-venv/bin/python -m pytest tests/test_openai_llm_timeout.py -q`
- `/tmp/pipecat-pr-venv/bin/ruff check src/pipecat/services/openai/base_llm.py tests/test_openai_llm_timeout.py`
