### PR TITLE
fix(daily): shut down the per-session cleanup executor after release()

### DIFF
--- a/changelog/5343.fixed.md
+++ b/changelog/5343.fixed.md
@@ -1,0 +1,6 @@
+- Fixed `DailyTransportClient` leaking one thread per session: the internal
+  `ThreadPoolExecutor` used to run `CallClient.release()` off the event loop
+  was never shut down, so its worker thread outlived the session. In a process
+  that serves sessions back to back (a Pipecat Cloud warm instance, for
+  example) threads accumulated, and on glibc Linux each one could pin a malloc
+  arena whose free lists are never returned to the OS.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -770,13 +770,21 @@ class DailyTransportClient(EventHandler):
         if self._video_task and self._task_manager:
             await self._task_manager.cancel_task(self._video_task)
             self._video_task = None
-        # Make sure we don't block the event loop in case `client.release()`
-        # takes extra time.
-        await self._get_event_loop().run_in_executor(self._executor, self._cleanup)
-        # The executor's job is done after the final cleanup; shut it down so
-        # its worker thread doesn't outlive the session (one leaked thread per
-        # session in a process that serves sessions back to back).
-        self._executor.shutdown(wait=False)
+        try:
+            # Make sure we don't block the event loop in case `client.release()`
+            # takes extra time. The `_client` guard keeps extra cleanup() calls
+            # a no-op (some wrappers, like the LemonSlice transport, call the
+            # shared client's cleanup from both input and output): without it a
+            # second call would schedule work on an already shut down executor.
+            if self._client:
+                await self._get_event_loop().run_in_executor(self._executor, self._cleanup)
+        finally:
+            # The executor's job is done after the final cleanup; shut it down
+            # so its worker thread doesn't outlive the session (one leaked
+            # thread per session in a process that serves sessions back to
+            # back). In a `finally` so a raising or cancelled release() still
+            # signals the worker thread to exit; shutdown() is idempotent.
+            self._executor.shutdown(wait=False)
 
     async def start(self, frame: StartFrame):
         """Start the client and initialize audio/video components.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -773,6 +773,10 @@ class DailyTransportClient(EventHandler):
         # Make sure we don't block the event loop in case `client.release()`
         # takes extra time.
         await self._get_event_loop().run_in_executor(self._executor, self._cleanup)
+        # The executor's job is done after the final cleanup; shut it down so
+        # its worker thread doesn't outlive the session (one leaked thread per
+        # session in a process that serves sessions back to back).
+        self._executor.shutdown(wait=False)
 
     async def start(self, frame: StartFrame):
         """Start the client and initialize audio/video components.

--- a/tests/test_daily_transport.py
+++ b/tests/test_daily_transport.py
@@ -6,7 +6,8 @@
 
 """Tests for the Daily transport."""
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -64,6 +65,69 @@ async def test_on_joined_skips_stt_metadata_when_transcription_disabled():
 
     transport._input.push_stt_metadata_frame.assert_not_awaited()
     transport._input.push_frame.assert_awaited_once()
+
+
+def _prepare_client_for_cleanup(transport: DailyTransport):
+    """Give the shared DailyTransportClient what cleanup() needs in a test.
+
+    Simulates the state after both the input and output transports have called
+    setup(): a task manager whose loop is the running loop, and a cleanup
+    counter of 2.
+    """
+    client = transport._client
+    task_manager = MagicMock()
+    task_manager.get_event_loop.return_value = asyncio.get_running_loop()
+    client._task_manager = task_manager
+    client._cleanup_counter = 2
+    return client
+
+
+@pytest.mark.asyncio
+async def test_final_cleanup_releases_client_and_shuts_down_executor():
+    transport = _make_transport()
+    client = _prepare_client_for_cleanup(transport)
+    call_client = client._client
+
+    # First call (input transport): refcounted, nothing released yet.
+    await client.cleanup()
+    call_client.release.assert_not_called()
+    assert not client._executor._shutdown
+
+    # Final call (output transport): releases the client and shuts down the
+    # executor so its worker thread doesn't outlive the session.
+    await client.cleanup()
+    call_client.release.assert_called_once()
+    assert client._client is None
+    assert client._executor._shutdown
+
+
+@pytest.mark.asyncio
+async def test_extra_cleanup_calls_are_a_no_op():
+    # Some wrappers (e.g. the LemonSlice transport) call the shared client's
+    # cleanup() from both input and output while setup() ran only once, so
+    # cleanup() can be reached again after the executor is shut down.
+    transport = _make_transport()
+    client = _prepare_client_for_cleanup(transport)
+    call_client = client._client
+
+    await client.cleanup()
+    await client.cleanup()
+    await client.cleanup()  # One more than setup() calls: must not raise.
+
+    call_client.release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_executor_shuts_down_even_when_release_raises():
+    transport = _make_transport()
+    client = _prepare_client_for_cleanup(transport)
+    client._cleanup_counter = 1
+    client._client.release.side_effect = RuntimeError("release failed")
+
+    with pytest.raises(RuntimeError, match="release failed"):
+        await client.cleanup()
+
+    assert client._executor._shutdown
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Every `DailyTransportClient` creates a `ThreadPoolExecutor(max_workers=1)` whose only job is running `_cleanup()` (which calls `CallClient.release()`) off the event loop. Nothing ever shut it down, so its worker thread outlived the session. In a process that serves sessions back to back (a Pipecat Cloud warm instance, for example) that is one leaked thread per session. On glibc Linux each leaked thread can pin a malloc arena, and freed memory on a non-main arena's free list is never returned to the OS.

The fix is one call: `self._executor.shutdown(wait=False)` after the final cleanup completes.

## Measurements

4 sequential sessions in one process, `python:3.12-slim` (glibc, arm64), full STT+LLM+TTS pipeline with a Daily transport, participant joining and leaving each session:

| Boundary | threads before | threads after | arenas before | arenas after |
|-|-|-|-|-|
| end of session 1 | 26 | 25 | 30 | 30 |
| end of session 2 | 30 | 29 | 35 | 34 |
| end of session 3 | 34 | 33 | 39 | 38 |
| end of session 4 | 38 | 37 | 43 | 42 |

Exactly one fewer surviving thread and one fewer glibc arena per session, which is precisely this executor's share.

## What this does NOT fix

The remaining +4 threads/session are daily-core threads (`SoupSignalling`, `mediasoup-manager`, `rtp_send_control`, `TaskQueuePacedSender`, ...) surviving `CallClient.release()`: daily-co/daily-python#33, tracked internally as CSDK-3005 (support ticket T-3321). Also tested and rejected: calling `Daily.deinit()` between sessions aborts the process with a non-unwinding panic in daily-core (`context.rs:248`), because those surviving threads still reference the global context.

## Testing

- `tests/test_daily_transport.py`: 7 passed, including three new regression tests: executor shuts down on the final refcounted `cleanup()`, extra `cleanup()` calls stay a no-op (the LemonSlice input+output shape), and a raising `release()` still shuts the executor down.
- 8 full real Daily sessions (join, greet, cloud recording, EndFrame teardown) ran through the patched `cleanup()` across two measurement runs with no functional change, plus a 3-session re-run after the review restructure with the same per-boundary numbers.
