### PR TITLE
fix(turns): release initial user mute on pipeline errors

### DIFF
--- a/changelog/5344.fixed.md
+++ b/changelog/5344.fixed.md
@@ -1,0 +1,1 @@
+- Released the initial user mute when the opening bot response reports an error.

--- a/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
+++ b/src/pipecat/turns/user_mute/mute_until_first_bot_complete_user_mute_strategy.py
@@ -6,7 +6,7 @@
 
 """User mute strategy that mutes the user until the bot completes its first speech."""
 
-from pipecat.frames.frames import BotStoppedSpeakingFrame, Frame
+from pipecat.frames.frames import BotStoppedSpeakingFrame, ErrorFrame, Frame
 from pipecat.turns.user_mute.base_user_mute_strategy import BaseUserMuteStrategy
 
 
@@ -15,10 +15,11 @@ class MuteUntilFirstBotCompleteUserMuteStrategy(BaseUserMuteStrategy):
 
     This strategy mutes user frames immediately from the start of the
     interaction, even if the bot has not started speaking yet. User input
-    remains muted until the bot finishes its first speaking turn.
+    remains muted until the bot finishes its first speaking turn or the
+    pipeline reports an error.
 
-    After the bot completes its initial speech, all subsequent user frames are
-    allowed to pass through without muting.
+    After either condition, all subsequent user frames are allowed to pass
+    through without muting.
 
     Use this strategy when the bot must fully control the beginning of the
     interaction and deliver its first response without any user interruption.
@@ -41,11 +42,7 @@ class MuteUntilFirstBotCompleteUserMuteStrategy(BaseUserMuteStrategy):
         """
         await super().process_frame(frame)
 
-        if isinstance(frame, BotStoppedSpeakingFrame):
-            await self._handle_bot_stopped_speaking(frame)
+        if isinstance(frame, (BotStoppedSpeakingFrame, ErrorFrame)):
+            self._first_speech_handled = True
 
         return not self._first_speech_handled
-
-    async def _handle_bot_stopped_speaking(self, frame: BotStoppedSpeakingFrame):
-        if not self._first_speech_handled:
-            self._first_speech_handled = True

--- a/tests/test_user_mute_strategy.py
+++ b/tests/test_user_mute_strategy.py
@@ -9,6 +9,7 @@ import unittest
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
+    ErrorFrame,
     FunctionCallCancelFrame,
     FunctionCallFromLLM,
     FunctionCallResultFrame,
@@ -52,6 +53,13 @@ class TestMuteUntilFirstBotCompleteUserMuteStrategy(unittest.IsolatedAsyncioTest
         self.assertTrue(await strategy.process_frame(BotStartedSpeakingFrame()))
         self.assertTrue(await strategy.process_frame(InterruptionFrame()))
         self.assertFalse(await strategy.process_frame(BotStoppedSpeakingFrame()))
+        self.assertFalse(await strategy.process_frame(InterruptionFrame()))
+
+    async def test_error_releases_mute(self):
+        strategy = MuteUntilFirstBotCompleteUserMuteStrategy()
+
+        self.assertTrue(await strategy.process_frame(InterruptionFrame()))
+        self.assertFalse(await strategy.process_frame(ErrorFrame(error="TTS failed")))
         self.assertFalse(await strategy.process_frame(InterruptionFrame()))
 
 


### PR DESCRIPTION
Fixes #5344

## Summary

- Release the one-shot initial user mute when the pipeline reports an error.
- Add regression coverage and a changelog entry for the recovery behavior.

## Root Cause

`MuteUntilFirstBotCompleteUserMuteStrategy` only released its mute after a
`BotStoppedSpeakingFrame`. When the opening response failed before producing
audio, that frame never arrived, so every later user turn stayed muted.

## Verification

- `python -m pytest tests/test_user_mute_strategy.py` - 8 passed.
- Relevant user-aggregator integration tests - 2 passed.
- `ruff check` and `ruff format --check` - passed with the locked Ruff version.
- Type checking for the changed source and test files - passed.
- Full unit, coverage, build, and all-extras type checks are delegated to CI.

## Notes for Reviewers

The error path fails open only for this one-shot initial mute. The normal
`BotStoppedSpeakingFrame` release behavior is unchanged.
