### PR TITLE
fix(observers): measure latency when a turn starts without VAD

### DIFF
--- a/changelog/5345.fixed.md
+++ b/changelog/5345.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `UserBotLatencyObserver` silently dropping turns started by `TranscriptionUserTurnStartStrategy` (and any other start that never emits VAD frames).

--- a/src/pipecat/observers/user_bot_latency_observer.py
+++ b/src/pipecat/observers/user_bot_latency_observer.py
@@ -24,6 +24,7 @@ from pipecat.frames.frames import (
     FunctionCallResultFrame,
     InterruptionFrame,
     MetricsFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -92,8 +93,9 @@ class LatencyBreakdown(BaseModel):
         text_aggregation: First text aggregation measurement, representing
             the latency cost of sentence aggregation in the TTS pipeline.
         user_turn_start_time: Unix timestamp when the user turn started
-            (actual user silence, adjusted for VAD stop_secs). ``None`` if
-            no ``VADUserStoppedSpeakingFrame`` was observed.
+            (actual user silence, adjusted for VAD stop_secs). Falls back
+            to ``UserStoppedSpeakingFrame`` time when VAD never fired.
+            ``None`` if neither stop frame was observed.
         user_turn_secs: Duration in seconds of the user's turn, measured
             from when the user actually stopped speaking to when the turn
             was released (``UserStoppedSpeakingFrame``). This includes
@@ -143,10 +145,12 @@ class LatencyBreakdown(BaseModel):
 class UserBotLatencyObserver(BaseObserver):
     """Observer that tracks user-to-bot response latency.
 
-    Measures the time between when a user stops speaking (VADUserStoppedSpeakingFrame)
-    and when the bot starts speaking (BotStartedSpeakingFrame). Emits events when
-    latency is measured, allowing consumers to log, trace, or otherwise process
-    the latency data.
+    Measures the time between when a user stops speaking and when the bot
+    starts speaking (BotStartedSpeakingFrame). The stop timestamp prefers
+    ``VADUserStoppedSpeakingFrame`` (VAD time minus ``stop_secs``). When VAD
+    never fires — for example ``TranscriptionUserTurnStartStrategy`` starting
+    a turn that STT heard but local VAD missed — ``UserStoppedSpeakingFrame``
+    is the fallback so the turn is not dropped silently.
 
     When ``enable_metrics=True`` in pipeline params, also collects per-service
     latency breakdown (TTFB, text aggregation) and emits an
@@ -233,15 +237,12 @@ class UserBotLatencyObserver(BaseObserver):
             return
 
         # Track speech and pipeline events for latency
-        if isinstance(data.frame, VADUserStartedSpeakingFrame):
-            # Reset when user starts speaking
-            self._user_stopped_time = None
-            self._user_turn_start_time = None
-            self._user_turn = None
-            self._reset_accumulators()
-            # If user speaks before the bot's first speech, abandon the
-            # first-bot-speech measurement — it's only meaningful for greetings.
-            self._first_bot_speech_measured = True
+        if isinstance(data.frame, (VADUserStartedSpeakingFrame, UserStartedSpeakingFrame)):
+            # New user turn. UserStartedSpeakingFrame is the strategy-level
+            # boundary (transcription / external / wake-phrase starts); VAD
+            # start is the audio-level one. Both must reset: otherwise a
+            # VAD-miss turn never clears first-bot-speech or stale stop time.
+            self._reset_user_speech_cycle()
         elif isinstance(data.frame, VADUserStoppedSpeakingFrame):
             # Record the actual time the user stopped speaking, which is
             # the VAD determination time minus the stop_secs silence duration
@@ -249,11 +250,18 @@ class UserBotLatencyObserver(BaseObserver):
             self._user_stopped_time = data.frame.timestamp - data.frame.stop_secs
             self._user_turn_start_time = self._user_stopped_time
         elif isinstance(data.frame, UserStoppedSpeakingFrame):
-            # Measure the user turn duration: from actual user silence to
-            # turn release. Includes VAD silence detection, STT finalization,
-            # and any turn analyzer wait.
             if self._user_stopped_time is not None:
+                # VAD path: turn release minus actual silence. Includes VAD
+                # stop_secs, STT finalization, and any turn analyzer wait.
                 self._user_turn = time.time() - self._user_stopped_time
+            else:
+                # No VAD stop this turn (TranscriptionUserTurnStartStrategy
+                # and any other start that never produced VAD frames).
+                # Turn release is the best stop timestamp we have. Do not
+                # invent user_turn_secs: stop and release are the same event.
+                now = time.time()
+                self._user_stopped_time = now
+                self._user_turn_start_time = now
         elif isinstance(data.frame, InterruptionFrame):
             # Discard stale metrics from cancelled LLM/TTS cycles
             self._reset_accumulators()
@@ -310,8 +318,9 @@ class UserBotLatencyObserver(BaseObserver):
         """Extract latency metrics from a MetricsFrame.
 
         Accumulates metrics when a measurement is in progress: either a
-        user→bot cycle (after ``VADUserStoppedSpeakingFrame``) or the
-        first-bot-speech window (after ``ClientConnectedFrame``).
+        user→bot cycle (after ``VADUserStoppedSpeakingFrame`` or the
+        ``UserStoppedSpeakingFrame`` fallback) or the first-bot-speech
+        window (after ``ClientConnectedFrame``).
         """
         waiting_for_first_speech = (
             self._client_connected_time is not None and not self._first_bot_speech_measured
@@ -339,6 +348,16 @@ class UserBotLatencyObserver(BaseObserver):
                         start_time=now - metrics_data.value,
                         duration_secs=metrics_data.value,
                     )
+
+    def _reset_user_speech_cycle(self):
+        """Clear stop timing and accumulators at the start of a user turn."""
+        self._user_stopped_time = None
+        self._user_turn_start_time = None
+        self._user_turn = None
+        self._reset_accumulators()
+        # If the user speaks before the bot's first speech, abandon the
+        # first-bot-speech measurement — it's only meaningful for greetings.
+        self._first_bot_speech_measured = True
 
     def _reset_accumulators(self):
         """Clear per-cycle metric accumulators."""

--- a/tests/test_user_bot_latency_observer.py
+++ b/tests/test_user_bot_latency_observer.py
@@ -7,6 +7,7 @@ from pipecat.frames.frames import (
     FunctionCallResultFrame,
     InterruptionFrame,
     MetricsFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
@@ -466,6 +467,157 @@ class TestUserBotLatencyObserver(unittest.IsolatedAsyncioTestCase):
             processor,
             frames_to_send=frames_to_send,
             expected_down_frames=expected_down_frames,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(first_speech_latencies), 0)
+
+    async def test_transcription_turn_measures_latency(self):
+        """VAD-miss path: UserStoppedSpeakingFrame must still open a measurement."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        latencies = []
+        breakdowns = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        @observer.event_handler("on_latency_breakdown")
+        async def on_breakdown(obs, breakdown):
+            breakdowns.append(breakdown)
+
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.15),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=[
+                UserStartedSpeakingFrame,
+                UserStoppedSpeakingFrame,
+                BotStartedSpeakingFrame,
+            ],
+            observers=[observer],
+        )
+
+        self.assertEqual(len(latencies), 1)
+        self.assertGreaterEqual(latencies[0], 0.1)
+        self.assertEqual(len(breakdowns), 1)
+        # Stop and turn-release are the same event; do not invent a wait.
+        self.assertIsNone(breakdowns[0].user_turn_secs)
+        self.assertIsNotNone(breakdowns[0].user_turn_start_time)
+
+    async def test_transcription_turn_collects_metrics_after_stop(self):
+        """Fallback stop must open the metrics window the VAD stop normally opens."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        breakdowns = []
+
+        @observer.event_handler("on_latency_breakdown")
+        async def on_breakdown(obs, breakdown):
+            breakdowns.append(breakdown)
+
+        llm_ttfb = TTFBMetricsData(processor="OpenAILLMService#0", value=0.250)
+
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            MetricsFrame(data=[llm_ttfb]),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(breakdowns), 1)
+        self.assertEqual(len(breakdowns[0].ttfb), 1)
+        self.assertEqual(breakdowns[0].ttfb[0].processor, "OpenAILLMService#0")
+
+    async def test_vad_stop_is_not_overwritten_by_user_stopped(self):
+        """Dual start strategies: VAD timing stays authoritative once set."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        breakdowns = []
+
+        @observer.event_handler("on_latency_breakdown")
+        async def on_breakdown(obs, breakdown):
+            breakdowns.append(breakdown)
+
+        frames_to_send = [
+            VADUserStartedSpeakingFrame(),
+            UserStartedSpeakingFrame(),
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.2),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(breakdowns), 1)
+        self.assertIsNotNone(breakdowns[0].user_turn_secs)
+        self.assertGreaterEqual(breakdowns[0].user_turn_secs, 0.1)
+
+    async def test_user_started_without_stop_does_not_measure(self):
+        """A turn that never ends must not emit stop-to-bot latency."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        latencies = []
+
+        @observer.event_handler("on_latency_measured")
+        async def on_latency(obs, latency_seconds):
+            latencies.append(latency_seconds)
+
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            observers=[observer],
+        )
+
+        self.assertEqual(len(latencies), 0)
+
+    async def test_first_bot_speech_skipped_when_transcription_turn_starts_first(self):
+        """UserStartedSpeakingFrame must abandon greeting latency, same as VAD start."""
+        observer = UserBotLatencyObserver()
+        processor = IdentityFilter()
+
+        first_speech_latencies = []
+
+        @observer.event_handler("on_first_bot_speech_latency")
+        async def on_first_bot_speech(obs, latency_seconds):
+            first_speech_latencies.append(latency_seconds)
+
+        frames_to_send = [
+            ClientConnectedFrame(),
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
             observers=[observer],
         )
 


### PR DESCRIPTION
## Summary

`UserBotLatencyObserver` only opened a measurement on `VADUserStoppedSpeakingFrame`. A turn started by `TranscriptionUserTurnStartStrategy` (the documented VAD-miss fallback) never set `_user_stopped_time`, so `BotStartedSpeakingFrame` dropped the whole cycle: no `on_latency_measured`, no `on_latency_breakdown`.

This is the SIP path in #5311: Deepgram heard "Yes.", the turn completed, the observer reported nothing.

## What changed

- `UserStoppedSpeakingFrame` is the fallback stop timestamp when VAD never fired.
- `UserStartedSpeakingFrame` is a turn boundary, same as VAD start. Without that, a VAD-miss first utterance still looks like a greeting and `on_first_bot_speech_latency` fires for the wrong thing.
- If VAD did fire, its `timestamp - stop_secs` stays authoritative. `UserStoppedSpeakingFrame` only computes `user_turn_secs` in that case.
- On the fallback, `user_turn_secs` stays `None`. Stop and turn-release are the same event; inventing a 0s wait would lie.

## Test plan

- [x] `pytest tests/test_user_bot_latency_observer.py` (22 passed)
  - transcription-only turn measures latency and opens the metrics window
  - dual VAD + user-stop keeps VAD timing
  - `UserStartedSpeakingFrame` without a stop does not measure
  - first-bot-speech is skipped when a transcription turn starts first
  - existing VAD cases unchanged

Fixes #5311
