### PR TITLE
Docs explaining how Pipecat keeps three versions of one response in sync.

### DIFF
--- a/docs/architecture/word-tracking-deck.html
+++ b/docs/architecture/word-tracking-deck.html
@@ -1,0 +1,1968 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Three Texts, One Cursor</title>
+<style>
+/* Minimal reset — a local file gets no host stylesheet. */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+button { font: inherit; color: inherit; }
+table { border-spacing: 0; }
+/* ============================================================
+   TOKENS — dark is the default (a deck is a projection surface).
+   Every colour is painted explicitly; [data-theme="light"] swaps
+   the same token set so nothing is defined only inside a block.
+   ============================================================ */
+:root {
+  --ground:      #0F1319;
+  --surface:     #161B23;
+  --surface-2:   #1E2530;
+  --line:        #2A3340;
+  --line-soft:   #212936;
+
+  --ink:         #E4E8EE;
+  --ink-dim:     #99A3B2;
+  --ink-faint:   #5F6B7C;
+
+  /* The three channels. Learned once, read for the whole deck. */
+  --tts:         #E8A33D;
+  --seg:         #4FC3B0;
+  --llm:         #B08BE8;
+
+  --tts-soft:    rgba(232,163,61,.13);
+  --seg-soft:    rgba(79,195,176,.13);
+  --llm-soft:    rgba(176,139,232,.13);
+
+  --warn:        #E8735A;
+  --warn-soft:   rgba(232,115,90,.13);
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+  --pad: clamp(2rem, 5vw, 5.5rem);
+}
+
+[data-theme="light"] {
+  --ground:      #F7F8FA;
+  --surface:     #FFFFFF;
+  --surface-2:   #EFF2F6;
+  --line:        #DDE2E9;
+  --line-soft:   #E7EBF0;
+
+  --ink:         #14181F;
+  --ink-dim:     #4E5866;
+  --ink-faint:   #8A94A3;
+
+  --tts:         #B87410;
+  --seg:         #14806F;
+  --llm:         #6E42B8;
+
+  --tts-soft:    rgba(184,116,16,.10);
+  --seg-soft:    rgba(20,128,111,.10);
+  --llm-soft:    rgba(110,66,184,.10);
+
+  --warn:        #C4432A;
+  --warn-soft:   rgba(196,67,42,.10);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ground);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ============================================================
+   DECK FRAME
+   ============================================================ */
+.deck { position: relative; width: 100vw; height: 100vh; }
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(2.2rem, 4vh, 3.4rem) var(--pad) 5.2rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.slide.is-active { display: flex; }
+
+.slide > * { max-width: 1180px; width: 100%; margin-inline: auto; flex-shrink: 0; }
+
+/* ============================================================
+   TYPE
+   ============================================================ */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+}
+.eyebrow .num { color: var(--tts); }
+.eyebrow .rule { flex: 1; height: 1px; background: var(--line); }
+
+h1.title {
+  font-size: clamp(2.6rem, 6.4vw, 5rem);
+  line-height: 1.02;
+  letter-spacing: -.035em;
+  font-weight: 800;
+  margin: 0 0 1.4rem;
+  text-wrap: balance;
+}
+h2.headline {
+  font-size: clamp(1.6rem, 3.4vw, 2.6rem);
+  line-height: 1.1;
+  letter-spacing: -.025em;
+  font-weight: 750;
+  margin: 0 0 1.1rem;
+  text-wrap: balance;
+}
+h3.sub {
+  font-family: var(--font-mono);
+  font-size: .78rem;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  font-weight: 600;
+  margin: 0 0 .7rem;
+}
+
+.lede {
+  font-size: clamp(1rem, 1.45vw, 1.22rem);
+  line-height: 1.55;
+  color: var(--ink-dim);
+  max-width: 62ch;
+  margin: 0 0 1.6rem;
+  text-wrap: pretty;
+}
+.lede strong { color: var(--ink); font-weight: 650; }
+.lede.tight { margin-bottom: 1rem; }
+
+p.note {
+  font-size: .92rem;
+  color: var(--ink-faint);
+  max-width: 68ch;
+  margin: 1.1rem 0 0;
+  line-height: 1.55;
+}
+p.note strong { color: var(--ink-dim); font-weight: 650; }
+
+/* ============================================================
+   CHANNEL CODE — the deck's one structural device
+   ============================================================ */
+.ch { font-family: var(--font-mono); font-weight: 600; }
+.ch-tts { color: var(--tts); }
+.ch-seg { color: var(--seg); }
+.ch-llm { color: var(--llm); }
+.ch-warn { color: var(--warn); }
+
+.legend { display: flex; flex-wrap: wrap; gap: .55rem; margin: 0 0 1.5rem; }
+.tag {
+  font-family: var(--font-mono);
+  font-size: .74rem;
+  letter-spacing: .06em;
+  padding: .3rem .6rem;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+  color: var(--ink-dim);
+  background: var(--surface);
+  white-space: nowrap;
+}
+.tag.t-tts  { color: var(--tts); border-color: color-mix(in srgb, var(--tts) 38%, transparent); background: var(--tts-soft); }
+.tag.t-seg  { color: var(--seg); border-color: color-mix(in srgb, var(--seg) 38%, transparent); background: var(--seg-soft); }
+.tag.t-llm  { color: var(--llm); border-color: color-mix(in srgb, var(--llm) 38%, transparent); background: var(--llm-soft); }
+.tag.t-warn { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 38%, transparent); background: var(--warn-soft); }
+
+/* ============================================================
+   PANELS & GRIDS
+   ============================================================ */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 1.15rem 1.3rem;
+}
+.panel.accent-tts  { border-left: 3px solid var(--tts); }
+.panel.accent-seg  { border-left: 3px solid var(--seg); }
+.panel.accent-llm  { border-left: 3px solid var(--llm); }
+.panel.accent-warn { border-left: 3px solid var(--warn); }
+
+.grid { display: grid; gap: 1rem; }
+.g2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
+.g3 { grid-template-columns: repeat(3, minmax(0,1fr)); }
+.g2-wide { grid-template-columns: minmax(0,1.25fr) minmax(0,1fr); }
+@media (max-width: 900px) {
+  .g2, .g3, .g2-wide { grid-template-columns: minmax(0,1fr); }
+}
+
+.stack { display: flex; flex-direction: column; gap: 1rem; }
+.stack-sm { display: flex; flex-direction: column; gap: .6rem; }
+
+/* ============================================================
+   TABLES
+   ============================================================ */
+.scroll { overflow-x: auto; }
+
+table.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .88rem;
+  font-variant-numeric: tabular-nums;
+}
+table.tbl th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  font-weight: 600;
+  padding: .5rem .8rem;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+table.tbl td {
+  padding: .58rem .8rem;
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--ink-dim);
+  vertical-align: top;
+}
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl td.k { color: var(--ink); font-weight: 600; white-space: nowrap; }
+table.tbl td.m, table.tbl th.m { font-family: var(--font-mono); font-size: .82rem; }
+table.tbl td.num { text-align: right; font-family: var(--font-mono); }
+table.tbl.compact td { padding: .42rem .7rem; }
+table.tbl th.c-tts { color: var(--tts); }
+table.tbl th.c-seg { color: var(--seg); }
+table.tbl th.c-llm { color: var(--llm); }
+table.tbl tr.hi td { background: var(--tts-soft); color: var(--ink); }
+table.tbl tr.dim td { color: var(--ink-faint); }
+
+/* ============================================================
+   CODE
+   ============================================================ */
+pre.code {
+  font-family: var(--font-mono);
+  font-size: .82rem;
+  line-height: 1.6;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: .95rem 1.1rem;
+  margin: 0;
+  overflow-x: auto;
+  color: var(--ink-dim);
+  tab-size: 2;
+}
+pre.code .c { color: var(--ink-faint); font-style: italic; }
+pre.code .kw { color: var(--llm); }
+pre.code .s { color: var(--seg); }
+pre.code .fn { color: var(--tts); }
+pre.code b { color: var(--ink); font-weight: 650; }
+
+code.inl {
+  font-family: var(--font-mono);
+  font-size: .87em;
+  background: var(--surface-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 3px;
+  padding: .08em .34em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+/* ============================================================
+   THE SENTENCE — recurring hero specimen
+   ============================================================ */
+.specimen {
+  font-family: var(--font-mono);
+  font-size: clamp(.86rem, 1.55vw, 1.18rem);
+  line-height: 1.75;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 1.1rem 1.25rem;
+  overflow-x: auto;
+  color: var(--ink);
+}
+.specimen .tagmark { color: var(--llm); }
+.specimen .redact { color: var(--tts); }
+
+/* ============================================================
+   FLOW DIAGRAM — the two split points
+   ============================================================ */
+.flow { display: flex; flex-direction: column; gap: .5rem; align-items: stretch; }
+.flow-node {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 6px;
+  padding: .8rem 1rem;
+}
+.flow-node .t {
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: .28rem;
+}
+.flow-node .b { font-size: .9rem; color: var(--ink); font-weight: 600; }
+.flow-node .d { font-size: .82rem; color: var(--ink-dim); margin-top: .25rem; }
+.flow-node.split { border-style: dashed; border-color: var(--tts); }
+.flow-arrow {
+  font-family: var(--font-mono);
+  color: var(--ink-faint);
+  font-size: .9rem;
+  padding-left: 1.1rem;
+}
+.flow-out {
+  display: flex;
+  gap: .7rem;
+  align-items: baseline;
+  font-family: var(--font-mono);
+  font-size: .84rem;
+  padding: .5rem .9rem;
+  border-radius: 5px;
+  border: 1px solid var(--line);
+}
+.flow-out.o-llm { background: var(--llm-soft); border-color: color-mix(in srgb, var(--llm) 34%, transparent); }
+.flow-out.o-seg { background: var(--seg-soft); border-color: color-mix(in srgb, var(--seg) 34%, transparent); }
+.flow-out.o-tts { background: var(--tts-soft); border-color: color-mix(in srgb, var(--tts) 34%, transparent); }
+.flow-out .who { font-weight: 700; min-width: 13ch; }
+.flow-out .dest { color: var(--ink-dim); }
+
+/* ============================================================
+   SLOT QUEUE DIAGRAM
+   ============================================================ */
+.queue { display: flex; gap: .6rem; align-items: stretch; flex-wrap: wrap; }
+.slot {
+  flex: 1 1 200px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: .8rem .9rem;
+  position: relative;
+}
+.slot .kind {
+  font-family: var(--font-mono);
+  font-size: .68rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  margin-bottom: .35rem;
+}
+.slot.spoken  { border-color: color-mix(in srgb, var(--tts) 40%, transparent); }
+.slot.spoken .kind { color: var(--tts); }
+.slot.skipped { border-color: color-mix(in srgb, var(--seg) 40%, transparent); background: var(--seg-soft); }
+.slot.skipped .kind { color: var(--seg); }
+.slot .txt { font-family: var(--font-mono); font-size: .82rem; color: var(--ink); }
+.slot .meta { font-family: var(--font-mono); font-size: .72rem; color: var(--ink-faint); margin-top: .4rem; }
+.slot .meta .no { color: var(--warn); }
+.slot .meta .yes { color: var(--seg); }
+
+/* ============================================================
+   THE CURSOR INSTRUMENT
+   ============================================================ */
+.walk { display: flex; flex-direction: column; gap: .85rem; }
+
+.walk-head { display: flex; align-items: center; gap: .8rem; flex-wrap: wrap; }
+.walk-tabs { display: flex; gap: .35rem; }
+.wtab {
+  font-family: var(--font-mono);
+  font-size: .74rem;
+  letter-spacing: .05em;
+  padding: .35rem .75rem;
+  border-radius: 4px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink-dim);
+  cursor: pointer;
+}
+.wtab[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--tts) 55%, transparent);
+  background: var(--tts-soft);
+  color: var(--tts);
+}
+.wtab:focus-visible { outline: 2px solid var(--tts); outline-offset: 2px; }
+
+.walk-note { font-size: .85rem; color: var(--ink-faint); font-family: var(--font-mono); }
+
+.tracks { display: flex; flex-direction: column; gap: .5rem; }
+.track {
+  display: grid;
+  grid-template-columns: 15ch minmax(0,1fr) 9ch;
+  align-items: center;
+  gap: .9rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: .7rem .95rem;
+  background: var(--surface);
+}
+.track .lbl {
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.track .body {
+  font-family: var(--font-mono);
+  font-size: clamp(.8rem, 1.35vw, 1.05rem);
+  white-space: pre;
+  overflow-x: auto;
+  line-height: 1.7;
+}
+.track .body .done { font-weight: 700; }
+.track .body .todo { color: var(--ink-faint); }
+.track .body .caret {
+  display: inline-block;
+  width: 2px;
+  height: 1.15em;
+  vertical-align: text-bottom;
+  margin: 0 -1px;
+  animation: blink 1.1s steps(2, start) infinite;
+}
+@keyframes blink { 0%,100% { opacity: 1; } 50% { opacity: .25; } }
+@media (prefers-reduced-motion: reduce) { .track .body .caret { animation: none; } }
+
+.track .pos {
+  font-family: var(--font-mono);
+  font-size: .78rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-faint);
+}
+.track .pos b { font-weight: 700; }
+
+.track.t-tts { border-left: 3px solid var(--tts); }
+.track.t-tts .lbl, .track.t-tts .body .done, .track.t-tts .pos b { color: var(--tts); }
+.track.t-tts .caret { background: var(--tts); }
+.track.t-seg { border-left: 3px solid var(--seg); }
+.track.t-seg .lbl, .track.t-seg .body .done, .track.t-seg .pos b { color: var(--seg); }
+.track.t-seg .caret { background: var(--seg); }
+.track.t-llm { border-left: 3px solid var(--llm); }
+.track.t-llm .lbl, .track.t-llm .body .done, .track.t-llm .pos b { color: var(--llm); }
+.track.t-llm .caret { background: var(--llm); }
+.track.held { background: var(--surface-2); }
+/* Text the tracker claimed without a word event ever naming it. */
+.track .body .swept { font-weight: 700; opacity: .7; text-decoration: underline dotted; text-underline-offset: 3px; }
+.track.claiming { background: color-mix(in srgb, var(--llm) 7%, transparent); }
+
+.walk-bar { display: flex; align-items: center; gap: .8rem; flex-wrap: wrap; }
+.wbtn {
+  font-family: var(--font-mono);
+  font-size: .78rem;
+  padding: .42rem .9rem;
+  border-radius: 4px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+}
+.wbtn:hover { border-color: var(--tts); color: var(--tts); }
+.wbtn:focus-visible { outline: 2px solid var(--tts); outline-offset: 2px; }
+.wbtn[disabled] { opacity: .35; cursor: default; }
+.wbtn[disabled]:hover { border-color: var(--line); color: var(--ink); }
+
+.wfeed {
+  font-family: var(--font-mono);
+  font-size: .84rem;
+  color: var(--ink-dim);
+}
+.wfeed b { color: var(--tts); font-weight: 700; }
+.wstate {
+  font-family: var(--font-mono);
+  font-size: .74rem;
+  padding: .28rem .6rem;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+  color: var(--ink-faint);
+  background: var(--surface);
+}
+.wstate.on {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+  background: var(--warn-soft);
+}
+.wguarantee {
+  font-family: var(--font-mono);
+  font-size: .8rem;
+  color: var(--ink-faint);
+  border-top: 1px solid var(--line-soft);
+  padding-top: .7rem;
+}
+.wguarantee b { color: var(--seg); }
+
+/* Names the frame text a worked example is walking. */
+.fcap {
+  font-family: var(--font-mono);
+  font-size: .76rem;
+  line-height: 1.5;
+  color: var(--ink-faint);
+  margin: 0 0 .55rem;
+}
+.fcap b { color: var(--ink); font-weight: 700; }
+
+/* ---- the call-trace instrument ---- */
+.callstack {
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  line-height: 1.55;
+  max-height: 46vh;
+  overflow: auto;
+  border: 1px solid var(--line-soft);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: .5rem .35rem;
+}
+.crow { padding: .05rem .5rem; border-radius: 3px; white-space: pre; color: var(--ink-faint); opacity: .45; }
+.crow.seen { opacity: 1; color: var(--ink-dim); }
+.crow.on { background: var(--tts-soft); opacity: 1; color: var(--ink); }
+.crow .ret { color: var(--ink-faint); }
+.crow.on .ret { color: var(--tts); }
+.framelog { display: flex; flex-direction: column; gap: .3rem; min-height: 6.5rem; }
+.frow {
+  font-family: var(--font-mono);
+  font-size: .73rem;
+  padding: .3rem .55rem;
+  border-radius: 4px;
+  border: 1px solid var(--line-soft);
+  background: var(--surface);
+  color: var(--ink-dim);
+}
+.frow.tts { border-left: 3px solid var(--llm); }
+.frow.prog { border-left: 3px solid var(--seg); }
+.frow b { color: var(--ink); font-weight: 700; }
+.frow .tag-raw { color: var(--llm); }
+.framelog .empty { font-family: var(--font-mono); font-size: .73rem; color: var(--ink-faint); }
+
+/* ============================================================
+   MISC BLOCKS
+   ============================================================ */
+.beforeafter { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 1rem; }
+@media (max-width: 780px) { .beforeafter { grid-template-columns: minmax(0,1fr); } }
+.ba {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: .95rem 1.1rem;
+  background: var(--surface);
+}
+.ba .h {
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  margin-bottom: .55rem;
+}
+.ba.bad { border-left: 3px solid var(--warn); }
+.ba.bad .h { color: var(--warn); }
+.ba.good { border-left: 3px solid var(--seg); }
+.ba.good .h { color: var(--seg); }
+.ba .m { font-family: var(--font-mono); font-size: .84rem; color: var(--ink); line-height: 1.65; word-break: break-word; }
+.ba .d { font-size: .85rem; color: var(--ink-dim); margin-top: .5rem; }
+
+ul.pts { margin: 0; padding-left: 1.15rem; color: var(--ink-dim); font-size: .95rem; line-height: 1.65; }
+ul.pts li { margin-bottom: .45rem; }
+ul.pts li::marker { color: var(--tts); }
+ul.pts strong { color: var(--ink); font-weight: 650; }
+
+.big-q {
+  font-family: var(--font-mono);
+  font-size: .82rem;
+  color: var(--ink-faint);
+  letter-spacing: .04em;
+}
+
+/* Two-halves thesis — the numbering is a real sequence (produce, then align) */
+.half-n {
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-bottom: .55rem;
+  color: var(--ink-faint);
+}
+.panel.accent-seg .half-n { color: var(--seg); }
+.panel.accent-tts .half-n { color: var(--tts); }
+.half-h {
+  font-size: clamp(1.1rem, 2.1vw, 1.55rem);
+  font-weight: 700;
+  letter-spacing: -.02em;
+  color: var(--ink);
+  margin: 0 0 .6rem;
+}
+.half-p {
+  margin: 0 0 1rem;
+  font-size: clamp(.94rem, 1.25vw, 1.06rem);
+  line-height: 1.55;
+  color: var(--ink-dim);
+}
+.half-p strong { color: var(--ink); font-weight: 650; }
+.half-map {
+  font-family: var(--font-mono);
+  font-size: .74rem;
+  letter-spacing: .04em;
+  color: var(--ink-faint);
+  border-top: 1px solid var(--line-soft);
+  padding-top: .65rem;
+}
+
+.divider-slide { justify-content: center; }
+.divider-slide .kicker {
+  font-family: var(--font-mono);
+  font-size: clamp(3rem, 11vw, 8rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--line);
+  letter-spacing: -.04em;
+  margin: 0 0 .4rem;
+}
+
+/* ============================================================
+   FOOT RAIL
+   ============================================================ */
+.rail {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  height: 3.1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 var(--pad);
+  border-top: 1px solid var(--line-soft);
+  background: var(--ground);
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  z-index: 20;
+}
+.rail .sec { color: var(--ink-dim); }
+.rail .spacer { flex: 1; }
+.rail .count { font-variant-numeric: tabular-nums; }
+.rail .count b { color: var(--tts); }
+.rail .keys { color: var(--ink-faint); opacity: .72; }
+.progress {
+  position: fixed;
+  left: 0; bottom: 0;
+  height: 2px;
+  background: var(--tts);
+  z-index: 21;
+  transition: width .22s ease;
+}
+@media (prefers-reduced-motion: reduce) { .progress { transition: none; } }
+</style>
+</head>
+<body>
+
+<div class="deck" id="deck">
+
+<!-- ══════════════════════════ 1 · TITLE ══════════════════════════ -->
+<section class="slide" data-sec="TTS word tracking">
+  <div>
+    <p class="eyebrow"><span class="num">Pipecat</span> <span class="rule"></span> <span>src/pipecat/utils/context/</span></p>
+    <h1 class="title">Three texts,<br>one cursor.</h1>
+    <p class="lede">How Pipecat keeps what the LLM wrote, what the screen renders, and what the TTS speaks in sync — word by word, while the audio is still playing.</p>
+    <div class="legend">
+      <span class="tag t-llm">① LLM TEXT — the conversation context</span>
+      <span class="tag t-seg">② SEGMENT TEXT — downstream consumers</span>
+      <span class="tag t-tts">③ TTS TEXT — the provider</span>
+    </div>
+    <p class="note">Learn these three colours now. They label every table, diagram and cursor for the rest of the deck.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 2 · THE GOAL ══════════════════════════ -->
+<section class="slide" data-sec="I · The end goal">
+  <div>
+    <p class="eyebrow"><span class="num">1.1</span> <span class="rule"></span> <span>One response, three consumers</span></p>
+    <h2 class="headline">The same sentence has to be three different strings.</h2>
+    <p class="lede tight">A bot prompted to wrap cards in <code class="inl">&lt;card&gt;</code> and code in <code class="inl">&lt;code&gt;</code> produces exactly one thing:</p>
+    <div class="specimen">Your card is <span class="tagmark">&lt;card&gt;</span>1234-5678-9012-3456<span class="tagmark">&lt;/card&gt;</span>. Run <span class="tagmark">&lt;code&gt;</span>npm install<span class="tagmark">&lt;/code&gt;</span> to start.</div>
+    <div class="scroll" style="margin-top:1.1rem">
+      <table class="tbl">
+        <tr><th>Consumer</th><th>Wants</th><th>Why</th></tr>
+        <tr>
+          <td class="k ch-llm">① Conversation context</td>
+          <td class="m">Your card is &lt;card&gt;1234-…-3456&lt;/card&gt;. Run &lt;code&gt;npm install&lt;/code&gt; to start.</td>
+          <td>The LLM must see its own tags next turn, or it stops producing them</td>
+        </tr>
+        <tr>
+          <td class="k ch-seg">② The user's screen</td>
+          <td class="m">Your card is XXXX-XXXX-XXXX-3456. <span style="color:var(--ink-faint)">+ a highlighted code block</span></td>
+          <td>The UI renders and redacts; raw tags are noise</td>
+        </tr>
+        <tr>
+          <td class="k ch-tts">③ The TTS provider</td>
+          <td class="m">Your card is &lt;spell&gt;1234-…-3456&lt;/spell&gt;. <span style="color:var(--ink-faint)">— and nothing for the code</span></td>
+          <td>Digits must be spelled out; code must not be read aloud</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 3 · THE ONLY SIGNAL ══════════════════════════ -->
+<section class="slide" data-sec="I · The end goal">
+  <div>
+    <p class="eyebrow"><span class="num">1.2</span> <span class="rule"></span> <span>What you get back</span></p>
+    <h2 class="headline">The provider reports only the words it actually spoke.</h2>
+    <p class="lede">No offsets. No segment ids. No tags. Just tokens, in order, with timestamps — and they are the <strong>only</strong> signal available. Everything in this deck exists to answer three questions for each one.</p>
+    <div class="grid g3">
+      <div class="panel accent-seg">
+        <h3 class="sub">Question one</h3>
+        <div style="font-size:1.05rem;font-weight:650;color:var(--ink);margin-bottom:.45rem">Where are we?</div>
+        <p style="margin:0;font-size:.88rem;color:var(--ink-dim)">Which position in the displayed text, so a UI can move a highlight.</p>
+      </div>
+      <div class="panel accent-llm">
+        <h3 class="sub">Question two</h3>
+        <div style="font-size:1.05rem;font-weight:650;color:var(--ink);margin-bottom:.45rem">What goes in the context?</div>
+        <p style="margin:0;font-size:.88rem;color:var(--ink-dim)">Which span of the LLM's own text, so the tags survive the round trip.</p>
+      </div>
+      <div class="panel accent-tts">
+        <h3 class="sub">Question three</h3>
+        <div style="font-size:1.05rem;font-weight:650;color:var(--ink);margin-bottom:.45rem">Can this frame go now?</div>
+        <p style="margin:0;font-size:.88rem;color:var(--ink-dim)">In what order, relative to everything else in the turn.</p>
+      </div>
+    </div>
+    <p class="note">Three questions, three layers — <code class="inl">TextSegmentMap</code>, <code class="inl">WordCompletionTracker</code>, <code class="inl">AggregatedFrameSequencer</code>. But first, what happened when they didn't exist.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 4 · DIVIDER: PROBLEMS ══════════════════════════ -->
+<section class="slide divider-slide" data-sec="II · What was broken">
+  <div>
+    <p class="kicker">II</p>
+    <h1 class="title" style="font-size:clamp(2rem,5vw,3.6rem)">What was broken</h1>
+    <p class="lede">Four failures, four provider quirks — and one capability that only works once they are solved.</p>
+    <div class="legend">
+      <span class="tag t-warn">2.1 Context drift</span>
+      <span class="tag t-warn">2.2 Out-of-order frames</span>
+      <span class="tag t-warn">2.3 No word ↔ sentence link</span>
+      <span class="tag t-warn">2.4 Useless RTVI transforms</span>
+      <span class="tag">2.5 Provider reality</span>
+      <span class="tag t-seg">2.6 Text transformations — the feature</span>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 5 · 2.1 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.1</span> <span class="rule"></span> <span>The context drifted from what the LLM wrote</span></p>
+    <h2 class="headline">The bot slowly forgets its own conventions.</h2>
+    <p class="lede tight">The text appended to the context was the text that came <strong>back from the TTS</strong> — so everything that made the output speakable was lost on the round trip.</p>
+    <div class="beforeafter">
+      <div class="ba bad">
+        <div class="h">Before — context receives</div>
+        <div class="m">Your card is 1234 5678 9012 3456</div>
+        <div class="d">Next turn: the LLM sees no tags and stops emitting them. The feature quietly decays over a handful of turns.</div>
+      </div>
+      <div class="ba good">
+        <div class="h">Now — context receives</div>
+        <div class="m">Your card is <span class="ch-llm">&lt;card&gt;</span>1234-5678-9012-3456<span class="ch-llm">&lt;/card&gt;</span></div>
+        <div class="d">The LLM sees its own convention and keeps it.</div>
+      </div>
+    </div>
+    <p class="note"><strong>Why this one is the worst:</strong> it fails silently and slowly. Nothing errors, nothing logs, and the regression shows up as "the model got lazy" several turns later.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 6 · 2.2 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.2</span> <span class="rule"></span> <span>Skipped frames arrived out of order</span></p>
+    <h2 class="headline">A frame with no audio has nothing to wait for.</h2>
+    <p class="lede tight">Configure <code class="inl">skip_aggregator_types=["code"]</code> and that frame is never synthesized — no audio, no word events. So it was pushed the moment it appeared, landing <em>before</em> the sentence that precedes it.</p>
+    <pre class="code">LLM:      <b>"Run this:"</b>  →  <b>&lt;code&gt;npm install&lt;/code&gt;</b>  →  <b>"Then reload."</b>
+
+Context:  &lt;code&gt;npm install&lt;/code&gt;      <span class="c">← arrived first, nothing to wait for</span>
+          "Run this:"                   <span class="c">← spoken later</span>
+          "Then reload."</pre>
+    <p class="note">The transcript reads out of order — and on interruption it is worse: <strong>text that was never spoken could still be recorded as if it had been.</strong></p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 7 · 2.3 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.3</span> <span class="rule"></span> <span>Highlighting spoken words was not possible</span></p>
+    <h2 class="headline">Two streams, no correspondence between them.</h2>
+    <div class="grid g2">
+      <div class="panel accent-seg">
+        <h3 class="sub">What the client renders</h3>
+        <div style="font-family:var(--font-mono);font-size:.86rem;color:var(--ink)">AggregationType.SENTENCE</div>
+        <p style="margin:.5rem 0 0;font-size:.88rem;color:var(--ink-dim)">Whole sentence frames, arriving before synthesis.</p>
+      </div>
+      <div class="panel accent-tts">
+        <h3 class="sub">What arrives as speech progresses</h3>
+        <div style="font-family:var(--font-mono);font-size:.86rem;color:var(--ink)">AggregationType.WORD</div>
+        <p style="margin:.5rem 0 0;font-size:.88rem;color:var(--ink-dim)">Word frames — carrying no indication of which sentence they belong to, or where inside it.</p>
+      </div>
+    </div>
+    <p class="lede" style="margin-top:1.3rem"><strong>The client could not turn a stream of words into a highlight moving through a rendered sentence.</strong> There was simply no key linking the two.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 8 · 2.4 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.4</span> <span class="rule"></span> <span>RTVI bot_output_transforms were useless word-by-word</span></p>
+    <h2 class="headline">You cannot redact a card number that arrives in four pieces.</h2>
+    <p class="lede tight">Client-side transforms operate on a <strong>segment</strong>. Receiving text word by word — with no segment identity, and no notion of "spoken so far" versus "remaining" — left nothing coherent to transform.</p>
+    <div class="scroll">
+      <table class="tbl compact">
+        <tr><th>Event</th><th class="m">1</th><th class="m">2</th><th class="m">3</th><th class="m">4</th></tr>
+        <tr><td class="k">Arrives as</td><td class="m">1234</td><td class="m">5678</td><td class="m">9012</td><td class="m">3456</td></tr>
+        <tr class="dim"><td class="k">Transform sees</td><td class="m">"1234"</td><td class="m">"5678"</td><td class="m">"9012"</td><td class="m">"3456"</td></tr>
+        <tr><td class="k ch-warn">Can it redact?</td><td class="m ch-warn">no</td><td class="m ch-warn">no</td><td class="m ch-warn">no</td><td class="m ch-warn">no</td></tr>
+      </table>
+    </div>
+    <p class="note">Four disconnected events, no segment, no split. To produce <code class="inl">XXXX-XXXX-XXXX-3456</code> a transform needs the <strong>whole segment plus the current spoken split</strong> — which is exactly what did not exist.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 9 · 2.5 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.5</span> <span class="rule"></span> <span>Problems found along the way</span></p>
+    <h2 class="headline">Then reality: providers, streaming, concurrency.</h2>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>Problem</th><th>What happens</th></tr>
+        <tr>
+          <td class="k">Streamed tokens</td>
+          <td>In <code class="inl">TOKEN</code> mode the service dispatches word-sized chunks, but tracking and progress need whole sentences — which are not known until a boundary is confirmed</td>
+        </tr>
+        <tr>
+          <td class="k">Concurrent contexts</td>
+          <td>Two back-to-back <code class="inl">TTSSpeakFrame</code>s on a websocket service can be in flight at once; their word streams interleave and must not consume each other's slots</td>
+        </tr>
+        <tr>
+          <td class="k">Straddling tokens</td>
+          <td>One provider token completes one frame and starts the next (<code class="inl">1111And</code>), so a single event must produce output for two slots, in the right order</td>
+        </tr>
+        <tr>
+          <td class="k">Dropped events</td>
+          <td>The provider silently never reports a word it spoke, leaving a frame — and everything queued behind it — waiting forever</td>
+        </tr>
+      </table>
+    </div>
+    <p class="note">These four are why <code class="inl">tests/test_word_completion_tracker.py</code> is 203 tests, most of them a regression corpus of real provider behaviour.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 10 · 2.6 ══════════════════════════ -->
+<section class="slide" data-sec="II · What was broken">
+  <div>
+    <p class="eyebrow"><span class="num">2.6</span> <span class="rule"></span> <span>And a feature: text transformations</span></p>
+    <h2 class="headline">Rewritten for the provider. For nobody else.</h2>
+    <p class="lede tight">TTS engines read what you give them, and written text is often not what you want spoken. <code class="inl">$42.50</code> can come out "dollar forty two point five zero"; <code class="inl">1994</code> as "one thousand nine hundred ninety four" when the sentence means a year. So Pipecat ships a bundle of transforms that <strong>rewrite the text on its way to the provider</strong> — and nowhere else.</p>
+    <div class="grid g2-wide">
+      <div class="scroll">
+        <table class="tbl compact">
+          <tr><th>Transform</th><th>Input</th><th class="c-tts">Sent to TTS</th></tr>
+          <tr><td class="m">expand_currency</td><td class="m">It costs $42.50</td><td class="m">forty-two dollars and fifty cents</td></tr>
+          <tr><td class="m">expand_percentages</td><td class="m">Up 12.5%</td><td class="m">twelve point five percent</td></tr>
+          <tr><td class="m">expand_units</td><td class="m">5 km away</td><td class="m">5 kilometers away</td></tr>
+          <tr><td class="m">normalize_dates</td><td class="m">on 2024-01-15</td><td class="m">on January 15th, two thousand…</td></tr>
+          <tr><td class="m">email_to_speech</td><td class="m">a@b.com</td><td class="m">a at b dot com</td></tr>
+          <tr><td class="m">expand_phone_numbers</td><td class="m">555-123-4567</td><td class="m">5 5 5 1 2 3 4 5 6 7</td></tr>
+          <tr><td class="m">expand_numbers</td><td class="m">room 1994</td><td class="m">room 1 9 9 4</td></tr>
+          <tr><td class="m">normalize_acronyms</td><td class="m">I work at IBM</td><td class="m">I work at I B M</td></tr>
+          <tr><td class="m">strip_markdown</td><td class="m">**bold** text</td><td class="m">bold text</td></tr>
+        </table>
+      </div>
+      <div class="stack">
+        <div class="panel accent-tts">
+          <h3 class="sub">Which ones you need depends on the provider</h3>
+          <p style="margin:0 0 .55rem;font-size:.89rem;color:var(--ink-dim)">This is <strong style="color:var(--ink)">not a fix for a bug</strong> — it's a way to make sure all TTS providers are going to work the same way.</p>
+        </div>
+        <div class="panel accent-seg">
+          <h3 class="sub">So it's opt-in, transform by transform</h3>
+          <p style="margin:0;font-size:.89rem;color:var(--ink-dim)"><code class="inl">expand_numbers</code> ships <strong style="color:var(--ink)">off</strong> — digits are often better read as digits. You enable what <em>your</em> provider gets wrong, per segment type if needed: <code class="inl">tts.add_text_transformer(fn, "credit_card")</code>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 11 · DIVIDER: SOLUTION ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="kicker">III</p>
+    <h1 class="title" style="font-size:clamp(2rem,5vw,3.6rem)">How they're solved</h1>
+    <p class="lede" style="font-size:clamp(1.05rem,1.7vw,1.4rem);color:var(--ink);max-width:70ch">The solution has <strong>two halves</strong> — and the first one is what makes the second possible.</p>
+    <div class="grid g2" style="margin-top:.5rem">
+      <div class="panel accent-seg">
+        <div class="half-n">Half one · at production time</div>
+        <div class="half-h">Kept distinct, never reconstructed</div>
+        <p class="half-p">The three texts are kept distinct <strong>as they are produced</strong>, so nothing has to be reconstructed later.</p>
+        <div class="half-map">3.1 split points · 3.2 six frames · 3.3 the guarantee</div>
+      </div>
+      <div class="panel accent-tts">
+        <div class="half-n">Half two · during playback</div>
+        <div class="half-h">Kept aligned, word by word</div>
+        <p class="half-p">Three layers keep them <strong>aligned word by word</strong> while the TTS speaks.</p>
+        <div class="half-map">3.4 the layers · the cursor · tracker · sequencer</div>
+      </div>
+    </div>
+    <p class="note"><strong>Rebuilding the context from what the TTS spoke is exactly what caused 2.1.</strong> Once the three texts exist separately from the moment they are created, there is nothing to reverse-engineer — the alignment problem becomes "where are we in each", not "what did this used to say".</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 12 · PROBLEM → SOLUTION MAP ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="eyebrow"><span class="num">3.0</span> <span class="rule"></span> <span>Every problem, and what answers it</span></p>
+    <h2 class="headline">The map for the rest of the deck.</h2>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>Problem</th><th>Solved by</th></tr>
+        <tr><td class="k">2.1 Context drift</td><td><code class="inl">TextSegmentMap</code>'s <span class="ch-llm">llm_pos</span> cursor + <code class="inl">WordCompletionTracker</code>'s span attribution</td></tr>
+        <tr><td class="k">2.2 Out-of-order skipped frames</td><td><code class="inl">AggregatedFrameSequencer</code>'s slot queue</td></tr>
+        <tr><td class="k">2.3 Word ↔ sentence correspondence</td><td><code class="inl">AggregatedTextProgressFrame</code>, built from the tracker's cursors</td></tr>
+        <tr><td class="k">2.4 Useless RTVI transforms</td><td><code class="inl">segment_id</code> + <code class="inl">accumulated_text</code> / <code class="inl">remaining_text</code> on every progress frame</td></tr>
+        <tr><td class="k">2.5 Streaming / concurrency / quirks</td><td>Sequencer (streaming, contexts) + tracker (straddle, drops)</td></tr>
+        <tr><td class="k ch-seg">2.6 Text transformations <span style="color:var(--ink-faint);font-weight:400">— the feature</span></td><td><strong>Made safe by</strong> <code class="inl">TextSegmentMap</code>'s transformed-segment handling</td></tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 13 · 3.1 SPLIT POINTS ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="eyebrow"><span class="num">3.1</span> <span class="rule"></span> <span>Three texts, produced at two split points</span></p>
+    <h2 class="headline">Nobody authors three strings. Two split points create them.</h2>
+    <div class="flow">
+      <div class="flow-node">
+        <div class="t">LLM tokens</div>
+      </div>
+      <div class="flow-arrow">▼</div>
+      <div class="flow-node split">
+        <div class="t">Split 1 — the aggregator</div>
+        <div class="b">LLMTextProcessor · BaseTextAggregator</div>
+        <div class="d">PatternPairAggregator / SimpleTextAggregator decide where segments end and what counts as a delimiter.</div>
+      </div>
+      <div class="flow-arrow">├─▶</div>
+      <div class="flow-out o-llm"><span class="who">① raw_text</span><span class="dest">LLM TEXT (&lt;card&gt;1234-5678-9012-3456&lt;/card&gt;) → conversation context</span></div>
+      <div class="flow-arrow">└─▶</div>
+      <div class="flow-out o-seg"><span class="who">② text</span><span class="dest">SEGMENT TEXT (1234-5678-9012-3456) → downstream consumers (the AggregatedTextFrame)</span></div>
+      <div class="flow-arrow" style="padding-left:3rem">▼</div>
+      <div class="flow-node split" style="margin-left:2rem">
+        <div class="t">Split 2 — the TTS service</div>
+        <div class="b">text filters · per-type transformers</div>
+        <div class="d">Rewrite for speech only — operating on a <em>copy</em> on its way out.</div>
+      </div>
+      <div class="flow-arrow" style="padding-left:3rem">▼</div>
+      <div class="flow-out o-tts" style="margin-left:2rem"><span class="who">③ tts text</span><span class="dest">TTS TEXT (&lt;spell&gt;1234-5678-9012-3456&lt;/spell&gt;) → the provider</span></div>
+    </div>
+    <p class="note"><strong>The middle channel is the <code class="inl">AggregatedTextFrame</code> itself</strong> — and it is never rewritten. With a <code class="inl">SimpleTextAggregator</code> and no transformers, all three are the same string; they diverge only where something acted.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 14 · 3.2 SIX FRAMES ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="eyebrow"><span class="num">3.2</span> <span class="rule"></span> <span>What that looks like for one response</span></p>
+    <h2 class="headline">One sentence in. Six frames out.</h2>
+    <div class="scroll">
+      <table class="tbl compact">
+        <tr>
+          <th>#</th><th>aggregated_by</th>
+          <th class="c-llm">① raw_text</th>
+          <th class="c-seg">② text</th>
+          <th class="c-tts">③ tts text</th>
+        </tr>
+        <tr><td class="num">1</td><td class="m">sentence</td><td class="m">Your card is </td><td class="m">Your card is</td><td class="m">Your card is</td></tr>
+        <tr class="hi"><td class="num">2</td><td class="m"><strong>credit_card</strong></td><td class="m">&lt;card&gt;1234-5678-9012-3456&lt;/card&gt;</td><td class="m">1234-5678-9012-3456</td><td class="m">&lt;spell&gt;1234-5678-9012-3456&lt;/spell&gt;</td></tr>
+        <tr><td class="num">3</td><td class="m">sentence</td><td class="m">.</td><td class="m">.</td><td class="m">.</td></tr>
+        <tr><td class="num">4</td><td class="m">sentence</td><td class="m">Run</td><td class="m">Run</td><td class="m">Run</td></tr>
+        <tr class="hi"><td class="num">5</td><td class="m"><strong>code</strong></td><td class="m">&lt;code&gt;npm install&lt;/code&gt;</td><td class="m">npm install</td><td class="m" style="color:var(--warn)">never sent — skipped</td></tr>
+        <tr><td class="num">6</td><td class="m">sentence</td><td class="m">to start.</td><td class="m">to start.</td><td class="m">to start.</td></tr>
+      </table>
+    </div>
+    <p class="note"><strong>Only the two tagged frames do anything interesting.</strong> Frame 2's delimiters moved into <code class="inl">raw_text</code>; its transformer wrapped the digits in <code class="inl">&lt;spell&gt;</code>. Frame 5 is never spoken — which is what creates the ordering problem in 2.2. <code class="inl">aggregated_by</code> is the routing key throughout: it picks the transformer, decides whether the frame is spoken at all, and selects the RTVI redaction.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 15 · 3.3 THE GUARANTEE ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="eyebrow"><span class="num">3.3</span> <span class="rule"></span> <span>The guarantee that makes it useful</span></p>
+    <h2 class="headline">One rule holds after every single word.</h2>
+    <div class="panel accent-seg" style="margin-bottom:1.3rem">
+      <div style="font-family:var(--font-mono);font-size:clamp(.85rem,1.8vw,1.3rem);color:var(--ink);text-align:center;padding:.5rem 0">
+        <span class="ch-seg">progress.accumulated_text</span> + <span class="ch-seg">progress.remaining_text</span> &nbsp;==&nbsp; <span class="ch-seg">AggregatedTextFrame.text</span>
+      </div>
+    </div>
+    <p class="lede">Exactly — <strong>character for character</strong>. Never a paraphrase, never a normalised copy, never off by a space. The two halves are always a clean split of the string the segment frame is already carrying.</p>
+    <ul class="pts">
+      <li>Highlight the first half, leave the second plain → <strong>word highlighting</strong></li>
+      <li>Redact both halves → <strong>redaction that keeps advancing</strong></li>
+      <li>Concatenate them → <strong>the original back, exactly</strong></li>
+    </ul>
+    <p class="note">That is what makes progress frames usable by <strong>anything, without coordination</strong>. A consumer holding the segment frame never has to guess how the text was transformed on its way to the TTS.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 16 · 3.4 THREE LAYERS ══════════════════════════ -->
+<section class="slide" data-sec="III · How they're solved">
+  <div>
+    <p class="eyebrow"><span class="num">3.4</span> <span class="rule"></span> <span>The three layers</span></p>
+    <h2 class="headline">Each owns one concern. None knows about the layer above.</h2>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>Layer</th><th>Scope</th><th>Question it answers</th></tr>
+        <tr>
+          <td class="k ch-seg">TextSegmentMap</td>
+          <td>One frame, segment by segment</td>
+          <td>Where in the other two texts are we, given this spoken word?</td>
+        </tr>
+        <tr>
+          <td class="k ch-llm">WordCompletionTracker</td>
+          <td>One frame</td>
+          <td>How much of this word is this frame's, which original text does it stand for, and is the frame finished?</td>
+        </tr>
+        <tr>
+          <td class="k ch-tts">AggregatedFrameSequencer</td>
+          <td>The whole turn</td>
+          <td>In what order do frames leave the TTS service?</td>
+        </tr>
+      </table>
+    </div>
+    <pre class="code" style="margin-top:1.1rem">  TTS provider ── word-timestamp events ──┐
+                                          ▼
+ ┌────────────────────────────────────────────────────────────────┐
+ │  <b>AggregatedFrameSequencer</b>            one per TTS service       │
+ │   ordered slot queue:  [ spoken ][ skipped ][ spoken ] …       │
+ │                    ┌────────────────┐   ┌────────────────┐     │
+ │                    │ <b>WordCompletion</b> │   │ <b>WordCompletion</b> │     │
+ │                    │ <b>Tracker</b>        │   │ <b>Tracker</b>        │     │
+ │                    │  ┌───────────┐ │   │  ┌───────────┐ │     │
+ │                    │  │ <b>TextSeg</b>   │ │   │  │ <b>TextSeg</b>   │ │     │
+ │                    │  │ <b>mentMap</b>   │ │   │  │ <b>mentMap</b>   │ │     │
+ │                    │  └───────────┘ │   │  └───────────┘ │     │
+ │                    └────────────────┘   └────────────────┘     │
+ └────────────────────────────────────────────────────────────────┘
+             │                                    │
+             ▼                                    ▼
+      <span class="s">TTSTextFrame</span>                   <span class="fn">AggregatedTextProgressFrame</span>
+   → conversation context                → RTVI → the client</pre>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 17 · DIVIDER: THE CURSOR ══════════════════════════ -->
+<section class="slide divider-slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="kicker">IV</p>
+    <h1 class="title" style="font-size:clamp(2rem,5vw,3.6rem)">The moving cursor</h1>
+    <p class="lede">The bottom layer, and the only one that touches the texts. One spoken word arrives — <strong>TextSegmentMap</strong> says where that leaves all three.</p>
+    <div class="legend">
+      <span class="tag t-seg">★ The walk</span>
+      <span class="tag t-seg">4.1 Building the map</span>
+      <span class="tag t-seg">4.2 Transformed spans</span>
+      <span class="tag t-seg">4.3 Counting alnums</span>
+      <span class="tag t-seg">4.4 Matching a token</span>
+      <span class="tag t-seg">4.5 The four outcomes</span>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 18 · ★ THE CURSOR ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor" id="slide-walk">
+  <div>
+    <p class="eyebrow"><span class="num">★</span> <span class="rule"></span> <span>TextSegmentMap · one real cursor drives three</span></p>
+    <h2 class="headline" style="margin-bottom:.7rem">Watch the followers hold, then jump.</h2>
+    <div class="walk">
+      <div class="walk-head">
+        <div class="walk-tabs" role="tablist" aria-label="Example">
+          <button class="wtab" role="tab" data-walk="currency" aria-selected="true">currency expansion</button>
+          <button class="wtab" role="tab" data-walk="tags" aria-selected="false">pattern delimiters</button>
+        </div>
+        <div class="walk-note" id="walkNote"></div>
+      </div>
+
+      <div class="tracks">
+        <div class="track t-tts" id="trk-tts">
+          <div class="lbl">③ tts text</div>
+          <div class="body" id="body-tts"></div>
+          <div class="pos">raw_pos <b id="pos-tts">0</b></div>
+        </div>
+        <div class="track t-seg" id="trk-seg">
+          <div class="lbl">② segment text</div>
+          <div class="body" id="body-seg"></div>
+          <div class="pos">user_facing <b id="pos-seg">0</b></div>
+        </div>
+        <div class="track t-llm" id="trk-llm">
+          <div class="lbl">① llm text</div>
+          <div class="body" id="body-llm"></div>
+          <div class="pos"><span id="lbl-llm">llm_pos</span> <b id="pos-llm">0</b></div>
+        </div>
+      </div>
+
+      <div class="walk-bar">
+        <button class="wbtn" id="wPrev">◀ prev</button>
+        <button class="wbtn" id="wNext">next word ▶</button>
+        <button class="wbtn" id="wReset">reset</button>
+        <div class="wfeed" id="wFeed">advance_word(<b id="wWord">—</b>)</div>
+        <div class="wstate" id="wTrans">in_transformed_segment: false</div>
+        <div class="wstate" id="wStep">0 / 0</div>
+      </div>
+
+      <div class="wguarantee" id="wGuarantee"></div>
+    </div>
+    <p class="note">Only <span class="ch-tts">raw_pos</span> is a real cursor. Through an <strong>unchanged</strong> segment the other two move by a <em>count</em> — however many letters and digits the word spent. Through a <strong>rewritten</strong> one they are held, then jump to the end of the original span in one step, because no position halfway through <code class="inl">$42.50</code> means anything. Nothing ever speaks a <code class="inl">&lt;/card&gt;</code>, so the walk ends on a beat that is not a word at all: once the frame is done, the <strong>tracker</strong> claims whatever <span class="ch-llm">llm text</span> has left — which is how a closing tag reaches the conversation context. <em>(↑ / ↓ also step.)</em></p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 19 · OPCODES ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="eyebrow"><span class="num">4.1</span> <span class="rule"></span> <span>Building the map</span></p>
+    <h2 class="headline">Diff the two texts once, at word level.</h2>
+    <p class="lede tight"><code class="inl">difflib.SequenceMatcher</code> compares TTS text against segment text, tokenized on whitespace <em>keeping the whitespace as tokens</em> so offsets stay exact. Each opcode becomes one <code class="inl">TextSegment</code>.</p>
+    <div class="grid g2-wide">
+      <div class="scroll">
+        <table class="tbl compact">
+          <tr><th>Opcode</th><th>Meaning</th></tr>
+          <tr><td class="m ch-seg">equal</td><td>Identical on both sides — the common case</td></tr>
+          <tr><td class="m ch-tts">replace</td><td>Rewritten — every value transform and added tag</td></tr>
+          <tr><td class="m ch-llm">delete</td><td>In the original, not in the TTS text</td></tr>
+          <tr><td class="m ch-llm">insert</td><td>In the TTS text, not in the original</td></tr>
+        </table>
+        <p class="note" style="margin-top:.8rem">All four occur and the code treats them the same way — none is a special case.</p>
+      </div>
+      <pre class="code">original = <span class="s">'Your balance is $42.50'</span>
+tts      = <span class="s">'Your balance is forty-two
+            dollars and fifty cents'</span>
+
+<span class="ch-seg">equal</span>    <span class="c">'Your balance is '</span>
+<span class="ch-tts">replace</span>  <span class="c">'$42.50'</span>
+         → <span class="c">'forty-two dollars…'</span>
+
+<span class="fn">TextSegment</span>(
+  original=<span class="s">'$42.50'</span>,
+  tts=<span class="s">'forty-two dollars…'</span>,
+  original_start=<b>16</b>,
+  original_end=<b>22</b>)</pre>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 20 · TRANSFORMED ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="eyebrow"><span class="num">4.2</span> <span class="rule"></span> <span>is_transformed · split_markup_runs</span></p>
+    <h2 class="headline">All-or-nothing, and how that cost is contained.</h2>
+    <div class="grid g2">
+      <div class="stack">
+        <div class="panel accent-warn">
+          <h3 class="sub">A segment is transformed when…</h3>
+          <ul class="pts" style="margin-top:.3rem">
+            <li>the letters and digits differ — <code class="inl">$42.50</code> vs <code class="inl">forty-two…</code></li>
+            <li>the number of words differs</li>
+            <li><strong>the TTS side contains a tag</strong> — even if the spoken words are identical</li>
+          </ul>
+        </div>
+        <p class="note" style="margin:0">Rule three is why <code class="inl">&lt;phoneme…&gt;Siobhan&lt;/phoneme&gt;</code> counts: the raw cursor must cross tag characters the other texts do not have.</p>
+      </div>
+      <div class="stack">
+        <div class="panel accent-seg">
+          <h3 class="sub">So cut the tag out into its own segment</h3>
+          <pre class="code" style="border:none;background:transparent;padding:.4rem 0"><span class="fn">split_markup_runs</span>(<span class="s">"I love to count &lt;spell&gt;1234&lt;/spell&gt;."</span>)
+<span class="c"># → ["I love to count ",
+#    "&lt;spell&gt;1234&lt;/spell&gt;."]</span></pre>
+          <table class="tbl compact" style="margin-top:.4rem">
+            <tr><td class="m">"I love to count "</td><td>plain — cursors move word by word</td></tr>
+            <tr><td class="m">"&lt;spell&gt;1234&lt;/spell&gt;."</td><td>all-or-nothing — lands as one</td></tr>
+          </table>
+        </div>
+        <p class="note" style="margin:0"><strong>Only <code class="inl">equal</code> opcodes can be split this way</strong> — both sides hold the same text, so a single offset cuts both. Where the sides differ there is no shared offset.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 21 · COUNTING ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="eyebrow"><span class="num">4.3</span> <span class="rule"></span> <span>advance_by_alnums</span></p>
+    <h2 class="headline">Counting is what attaches tags to words.</h2>
+    <p class="lede tight">Nothing decides which words own which tags. <strong>One loop counts letters and digits and steps over everything else</strong> — where the tags land simply follows from that.</p>
+    <div class="grid g2">
+      <div class="panel accent-llm">
+        <h3 class="sub">Rule one</h3>
+        <p style="margin:0 0 .5rem;font-size:.92rem;color:var(--ink-dim)">A <code class="inl">&lt;...&gt;</code> tag is <strong>crossed for free</strong>, without using up any of the count — so an opening tag travels with the word that follows it.</p>
+        <pre class="code" style="border:none;background:transparent;padding:.2rem 0">llm: Your card is <span class="ch-llm">&lt;card&gt;</span>4111<span class="ch-llm">&lt;/card&gt;</span>
+                  <span class="c">↑ costs 0    ↑ 4 digits = 4</span>
+llm_pos = <b>23</b>, not 17</pre>
+      </div>
+      <div class="panel accent-llm">
+        <h3 class="sub">Rule two</h3>
+        <p style="margin:0 0 .5rem;font-size:.92rem;color:var(--ink-dim)">Punctuation right after the count runs out is <strong>taken too</strong> — so a trailing comma travels with the word before it.</p>
+        <pre class="code" style="border:none;background:transparent;padding:.2rem 0">provider reports:  <span class="s">"Yeah"</span>
+context records:   <span class="s">"Yeah,"</span></pre>
+      </div>
+    </div>
+    <p class="note">The closing tag is the one thing the loop deliberately stops short of — it is swept up by <code class="inl">WordCompletionTracker</code> when the frame completes. <strong>Why no diff for <code class="inl">llm_text</code>?</strong> It holds the same letters and digits as the segment text, in the same order, differing only in what wraps them. So the map never finds positions in it — it only counts.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 22 · MATCHING ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="eyebrow"><span class="num">4.4</span> <span class="rule"></span> <span>_classify_hop</span></p>
+    <h2 class="headline">Challenge: Provider tokens are messy.</h2>
+    <h3 class="headline">Three strategies, first hit wins.</h3>
+    <div class="grid g2-wide">
+      <div class="scroll">
+        <table class="tbl compact">
+          <tr><th>Provider behaviour</th><th>Remaining</th><th>Token</th><th>Strategy</th></tr>
+          <tr><td>Plain word</td><td class="m">hello world</td><td class="m">hello</td><td class="m ch-seg">1 literal</td></tr>
+          <tr><td>Carries its own space <span style="color:var(--ink-faint)">(Inworld)</span></td><td class="m">" world"</td><td class="m">" world"</td><td class="m ch-seg">1 literal</td></tr>
+          <tr><td>Skipped punctuation it didn't speak</td><td class="m">", I can help"</td><td class="m">I</td><td class="m ch-seg">1 <span style="color:var(--ink-faint)">skip offset</span></td></tr>
+          <tr><td>Added a terminal period</td><td class="m">account and more</td><td class="m">account.</td><td class="m ch-seg">1 <span style="color:var(--ink-faint)">trim</span></td></tr>
+          <tr><td>Lowercased the word</td><td class="m">SQL is great</td><td class="m">sql</td><td class="m ch-tts">2 folded</td></tr>
+          <tr><td>Stripped a diacritic</td><td class="m">café open</td><td class="m">cafe</td><td class="m ch-tts">2 folded</td></tr>
+          <tr><td>Normalized an apostrophe</td><td class="m">don’t worry</td><td class="m">don't</td><td class="m ch-tts">2 folded</td></tr>
+          <tr><td>Reported without its tags</td><td class="m">&lt;spell&gt;1234&lt;/spell&gt;</td><td class="m">1234</td><td class="m ch-llm">3 markup</td></tr>
+          <tr><td>Straddles the frame boundary</td><td class="m">1111</td><td class="m">1111And</td><td class="m ch-seg">1 → CROSSES</td></tr>
+          <tr class="dim"><td>Foreign token (dropped event)</td><td class="m">hello world</td><td class="m">goodbye</td><td class="m ch-warn">none</td></tr>
+        </table>
+      </div>
+      <div class="stack">
+        <div class="panel accent-seg"><h3 class="sub">1 · literal</h3><p style="margin:0;font-size:.87rem;color:var(--ink-dim)">Character for character, at three skip offsets: as-is, past whitespace, past all punctuation.</p></div>
+        <div class="panel accent-tts"><h3 class="sub">2 · variation folded</h3><p style="margin:0;font-size:.87rem;color:var(--ink-dim)">Case, accents, typography. Folding is 1:1 on length, so an offset found in the folded copy is valid in the original. Requires a word boundary — otherwise <code class="inl">account</code> matches <code class="inl">Accountant</code>.</p></div>
+        <div class="panel accent-llm"><h3 class="sub">3 · markup stripped</h3><p style="margin:0;font-size:.87rem;color:var(--ink-dim)">Tags removed from both sides, then the offset translated back.</p></div>
+        <p class="note" style="margin:0"><strong>The whole thing is stateless</strong> — worked out fresh on every call, with no tag parsing and nothing remembered between words.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 23 · OUTCOMES ══════════════════════════ -->
+<section class="slide" data-sec="IV · The moving cursor">
+  <div>
+    <p class="eyebrow"><span class="num">4.5</span> <span class="rule"></span> <span>The four outcomes</span></p>
+    <h2 class="headline">Two end the walk. Two carry the token onward.</h2>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>Outcome</th><th>Meaning</th><th>Effect</th></tr>
+        <tr><td class="k m ch-seg">PLACED</td><td>Token fits inside this segment</td><td>Move to the end of the match, stop</td></tr>
+        <tr><td class="k m ch-tts">CROSSES</td><td>This segment holds only the start of the token</td><td>Finish the segment, carry <strong>the rest of the token</strong> onward</td></tr>
+        <tr><td class="k m ch-tts">EXHAUSTED</td><td>Nothing here can be spoken</td><td>Finish the segment, carry <strong>the whole token</strong> onward</td></tr>
+        <tr><td class="k m ch-warn">NO_MATCH</td><td>Token does not belong here</td><td>Step past leading punctuation, stop</td></tr>
+      </table>
+    </div>
+    <div class="grid g2" style="margin-top:1.1rem">
+      <pre class="code">tts=<span class="s">'Hello five'</span>  original=<span class="s">'Hello 5'</span>
+
+token <span class="s">'Hello five'</span>
+  ├─ seg0: <span class="ch-tts">CROSSES</span>, 6 chars → completes
+  └─ seg1: <span class="ch-seg">PLACED</span> → user_facing_pos <b>7</b>
+
+<span class="c"># one token completed two segments and
+# crossed a transform, in one call</span></pre>
+      <div class="panel accent-warn">
+        <h3 class="sub">The symbol case</h3>
+        <p style="margin:0 0 .5rem;font-size:.88rem;color:var(--ink-dim)">A token with no letters or digits — an emoji, or a symbol the provider swapped (ElevenLabs reports <code class="inl">→</code> as <code class="inl">-</code>) — cannot be matched by any strategy.</p>
+        <p style="margin:0;font-size:.88rem;color:var(--ink-dim)">It passes the dry run via <code class="inl">_symbol_belongs_here</code> so the slot is <strong>not force-completed</strong> over it, then classifies <code class="inl">NO_MATCH</code>: the raw cursor nudges past <code class="inl">' → '</code> so the next token isn't blocked, while the segment cursor holds. Accepted without being placed.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 24 · DIVIDER: POLICY AND ORDER ══════════════════════════ -->
+<section class="slide divider-slide" data-sec="V · Policy and order">
+  <div>
+    <p class="kicker">V</p>
+    <h1 class="title" style="font-size:clamp(2rem,5vw,3.6rem)">Policy and order</h1>
+    <p class="lede">A position is not a decision. <strong>WordCompletionTracker</strong> decides what text should be emitted; <strong>AggregatedFrameSequencer</strong> decides what means for the turn.</p>
+    <div class="legend">
+      <span class="tag t-llm">5.1 The tracker</span>
+      <span class="tag t-llm">5.2 Span attribution</span>
+      <span class="tag t-llm">5.3 Misbehaving providers</span>
+      <span class="tag t-tts">5.4 The slot queue</span>
+      <span class="tag t-tts">5.5 Concurrent contexts</span>
+      <span class="tag t-tts">5.6 Token mode</span>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 25 · TRACKER ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.1</span> <span class="rule"></span> <span>WordCompletionTracker</span></p>
+    <h2 class="headline">The map says where. The tracker decides what that means.</h2>
+    <p class="lede tight">One call in, several answers out — each read back by the sequencer to build the frames it pushes.</p>
+    <div class="scroll">
+      <table class="tbl compact">
+        <tr><th>Accessor</th><th>Used for</th><th class="c-seg">On the map</th></tr>
+        <tr><td class="m">word_belongs_here()</td><td>Decide whether the provider dropped an event, and this slot must be force-completed</td><td class="m ch-seg">word_belongs_current_segment()</td></tr>
+        <tr><td class="m">add_word_and_check_complete()</td><td>Advance, and learn whether the slot is now done</td><td class="m ch-seg"><strong>advance_word()</strong></td></tr>
+        <tr><td class="m ch-seg">get_word_for_frame()</td><td>The <strong>text</strong> of the emitted <code class="inl">TTSTextFrame</code></td><td class="m ch-seg">last_leading_duplicate · last_overflow</td></tr>
+        <tr><td class="m ch-llm">get_llm_consumed()</td><td>The <strong>raw_text</strong> of that frame — what the conversation context records</td><td class="m ch-seg">llm_pos · last_completed_segment</td></tr>
+        <tr><td class="m">suppress_in_context()</td><td>Sets <code class="inl">append_to_context=False</code> and skips the progress frame</td><td class="m ch-seg">in_transformed_segment</td></tr>
+        <tr><td class="m">get_overflow_word()</td><td>Re-entered as a new word against the <em>next</em> slot</td><td class="m ch-seg">last_overflow</td></tr>
+        <tr><td class="m ch-seg">get_accumulated_user_facing_text()</td><td><code class="inl">accumulated_text</code> → the spoken part of the segment</td><td class="m ch-seg">user_facing_pos</td></tr>
+        <tr><td class="m ch-seg">get_remaining_user_facing_text(strip=False)</td><td><code class="inl">remaining_text</code> → the unspoken part</td><td class="m ch-seg">user_facing_pos</td></tr>
+        <tr><td class="m">get_remaining_tts_text()</td><td>Text of the catch-up frame when a provider goes silent</td><td class="m ch-seg">raw_pos</td></tr>
+      </table>
+    </div>
+    <p class="note">A single <code class="inl">process_word</code> call reads six of these to build one <code class="inl">TTSTextFrame</code> plus one <code class="inl">AggregatedTextProgressFrame</code>. Note the right-hand column: only <code class="inl">add_word_and_check_complete()</code> ever calls <code class="inl">advance_word()</code> — <strong>one entry point moves the map</strong>, and every other accessor just reads the state that call left behind. And <code class="inl">is_complete</code> is <strong>delegated, not tracked</strong> — forwarded to the segment map, except on a force-completed slot where the map was deliberately never advanced.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 26 · ATTRIBUTION ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.2</span> <span class="rule"></span> <span>Span attribution</span></p>
+    <h2 class="headline">Recovering structure the TTS never saw.</h2>
+    <div class="grid g2">
+      <div>
+        <h3 class="sub">Tags the provider never reported</h3>
+        <div class="scroll">
+          <table class="tbl compact">
+            <tr><th>word</th><th>complete</th><th class="c-seg">for frame</th><th class="c-llm">llm consumed</th></tr>
+            <tr><td class="m">Your</td><td class="m">False</td><td class="m">Your</td><td class="m">Your</td></tr>
+            <tr><td class="m">card</td><td class="m">False</td><td class="m">card</td><td class="m">card</td></tr>
+            <tr><td class="m">is</td><td class="m">False</td><td class="m">is</td><td class="m">is</td></tr>
+            <tr class="hi"><td class="m">4111</td><td class="m">False</td><td class="m">4111</td><td class="m"><strong>&lt;card&gt;4111</strong></td></tr>
+            <tr><td class="m">1111</td><td class="m">False</td><td class="m">1111</td><td class="m">1111</td></tr>
+            <tr class="hi"><td class="m">thanks</td><td class="m"><strong>True</strong></td><td class="m">thanks</td><td class="m"><strong>&lt;/card&gt; thanks</strong></td></tr>
+          </table>
+        </div>
+        <p class="note">The context is rebuilt from the right-hand column, so it stores <code class="inl">&lt;card&gt;4111 1111&lt;/card&gt;</code> — not the bare digits.</p>
+      </div>
+      <div>
+        <h3 class="sub">Suppressing mid-transform words</h3>
+        <div class="scroll">
+          <table class="tbl compact">
+            <tr><th>word</th><th class="c-seg">for frame</th><th class="c-llm">llm consumed</th><th>suppress</th></tr>
+            <tr><td class="m">is</td><td class="m">is</td><td class="m">is</td><td class="m">False</td></tr>
+            <tr class="dim"><td class="m">forty-two</td><td class="m">forty-two</td><td class="m">None</td><td class="m ch-warn">True</td></tr>
+            <tr class="dim"><td class="m">dollars</td><td class="m">dollars</td><td class="m">None</td><td class="m ch-warn">True</td></tr>
+            <tr class="dim"><td class="m">and</td><td class="m">and</td><td class="m">None</td><td class="m ch-warn">True</td></tr>
+            <tr class="dim"><td class="m">fifty</td><td class="m">fifty</td><td class="m">None</td><td class="m ch-warn">True</td></tr>
+            <tr class="hi"><td class="m">cents</td><td class="m">cents</td><td class="m"><strong>$42.50</strong></td><td class="m">False</td></tr>
+          </table>
+        </div>
+        <p class="note">The words are still emitted — the UI needs them to highlight — but <strong>only the last one writes to the context, and it writes <code class="inl">$42.50</code></strong>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 27 · RECOVERY ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.3</span> <span class="rule"></span> <span>When providers misbehave</span></p>
+    <h2 class="headline">Never stall. Emit the remainder and move on.</h2>
+    <div class="grid g2">
+      <div class="stack">
+        <div>
+          <h3 class="sub">Dropped event → force-complete</h3>
+          <p class="fcap">frame <b>"Hello there world", next frame "Goodbye"</b><br>the provider reports <b>"Hello"</b>, never reports <b>"there world"</b>, and the next thing to arrive is the following frame's first word</p>
+          <div class="scroll">
+            <table class="tbl compact">
+              <tr><th>word</th><th>belongs</th><th>complete</th><th class="c-seg">for frame</th><th>overflow</th></tr>
+              <tr><td class="m">Hello</td><td class="m">True</td><td class="m">False</td><td class="m">Hello</td><td class="m">None</td></tr>
+              <tr class="hi"><td class="m">Goodbye</td><td class="m ch-warn">False</td><td class="m"><strong>True</strong></td><td class="m"><strong>there world</strong></td><td class="m"><strong>Goodbye</strong></td></tr>
+            </table>
+          </div>
+          <p class="note"><strong>The unspoken remainder is still emitted</strong>, so the context keeps the full sentence; the foreign word is handed back for the next slot.</p>
+        </div>
+      </div>
+      <div class="stack">
+        <div>
+          <h3 class="sub">Straddling token → split at both ends</h3>
+          <p class="fcap">frame <b>"Your card is 1111"</b>, next frame <b>"And that's it."</b><br>the provider merges across the boundary into one token</p>
+          <div class="scroll">
+            <table class="tbl compact">
+              <tr><th>word</th><th>complete</th><th class="c-seg">for frame</th><th>overflow</th></tr>
+              <tr><td class="m">Your … card</td><td class="m">False</td><td class="m">…</td><td class="m">None</td></tr>
+              <tr><td class="m">is</td><td class="m">False</td><td class="m">is</td><td class="m">None</td></tr>
+              <tr class="hi"><td class="m">1111And</td><td class="m"><strong>True</strong></td><td class="m"><strong>1111</strong></td><td class="m"><strong>And</strong></td></tr>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 28 · SLOT QUEUE ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.4</span> <span class="rule"></span> <span>AggregatedFrameSequencer</span></p>
+    <h2 class="headline">Every frame takes a slot — spoken or not.</h2>
+    <div class="queue">
+      <div class="slot spoken"><div class="kind">slot 1 · spoken</div><div class="txt">"Here is the code:"</div><div class="meta">tracker ● &nbsp; complete: <span class="no">✗</span></div></div>
+      <div class="slot skipped"><div class="kind">slot 2 · skipped</div><div class="txt">npm install</div><div class="meta">no tracker</div></div>
+      <div class="slot spoken"><div class="kind">slot 3 · spoken</div><div class="txt">"Then reload."</div><div class="meta">tracker ● &nbsp; complete: <span class="no">✗</span></div></div>
+    </div>
+    <div class="grid g2-wide" style="margin-top:1.2rem">
+      <div class="scroll">
+        <table class="tbl">
+          <tr><th>Slot at head</th><th>Action</th></tr>
+          <tr><td class="k">Spoken <strong>and</strong> complete</td><td>Pop it, keep walking</td></tr>
+          <tr><td class="k">Skipped</td><td>Emit it, pop it, keep walking</td></tr>
+          <tr><td class="k">Spoken <strong>and not</strong> complete</td><td class="ch-warn">Stop</td></tr>
+        </table>
+        <p class="note"><strong>That single rule is the whole ordering guarantee.</strong> On interruption <code class="inl">clear()</code> drops the queue, so a skipped frame whose preceding sentence was never finished is never recorded either.</p>
+      </div>
+      <div class="scroll">
+        <table class="tbl compact">
+          <tr><th>call</th><th>frames returned</th></tr>
+          <tr><td class="m">process_word("Here")</td><td class="m">TTSText, Progress</td></tr>
+          <tr><td class="m">process_word("is")</td><td class="m">TTSText, Progress</td></tr>
+          <tr><td class="m">process_word("the")</td><td class="m">TTSText, Progress</td></tr>
+          <tr class="hi"><td class="m">process_word("code")</td><td class="m">TTSText, Progress, <strong>AggregatedTextFrame("npm install")</strong></td></tr>
+        </table>
+        <p class="note">The code block is released by <strong>the very word that completes the sentence in front of it</strong> — same call, correct position.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 29 · CONCURRENCY ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.5</span> <span class="rule"></span> <span>Concurrent contexts</span></p>
+    <h2 class="headline">Two utterances in flight, one timeline.</h2>
+    <p class="lede tight">Two back-to-back <code class="inl">TTSSpeakFrame</code>s may overlap <code class="inl">run_tts</code> returns before synthesis finishes. Ordering still has to hold across both.</p>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>Field</th><th>Scope</th><th>Lifetime</th></tr>
+        <tr><td class="m ch-tts">_slots</td><td><strong>Global</strong></td><td>The one ordered timeline across all contexts — ordering is the point, so this stays a single list</td></tr>
+        <tr><td class="m ch-seg">_context_append_to_context</td><td><strong>Per context</strong></td><td>Created at registration, removed by <code class="inl">force_complete</code>. Its <em>presence</em> marks the context live</td></tr>
+        <tr><td class="m ch-llm">_streaming_contexts</td><td><strong>Per context</strong></td><td>Only while a sentence accumulates from tokens; released by <code class="inl">finalize</code></td></tr>
+      </table>
+    </div>
+    <pre class="code" style="margin-top:1rem">seq.<span class="fn">process_word</span>(<span class="s">"beta"</span>,  pts=1000, context_id=<span class="s">"ctxB"</span>)   <span class="c"># → TTSTextFrame('beta')</span>
+seq.<span class="fn">process_word</span>(<span class="s">"alpha"</span>, pts=1000, context_id=<span class="s">"ctxA"</span>)   <span class="c"># → TTSTextFrame('alpha')</span></pre>
+    <p class="note">ctxB's word reaches ctxB's slot even though ctxA's slot sits earlier and is still incomplete. A word for a context with <strong>no live entry is dropped as stale</strong> — that is what stops timestamps delivered seconds after an interruption from bleeding into the next turn. A <code class="inl">None</code> context id matches any slot (legacy providers, where concurrency cannot occur).</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 30 · TOKEN MODE ══════════════════════════ -->
+<section class="slide" data-sec="V · Policy and order">
+  <div>
+    <p class="eyebrow"><span class="num">5.6</span> <span class="rule"></span> <span>Token mode (streaming)</span></p>
+    <h2 class="headline">The sentence is always known one token late.</h2>
+    <p class="lede tight">In <code class="inl">TextAggregationMode.TOKEN</code> the service dispatches word-sized chunks — but tracking and progress need a sentence, and a boundary is only confirmed by <strong>lookahead</strong>: the first non-whitespace character of the <em>next</em> sentence.</p>
+    <div class="grid g2">
+      <div class="scroll">
+        <table class="tbl compact">
+          <tr><th>call</th><th>frames returned</th></tr>
+          <tr class="dim"><td class="m">register_spoken("Hi")</td><td class="m">— nothing</td></tr>
+          <tr class="dim"><td class="m">register_spoken(" there!")</td><td class="m">— boundary not yet confirmed</td></tr>
+          <tr class="hi"><td class="m">register_spoken(" Bye")</td><td class="m"><strong>AggregatedTextFrame('Hi there!')</strong></td></tr>
+          <tr><td class="m">process_word("Hi")</td><td class="m">TTSText, Progress</td></tr>
+          <tr class="hi"><td class="m">finalize("ctx1")</td><td class="m"><strong>AggregatedTextFrame(' Bye')</strong></td></tr>
+        </table>
+        <p class="note"><code class="inl">finalize</code> is what rescues a response that ends without terminal punctuation.</p>
+      </div>
+      <div class="stack">
+        <div class="panel accent-tts">
+          <h3 class="sub">Buffered words</h3>
+          <p style="margin:0;font-size:.88rem;color:var(--ink-dim)">Because promotion lags, <strong>a word can arrive before its slot exists</strong>. It is parked in <code class="inl">_buffered_words</code>, then replayed on the next promotion. <code class="inl">_drain_buffered_words</code> snapshots and clears before replaying, so a word that still matches nothing is re-buffered rather than looping.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 31 · DIVIDER: IN PRACTICE ══════════════════════════ -->
+<section class="slide divider-slide" data-sec="VI · In practice">
+  <div>
+    <p class="kicker">VI</p>
+    <h1 class="title" style="font-size:clamp(2rem,5vw,3.6rem)">In practice</h1>
+    <p class="lede">Where the three layers are wired together, what a client builds on top of them, and where to look in the code.</p>
+    <div class="legend">
+      <span class="tag">6.1 Where they're wired up</span>
+      <span class="tag">6.2 One sentence, end to end</span>
+      <span class="tag">6.3 code-helper</span>
+      <span class="tag">6.4 Where to look</span>
+    </div>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 32 · WIRING ══════════════════════════ -->
+<section class="slide" data-sec="VI · In practice">
+  <div>
+    <p class="eyebrow"><span class="num">6.1</span> <span class="rule"></span> <span>Where they're wired up</span></p>
+    <h2 class="headline">All three are driven from TTSService.</h2>
+    <p class="lede tight">The service owns one sequencer; the sequencer builds a tracker per slot; each tracker builds one segment map. <code class="inl">src/pipecat/services/tts_service.py</code></p>
+    <div class="scroll">
+      <table class="tbl">
+        <tr><th>TTSService</th><th>Sequencer method</th><th>When</th></tr>
+        <tr><td class="m">_push_tts_frames</td><td class="m ch-tts">register_spoken</td><td>A frame is dispatched to the TTS</td></tr>
+        <tr><td class="m">_push_tts_frames</td><td class="m ch-tts">register_skipped</td><td>A frame bypasses TTS (e.g. a code block)</td></tr>
+        <tr><td class="m">_add_word_timestamps</td><td class="m ch-tts">process_word</td><td>A word-timestamp event arrives</td></tr>
+        <tr><td class="m">_apply_force_complete</td><td class="m ch-tts">force_complete</td><td>An audio context ends</td></tr>
+        <tr><td class="m">end of text input</td><td class="m ch-tts">finalize</td><td>No more tokens for this context</td></tr>
+        <tr><td class="m">interruption</td><td class="m ch-tts">clear</td><td>The turn is cancelled</td></tr>
+      </table>
+    </div>
+    <p class="note" style="margin-top:1.1rem"><strong>Two ordering problems stay with the service</strong>, because both concern queues the sequencer cannot see: <code class="inl">push_frame</code> stamps the <code class="inl">will_be_spoken</code> anchor with <code class="inl">max(_word_last_pts, clock.now())</code> so it rides the clock queue alongside its progress frames; and <code class="inl">_push_sequencer_frames</code> routes sequencer output through the audio-context queue when streaming, so a single consumer emits anchors, words and audio in order.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 33 · TRACE ══════════════════════════ -->
+<section class="slide" data-sec="VI · In practice" id="slide-trace">
+  <div>
+    <p class="eyebrow"><span class="num">6.2</span> <span class="rule"></span> <span>One sentence, end to end</span></p>
+    <h2 class="headline" style="margin-bottom:.6rem">Step through every call the three layers make.</h2>
+    <p class="fcap">the LLM wrote <b>"Your card is &lt;card&gt;4111&lt;/card&gt;"</b> · the aggregator split the delimiters into <code class="inl">raw_text</code>, so <b>"Your card is 4111"</b> is what reaches the TTS</p>
+    <div class="grid g2-wide">
+      <div class="callstack" id="callStack"></div>
+      <div class="stack">
+        <div class="tracks">
+          <div class="track t-tts">
+            <div class="lbl">③ tts text</div>
+            <div class="body" id="body-xtts"></div>
+            <div class="pos">raw_pos <b id="pos-xtts">0</b></div>
+          </div>
+          <div class="track t-seg">
+            <div class="lbl">② segment text</div>
+            <div class="body" id="body-xseg"></div>
+            <div class="pos">user_facing <b id="pos-xseg">0</b></div>
+          </div>
+          <div class="track t-llm">
+            <div class="lbl">① llm text</div>
+            <div class="body" id="body-xllm"></div>
+            <div class="pos">llm_pos <b id="pos-xllm">0</b></div>
+          </div>
+        </div>
+        <div class="framelog" id="frameLog"></div>
+      </div>
+    </div>
+    <div class="walk-bar" style="margin-top:.9rem">
+      <button class="wbtn" id="tPrev">◀ prev</button>
+      <button class="wbtn" id="tNext">next call ▶</button>
+      <button class="wbtn" id="tWord">next word ⏭</button>
+      <button class="wbtn" id="tReset">reset</button>
+      <div class="wfeed" id="tFeed">—</div>
+      <div class="wstate" id="tStep">0 / 0</div>
+    </div>
+    <p class="note" style="margin-top:.7rem">Captured from a real run. Note <code class="inl">word_belongs_here</code> runs <strong>twice</strong> per word — once for the sequencer to pick the slot, once inside <code class="inl">add_word_and_check_complete</code> to decide force-completion — and that <code class="inl">advance_word</code> is the <strong>only</strong> call that moves a cursor. Everything after it reads back what it left. <em>(↑ / ↓ also step.)</em></p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 34 · PAYOFF ══════════════════════════ -->
+<section class="slide" data-sec="VI · In practice">
+  <div>
+    <p class="eyebrow"><span class="num">6.3</span> <span class="rule"></span> <span>code-helper</span></p>
+    <h2 class="headline">Four settings. Four independent channels.</h2>
+    <div class="grid g2-wide">
+      <pre class="code"><span class="c"># 1. Aggregate tagged segments separately</span>
+llm_text_aggregator.<span class="fn">add_pattern</span>(
+    type=<span class="s">"credit_card"</span>,
+    start_pattern=<span class="s">"&lt;card&gt;"</span>, end_pattern=<span class="s">"&lt;/card&gt;"</span>,
+    action=MatchAction.AGGREGATE)
+
+<span class="c"># 2. Never speak code blocks</span>
+tts = <span class="fn">CartesiaTTSService</span>(..., skip_aggregator_types=[<span class="s">"code"</span>])
+
+<span class="c"># 3. Rewrite what the TTS receives, per segment type</span>
+tts.<span class="fn">add_text_transformer</span>(spell_out_text, <span class="s">"credit_card"</span>)
+tts.<span class="fn">add_text_transformer</span>(strip_url_protocol, <span class="s">"link"</span>)
+
+<span class="c"># 4. Redact what the client renders, per segment type</span>
+rtvi_observer_params=<span class="fn">RTVIObserverParams</span>(
+    bot_output_transforms=[(<span class="s">"credit_card"</span>, obfuscate_credit_card)])</pre>
+      <div class="stack">
+        <div class="scroll">
+          <table class="tbl compact">
+            <tr><th>Channel</th><th>Text</th></tr>
+            <tr><td class="k ch-llm">LLM produced</td><td class="m">Your card is &lt;card&gt;1234-…-3456&lt;/card&gt;</td></tr>
+            <tr><td class="k ch-tts">TTS received</td><td class="m">Your card is &lt;spell&gt;1234-…-3456&lt;/spell&gt;</td></tr>
+            <tr><td class="k ch-llm">Context stored</td><td class="m">Your card is &lt;card&gt;1234-…-3456&lt;/card&gt;</td></tr>
+            <tr><td class="k ch-seg">User saw</td><td class="m">Your card is XXXX-XXXX-XXXX-3456<br><span style="color:var(--ink-faint)">bolded word by word</span></td></tr>
+          </table>
+        </div>
+        <div class="panel accent-seg">
+          <h3 class="sub">The client</h3>
+          <pre class="code" style="border:none;background:transparent;padding:.2rem 0;font-size:.76rem">const cur = this.botSpans[data.<b>segment_id</b>];
+cur.innerHTML =
+  <span class="s">`&lt;strong&gt;${acc}&lt;/strong&gt;${rem}`</span>;</pre>
+          <p style="margin:.4rem 0 0;font-size:.86rem;color:var(--ink-dim)"><strong style="color:var(--ink)">~10 lines of rendering logic</strong>, because the hard part is already done server-side.</p>
+        </div>
+      </div>
+    </div>
+    <p class="note">And the code block, never spoken, still lands in the transcript <strong>after</strong> the sentence that precedes it — because it waited its turn in the slot queue.</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════ 35 · TESTS ══════════════════════════ -->
+<section class="slide" data-sec="VI · In practice">
+  <div>
+    <p class="eyebrow"><span class="num">6.4</span> <span class="rule"></span> <span>Where to look</span></p>
+    <h2 class="headline">Code coverage.</h2>
+    <div class="grid g2">
+      <div class="scroll">
+        <h3 class="sub">Source</h3>
+        <table class="tbl compact">
+          <tr><td class="m ch-seg">utils/context/text_segment_map.py</td><td class="num">881</td></tr>
+          <tr><td class="m ch-llm">utils/context/word_completion_tracker.py</td><td class="num">376</td></tr>
+          <tr><td class="m ch-tts">utils/context/aggregated_frame_sequencer.py</td><td class="num">882</td></tr>
+          <tr><td class="m">utils/text/markup_utils.py</td><td class="num">145</td></tr>
+          <tr><td class="m">utils/text/alnum_utils.py</td><td class="num">—</td></tr>
+          <tr><td class="m">services/tts_service.py</td><td class="num">2076</td></tr>
+        </table>
+      </div>
+      <div class="scroll">
+        <h3 class="sub">Tests</h3>
+        <table class="tbl compact">
+          <tr><td class="m">test_word_completion_tracker.py</td><td class="num">203</td><td>Completion, attribution, provider quirks</td></tr>
+          <tr><td class="m">test_aggregated_frame_sequencer.py</td><td class="num">134</td><td>Slot ordering, streaming, contexts</td></tr>
+          <tr><td class="m">test_text_segment_map.py</td><td class="num">54</td><td>Alignment, markup, hop classification</td></tr>
+          <tr><td class="m">test_tts_frame_ordering.py</td><td class="num">43</td><td>End-to-end through real services</td></tr>
+          <tr><td class="m">test_markup_utils.py</td><td class="num">20</td><td>The shared helpers</td></tr>
+          <tr><td class="m">test_cartesia_tts.py</td><td class="num">13</td><td>Cartesia timestamp shapes</td></tr>
+          <tr><td class="m">test_soniox_tts.py</td><td class="num">11</td><td>Soniox timestamp shapes</td></tr>
+        </table>
+      </div>
+    </div>
+    <pre class="code" style="margin-top:1rem">uv run pytest tests/test_text_segment_map.py tests/test_word_completion_tracker.py \
+  tests/test_aggregated_frame_sequencer.py tests/test_tts_frame_ordering.py \
+  tests/test_cartesia_tts.py tests/test_soniox_tts.py</pre>
+    <p class="note">Full write-ups in <code class="inl">docs/architecture/</code> — one document per layer, plus RTVI integration and known rough edges.</p>
+  </div>
+</section>
+
+</div>
+
+<div class="progress" id="progress"></div>
+<div class="rail">
+  <span class="sec" id="railSec">TTS word tracking</span>
+  <span class="spacer"></span>
+  <span class="keys">← → slides · ↑ ↓ step · T theme · F full</span>
+  <span class="count"><b id="railNum">1</b> / <span id="railTot">35</span></span>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  /* ---------------- deck navigation ---------------- */
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+  var railSec = document.getElementById('railSec');
+  var railNum = document.getElementById('railNum');
+  var railTot = document.getElementById('railTot');
+  var progress = document.getElementById('progress');
+  var idx = 0;
+
+  railTot.textContent = slides.length;
+
+  function show(n) {
+    idx = Math.max(0, Math.min(slides.length - 1, n));
+    slides.forEach(function (s, i) { s.classList.toggle('is-active', i === idx); });
+    var cur = slides[idx];
+    railSec.textContent = cur.getAttribute('data-sec') || '';
+    railNum.textContent = idx + 1;
+    progress.style.width = ((idx + 1) / slides.length * 100) + 'vw';
+    cur.scrollTop = 0;
+    if (location.hash !== '#' + (idx + 1)) {
+      history.replaceState(null, '', '#' + (idx + 1));
+    }
+  }
+
+  /* ---------------- the cursor instrument ---------------- */
+  var WALKS = {
+    currency: {
+      note: 'expand_currency rewrote $42.50 for the synthesizer',
+      tts: 'Your balance is forty-two dollars and fifty cents',
+      seg: 'Your balance is $42.50',
+      llm: 'Your balance is $42.50',
+      steps: [
+        { w: 'Your',      raw: 4,  seg: 4,  llm: 4,  t: false },
+        { w: 'balance',   raw: 12, seg: 12, llm: 12, t: false },
+        { w: 'is',        raw: 15, seg: 15, llm: 15, t: false },
+        { w: 'forty-two', raw: 25, seg: 15, llm: 15, t: true  },
+        { w: 'dollars',   raw: 33, seg: 15, llm: 15, t: true  },
+        { w: 'and',       raw: 37, seg: 15, llm: 15, t: true  },
+        { w: 'fifty',     raw: 43, seg: 15, llm: 15, t: true  },
+        { w: 'cents',     raw: 49, seg: 22, llm: 22, t: false }
+      ]
+    },
+    tags: {
+      note: 'PatternPairAggregator split <card> delimiters into raw_text',
+      tts: 'Your card is 4111',
+      seg: 'Your card is 4111',
+      llm: 'Your card is <card>4111</card>',
+      steps: [
+        { w: 'Your', raw: 4,  seg: 4,  llm: 4,  t: false },
+        { w: 'card', raw: 9,  seg: 9,  llm: 9,  t: false },
+        { w: 'is',   raw: 12, seg: 12, llm: 12, t: false },
+        { w: '4111', raw: 17, seg: 17, llm: 23, t: false },
+        { w: null, raw: 17, seg: 17, llm: 30, t: false, sweep: 23 }
+      ]
+    }
+  };
+
+  var walkKey = 'currency';
+  var step = 0;
+
+  var el = {
+    note: document.getElementById('walkNote'),
+    feed: document.getElementById('wFeed'),
+    lblLlm: document.getElementById('lbl-llm'),
+    trans: document.getElementById('wTrans'),
+    stepN: document.getElementById('wStep'),
+    guarantee: document.getElementById('wGuarantee'),
+    prev: document.getElementById('wPrev'),
+    next: document.getElementById('wNext'),
+    reset: document.getElementById('wReset')
+  };
+
+  function esc(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function paint(id, text, pos, sweptFrom) {
+    var node = document.getElementById('body-' + id);
+    var spoken = sweptFrom == null ? pos : sweptFrom;
+    node.innerHTML =
+      '<span class="done">' + esc(text.slice(0, spoken)) + '</span>' +
+      (sweptFrom == null ? '' :
+        '<span class="swept">' + esc(text.slice(spoken, pos)) + '</span>') +
+      '<span class="caret"></span>' +
+      '<span class="todo">' + esc(text.slice(pos)) + '</span>';
+    document.getElementById('pos-' + id).textContent = pos;
+  }
+
+  function render() {
+    var walk = WALKS[walkKey];
+    var s = step > 0 ? walk.steps[step - 1] : { w: null, raw: 0, seg: 0, llm: 0, t: false };
+
+    el.note.textContent = walk.note;
+    paint('tts', walk.tts, s.raw);
+    paint('seg', walk.seg, s.seg);
+    paint('llm', walk.llm, s.llm, s.sweep);
+
+    document.getElementById('trk-seg').classList.toggle('held', s.t);
+    document.getElementById('trk-llm').classList.toggle('held', s.t);
+    document.getElementById('trk-llm').classList.toggle('claiming', s.sweep != null);
+
+    // The sweep is not a word event: nothing was spoken, so the map never moved.
+    // It is the tracker taking the text left over once the frame is done.
+    if (s.sweep != null) {
+      el.feed.innerHTML = 'frame complete \u2192 tracker claims <b>' +
+        esc(walk.llm.slice(s.sweep, s.llm)) + '</b>';
+      el.lblLlm.textContent = 'llm consumed';
+    } else {
+      el.feed.innerHTML = 'advance_word(<b id="wWord">' +
+        (s.w ? '"' + esc(s.w) + '"' : '\u2014') + '</b>)';
+      el.lblLlm.textContent = 'llm_pos';
+    }
+    el.trans.textContent = 'in_transformed_segment: ' + s.t;
+    el.trans.classList.toggle('on', s.t);
+    el.stepN.textContent = step + ' / ' + walk.steps.length;
+
+    var acc = walk.seg.slice(0, s.seg);
+    var rem = walk.seg.slice(s.seg);
+    el.guarantee.innerHTML =
+      'accumulated <b>"' + esc(acc) + '"</b> + remaining <b>"' + esc(rem) +
+      '"</b> === frame.text &nbsp;<span style="color:var(--seg)">✓</span>';
+
+    el.prev.disabled = step === 0;
+    el.next.disabled = step === walk.steps.length;
+  }
+
+  function stepWalk(d) {
+    var max = WALKS[walkKey].steps.length;
+    step = Math.max(0, Math.min(max, step + d));
+    render();
+  }
+
+  document.querySelectorAll('.wtab').forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      document.querySelectorAll('.wtab').forEach(function (t) {
+        t.setAttribute('aria-selected', String(t === tab));
+      });
+      walkKey = tab.getAttribute('data-walk');
+      step = 0;
+      render();
+    });
+  });
+
+  el.prev.addEventListener('click', function () { stepWalk(-1); });
+  el.next.addEventListener('click', function () { stepWalk(1); });
+  el.reset.addEventListener('click', function () { step = 0; render(); });
+
+  function onWalkSlide() {
+    return slides[idx].id === 'slide-walk';
+  }
+
+  /* ---------------- the call-trace instrument ---------------- */
+  /* Captured from a real run: one entry per call, with the cursor state as the
+     call was entered and any frames that had been emitted by the time it ended. */
+  var TRACE_STEPS = [{"d":0,"l":"seq","n":"register_spoken","a":"frame, 'ctx1', 'Your card is 4111', True","s":[0,0,0,0,0],"r":"","f":[],"after":[0,0,0,0,0]},{"d":0,"l":"seq","n":"process_word","a":"'Your', pts=1000, context_id='ctx1'","s":[0,0,0,0,0],"r":"","f":[]},{"d":1,"l":"trk","n":"word_belongs_here","a":"'Your'","s":[0,0,0,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"word_belongs_current_segment","a":"'Your'","s":[0,0,0,0,0],"r":"True","f":[]},{"d":1,"l":"trk","n":"add_word_and_check_complete","a":"'Your'","s":[0,0,0,0,0],"r":"False","f":[]},{"d":2,"l":"trk","n":"word_belongs_here","a":"'Your'","s":[0,0,0,0,0],"r":"True","f":[]},{"d":3,"l":"map","n":"word_belongs_current_segment","a":"'Your'","s":[0,0,0,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"advance_word","a":"'Your'","s":[0,0,0,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_overflow_word","a":"","s":[4,4,4,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_word_for_frame","a":"","s":[4,4,4,0,0],"r":"'Your'","f":[]},{"d":1,"l":"trk","n":"get_llm_consumed","a":"","s":[4,4,4,0,0],"r":"'Your'","f":[]},{"d":1,"l":"trk","n":"suppress_in_context","a":"","s":[4,4,4,0,0],"r":"False","f":[]},{"d":1,"l":"trk","n":"get_accumulated_user_facing_text","a":"","s":[4,4,4,0,0],"r":"'Your'","f":[]},{"d":1,"l":"trk","n":"get_remaining_user_facing_text","a":"strip=False","s":[4,4,4,0,0],"r":"' card is 4111'","f":[],"emit":[["tts","Your","Your",1],["prog","Your"," card is 4111",0]],"after":[4,4,4,0,0]},{"d":0,"l":"seq","n":"process_word","a":"'card', pts=2000, context_id='ctx1'","s":[4,4,4,0,0],"r":"","f":[]},{"d":1,"l":"trk","n":"word_belongs_here","a":"'card'","s":[4,4,4,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"word_belongs_current_segment","a":"'card'","s":[4,4,4,0,0],"r":"True","f":[]},{"d":1,"l":"trk","n":"add_word_and_check_complete","a":"'card'","s":[4,4,4,0,0],"r":"False","f":[]},{"d":2,"l":"trk","n":"word_belongs_here","a":"'card'","s":[4,4,4,0,0],"r":"True","f":[]},{"d":3,"l":"map","n":"word_belongs_current_segment","a":"'card'","s":[4,4,4,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"advance_word","a":"'card'","s":[4,4,4,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_overflow_word","a":"","s":[9,9,9,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_word_for_frame","a":"","s":[9,9,9,0,0],"r":"'card'","f":[]},{"d":1,"l":"trk","n":"get_llm_consumed","a":"","s":[9,9,9,0,0],"r":"'card'","f":[]},{"d":1,"l":"trk","n":"suppress_in_context","a":"","s":[9,9,9,0,0],"r":"False","f":[]},{"d":1,"l":"trk","n":"get_accumulated_user_facing_text","a":"","s":[9,9,9,0,0],"r":"'Your card'","f":[]},{"d":1,"l":"trk","n":"get_remaining_user_facing_text","a":"strip=False","s":[9,9,9,0,0],"r":"' is 4111'","f":[],"emit":[["tts","card","card",1],["prog","Your card"," is 4111",0]],"after":[9,9,9,0,0]},{"d":0,"l":"seq","n":"process_word","a":"'is', pts=3000, context_id='ctx1'","s":[9,9,9,0,0],"r":"","f":[]},{"d":1,"l":"trk","n":"word_belongs_here","a":"'is'","s":[9,9,9,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"word_belongs_current_segment","a":"'is'","s":[9,9,9,0,0],"r":"True","f":[]},{"d":1,"l":"trk","n":"add_word_and_check_complete","a":"'is'","s":[9,9,9,0,0],"r":"False","f":[]},{"d":2,"l":"trk","n":"word_belongs_here","a":"'is'","s":[9,9,9,0,0],"r":"True","f":[]},{"d":3,"l":"map","n":"word_belongs_current_segment","a":"'is'","s":[9,9,9,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"advance_word","a":"'is'","s":[9,9,9,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_overflow_word","a":"","s":[12,12,12,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_word_for_frame","a":"","s":[12,12,12,0,0],"r":"'is'","f":[]},{"d":1,"l":"trk","n":"get_llm_consumed","a":"","s":[12,12,12,0,0],"r":"'is'","f":[]},{"d":1,"l":"trk","n":"suppress_in_context","a":"","s":[12,12,12,0,0],"r":"False","f":[]},{"d":1,"l":"trk","n":"get_accumulated_user_facing_text","a":"","s":[12,12,12,0,0],"r":"'Your card is'","f":[]},{"d":1,"l":"trk","n":"get_remaining_user_facing_text","a":"strip=False","s":[12,12,12,0,0],"r":"' 4111'","f":[],"emit":[["tts","is","is",1],["prog","Your card is"," 4111",0]],"after":[12,12,12,0,0]},{"d":0,"l":"seq","n":"process_word","a":"'4111', pts=4000, context_id='ctx1'","s":[12,12,12,0,0],"r":"","f":[]},{"d":1,"l":"trk","n":"word_belongs_here","a":"'4111'","s":[12,12,12,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"word_belongs_current_segment","a":"'4111'","s":[12,12,12,0,0],"r":"True","f":[]},{"d":1,"l":"trk","n":"add_word_and_check_complete","a":"'4111'","s":[12,12,12,0,0],"r":"True","f":[]},{"d":2,"l":"trk","n":"word_belongs_here","a":"'4111'","s":[12,12,12,0,0],"r":"True","f":[]},{"d":3,"l":"map","n":"word_belongs_current_segment","a":"'4111'","s":[12,12,12,0,0],"r":"True","f":[]},{"d":2,"l":"map","n":"advance_word","a":"'4111'","s":[12,12,12,0,0],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_overflow_word","a":"","s":[17,17,23,0,1],"r":"None","f":[]},{"d":1,"l":"trk","n":"get_word_for_frame","a":"","s":[17,17,23,0,1],"r":"'4111'","f":[]},{"d":1,"l":"trk","n":"get_llm_consumed","a":"","s":[17,17,23,0,1],"r":"'<card>4111</card>'","f":[]},{"d":1,"l":"trk","n":"suppress_in_context","a":"","s":[17,17,23,0,1],"r":"False","f":[]},{"d":1,"l":"trk","n":"get_accumulated_user_facing_text","a":"","s":[17,17,23,0,1],"r":"'Your card is 4111'","f":[]},{"d":1,"l":"trk","n":"get_remaining_user_facing_text","a":"strip=False","s":[17,17,23,0,1],"r":"''","f":[]},{"d":1,"l":"seq","n":"flush","a":"last_word_pts=4000","s":[17,17,23,0,1],"r":"","f":[],"emit":[["tts","4111","<card>4111</card>",1],["prog","Your card is 4111","",0]],"after":[17,17,23,0,1]}];
+
+  var TRACE_TEXT = {
+    xtts: 'Your card is 4111',
+    xseg: 'Your card is 4111',
+    xllm: 'Your card is <card>4111</card>'
+  };
+  var LAYER_CLASS = { seq: 'ch-tts', trk: 'ch-llm', map: 'ch-seg' };
+  var tStep = 0;
+
+  var tEl = {
+    stack: document.getElementById('callStack'),
+    log: document.getElementById('frameLog'),
+    feed: document.getElementById('tFeed'),
+    stepN: document.getElementById('tStep'),
+    prev: document.getElementById('tPrev'),
+    next: document.getElementById('tNext'),
+    word: document.getElementById('tWord'),
+    reset: document.getElementById('tReset')
+  };
+
+  function buildTraceStack() {
+    tEl.stack.innerHTML = TRACE_STEPS.map(function (st, i) {
+      var pad = new Array(st.d + 1).join('  ');
+      var ret = st.r ? ' <span class="ret">→ ' + esc(st.r) + '</span>' : '';
+      return '<div class="crow" data-i="' + i + '">' + pad +
+        '<span class="' + LAYER_CLASS[st.l] + '">' + esc(st.n) + '</span>(' +
+        esc(st.a) + ')' + ret + '</div>';
+    }).join('');
+  }
+
+  function renderTrace() {
+    var st = tStep > 0 ? TRACE_STEPS[tStep - 1] : null;
+    // Cursors are shown as the highlighted call was *entered*, so a step lands on
+    // the state that call is about to act on rather than the one it produced.
+    var pos = st ? st.s : [0, 0, 0, 0, 0];
+
+    paint('xtts', TRACE_TEXT.xtts, pos[0]);
+    paint('xseg', TRACE_TEXT.xseg, pos[1]);
+    paint('xllm', TRACE_TEXT.xllm, pos[2]);
+
+    var rows = tEl.stack.querySelectorAll('.crow');
+    for (var i = 0; i < rows.length; i++) {
+      rows[i].classList.toggle('seen', i < tStep);
+      rows[i].classList.toggle('on', i === tStep - 1);
+    }
+    if (st) {
+      var on = tEl.stack.querySelector('.crow.on');
+      if (on && on.scrollIntoView) on.scrollIntoView({ block: 'nearest' });
+    } else {
+      tEl.stack.scrollTop = 0;
+    }
+
+    var emitted = [];
+    for (var j = 0; j < tStep; j++) {
+      if (TRACE_STEPS[j].emit) emitted = emitted.concat(TRACE_STEPS[j].emit);
+    }
+    tEl.log.innerHTML = emitted.length
+      ? emitted.map(function (f) {
+          if (f[0] === 'tts') {
+            var raw = f[2] !== f[1]
+              ? ' <span class="tag-raw">raw_text=<b>"' + esc(f[2]) + '"</b></span>'
+              : ' raw_text="' + esc(f[2]) + '"';
+            return '<div class="frow tts">TTSTextFrame <b>"' + esc(f[1]) + '"</b>' + raw + '</div>';
+          }
+          return '<div class="frow prog">Progress acc=<b>"' + esc(f[1]) +
+            '"</b> rem="' + esc(f[2]) + '"</div>';
+        }).join('')
+      : '<div class="empty">no frames emitted yet</div>';
+
+    tEl.feed.innerHTML = st
+      ? '<span class="' + LAYER_CLASS[st.l] + '">' + esc(st.n) + '</span>' +
+        (st.r ? ' → <b>' + esc(st.r) + '</b>' : '')
+      : '—';
+    tEl.stepN.textContent = tStep + ' / ' + TRACE_STEPS.length;
+    tEl.prev.disabled = tStep === 0;
+    tEl.next.disabled = tStep === TRACE_STEPS.length;
+    tEl.word.disabled = tStep === TRACE_STEPS.length;
+  }
+
+  function stepTrace(d) {
+    tStep = Math.max(0, Math.min(TRACE_STEPS.length, tStep + d));
+    renderTrace();
+  }
+
+  function traceNextWord() {
+    for (var i = tStep; i < TRACE_STEPS.length; i++) {
+      if (TRACE_STEPS[i].n === 'process_word') { tStep = i + 1; renderTrace(); return; }
+    }
+    tStep = TRACE_STEPS.length;
+    renderTrace();
+  }
+
+  tEl.prev.addEventListener('click', function () { stepTrace(-1); });
+  tEl.next.addEventListener('click', function () { stepTrace(1); });
+  tEl.word.addEventListener('click', traceNextWord);
+  tEl.reset.addEventListener('click', function () { tStep = 0; renderTrace(); });
+
+  function onTraceSlide() {
+    return slides[idx].id === 'slide-trace';
+  }
+
+  /* ---------------- keyboard ---------------- */
+  document.addEventListener('keydown', function (e) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    switch (e.key) {
+      case 'ArrowRight': case 'PageDown': show(idx + 1); e.preventDefault(); break;
+      case 'ArrowLeft':  case 'PageUp':   show(idx - 1); e.preventDefault(); break;
+      case ' ':          show(idx + 1); e.preventDefault(); break;
+      case 'Home':       show(0); e.preventDefault(); break;
+      case 'End':        show(slides.length - 1); e.preventDefault(); break;
+      case 'ArrowDown':
+        if (onWalkSlide()) { stepWalk(1); e.preventDefault(); }
+        else if (onTraceSlide()) { stepTrace(1); e.preventDefault(); }
+        break;
+      case 'ArrowUp':
+        if (onWalkSlide()) { stepWalk(-1); e.preventDefault(); }
+        else if (onTraceSlide()) { stepTrace(-1); e.preventDefault(); }
+        break;
+      case 't': case 'T':
+        document.documentElement.setAttribute(
+          'data-theme',
+          document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light'
+        );
+        break;
+      case 'f': case 'F':
+        if (document.fullscreenElement) { document.exitFullscreen(); }
+        else { document.documentElement.requestFullscreen(); }
+        break;
+    }
+  });
+
+  /* ---------------- click-to-advance (ignore controls) ---------------- */
+  document.addEventListener('click', function (e) {
+    if (e.target.closest('button, a, .scroll, pre, .track, .callstack, .framelog')) return;
+    if (e.clientX > window.innerWidth * 0.75) show(idx + 1);
+    else if (e.clientX < window.innerWidth * 0.25) show(idx - 1);
+  });
+
+  /* ---------------- boot ---------------- */
+  var start = parseInt((location.hash || '').slice(1), 10);
+  render();
+  buildTraceStack();
+  renderTrace();
+  show(isNaN(start) ? 0 : start - 1);
+})();
+</script>
+</body>
+</html>

--- a/docs/architecture/word-trecking/README.md
+++ b/docs/architecture/word-trecking/README.md
@@ -1,0 +1,376 @@
+# TTS Word Tracking Architecture
+
+How Pipecat keeps what the LLM wrote, what downstream consumers render, and what the TTS
+speaks in sync — word by word, while audio is playing.
+
+---
+
+## 1. The end goal
+
+One response from the LLM has to satisfy three consumers that want *different text*.
+
+Take a bot that has been prompted to wrap credit cards in `<card>` tags and code in
+`<code>` tags (this is the [`code-helper`](#36-end-to-end-the-code-helper-example) example):
+
+**What the LLM produces:**
+
+```
+Your card is <card>1234-5678-9012-3456</card>. Run <code>npm install</code> to start.
+```
+
+From that single output, three things must happen:
+
+| Consumer | Wants | Why |
+| --- | --- | --- |
+| **Conversation context** | `Your card is <card>1234-5678-9012-3456</card>. Run <code>npm install</code> to start.` | The LLM must see its own tags on the next turn, or it stops producing them |
+| **The user's screen** *(the example used throughout — but any downstream consumer works the same way)* | `Your card is XXXX-XXXX-XXXX-3456.` + a syntax-highlighted code block, with each word bolded as it is spoken | The UI renders and redacts; the raw tags are noise |
+| **The TTS provider** | `Your card is <spell>1234-5678-9012-3456</spell>.` — and *nothing* for the code block | Digits must be spelled out; code must not be read aloud |
+
+The provider streams back word-timestamp events containing **only the words it actually
+spoke**. Those words are the *only* signal available.
+Everything in these documents exists to answer, for each incoming word:
+
+1. **Where are we?** — which position in the displayed text, so the UI can highlight it
+2. **What should I add to the context?** — which span of the LLM's own text, so the context keeps the tags
+3. **Is this frame ready to be pushed?** — in what order, relative to everything else in the turn
+
+[§2](#2-the-original-problems) is what went wrong before those questions had answers;
+[§3](#3-how-the-problems-are-solved) is how they are solved.
+
+---
+
+## 2. The original problems
+
+### 2.1 The context drifted from what the LLM wrote
+
+The text appended to the conversation context was the text that came *back from the TTS*,
+not the text the LLM produced. Everything that made the output speakable — the tags removed
+before synthesis, the values rewritten for pronunciation — was lost on the round trip, so
+what landed in the context **was never quite what the LLM had written**.
+
+The failure mode was subtle and slow: the LLM is asked to wrap credit cards in `<card>`
+tags, does so on turn one, and then sees a context where its own tags are absent. After a
+few turns it concludes the tags are not part of the conversation and **stops producing
+them**. The feature quietly decays.
+
+| | Before | Now |
+| --- | --- | --- |
+| Context receives | `Your card is 1234 5678 9012 3456` | `Your card is <card>1234-5678-9012-3456</card>` |
+| Next turn | LLM sees no tags, stops emitting them | LLM sees its own convention, keeps it |
+
+### 2.2 Skipped frames arrived out of order
+
+A frame that is never sent to the TTS — a code block, with
+`skip_aggregator_types=["code"]` — has no audio and no word events to wait for. It was
+**pushed the moment it appeared**, so it landed *before* the sentence that precedes it:
+
+```
+LLM:      "Run this:"  →  <code>npm install</code>  →  "Then reload."
+
+Context:  <code>npm install</code>      ← arrived first, nothing to wait for
+          "Run this:"                   ← spoken later
+          "Then reload."
+```
+
+The transcript reads out of order, and on interruption the mismatch is worse: **text that
+was never spoken could still be recorded as if it had been**.
+
+### 2.3 Highlighting spoken words was not possible
+
+The UI receives sentence-level frames (`AggregationType.SENTENCE`) to render, and
+word-level frames (`AggregationType.WORD`) as speech progresses. There was **no
+correspondence between them** — a word frame carried no indication of which sentence
+frame it belonged to, or where inside it. **The client could not turn a stream of words
+into a highlight moving through a rendered sentence.**
+
+### 2.4 RTVI `bot_output_transforms` were useless word-by-word
+
+Client-side transforms — obfuscating a credit card before it reaches the screen — operate
+on a segment. Receiving text word by word, with no segment identity and no notion of
+"spoken so far" versus "remaining", **left nothing coherent to transform**. You could not
+redact a credit card number that arrives as `1234`, `5678`, `9012`, `3456` across four
+disconnected events.
+
+### 2.5 Problems found along the way
+
+| Problem | What happens |
+| --- | --- |
+| **Streamed tokens** | In `TOKEN` mode the service dispatches word-sized chunks, but tracking and progress need whole sentences — which are not known until a boundary is confirmed |
+| **Concurrent contexts** | Two back-to-back `TTSSpeakFrame`s on a websocket service can be in flight at once; their word streams interleave and must not consume each other's slots |
+| **Straddling tokens** | One provider token completes one frame and starts the next (`1111And`), so a single event must produce output for two slots, in the right order |
+| **Dropped events** | The provider silently never reports a word it spoke, leaving a frame — and everything queued behind it — waiting forever |
+
+### 2.6 And a feature: text transformations
+
+TTS engines read what you give them, and written text is often not what you want spoken.
+`$42.50` may come out as "dollar forty two point five zero"; `1994` as "one thousand nine
+hundred ninety four" when the sentence means "nineteen ninety four"; markdown asterisks
+get read aloud; a URL becomes "h t t p s colon slash slash". The fix is to **rewrite the
+text before it reaches the TTS**, so the audio comes out right.
+
+The obstacle was that the rewritten text was also the text everything else saw. Expanding
+`$42.50` for the synthesizer meant the user read "forty-two dollars and fifty cents" on
+screen and the conversation context recorded it that way too — so **a transform that
+improved the audio corrupted the transcript**. Tracking the three texts separately is what
+makes the rewrite safe: **it reaches the TTS and nothing else**.
+
+These are the built-in transforms (`src/pipecat/utils/text/transforms/`, bundled by
+`VoiceFormatter`):
+
+| Transform | Input | Sent to TTS |
+| --- | --- | --- |
+| `expand_currency` | `It costs $42.50` | `It costs forty-two dollars and fifty cents` |
+| `expand_percentages` | `Up 12.5%` | `Up twelve point five percent` |
+| `expand_units` | `It is 5 km away` | `It is 5 kilometers away` |
+| `normalize_dates` | `on 2024-01-15` | `on January 15th, two thousand and twenty-four` |
+| `email_to_speech` | `a@b.com` | `a at b dot com` |
+| `expand_phone_numbers` | `call 555-123-4567` | `call 5 5 5 1 2 3 4 5 6 7` |
+| `expand_numbers` | `room 1994` | `room 1 9 9 4` |
+| `normalize_acronyms` | `I work at IBM` | `I work at I B M` |
+| `strip_markdown` | `**bold** text` | `bold text` |
+
+Plus per-segment transformers registered on the service itself
+(`tts.add_text_transformer(fn, "credit_card")`), which is how the `code-helper` example
+wraps card numbers in `<spell>` tags and strips `https://` from links.
+
+Each one buys better audio at the cost of widening the gap between what is spoken and what
+is displayed — which is exactly the gap the three layers have to close. They are applied at
+[SPLIT 2](#31-three-texts-produced-at-two-split-points).
+
+---
+
+## 3. How the problems are solved
+
+The solution has two halves. First, the three texts are kept **distinct as they are
+produced**, so nothing has to be reconstructed later (3.1–3.3). Second, three layers keep
+them **aligned word by word** while the TTS speaks (3.4–3.5).
+
+| Problem | Solved by |
+| --- | --- |
+| [2.1](#21-the-context-drifted-from-what-the-llm-wrote) Context drift | `TextSegmentMap`'s `llm_pos` cursor + `WordCompletionTracker`'s span attribution |
+| [2.2](#22-skipped-frames-arrived-out-of-order) Out-of-order skipped frames | `AggregatedFrameSequencer`'s slot queue |
+| [2.3](#23-highlighting-spoken-words-was-not-possible) Word ↔ sentence correspondence | `AggregatedTextProgressFrame`, built from the tracker's cursors |
+| [2.4](#24-rtvi-bot_output_transforms-were-useless-word-by-word) Useless RTVI transforms | `segment_id` + `accumulated_text` / `remaining_text` on every progress frame |
+| [2.5](#25-problems-found-along-the-way) Streaming / concurrency / TTS provider quirks | Sequencer (streaming, contexts) + tracker (straddle, drops) |
+| [2.6](#26-and-a-feature-text-transformations) Text transformations | `TextSegmentMap`'s transformed-segment handling |
+
+### 3.1 Three texts, produced at two split points
+
+They are not authored separately. Two **split points** create them, one owned by an
+aggregator and one by the TTS service's transformers:
+
+```
+   LLM tokens
+        │
+        ▼
+ ┌───────────────────────────────────────────────┐
+ │  LLMTextProcessor  (or TTSService itself)     │   SPLIT 1 — the aggregator
+ │  BaseTextAggregator, e.g.                     │   decides where segments end
+ │  PatternPairAggregator / SimpleTextAggregator │   and what counts as a delimiter
+ └───────────────────────────────────────────────┘
+        │
+        ├──────── raw_text ─────────▶  ① LLM TEXT        → conversation context
+        │
+        └──────── text ─────────────▶  ② SEGMENT TEXT    → downstream consumers
+                                            │                (the AggregatedTextFrame)
+                                            ▼
+                                  ┌──────────────────────┐
+                                  │  TTSService          │   SPLIT 2 — filters and
+                                  │  text filters        │   per-type transformers
+                                  │  text transformers   │   rewrite for speech only
+                                  └──────────────────────┘
+                                            │
+                                            ▼
+                                       ③ TTS TEXT         → the provider
+```
+
+Both `text` and `raw_text` come off the same aggregation: `raw_text` is its `full_match`
+when the aggregator produced a `PatternMatch`, and identical to `text` otherwise. SPLIT 2
+is where the transforms listed in [§2.6](#26-and-a-feature-text-transformations) run.
+
+Three properties fall out of this shape:
+
+- **The middle channel is the `AggregatedTextFrame` itself.** These documents call it the
+  **segment text**, because that is what it is — `frame.text`, the segment as the
+  aggregator produced it.
+- **It is never rewritten.** Filters and transformers operate on a *copy* on its way to
+  the TTS; `frame.text` keeps what the aggregator produced.
+- **The three only diverge where something acted.** With a `SimpleTextAggregator` and no
+  transformers, all three are the same string.
+
+### 3.2 What that looks like for one response
+
+The `PatternPairAggregator` splits that one response into **six** frames — each tagged
+span becomes its own segment, with its own type:
+
+| # | `aggregated_by` | ① LLM text (`raw_text`) | ② Segment text (`text`) | ③ TTS text |
+| --- | --- | --- | --- | --- |
+| 1 | `sentence` | `Your card is ` | `Your card is` | `Your card is` |
+| 2 | **`credit_card`** | `<card>1234-5678-9012-3456</card>` | `1234-5678-9012-3456` | `<spell>1234-5678-9012-3456</spell>` |
+| 3 | `sentence` | `.` | `.` | `.` |
+| 4 | `sentence` | ` Run ` | `Run` | `Run` |
+| 5 | **`code`** | `<code>npm install</code>` | `npm install` | *(never sent — skipped)* |
+| 6 | `sentence` | ` to start.` | `to start.` | `to start.` |
+
+**Only the two tagged frames do anything interesting.** Frame 2's delimiters moved into
+`raw_text` so the context keeps them, while its `credit_card` transformer wrapped the
+digits in Cartesia's `<spell>` tags so they are read out one by one. Frame 5 is never
+spoken at all — which is what creates the ordering problem in
+[§2.2](#22-skipped-frames-arrived-out-of-order). The four `sentence` frames are identical
+in all three columns.
+
+`aggregated_by` is **the routing key throughout**: it selects which transformer applies
+(`tts.add_text_transformer(fn, "credit_card")`), whether the frame is spoken at all
+(`skip_aggregator_types=["code"]`), and which RTVI transform redacts it
+(`bot_output_transforms=[("credit_card", …)]`).
+
+### 3.3 The guarantee that makes it useful
+
+Whatever the aggregator put in `frame.text`, one rule always holds while that segment is
+being spoken:
+
+```
+progress.accumulated_text + progress.remaining_text  ==  AggregatedTextFrame.text
+```
+
+Exactly — **character for character, after every single word**. The two halves of a progress
+frame are always a clean split of the string the segment frame is already carrying: never
+a paraphrase of it, never a normalised copy, never off by a space.
+
+That is what makes the progress frames **usable by anything, without coordination**. A
+consumer that has the segment frame does not have to guess how the text was transformed on
+its way to the TTS, or re-derive positions itself — it can index straight into the string
+it already holds. Highlight the first half and leave the second plain, and you have word
+highlighting; redact both halves and you have redaction; concatenate them and you get the
+original back.
+
+**These documents use a UI highlighting spoken words as the running example**, because it
+makes the moving cursor easy to picture — but that is all it is, an example. A custom
+processor, a transcript writer, a redaction filter, or a logger consumes the same frames on
+exactly the same terms.
+
+> The API spells this channel `user_facing_*` (`user_facing_text`, `user_facing_pos`,
+> `get_accumulated_user_facing_text()`). These documents say **segment text** for the
+> concept and keep `user_facing_*` when naming actual API members — see
+> [possible improvements](./improvements.md#1-the-user_facing_-naming).
+
+### 3.4 The three layers
+
+```
+  TTS provider ── word-timestamp events ──┐
+                                          ▼
+ ┌────────────────────────────────────────────────────────────────┐
+ │  AggregatedFrameSequencer            one per TTS service       │
+ │                                                                │
+ │   ordered slot queue:  [ spoken ][ skipped ][ spoken ] …        │
+ │                            │                    │              │
+ │                    ┌───────▼────────┐   ┌───────▼────────┐     │
+ │                    │ WordCompletion │   │ WordCompletion │     │
+ │                    │ Tracker        │   │ Tracker        │     │
+ │                    │  ┌───────────┐ │   │  ┌───────────┐ │     │
+ │                    │  │ TextSeg   │ │   │  │ TextSeg   │ │     │
+ │                    │  │ mentMap   │ │   │  │ mentMap   │ │     │
+ │                    │  └───────────┘ │   │  └───────────┘ │     │
+ │                    └────────────────┘   └────────────────┘     │
+ └────────────────────────────────────────────────────────────────┘
+             │                                    │
+             ▼                                    ▼
+      TTSTextFrame                   AggregatedTextProgressFrame
+   → conversation context                → RTVI → the client
+```
+
+Each layer owns one concern, and none of them knows about the layer above:
+
+| Layer | Scope | Question it answers | Why it has to exist |
+| --- | --- | --- | --- |
+| [`TextSegmentMap`](./text-segment-map.md) | One frame, segment by segment | Where in the other two texts are we, given this spoken word? | The text sent to the TTS is not the text the LLM wrote or the segment carries, so something has to hold three cursors in alignment across transforms and markup while matching noisy, provider-specific tokens |
+| [`WordCompletionTracker`](./word-completion-tracker.md) | One frame | How much of this word is this frame's, which original text does it stand for, and is the frame finished? | One frame needs a completion verdict and an attributed LLM span per word even when the TTS provider misbehaves |
+| [`AggregatedFrameSequencer`](./aggregated-frame-sequencer.md) | The whole turn | In what order do frames leave the TTS service? | Words arrive per-frame but the conversation context is global and ordered, so spoken, skipped, buffered, and concurrent-context frames must be serialized into one timeline |
+
+### 3.5 Where they are wired up
+
+All three are driven from `TTSService` (`src/pipecat/services/tts_service.py`). The
+service owns one `AggregatedFrameSequencer`; the sequencer builds a
+`WordCompletionTracker` per slot; each tracker builds one `TextSegmentMap`.
+
+| `TTSService` | Sequencer method | When |
+| --- | --- | --- |
+| `_push_tts_frames` | `register_spoken` | A frame is dispatched to the TTS |
+| `_push_tts_frames` | `register_skipped` | A frame bypasses TTS (e.g. a code block) |
+| `_add_word_timestamps` | `process_word` | A word-timestamp event arrives |
+| `_apply_force_complete` | `force_complete` | An audio context ends |
+| end of text input | `finalize` | No more tokens for this context |
+| interruption | `clear` | The turn is cancelled |
+
+Two ordering problems stay with the service rather than the sequencer, because both are
+about queues the sequencer cannot see:
+
+| `TTSService` | What it does                                                                            | Why |
+| --- |-----------------------------------------------------------------------------------------| --- |
+| `push_frame` | Stamps the `will_be_spoken` anchor with `max(_word_last_pts, clock.now())`              | Progress frames carry a PTS and travel the transport's clock queue. |
+| `_push_sequencer_frames` | Routes all the frames received from the AggregatedFrameSequencer through the audio-context queue when streaming | Keeps a single consumer emitting anchors, words and audio in order, rather than racing the audio-context task |
+
+### 3.6 End to end: the code-helper example
+
+[`code-helper`](https://github.com/pipecat-ai/pipecat-examples/tree/main/code-helper), in
+the `pipecat-examples` repository, exercises every part of this stack at once. Its bot
+prompts the LLM to tag its output, then routes each tag type differently:
+
+```python
+# 1. Aggregate tagged segments separately
+llm_text_aggregator.add_pattern(type="credit_card",
+                                start_pattern="<card>", end_pattern="</card>",
+                                action=MatchAction.AGGREGATE)
+
+# 2. Never speak code blocks
+tts = CartesiaTTSService(..., skip_aggregator_types=["code"])
+
+# 3. Rewrite what the TTS receives, per segment type
+tts.add_text_transformer(spell_out_text, "credit_card")   # wraps in <spell> tags
+tts.add_text_transformer(strip_url_protocol, "link")      # drops "https://"
+
+# 4. Redact what the client renders, per segment type
+rtvi_observer_params=RTVIObserverParams(
+    bot_output_transforms=[("credit_card", obfuscate_credit_card)]
+)
+```
+
+Those four settings produce the six frames tabulated in
+[§3.2](#32-what-that-looks-like-for-one-response), plus one thing that table does not
+show: the client renders `XXXX-XXXX-XXXX-3456` rather than the real digits, because step 4
+redacts the segment on its way out while the highlight keeps advancing over the redacted
+form.
+
+The client is **only ~10 lines of rendering logic**, because the hard part is already done
+server-side.
+
+### 3.7 Going deeper
+
+Each layer has its own document, with worked examples traced from the real code:
+
+| Document | Contents |
+| --- | --- |
+| [TextSegmentMap](./text-segment-map.md) | Aligns the three texts |
+| [WordCompletionTracker](./word-completion-tracker.md) | Tracks one frame to completion |
+| [AggregatedFrameSequencer](./aggregated-frame-sequencer.md) | Orders frames downstream |
+| [RTVI integration](./rtvi-integration.md) | How the frames reach the client |
+| [Possible improvements](./improvements.md) | Known rough edges, with reasoning |
+
+---
+
+## 4. Tests
+
+| File | Tests | Covers |
+| --- | ---: | --- |
+| `tests/test_text_segment_map.py` | 66 | Alignment, markup helpers, hop classification |
+| `tests/test_word_completion_tracker.py` | 203 | Completion, span attribution, TTS provider quirks |
+| `tests/test_aggregated_frame_sequencer.py` | 134 | Slot ordering, streaming, concurrent contexts |
+| `tests/test_tts_frame_ordering.py` | 46 | End-to-end frame order through real services |
+| `tests/test_cartesia_tts.py` | 13 | Cartesia word-timestamp shapes |
+| `tests/test_soniox_tts.py` | 11 | Soniox word-timestamp shapes |
+
+```bash
+uv run pytest tests/test_text_segment_map.py tests/test_word_completion_tracker.py \
+  tests/test_aggregated_frame_sequencer.py tests/test_tts_frame_ordering.py \
+  tests/test_cartesia_tts.py tests/test_soniox_tts.py
+```

--- a/docs/architecture/word-trecking/aggregated-frame-sequencer.md
+++ b/docs/architecture/word-trecking/aggregated-frame-sequencer.md
@@ -1,0 +1,364 @@
+# AggregatedFrameSequencer
+
+`src/pipecat/utils/context/aggregated_frame_sequencer.py`
+
+> **Job:** decide the order in which frames leave the TTS service.
+
+A [`WordCompletionTracker`](./word-completion-tracker.md) knows everything about *one*
+frame and nothing about the turn it belongs to. But the conversation context is a single
+ordered transcript. The sequencer is where that ordering is enforced.
+
+Section 1 covers **what** it emits. The rest cover the three distinct ordering concerns it
+exists to solve:
+
+| # | Concern | Core mechanism |
+| --- | --- | --- |
+| **2** | [Frame ordering](#2-frame-ordering) — including frames that are never spoken | The ordered slot queue |
+| **3** | [Concurrent contexts](#3-concurrent-contexts) — two utterances in flight at once | Per-context routing and liveness |
+| **4** | [Token mode](#4-token-mode-streaming) — word-sized chunks that must become sentences | Pending-sentence promotion + word buffering |
+
+---
+
+## 1. The output: two frames per word
+
+Before the ordering rules, it helps to know what the sequencer actually emits. Every call
+to `process_word` builds up to two frames — `_build_word_frame` and
+`_build_progress_frame` — each aimed at a different consumer:
+
+| Frame | Destination | Carries |
+| --- | --- | --- |
+| `TTSTextFrame` | The **conversation context** | The word, plus `raw_text` — the LLM span it represents |
+| `AggregatedTextProgressFrame` | **Any downstream consumer** — a UI via RTVI is the usual one | `segment_id` + `accumulated_text` / `remaining_text` |
+
+```mermaid
+flowchart LR
+    PW["process_word('cents')"] --> TF["<b>TTSTextFrame</b><br/>text='cents'<br/>raw_text='$42.50'<br/>append_to_context=True"]
+    PW --> PF["<b>AggregatedTextProgressFrame</b><br/>segment_id=42<br/>accumulated='Your balance is $42.50'<br/>remaining=''"]
+    TF --> CTX["conversation context"]
+    PF --> OBS["RTVIObserver<br/><i>or any consumer</i>"] --> CLIENT["the UI"]
+```
+
+### The context frame
+
+`TTSTextFrame.raw_text` is the tracker's `get_llm_consumed()` — the LLM span attributed to
+this word. That is what keeps `<card>…</card>` in the context instead of bare digits.
+
+Two flags control whether a word is recorded at all:
+
+| Flag | Set when | Effect |
+| --- | --- | --- |
+| `append_to_context` | Per context, at registration | Whole context excluded from the transcript |
+| `suppress_in_context` | Tracker is mid-transformed-segment | This word excluded; only the completing word carries the original span |
+
+That second one is why `forty-two`, `dollars`, `and` and `fifty` never reach the context —
+only `cents` does, carrying `raw_text='$42.50'`.
+
+### The progress frame
+
+`AggregatedTextProgressFrame` is what made word highlighting possible. It solves the
+correspondence problem directly: `segment_id` is the **id of the sentence
+`AggregatedTextFrame`** the word belongs to, so a client can match a stream of words back
+to the sentence it already rendered.
+
+```python
+AggregatedTextProgressFrame(
+    segment_id=slot.frame.id,                              # ← the sentence's id
+    context_id=slot.context_id,
+    text=slot.frame.text,                                  # full sentence
+    aggregated_by=slot.frame.aggregated_by,
+    accumulated_text=tracker.get_accumulated_user_facing_text(),
+    remaining_text=tracker.get_remaining_user_facing_text(strip=False),
+)
+```
+
+`accumulated_text + remaining_text` reconstructs `AggregatedTextFrame.text` exactly (hence
+`strip=False`), so any consumer holding the segment frame can position into the string it
+already has without ever losing a character. Highlighting text in a UI is the usual case
+and the example used throughout, but nothing here is UI- or RTVI-specific; see
+[the guarantee](./README.md#33-the-guarantee-that-makes-it-useful). What the client does with it
+is covered in [RTVI integration](./rtvi-integration.md).
+
+A progress frame accompanies a word frame whenever the word was matched to a real slot and
+`suppress_in_context()` is False. Two cases produce a word frame alone: a word held
+mid-transform (no meaningful position to report yet), and a passthrough word that no slot
+recognised (no segment to report progress against).
+
+---
+
+## 2. Frame ordering
+
+### The problem
+
+Not every frame reaches the TTS. A code block configured with
+`skip_aggregator_types=["code"]` is never synthesized, so it has no audio and no word
+events to wait for. Pushed the moment it appears, it lands *before* the sentence that
+precedes it — because that sentence is still being spoken.
+
+```
+LLM emits:   "Run this:"      <code>npm install</code>      "Then reload."
+                  │                      │                        │
+                  │ sent to TTS          │ skipped                │ sent to TTS
+                  ▼                      ▼                        ▼
+             (speaking…)            pushed instantly         (speaking…)
+
+Context:     <code>npm install</code>   ← WRONG: arrived first
+             "Run this:"
+             "Then reload."
+```
+
+### The model: an ordered slot queue
+
+**Every** frame passing through `_push_tts_frames` takes a slot, whether or not it is
+spoken. **A skipped frame waits in the queue at its correct position.**
+
+```
+        head                                                   tail
+         │                                                       │
+         ▼                                                       ▼
+    ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
+    │  slot 1      │   │  slot 2      │   │  slot 3      │
+    │  SPOKEN      │──▶│  SKIPPED     │──▶│  SPOKEN      │
+    │ "Run this:"  │   │ npm install  │   │"Then reload."│
+    │ tracker ●    │   │ no tracker   │   │ tracker ●    │
+    │ complete: ✗  │   │              │   │ complete: ✗  │
+    └──────────────┘   └──────────────┘   └──────────────┘
+         ▲
+         └── flush() stops here: spoken, not complete
+```
+
+`flush()` walks from the head and applies one rule:
+
+| Slot at head | Action |
+| --- | --- |
+| Spoken **and** complete | Pop it, keep walking |
+| Skipped | Emit it, pop it, keep walking |
+| Spoken **and not** complete | **Stop** |
+
+**That single rule is the whole ordering guarantee.** As words arrive and slot 1 completes,
+the queue drains and slot 2 is released — in the right position, at the right time:
+
+```
+after "Run"      ┌─ SPOKEN ✗ ─┐  ┌─ SKIPPED ─┐  ┌─ SPOKEN ✗ ─┐   flush → nothing
+after "this:"    ┌─ SPOKEN ✓ ─┐  ┌─ SKIPPED ─┐  ┌─ SPOKEN ✗ ─┐   flush → pop, emit code, stop
+                                    ▲
+                                    └── released here
+```
+
+### Example: a blocked code block
+
+```python
+seq = AggregatedFrameSequencer(name="demo")
+await seq.register_spoken(spoken_frame, "ctx1", "Here is the code", append_to_context=True)
+await seq.register_skipped(code_frame, "ctx1", None)     # -> []  blocked
+```
+
+| call | frames returned |
+| --- | --- |
+| `register_skipped(code)` | *(nothing — held in the queue)* |
+| `process_word("Here")` | `TTSTextFrame('Here')`, `Progress(acc='Here', rem=' is the code')` |
+| `process_word("is")` | `TTSTextFrame('is')`, `Progress(acc='Here is', rem=' the code')` |
+| `process_word("the")` | `TTSTextFrame('the')`, `Progress(acc='Here is the', rem=' code')` |
+| `process_word("code")` | `TTSTextFrame('code')`, `Progress(…, rem='')`, **`AggregatedTextFrame("print('hi')")`** |
+
+The code block is released by **the very word that completes the sentence in front of
+it** — in the same call, in the correct position.
+
+On interruption `clear()` drops the whole queue, so a skipped frame whose preceding
+sentence was never finished is never recorded either.
+
+### Example: a straddling token
+
+A provider can return one token spanning two frames (`1111And`). The tracker splits it;
+the sequencer re-enters the overflow half against the next slot:
+
+| call | frames returned |
+| --- | --- |
+| `process_word("is")` | `TTSTextFrame('is')`, `Progress(acc='The code is', rem=' 1111')` |
+| `process_word("1111And")` | `TTSTextFrame('1111')`, `Progress(acc='The code is 1111', rem='')`, `TTSTextFrame('And')`, `Progress(acc='And', rem=' that is all')` |
+
+Both halves are attributed to the frame they actually belong to, and both progress frames
+reference the right segment.
+
+### Where a word goes when it does not fit
+
+A word that fails the active slot's `word_belongs_here` is not automatically a dropped
+event. Before force-completing anything, `process_word` asks **the next** slot for this
+context whether the word fits *there*:
+
+| Fits current | Fits next | Outcome |
+| --- | --- | --- |
+| yes | — | Normal advance |
+| no | **yes** | The provider dropped an event: the current slot is force-completed and the word carries over |
+| no | **no** | Buffered (streaming) or emitted as passthrough (non-streaming) — **the active tracker is left untouched** |
+
+That third row is what keeps one unrecognisable token from destroying a healthy slot. A
+word matching nothing is far more likely to be a provider quirk than proof that the
+sentence in front of it was skipped, so the sequencer declines to draw that conclusion
+from a single token. In streaming mode it is not even necessarily foreign — the sentence
+it belongs to may simply not have been promoted yet, which is why it is parked rather
+than passed through (see [§4](#4-token-mode-streaming)).
+
+### Example: a provider that drops events
+
+`force_complete` is the safety net. When an audio context ends with words still owed, it
+emits the remaining unspoken text so the context keeps the full sentence:
+
+```python
+seq.process_word("Hello", pts=1000, context_id="ctx1")   # -> TTSTextFrame + Progress
+seq.force_complete("ctx1", last_word_pts=2000)           # -> TTSTextFrame('there world')
+seq.process_word("there", pts=3000, context_id="ctx1")   # -> []  stale, dropped
+```
+
+---
+
+## 3. Concurrent contexts
+
+### The problem
+
+Two back-to-back `TTSSpeakFrame`s on a websocket service can be in flight simultaneously —
+`run_tts` returns before synthesis finishes. Their word-timestamp streams interleave. If
+words were routed to "the first incomplete slot", context B's words would be consumed by
+context A's slot and the transcript would be scrambled.
+
+### The model: three tiers of state
+
+**State is deliberately split rather than kept in one structure:**
+
+| Field | Scope | Lifetime |
+| --- | --- | --- |
+| `_slots` | **Global** | The one ordered timeline across all contexts — ordering is the point, so this stays a single list |
+| `_context_append_to_context` | **Per context** | Created at slot registration, removed by `force_complete`. Its *presence* marks the context live |
+| `_streaming_contexts` | **Per context** | Only while a sentence accumulates from tokens; released by `finalize` |
+
+Word routing is scoped by context, so an earlier incomplete slot belonging to another
+context is skipped over:
+
+```python
+await seq.register_spoken(a, "ctxA", "alpha one", append_to_context=True)
+await seq.register_spoken(b, "ctxB", "beta two", append_to_context=True)
+
+seq.process_word("beta",  pts=1000, context_id="ctxB")   # -> TTSTextFrame('beta')
+seq.process_word("alpha", pts=1000, context_id="ctxA")   # -> TTSTextFrame('alpha')
+```
+
+`ctxB`'s word reaches `ctxB`'s slot even though `ctxA`'s slot sits earlier in the queue and
+is still incomplete. A `None` context ID — legacy providers with no per-context tagging,
+where concurrency cannot occur — matches any slot.
+
+### Liveness and stale words
+
+**The presence of a `_context_append_to_context` entry is the "this context is live"
+signal.** A word for a context with no entry is **dropped as stale**. That is what stops
+word-timestamps a provider delivers seconds after an interruption from being interleaved
+into the next turn, and it is why `force_complete` forgets its context on the way out.
+
+`force_complete` deliberately leaves slots for *other* contexts alone, so their own words —
+or their own `force_complete` — finish them.
+
+---
+
+## 4. Token mode (streaming)
+
+### The problem
+
+With `TextAggregationMode.TOKEN`, the service dispatches word-sized chunks to the TTS
+rather than whole sentences. But word tracking and RTVI progress both need a *sentence*:
+you cannot report "accumulated vs remaining" for a segment that does not exist yet.
+
+Worse, a sentence boundary is only confirmed by **lookahead** — the first non-whitespace
+character of the *next* sentence. So **the sentence is always known one token late**, and
+word events for it can arrive before it exists.
+
+### The model: accumulate, promote, replay
+
+```mermaid
+flowchart TD
+    T["register_spoken(token)"] --> AGG["_ParallelSentenceAggregator<br/><i>tts · llm · user channels,<br/>accumulated in lockstep</i>"]
+    AGG -->|boundary confirmed| P["_promote()"]
+    AGG -->|end of turn| F["finalize()"] --> P
+    P --> SLOT["real slot + WordCompletionTracker"]
+    P --> REPLAY["_drain_buffered_words()"]
+    W["process_word(word)"] -->|no slot yet| BUF["_buffered_words"]
+    BUF --> REPLAY
+    REPLAY --> OUT["frames downstream"]
+    SLOT --> OUT
+```
+
+Promotion lagging one token behind, in practice:
+
+| call | frames returned |
+| --- | --- |
+| `register_spoken("Hi")` | *(nothing)* |
+| `register_spoken(" there!")` | *(nothing — boundary not yet confirmed)* |
+| `register_spoken(" Bye")` | **`AggregatedTextFrame('Hi there!')`** ← confirmed by the next token |
+| `process_word("Hi")` | `TTSTextFrame('Hi')`, `Progress(acc='Hi', rem=' there!')` |
+| `finalize("ctx1")` | **`AggregatedTextFrame(' Bye')`** |
+
+`finalize` is what rescues a response that ends without terminal punctuation.
+
+### Buffered words
+
+Because promotion lags, **a word can arrive before its slot exists**. It is parked, then
+replayed on the next promotion:
+
+| call | frames returned |
+| --- | --- |
+| `register_spoken("Hello")` | *(nothing)* |
+| `process_word("Hello")` | *(nothing — buffered)* |
+| `finalize("ctx1")` | `AggregatedTextFrame('Hello')`, `TTSTextFrame('Hello')`, `Progress(acc='Hello', rem='')` |
+
+`_drain_buffered_words` snapshots and clears the buffer before replaying, so a word that
+still matches nothing is re-buffered by `process_word` itself and waits for the next
+promotion, instead of looping.
+
+### Keeping the three channels aligned
+
+`_ParallelSentenceAggregator` accumulates all three texts in lockstep. A token stream is
+not guaranteed to be one word per token — a coarse chunk can carry the tail of one sentence
+*and* the head of the next — so where the cut lands matters:
+
+| Condition | Cut |
+| --- | --- |
+| All three channels identical (`_aligned`) | *Inside* the token, at the confirmed offset |
+| A transform has diverged them | At the token boundary |
+
+Once a transform has made the channels differ in length there is no shared character
+offset to cut at, so the whole triggering token starts the next sentence's buffer.
+
+Token mode requires `reuse_context_id_within_turn=True`: a promoted sentence built from
+several tokens is registered under one context ID, and every token's word events must
+arrive tagged with that same ID.
+
+---
+
+## Public surface
+
+| Method | Async | Purpose |
+| --- | :---: | --- |
+| `register_spoken(...)` | ✓ | A frame (or token) went to the TTS |
+| `register_skipped(...)` | ✓ | A frame bypassed the TTS; finalizes any pending sentence first |
+| `finalize(context_id)` | ✓ | End of text input — force-promote what is pending |
+| `process_word(word, pts, context_id)` | | One word-timestamp event |
+| `complete_spoken_slot()` | | Completion path for `push_text_frames=True` services |
+| `flush(last_word_pts=None)` | | Release whatever is now unblocked |
+| `force_complete(context_id, pts)` | | An audio context ended |
+| `clear()` | | Interruption — drop everything |
+
+The three async methods are async only because they may drive the token aggregator.
+Everything else is synchronous and returns a list of frames for the caller to push, which
+is what makes the sequencer straightforward to test.
+
+## Tests
+
+`tests/test_aggregated_frame_sequencer.py` — 134 tests.
+
+| Group | Classes |
+| --- | --- |
+| Slot mechanics | `RegisterSkipped`, `CompleteSpokenSlot`, `Flush`, `ForceComplete`, `Clear` |
+| Word routing | `ProcessWordBasic`, `ProcessWordRawText`, `ProcessWordOverflow`, `ProcessWordForcesComplete`, `WordsAfterUnrepeatedPunctuation`, `TokenizationShapeResilience` |
+| Streaming | `RegisterSpokenStreaming`, `RegisterSpokenBufferedWords`, `RegisterSkippedForcesFinalize`, `FinalizeEndOfTurn`, `FinalizeRescuesMidSentencePrefix`, `ClearResetsStreamingState`, `ParallelSentenceAggregator` |
+| Concurrency | `ConcurrentContexts` |
+| Language / RTVI | `CJKLanguages`, `CJKContextAssembly`, `CJKProcessWordFlagPropagation`, `AggregatedTextProgressFrame`, `VoiceFormattingTransforms` |
+
+End-to-end coverage lives in `tests/test_tts_frame_ordering.py`, which drives all three
+layers through mock HTTP, websocket, paused-websocket, and token-streaming services.

--- a/docs/architecture/word-trecking/improvements.md
+++ b/docs/architecture/word-trecking/improvements.md
@@ -1,0 +1,35 @@
+# Possible Improvements
+
+Observations about the current implementation that are worth revisiting. Nothing here is
+a bug — the behaviour is correct and covered by tests. These are places where the code
+could be clearer or sturdier, recorded so the reasoning is not lost.
+
+---
+
+## 1. The `user_facing_*` naming
+
+**Where:** `TextSegmentMap.user_facing_pos`, `WordCompletionTracker.user_facing_text`,
+`get_accumulated_user_facing_text()`, `get_remaining_user_facing_text()`, plus internal
+uses in `AggregatedFrameSequencer`.
+
+**The name describes one consumer rather than the text itself.** The channel is simply
+`AggregatedTextFrame.text` — the segment as the aggregator produced it — and the property
+that makes it useful is that a progress frame always splits it exactly:
+
+```
+accumulated_text + remaining_text == AggregatedTextFrame.text
+```
+
+Any processor holding the segment frame can rely on that. A UI highlighting spoken words
+is the common case, but a transcript writer, redaction filter, or logger consumes it on
+identical terms — so naming the channel after the UI makes the API read as more
+RTVI-specific than it is.
+
+**Candidate replacement:** `segment_text` / `segment_pos`, matching the `segment_id`
+already used on `AggregatedTextProgressFrame` and in the RTVI protocol.
+
+**Cost:** three public members plus a constructor parameter, all in
+`src/pipecat/utils/context/`. Nothing under `services/`, `processors/`, or `frames/`
+references the name, so a bot author never types it — but the members are public, so a
+rename needs the usual deprecation cycle.
+

--- a/docs/architecture/word-trecking/rtvi-integration.md
+++ b/docs/architecture/word-trecking/rtvi-integration.md
@@ -1,0 +1,174 @@
+# RTVI Integration
+
+> **Job:** turn tracked words into something a client can render and redact.
+
+The three tracking layers exist to produce two frames per spoken word. This document
+covers how those frames become RTVI messages, and how the [`code-helper`](https://github.com/pipecat-ai/pipecat-examples/tree/main/code-helper)
+client uses them. For how the frames themselves are built, see
+[AggregatedFrameSequencer](./aggregated-frame-sequencer.md#1-the-output-two-frames-per-word).
+
+## 1. What arrives here
+
+[`AggregatedFrameSequencer`](./aggregated-frame-sequencer.md#1-the-output-two-frames-per-word)
+emits two frames for every spoken word. Only one of them concerns RTVI:
+
+| Frame | Destination | Carries |
+| --- | --- | --- |
+| `TTSTextFrame` | The conversation context | The word, plus `raw_text` — the LLM span it represents |
+| `AggregatedTextProgressFrame` | **RTVI → the client** — and any other consumer | `segment_id` + `accumulated_text` / `remaining_text` |
+
+The progress frame is the one `RTVIObserver` turns into client messages: `segment_id` is
+the id of the sentence `AggregatedTextFrame` the word belongs to, which is **what lets a
+client match a stream of words back to a sentence it already rendered**.
+
+Nothing about the frame is RTVI-specific, though — `accumulated_text + remaining_text`
+reconstructs that frame's text exactly, so any processor holding the segment can position
+into it. RTVI is simply the consumer Pipecat ships, and the one this document follows.
+
+## 2. The segment lifecycle over RTVI
+
+`RTVIObserver` turns those frames into `bot-output` messages with a three-state lifecycle
+(protocol v2+):
+
+```
+   AggregatedTextFrame (sentence, will_be_spoken=True)
+            │
+            ▼
+   spoken_status = "new"            accumulated=""              remaining=<full sentence>
+            │                        ← client renders the sentence, stores segment_id
+            │
+   AggregatedTextProgressFrame (per word)
+            │
+            ▼
+   spoken_status = "in-progress"    accumulated="Your balance"  remaining=" is $42.50"
+   spoken_status = "in-progress"    accumulated="Your balance is" remaining=" $42.50"
+            │                        ← client re-renders the bold/plain split
+            ▼
+   spoken_status = "completed"      accumulated=<full sentence> remaining=""
+```
+
+**The status is derived, not tracked:** the observer emits `"completed"` exactly when
+`remaining == ""`.
+
+Word- and token-level `bot-output` events are **suppressed** for v2 clients — progress is
+covered entirely by `spoken_status` / `spoken_progress`, so the client sees one clean
+stream of sentence-scoped updates rather than two overlapping ones.
+
+That lifecycle belongs to the word-timestamp path. A `push_text_frames=True` service has
+no word events to drive it, so its `TTSTextFrame` arrives only once synthesis is done and
+the observer emits a single `"completed"` with the whole segment already accumulated. A
+client that assumes it will always see `"new"` first has to handle that.
+
+## 3. Bot output transforms
+
+`bot_output_transforms` let the application rewrite text before it reaches the client —
+the credit-card redaction case. The progress-aware signature receives all three pieces:
+
+```python
+async def obfuscate_credit_card(
+    text: str,
+    agg_type: str,
+    accumulated_text: str | None = None,
+    remaining_text: str | None = None,
+) -> BotOutputTransformResult:
+    transformed = "XXXX-XXXX-XXXX-" + text[-4:]
+    if accumulated_text is not None and remaining_text is not None:
+        # Keep the highlight split proportional to the original
+        ratio = len(accumulated_text) / max(len(text), 1)
+        split = int(ratio * len(transformed))
+        return BotOutputTransformResult(
+            text=transformed,
+            accumulated_text=transformed[:split],
+            remaining_text=transformed[split:],
+        )
+    return BotOutputTransformResult(text=transformed)
+```
+
+**This is the capability that was impossible before:** the transform receives a **whole
+segment** plus the current spoken split, so it can redact the full card number *and* keep
+the highlight advancing over the redacted form. Given only disconnected word events
+(`1234`, `5678`, `9012`, `3456`) there is nothing coherent to redact.
+
+Transforms are registered per aggregation type, matching the types defined by the
+`PatternPairAggregator`:
+
+```python
+rtvi_observer_params=RTVIObserverParams(
+    bot_output_transforms=[("credit_card", obfuscate_credit_card)]
+)
+```
+
+Use `"*"` to match every type.
+
+## 4. The client side
+
+With the server doing the work, `code-helper`'s client is almost trivial
+(`client/src/app.js`):
+
+```js
+onBotOutput: (data) => {
+  // A segment that is being spoken → update the highlight
+  if (data.will_be_spoken && data.spoken_status !== 'new') {
+    this.highlightSpokenText(data);
+    return;
+  }
+  // Anything else (including spoken_status "new") → render a new bubble element
+  this.addConversationMessage(
+    data.text, 'bot', data.aggregated_by, data.segment_id,
+  );
+}
+
+highlightSpokenText(data) {
+  const curSpan = this.botSpans[data.segment_id];      // ← segment_id closes the loop
+  if (!curSpan) return;
+  const accumulatedText = data.spoken_progress.accumulated_text.replace(/\n/g, ' <br> ');
+  const remainingText   = data.spoken_progress.remaining_text.replace(/\n/g, ' <br> ');
+  curSpan.innerHTML = `<strong>${accumulatedText}</strong>${remainingText}`;
+}
+```
+
+`data.aggregated_by` carries the segment type, so the client also renders a `code` segment
+as a syntax-highlighted `<pre>` block and a `link` segment as an anchor — **without parsing
+any tags itself**.
+
+## 5. Everything together: code-helper
+
+The bot ([`code-helper/server/bot.py`](https://github.com/pipecat-ai/pipecat-examples/tree/main/code-helper/server/bot.py)) wires the whole stack in
+four steps:
+
+```python
+# 1. Aggregate the LLM's tagged segments into typed units
+llm_text_aggregator.add_pattern(type="credit_card",
+                                start_pattern="<card>", end_pattern="</card>",
+                                action=MatchAction.AGGREGATE)
+
+# 2. Never send code blocks to the TTS  →  sequencer holds them in order
+tts = CartesiaTTSService(..., skip_aggregator_types=["code"])
+
+# 3. Rewrite what the TTS receives  →  TextSegmentMap tracks the divergence
+tts.add_text_transformer(spell_out_text, "credit_card")   # wraps in <spell> tags
+tts.add_text_transformer(strip_url_protocol, "link")      # drops "https://"
+
+# 4. Redact what the client renders  →  progress frames make it possible
+rtvi_observer_params=RTVIObserverParams(
+    bot_output_transforms=[("credit_card", obfuscate_credit_card)]
+)
+```
+
+For one sentence, all four channels stay correct and independent:
+
+| Channel | Text |
+| --- | --- |
+| What the LLM produced | `Your card is <card>1234-5678-9012-3456</card>` |
+| What the TTS received | `Your card is <spell>1234-5678-9012-3456</spell>` |
+| What the context stored | `Your card is <card>1234-5678-9012-3456</card>` |
+| What the user saw | `Your card is XXXX-XXXX-XXXX-3456`, bolded word by word |
+
+And the code block, which is never spoken, still lands in the transcript **after** the
+sentence that precedes it — **because it waited its turn in the sequencer's slot queue**.
+
+## Related
+
+- [Architecture overview](./README.md)
+- [TextSegmentMap](./text-segment-map.md) — where the accumulated/remaining split comes from
+- [AggregatedFrameSequencer](./aggregated-frame-sequencer.md) — where the frames are built

--- a/docs/architecture/word-trecking/text-segment-map.md
+++ b/docs/architecture/word-trecking/text-segment-map.md
@@ -1,0 +1,552 @@
+# TextSegmentMap
+
+`src/pipecat/utils/context/text_segment_map.py`
+
+> **Job:** given a word the TTS just spoke, say where we are in *all three* texts.
+
+## 1. The problems
+
+### 1.1 The spoken word does not appear in the original text
+
+A provider tells you it just spoke `dollars`. Nothing in that event says which part of
+`Your balance is $42.50` you have reached — **the word does not appear in that text at
+all**.
+
+Every transform opens the same gap:
+
+| Transform | Original | Sent to TTS |
+| --- | --- | --- |
+| Currency expansion | `$42.50` | `forty-two dollars and fifty cents` |
+| Number expansion | `room 1994` | `room 1 9 9 4` |
+| SSML markup | `1234-5678` | `<spell>1234-5678</spell>` |
+| URL cleanup | `https://pipecat.ai` | `pipecat.ai` |
+| Pattern delimiters | `<card>4111</card>` | `4111` |
+
+Without a mapping, **a consumer cannot tell where in the sentence the audio has reached** —
+a UI has nothing to highlight, and a redaction filter has no split to redact around.
+
+### 1.2 The context drifted from what the LLM wrote
+
+The second problem is the one that silently degrades a bot over time. When an aggregator
+splits a segment into content and delimiters — a `PatternPairAggregator` match yields
+`text='4111'` alongside `raw_text='<card>4111</card>'` — only the content is synthesized.
+If the context is then rebuilt from what the TTS spoke, **the tags vanish from the
+conversation history**. The LLM sees a transcript where its own convention is absent and
+stops producing it.
+
+That is why the map tracks a *third* text. The two it compares are `tts_text` and
+`original_text` (the **segment text** — see
+[how the three texts are produced](./README.md#31-three-texts-produced-at-two-split-points));
+`llm_text` rides along on its own cursor:
+
+| Cursor | Text | Indexes |
+| --- | --- | --- |
+| `raw_pos` | `Your card is 4111` | The TTS text — the only cursor that really moves |
+| `user_facing_pos` | `Your card is 4111` | The segment text — e.g. what the UI highlights |
+| `llm_pos` | `Your card is <card>4111</card>` | The LLM text — what the conversation context records |
+
+All three are **zero-based character indices**, and each points *just past* what has been
+consumed: `text[:pos]` is everything spoken so far, `text[pos]` is the next character. A
+cursor equal to `len(text)` therefore means finished. Character indices, not byte offsets
+— `→` advances a cursor by 1, not by its 3 UTF-8 bytes.
+
+Walking that example one word at a time, the two follower cursors stay together until the
+tag appears, then part:
+
+| word | `raw_pos` | `user_facing_pos` | `llm_pos` | LLM text consumed |
+| --- | ---: | ---: | ---: | --- |
+| `Your` | 4 | 4 | 4 | `Your` |
+| `card` | 9 | 9 | 9 | `Your card` |
+| `is` | 12 | 12 | 12 | `Your card is` |
+| `4111` | 17 | 17 | **23** | `Your card is <card>4111` |
+
+`llm_pos` jumps to 23 rather than 17 because it stepped over `<card>` on the way to the
+digits. The opening tag is therefore attributed to the word `4111` and reaches the context
+with it. (The closing tag is swept up by
+[`WordCompletionTracker`](./word-completion-tracker.md) when the frame completes.)
+
+Something has to translate a position in the spoken stream into a position in *both* other
+texts. That is the entire job of `TextSegmentMap`.
+
+### Why the third text needs no comparison
+
+Only two of the three texts are ever compared against each other. `llm_text` is not, and
+does not need to be, because of one fact about it:
+
+> **`llm_text` holds the same letters and digits as `original_text`, in the same order.
+> It differs only in what is wrapped around them** — tags, delimiters, punctuation.
+
+So the map never has to find matching *positions* in `llm_text`; it only has to count.
+Each time a word is spoken, it counts the letters and digits that word used up and moves
+`llm_pos` past that many, stepping over any tags on the way for free.
+
+**Where the two texts come from.** Both are fields of the same `AggregatedTextFrame`, and
+the sequencer hands them over as `user_facing_text=frame.text` and
+`llm_text=frame.raw_text or frame.text`:
+
+| Field | Holds | Set by |
+| --- | --- | --- |
+| `text` | The content alone — `4111` | Every aggregation |
+| `raw_text` | The content *with* its delimiters — `<card>4111</card>` | Only a `PatternMatch` |
+
+That is what makes the premise hold today, in two steps:
+
+1. **For an ordinary aggregation, the two are the same string.** `LLMTextProcessor` sets
+   `raw_text=aggregation.text` for anything that is not a `PatternMatch`, so there is
+   nothing to keep in step. This is the common case, including every
+   `SimpleTextAggregator` sentence.
+2. **For a `PatternMatch`, `raw_text` is `full_match`** — the regex match of
+   start-delimiter + content + end-delimiter — while `text` is the content between them.
+   Same characters, in the same order, with delimiters added around them.
+
+**The condition step 2 rests on** is that a delimiter contributes no letters or digits of
+its own. Tag-shaped delimiters satisfy it because `advance_by_alnums` crosses `<...>` for
+free and `alnum_only` strips it; punctuation-only delimiters satisfy it because they have
+no letters to begin with:
+
+```
+llm_text                    after speaking "hello world"
+'<card>hello world</card>'  llm_pos=17  consumed '<card>hello world'
+'**hello world**'           llm_pos=15  consumed '**hello world**'
+```
+
+## 2. Building the map: opcodes
+
+At construction the map compares the TTS text against the original text using
+`difflib.SequenceMatcher`, **at word level** (the text is tokenized on whitespace, keeping
+the whitespace as tokens so offsets stay exact).
+
+### What an opcode is
+
+`SequenceMatcher` does not just say "these differ" — it returns a list of **opcodes**,
+each one an instruction describing how a run of the original maps onto a run of the TTS
+text. There are four kinds:
+
+| Opcode | Meaning | Produced by |
+| --- | --- | --- |
+| `equal` | This run is identical on both sides | Any untouched text — the common case |
+| `replace` | This run of the original was rewritten into that run of the TTS text | Every value transform and every added tag |
+| `delete` | This run exists in the original but not in the TTS text | A filter that removes a whole word |
+| `insert` | This run exists in the TTS text but not in the original | A transform that adds a whole word |
+
+All four occur, and the code treats them the same way, so none is a special case.
+`equal` and `replace` are by far the most common.
+
+What that looks like for a currency expansion:
+
+```
+original = 'Your balance is $42.50'
+tts      = 'Your balance is forty-two dollars and fifty cents'
+
+   equal    original='Your balance is '   tts='Your balance is '
+   replace  original='$42.50'             tts='forty-two dollars and fifty cents'
+```
+
+`delete` and `insert` produce a segment with one empty side; both are covered in
+[Empty-sided segments](#empty-sided-segments).
+
+Each opcode becomes one `TextSegment`, carrying both sides plus the span it occupies in
+the original text:
+
+```python
+TextSegment(original='$42.50',
+            tts='forty-two dollars and fifty cents',
+            original_start=16, original_end=22)
+```
+
+### Transformed vs unchanged segments
+
+A segment is **transformed** (`TextSegment.is_transformed`) when **its two sides cannot be
+followed together, character by character**. Three things trigger it:
+
+1. The letters and digits differ (`$42.50` vs `forty-two dollars…`)
+2. The number of words differs (a replacement changed how the text splits)
+3. The TTS side contains a tag — even if the spoken words are identical
+
+That third rule is why `<phoneme alphabet="ipa">Siobhan</phoneme>` counts as transformed:
+the raw cursor must move through the tag characters while the original cursor stays put.
+
+### Splitting markup into its own segment
+
+Rule 3 has a cost. A segment holding *any* tag is all-or-nothing, so one tag in the middle
+of otherwise identical text would hold the cursors still across the whole sentence. To
+limit that, `_build_segments` cuts an `equal` opcode around the tags it carries, using
+`split_markup_runs` from
+[`pipecat.utils.text.markup_utils`](#5-the-two-markup-strippers):
+
+```python
+split_markup_runs("I love to count <spell>1234</spell>.")
+# -> ["I love to count ", "<spell>1234</spell>."]
+```
+
+```
+"I love to count "       plain           — cursors move word by word
+"<spell>1234</spell>."   all-or-nothing  — lands as one when its last word arrives
+```
+
+Only `equal` opcodes can be split this way: both sides hold the same text, so a single
+offset cuts both. The other kinds differ side to side, leaving no shared offset to cut at.
+
+## 3. Walking the map: one cursor drives three
+
+There is exactly one real cursor — `raw_pos`, the position reached in the TTS text.
+`user_facing_pos` and `llm_pos` are derived from it:
+
+- **Unchanged segment** — they move by a **count, not a position**: however many letters
+  and digits the word used up on the TTS side is how many each of the other two cursors
+  moves past.
+- **Transformed segment** — they are *held* until the segment's entire TTS text is
+  consumed, then **jump to the end of its original span in one step**. There is no
+  meaningful position halfway through `$42.50`, so the map refuses to invent one.
+
+  The count spent on that jump is the **original's** letters and digits, not the spoken
+  one's: `llm_text` holds `$42.50` (four digits), never `forty-two dollars and fifty
+  cents`. That is why `TextSegment` carries both `tts_alnum_count` and
+  `original_alnum_count` — the two sides of a rewritten segment need different counts.
+
+### Counting is what attaches tags to words
+
+`advance_by_alnums` does the counting, and two of its rules are the whole reason the tag
+behaviour in [§1.2](#12-the-context-drifted-from-what-the-llm-wrote) works:
+
+- **A `<...>` tag is crossed for free**, without using up any of the count. The cursor
+  ends up past the tag with its count untouched, so an opening tag travels with the word
+  that follows it. This is why `llm_pos` reaches 23 rather than 17 in that section's
+  table: `<card>` cost nothing, and four digits cost four.
+- **Punctuation right after the count runs out is taken too**, stopping before the next
+  space, letter, digit, or `<`. So a trailing `,` or `.` travels with the word *before*
+  it — the provider reports `Yeah`, the context records `Yeah,`.
+
+Nothing decides which words own which tags. One loop counts letters and digits and steps
+over everything else; where the tags land simply follows from that. The closing tag is
+the one thing the loop deliberately stops short of — it is swept up by
+[`WordCompletionTracker`](./word-completion-tracker.md) when the frame completes.
+
+### Worked example
+
+```python
+TextSegmentMap(
+    tts_text      = "Your balance is forty-two dollars and fifty cents",
+    original_text = "Your balance is $42.50",     # frame.text — the segment text
+    llm_text      = "Your balance is $42.50",     # frame.raw_text
+)
+```
+
+Feeding the eight spoken words in one at a time:
+
+| word | `raw_pos` | `user_facing_pos` | `llm_pos` | `in_transformed_segment` | segment text consumed |
+| --- | ---: | ---: | ---: | --- | --- |
+| `Your` | 4 | 4 | 4 | False | `Your` |
+| `balance` | 12 | 12 | 12 | False | `Your balance` |
+| `is` | 15 | 15 | 15 | False | `Your balance is` |
+| `forty-two` | 25 | 15 | 15 | **True** | `Your balance is` |
+| `dollars` | 33 | 15 | 15 | **True** | `Your balance is` |
+| `and` | 37 | 15 | 15 | **True** | `Your balance is` |
+| `fifty` | 43 | 15 | 15 | **True** | `Your balance is` |
+| `cents` | 49 | **22** | **22** | False | `Your balance is $42.50` |
+
+The raw cursor climbs steadily. **The other two freeze at 15 for four words, then jump
+straight to 22** when the segment completes. `last_completed_segment` then reports the
+`$42.50` segment — the signal callers use to attribute the whole original span to the word
+that finished it.
+
+Here `llm_text` and the segment text are the same string, so the last two columns move
+together — the common case with the default `SimpleTextAggregator`. They diverge only when
+an aggregator splits content from delimiters: with `llm_text="Your balance is
+<price>$42.50</price>"`, `llm_pos` steps over the tags that `user_facing_pos` never sees.
+
+### Empty-sided segments
+
+A `delete` or `insert` opcode produces a segment with nothing on one side. Both count as
+transformed, since their two sides differ, and both work out without any special case in
+the code:
+
+**`delete` — text that exists only in the original.** The segment's TTS side is empty, so
+no word will ever arrive for it. It is finished as soon as the next word shows up, and its
+original text is credited to that word:
+
+```
+tts='Hello world'   original='Hello there world'
+
+  word='Hello'   user_facing_pos=5    'Hello'
+  word='world'   user_facing_pos=17   'Hello there world'   ← 'there ' folded in here
+```
+
+The deleted word is never lost from the segment text or the context; it is simply never
+spoken.
+
+**`insert` — text that exists only in the TTS side.** The segment's original span is
+empty (`original_start == original_end`), so the inserted word consumes raw text but
+advances the other two cursors by nothing:
+
+```
+tts='Hello there world'   original='Hello world'
+
+  word='Hello'   raw_pos=5    user_facing_pos=5
+  word='there'   raw_pos=12   user_facing_pos=6    ← raw moves, original does not
+  word='world'   raw_pos=17   user_facing_pos=11
+```
+
+## 4. Matching real provider tokens
+
+The other half of the job: word-timestamp tokens are *messy*, and no two providers agree.
+**Rather than special-casing each one**, `_classify_hop` matches the token against the
+text left in the segment using three strategies, in order, stopping at the first hit. Each
+one lives in its own method — `_literal_hop`, `_folded_hop`, `_markup_hop` — so
+`_classify_hop` itself only decides the order and what to do when all three miss.
+
+```mermaid
+flowchart TD
+    W(["incoming token"]) --> S1
+
+    S1{"<b>1 · literal</b><br/>at 3 skip offsets<br/><i>as-is · past whitespace ·<br/>past all punctuation</i>"}
+    S1 -->|hit| R
+    S1 -->|miss| S2
+
+    S2{"<b>2 · variation folded</b><br/><i>case · accents · typography,<br/>word boundary required</i>"}
+    S2 -->|hit| R
+    S2 -->|miss| S3
+
+    S3{"<b>3 · markup stripped</b><br/><i>tags removed from<br/>both sides</i>"}
+    S3 -->|hit| R
+    S3 -->|miss| ST
+
+    R(["<b>PLACED</b> — fits here<br/><b>CROSSES</b> — spills onward"])
+    ST{"any alphanumeric<br/>left in this segment?"}
+    ST -->|no| EX(["<b>EXHAUSTED</b><br/>finish segment, try the next"])
+    ST -->|yes| NM(["<b>NO_MATCH</b><br/>nudge past punctuation, stop"])
+```
+
+Every strategy also retries with the token's own trailing punctuation removed
+(`_word_variants`), and the first two are offered three starting points into the segment
+(`_match_candidates`): the text as it is, past any spaces, and past everything that is not
+a letter or digit.
+
+**The whole thing is stateless** — worked out fresh on every call, with no tag parsing and
+nothing remembered between words.
+
+### Which strategy fires, for real token shapes
+
+| Provider behaviour | Segment remaining | Token | Strategy | Result |
+| --- | --- | --- | --- | --- |
+| Plain word | `hello world` | `hello` | 1 literal | `PLACED` (5 chars) |
+| Token carries its own leading space (Inworld) | `" world"` | `" world"` | 1 literal | `PLACED` (6 chars) |
+| Provider skipped punctuation it did not speak | `", I can help"` | `I` | 1 literal *(skip offset)* | `PLACED` (3 chars) |
+| Provider added a terminal period | `account and more` | `account.` | 1 literal *(trailing trim)* | `PLACED` (7 chars) |
+| Provider lowercased the word | `SQL is great` | `sql` | 2 folded | `PLACED` (3 chars) |
+| Provider stripped a diacritic | `café open` | `cafe` | 2 folded | `PLACED` (4 chars) |
+| Provider normalized an apostrophe | `don’t worry` | `don't` | 2 folded | `PLACED` (5 chars) |
+| Token reported without its tags | `<spell>1234</spell> ok` | `1234` | 3 markup | `PLACED` (11 chars) |
+| Token straddles the frame boundary | `1111` | `1111And` | 1 literal | `CROSSES` (4 chars used) |
+| Foreign token (dropped event upstream) | `hello world` | `goodbye` | none | `NO_MATCH` |
+| Nothing spoken left here | `<break/>` | `hello` | none | `EXHAUSTED` |
+
+Note how strategy 1 alone covers four different provider quirks, because it tries three
+starting points *and* a trailing-punctuation-trimmed form of the token.
+
+Strategy 2 has one extra rule: because folding hides case, `account` would otherwise match
+the start of `Accountant`, so a match there is only accepted if it ends where a word ends.
+Strategy 1 needs no such guard, being case-sensitive already.
+
+### The four outcomes
+
+| Outcome | Meaning | Effect |
+| --- | --- | --- |
+| `PLACED` | Token fits inside this segment | Move to the end of the match, stop |
+| `CROSSES` | This segment holds only the start of the token | Finish the segment, carry the **rest of the token** onward |
+| `EXHAUSTED` | Nothing here can be spoken | Finish the segment, carry the **whole token** onward |
+| `NO_MATCH` | Token does not belong here | Step past leading punctuation, stop |
+
+Each outcome is returned as a `_Hop`, carrying two numbers: `segment_advance`, how far to
+move in this segment, and `word_consumed`, how much of the token this segment used up.
+
+`PLACED` and `NO_MATCH` end the walk. **`CROSSES` and `EXHAUSTED` do not** — they finish
+the current segment and move to the next one, where the token is matched again from
+scratch. The difference between them is only **how much of the token survives the hop**.
+
+The walk itself is worked out by `_plan_hops`, which decides what every segment would
+answer without moving anything. `_consume_word` then applies those answers, and
+`_can_consume_word` (the dry run behind `word_belongs_current_segment`) just reads the
+last one. Both go through the same walk, so the dry run cannot disagree with the real one.
+
+**`CROSSES` — the token outlives the segment.** A provider that merges two words into one
+token produces this. The segment's remaining text is consumed as a prefix of the token,
+the segment completes (jumping the cursors, since it is now finished), and the unmatched
+tail is re-classified against the next segment:
+
+```
+tts='Hello five'   original='Hello 5'
+  seg0: 'Hello '  (unchanged)
+  seg1: '5' → 'five'  (transformed)
+
+  token 'Hello five'
+    ├─ seg0: CROSSES, 6 chars consumed → seg0 completes, remainder 'five'
+    └─ seg1: PLACED  → seg1 completes, user_facing_pos jumps to 7 ('Hello 5')
+```
+
+One incoming token therefore completed two segments and moved the segment-text cursor
+across a transform, in a single `advance_word` call.
+
+**`EXHAUSTED` — the segment has nothing to give.** No letters or digits are left to speak
+here (a `delete` opcode's empty side, a self-closing `<break/>`, or only trailing spaces),
+so no word will ever match it. The segment is finished and the *entire* token — none of it
+was used — moves to the next segment:
+
+```
+tts='Hello world'   original='Hello there world'
+  seg1: 'there ' → ''   (delete opcode, nothing to speak)
+
+  token 'world'
+    ├─ seg1: EXHAUSTED, 0 chars consumed → seg1 completes, token unchanged
+    └─ seg2: PLACED  → 'world' lands, user_facing_pos jumps past 'there ' too
+```
+
+If a `CROSSES` remainder runs out of segments entirely, the leftover is exposed as
+`last_overflow` — that is the straddling-token case the frame above handles.
+
+### Symbol tokens: the dry run accepts what the walk will not place
+
+A token with no letters or digits in it at all — an emoji, a bare punctuation mark, or a
+symbol the provider swapped for another (ElevenLabs reports `→` as `-`) — cannot be
+matched by any of the three strategies, because there is nothing to compare.
+`word_belongs_current_segment` falls through to a separate check, `_symbol_belongs_here`,
+which accepts the token when either:
+
+1. it appears as-is in the text still to be spoken (the search starts a little before the
+   cursor, since punctuation is often taken along with the word before it), or
+2. words remain to be spoken **and** the next thing in the text is itself a symbol — the
+   swap case, where the reported symbol will never match the character it stands for.
+
+`advance_word` does **not** consult this path. A substituted symbol therefore passes
+`word_belongs_here` — so the slot is not force-completed over it — and then classifies as
+`NO_MATCH`, nudging the raw cursor past leading punctuation and stopping. The token is
+accepted without being placed, which is the right outcome for a mark the source text
+spells differently.
+
+Feeding a provider's tokens for `Step one → step two`, where the arrow is reported as `-`:
+
+| token | `word_belongs_…` | outcome | `raw_pos` | `user_facing_pos` |
+| --- | --- | --- | ---: | ---: |
+| `Step` | True | `PLACED` | 4 | 4 |
+| `one` | True | `PLACED` | 8 | 8 |
+| `-` | **True** | **`NO_MATCH`** | **11** | **8** |
+| `step` | True | `PLACED` | 15 | 15 |
+| `two` | True | `PLACED` | 19 | 19 |
+
+The `-` is accepted but never placed. On its row the raw cursor moves from 8 to 11,
+stepping over ` → ` so the next token is not blocked by it, while `user_facing_pos` holds
+at 8 — nothing the source text spells was actually spoken. `step` then lands normally and
+the frame completes.
+
+Spelling out what each `raw_pos` above points at:
+
+```
+  pos= 4  consumed='Step'                 next char=' '
+  pos= 8  consumed='Step one'             next char=' '
+  pos=11  consumed='Step one → '          next char='s'
+  pos=15  consumed='Step one → step'      next char=' '
+  pos=19  consumed='Step one → step two'  next char=(end)
+```
+
+Had the dry run rejected `-`, the caller would have read that as a dropped event and
+force-completed the frame. No text would be lost — `_force_complete` emits the entire
+unspoken remainder at once — but `→ step two` would arrive as a single lump attributed to
+the `-`, instead of `step` and `two` arriving as their own timed words.
+
+### Trimming a token to what it actually covers
+
+The raw cursor stops *before* punctuation trailing a word, so the next token can still
+match it. `advance_by_alnums` meanwhile sweeps that same mark into the preceding word's
+span. The two conventions differ by exactly one character:
+
+```
+"Yeah, I can do that."   after advance_word("Yeah")
+   raw_pos = 4    ← before the comma, so ", I" can still match here
+   llm_pos = 5    ← after it, swept into Yeah's span
+```
+
+Both are deliberate, and the gap is visible whenever a provider reports the mark leading
+the *following* token (`, I` rather than `I`) — it would then be carried twice.
+`last_leading_duplicate` reports how many of the token's leading characters to drop,
+positionally: the token's leading punctuation run, when `llm_pos` has just moved past
+exactly that mark.
+
+| after | token | `last_leading_duplicate` | |
+| --- | --- | ---: | --- |
+| `Yeah` (span `Yeah,`) | `, I` | **2** | the comma and its space |
+| `Yeah` (span `Yeah,`) | `I` | 0 | nothing repeated |
+| `Yeah` (span `Yeah,`) | `, ` | 0 | the mark as its own event stands for this position |
+| `He said` | `"hello` | 0 | the quote is content, not yet passed |
+
+It is the mirror of [`last_overflow`](#the-four-outcomes): one reports the head of the
+token that is not this frame's, the other the tail. Callers keep what is between them.
+
+## 5. The two markup strippers
+
+These are not in this file — they live in `src/pipecat/utils/text/markup_utils.py`,
+shared so that every part of the codebase decides what counts as a tag the same way. Two
+of them matter here, and they treat a lone `<` in **opposite** ways:
+
+| Function | Input | `5 < 10` becomes | Used by |
+| --- | --- | --- | --- |
+| `strip_markup` | A token that may be cut off mid-tag | `5 ` | `_markup_hop` |
+| `strip_complete_markup` | A whole, finished text | `5 < 10` | `is_transformed`, default segment text |
+
+Each is only ever applied where its assumption holds, so the disagreement never bites.
+Provider tokens really can end mid-tag — some providers split `<phoneme alphabet="ipa"`
+across two word-timestamp events — and there a trailing `<` is an unfinished tag. Texts we
+assembled ourselves are never cut off, so there a lone `<` is content the LLM wrote:
+`5 < 10`, `I <3 this`, `List<int>`. Swallowing the rest of the sentence would silently
+drop real text.
+
+## 6. Public surface
+
+| Member | Purpose |
+| --- | --- |
+| `advance_word(word)` | Consume one token, moving all cursors |
+| `word_belongs_current_segment(word)` | Non-mutating dry run, plus the symbol check `advance_word` skips |
+| `user_facing_pos` / `llm_pos` / `raw_pos` | The three cursors (`user_facing_pos` indexes the segment text) |
+| `is_complete` | Every letter and digit has been spoken |
+| `in_transformed_segment` | Cursor sits mid-transform (callers suppress context writes) |
+| `last_completed_segment` | Segment finished by the last `advance_word` |
+| `last_overflow` | Raw suffix that ran past the end of the TTS text |
+| `last_leading_duplicate` | Leading chars of the token already carried by the previous word |
+| `reset()` | Rewind every cursor, keep the segments |
+
+Two details in `is_complete` are worth knowing. A frame whose remaining text is nothing
+but punctuation or tags already counts as complete, because a closing tag never arrives as
+its own token. The exception is punctuation set off by a space, as French writes
+`Comment ça va ?` — that *does* arrive as its own token, so
+`_pending_separated_punctuation` keeps the frame open until it does.
+
+## 7. Tests
+
+`tests/test_text_segment_map.py` — 54 tests.
+
+| Class | Covers |
+| --- | --- |
+| `TestTextSegmentMapBuild` | Segment construction and spans |
+| `TestTextSegmentMapAdvance` | Cursors holding and jumping |
+| `TestTextSegmentMapWithLlmText` | The third cursor |
+| `TestTextSegmentMapReset` | Rewind and replay |
+| `TestTextSegmentMapEqualTexts` | The no-transform case |
+| `TestTextSegmentMapTokenChangingReplacements` | Replacements that change the word count |
+| `TestTextSegmentMapSsmlPhonemeTag` | Tag segments |
+| `TestTextSegmentMapStrayAngleBracket` | A lone `<` as content |
+| `TestClassifyHopLiteralMatchHandlesStrayAngleBracket` | Which strategy matched a `<` |
+| `TestClassifyHopSkipsLeadingPunctuation` | The three starting points |
+| `TestClassifyHopCaseFoldRequiresWordBoundary` | The `account` / `Accountant` guard |
+| `TestClassifyHopFoldsTypographicVariants` | Quotes and dashes |
+| `TestFoldPreservesLength` | Folding never changes a string's length |
+| `TestProviderTokenShapes` | Tokens carrying their own spacing |
+| `TestWordCarriesItsOwnPunctuation` | Provider-added terminal punctuation |
+| `TestLeadingDuplicatePunctuation` | A mark reported with the following word |
+
+`tests/test_markup_utils.py` — 20 tests, covering the shared helpers this file leans on.
+
+| Class | Covers |
+| --- | --- |
+| `TestStripMarkupHelpers` | `strip_markup` and the `raw_offset_after_clean_chars` round-trip |
+| `TestStripCompleteMarkupHelper` | A lone `<` kept as content |
+| `TestSplitMarkupRuns` | Giving a tag its own run |
+| `TestHasAlnum` | `has_alnum` agreeing with `alnum_only`, tags included |

--- a/docs/architecture/word-trecking/word-completion-tracker.md
+++ b/docs/architecture/word-trecking/word-completion-tracker.md
@@ -1,0 +1,245 @@
+# WordCompletionTracker
+
+`src/pipecat/utils/context/word_completion_tracker.py`
+
+> **Job:** for each spoken word — how much of it is this frame's, which original text
+> does it stand for, and is the frame finished?
+
+## 1. The problem
+
+[`TextSegmentMap`](./text-segment-map.md) will tell you where a spoken word lands. It
+will not tell you what to *do* about it, and it assumes the provider behaves.
+
+TTS providers do not behave. A tracker owns one `AggregatedTextFrame` from dispatch to
+"fully spoken", and has to survive:
+
+- **Dropped events** — the provider silently never reports a word it spoke. Waiting
+  forever would stall the frame and everything queued behind it, so the frame ends early
+  and emits its own remainder.
+- **Text no word arrives for** — a closing `</card>`, or a tag between the last word and
+  its punctuation, is never spoken. Whatever is left once everything speakable is done
+  belongs to this frame, so the word that finishes it claims the rest.
+- **Tokens that overhang the frame** — a token can spill into the next frame (`1111And`)
+  or lead with punctuation the previous word already carried (`, I`). Only the middle is
+  this frame's.
+
+So the tracker is the *policy* layer: **the map says where things are, the tracker decides
+what that means for this frame**.
+
+## 2. What it produces per word
+
+One call in, several answers out — each one read back by
+[`AggregatedFrameSequencer`](./aggregated-frame-sequencer.md) to build the frames it
+pushes downstream:
+
+```python
+tracker = WordCompletionTracker(
+    tts_text="Your card is 4111 1111 thanks",
+    llm_text="Your card is <card>4111 1111</card> thanks",
+    user_facing_text="Your card is 4111 1111 thanks",
+)
+complete = tracker.add_word_and_check_complete("4111")
+```
+
+| Accessor | Read by | Used for |
+| --- | --- | --- |
+| `word_belongs_here()` | `process_word` | Decide whether the provider dropped an event, and this slot must be force-completed |
+| `add_word_and_check_complete()` | `process_word` | Advance, and learn whether the slot is now done |
+| `get_word_for_frame()` | `process_word` | The **text** of the emitted `TTSTextFrame` |
+| `get_llm_consumed()` | `process_word` | The **`raw_text`** of that frame — what the conversation context records |
+| `suppress_in_context()` | `process_word` | Sets `append_to_context=False` and skips the progress frame |
+| `get_overflow_word()` | `process_word` | Re-entered as a new word against the *next* slot |
+| `get_accumulated_user_facing_text()` | `_build_progress_frame` | `accumulated_text` → the spoken part of the segment text (what a UI highlights) |
+| `get_remaining_user_facing_text(strip=False)` | `_build_progress_frame` | `remaining_text` → the unspoken part of the segment text (what a UI leaves plain) |
+| `get_remaining_tts_text()` | `force_complete` | Text of the catch-up frame when a provider goes silent |
+| `get_remaining_llm_text()` | `force_complete` | `raw_text` of that catch-up frame |
+
+So a single `process_word` call reads six of these to build one `TTSTextFrame` plus one
+`AggregatedTextProgressFrame` — see [RTVI integration](./rtvi-integration.md).
+
+### Recovering the LLM structure
+
+The TTS only ever synthesized the segment text, so word events carry no trace of the
+delimiters the aggregator split off into `raw_text`. The tracker maps each word back onto
+that fuller string:
+
+| word     | complete | `get_word_for_frame()` | `get_llm_consumed()` |
+| -------- | -------- | ---------------------- | -------------------- |
+| `Your`   | False    | `Your`                 | `Your`               |
+| `card`   | False    | `card`                 | `card`               |
+| `is`     | False    | `is`                   | `is`                 |
+| `4111`   | False    | `4111`                 | **`<card>4111`**     |
+| `1111`   | False    | `1111`                 | `1111`               |
+| `thanks` | **True** | `thanks`               | **`</card> thanks`** |
+
+The conversation context is rebuilt from the `raw_text` column, so it stores
+`<card>4111 1111</card>` — not the bare digits the provider reported.
+
+### Suppressing mid-transform words
+
+For a transformed segment the individual spoken words are meaningless to the context.
+`suppress_in_context()` is True while the map sits mid-segment, and attribution is
+withheld until the completing word carries the whole original span:
+
+| word      | `get_word_for_frame()` | `get_llm_consumed()` | `suppress_in_context()` |
+| --------- | ---------------------- | -------------------- | ----------------------- |
+| `is`      | `is`                   | `is`                 | False                   |
+| `forty-two` | `forty-two`          | `None`               | **True**                |
+| `dollars` | `dollars`              | `None`               | **True**                |
+| `and`     | `and`                  | `None`               | **True**                |
+| `fifty`   | `fifty`                | `None`               | **True**                |
+| `cents`   | `cents`                | **`$42.50`**         | False                   |
+
+The words are still emitted — the UI needs them to highlight progress — but **only the
+last one writes to the context, and it writes `$42.50`**.
+
+## 3. Recovery: dropped events
+
+Before advancing, every word is checked with `word_belongs_here`. A word that does not
+match means the provider skipped something, so the slot is **force-completed** rather
+than left hanging:
+
+```python
+tracker = WordCompletionTracker("Hello there world")
+tracker.add_word_and_check_complete("Hello")     # normal
+tracker.add_word_and_check_complete("Goodbye")   # belongs to the *next* frame
+```
+
+| word      | `word_belongs_here` | complete | `get_word_for_frame()` | `get_overflow_word()` |
+| --------- | ------------------- | -------- | ---------------------- | --------------------- |
+| `Hello`   | True                | False    | `Hello`                | `None`                |
+| `Goodbye` | **False**           | **True** | **`there world`**      | **`Goodbye`**         |
+
+**The unspoken remainder `there world` is still emitted**, so the context keeps the full
+sentence; the foreign word is handed back as overflow for the next slot. From this point
+`_force_completed` — not the map — is the authoritative completion signal, since the map
+was never advanced and its own `is_complete` stays stale.
+
+## 4. Trimming a token to this frame's share
+
+Neither end of an incoming token necessarily belongs to this frame, and
+[`TextSegmentMap`](./text-segment-map.md#trimming-a-token-to-what-it-actually-covers)
+measures both:
+
+| Map output | The part that is not this frame's | Example |
+| --- | --- | --- |
+| `last_leading_duplicate` | Head repeating punctuation the previous word already carried | `, I` → drop 2 |
+| `last_overflow` | Tail spilling into the next frame | `1111And` → `And` |
+
+The tracker keeps what is between them:
+
+```python
+self._frame_word = word[head:tail]
+```
+
+**A tail example.** One token closes this frame and opens the next:
+
+```python
+tracker = WordCompletionTracker("The code is 1111")
+```
+
+| word | complete | `get_word_for_frame()` | `get_overflow_word()` |
+| --------- | -------- | ---------------------- | --------------------- |
+| `The`     | False    | `The`                  | `None`                |
+| `code`    | False    | `code`                 | `None`                |
+| `is`      | False    | `is`                   | `None`                |
+| `1111And` | **True** | **`1111`**             | **`And`**             |
+
+The overflow is fed to the next frame's tracker, so each half is attributed to the frame
+it actually belongs to.
+
+**A head example.** The comma trailing `Yeah` is already part of its span, so a provider
+reporting it again on the next token would emit it twice:
+
+| after | token | `get_word_for_frame()` |
+| --- | --- | --- |
+| `Yeah` (span `Yeah,`) | `, I` | **`I`** |
+
+That is the whole of the tracker's word-text handling — both decisions are the map's,
+because both come from cursors it owns.
+
+The attributed LLM span is used as given. The spans cover `llm_text` in order, so dropping
+one removes text from the transcript rather than protecting it.
+
+## 5. Public surface
+
+| Member                                | Purpose                                            |
+| ------------------------------------- | -------------------------------------------------- |
+| `add_word_and_check_complete(word)`   | Record a word; returns True when the frame is done |
+| `word_belongs_here(word)`             | Dry run, used to detect dropped events              |
+| `get_word_for_frame()`                | This frame's share of the last word                 |
+| `get_overflow_word()`                 | The next frame's share                              |
+| `get_llm_consumed()`                  | LLM span for the last word                          |
+| `suppress_in_context()`               | Mid-transform, keep out of the context              |
+| `get_accumulated_*` / `get_remaining_*` | Spoken and unspoken text, per channel             |
+| `is_complete`                         | Force-completed, or the segment map says done       |
+| `reset()`                             | Rewind cursors, keep the texts                      |
+
+The paired accessors are what drive RTVI progress. Mid-sentence:
+
+```python
+tracker = WordCompletionTracker("Hello there world")
+tracker.add_word_and_check_complete("Hello")
+
+tracker.get_accumulated_user_facing_text()   # 'Hello'
+tracker.get_remaining_user_facing_text()     # 'there world'
+```
+
+`get_remaining_user_facing_text(strip=False)` preserves leading whitespace, so accumulated
++ remaining reconstructs the segment text exactly. That guarantee is what every consumer
+of a progress frame relies on (see
+[the guarantee](./README.md#33-the-guarantee-that-makes-it-useful)).
+
+### `is_complete` is delegated, not tracked
+
+**The tracker keeps no completion bookkeeping of its own.** It forwards the question to
+the segment map, which owns the only cursor that can answer it:
+
+```python
+@property
+def is_complete(self) -> bool:
+    return self._force_completed or self._segment_map.is_complete
+```
+
+The one exception is the force-completed slot. There the map was deliberately **never
+advanced** — the offending word was routed to the next slot instead — so its own
+`is_complete` stays stale and would keep reporting `False` forever. `_force_completed` is
+the override that makes the verdict stick, and from that point on it is the authoritative
+answer.
+
+### "Complete" and "no room left" are different questions
+
+`is_complete` is alphanumeric-based: a frame whose remainder is only punctuation or markup
+reports True before that remainder has been walked. That is the right question for
+releasing whatever is queued behind the slot, and the wrong one for deciding whether to
+accept another word — a frame ending in an emoji is already `is_complete` when the
+emoji's own event arrives.
+
+The guard that rejects a late word therefore asks the stricter question, whether every raw
+character of `tts_text` has been consumed:
+
+```python
+if self._force_completed or self._segment_map.raw_pos >= len(self._tts_text):
+```
+
+The gap between the two answers is exactly the trailing non-alphanumeric content, and it
+is the window in which a final emoji or a separated punctuation mark is still welcome.
+
+## 6. Tests
+
+`tests/test_word_completion_tracker.py` — 203 tests, the largest suite of the three.
+Most of it is a regression corpus of real provider behaviour.
+
+| Group                    | Classes                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| Mechanics                | `Basic`, `Reset`, `EdgeCases`, `RemainingText`, `AccumulatedText`, `UserFacingText` |
+| Recovery                 | `MissingWord`, `Overflow`, `MultiFrameSimulation`, `ForceCompleteAttributesTaggedRemainder` |
+| TTS provider quirks      | `UnicodeSymbolSubstitution`, `AddedTerminalPunctuation`, `CaseFolding`, `AccentFolding`, `SpaceBeforePunctuation`, `MultiAttributeSsmlTag`, `EmojiInSentence`, `CJK`, `StrayAngleBracket` |
+| Transform interaction    | `WithTransforms`, `TokenChangingReplacements`, `TransformAtEndOfUtterance`, `LLMText`, `Normalization` |
+
+## Related
+
+- [Architecture overview](./README.md)
+- [TextSegmentMap](./text-segment-map.md) — the alignment this layer drives
+- [AggregatedFrameSequencer](./aggregated-frame-sequencer.md) — the layer that owns these trackers
+- [RTVI integration](./rtvi-integration.md) — where the accumulated/remaining text ends up


### PR DESCRIPTION
## Summary

  - Adds `docs/architecture/`, explaining how Pipecat keeps three versions of one LLM response in sync — what the conversation context stores, what a client renders, and what the TTS speaks — using only the word-timestamp events a provider streams back during playback.
  - `README.md` is the entry point: the three consumers that each want *different* text out of a single response, what went wrong before this machinery existed, and how each problem is solved. A `code-helper` bot carries the example from end to end.
  - One page per component, each written to be read on its own:
    - `text-segment-map.md` — where a spoken word lands in all three texts, how the diff into segments works, and how noisy provider tokens are matched
    - `word-completion-tracker.md` — per-frame bookkeeping, recovery from dropped events, and trimming a token to the part that  belongs to this frame
    - `aggregated-frame-sequencer.md` — the two frames emitted per word, frame ordering, concurrent contexts, and streaming mode