### PR TITLE
fix: gate OpenAI Realtime audio until session ready

### DIFF
--- a/changelog/5354.fixed.md
+++ b/changelog/5354.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `OpenAIRealtimeLLMService` sending user audio before the realtime session configuration was acknowledged, which could let server-side VAD start the first response before the configured instructions took effect.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -1305,6 +1305,10 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
             )
 
     async def _send_user_audio(self, frame):
+        """Send user audio after the realtime session has been configured."""
+        if not self._api_session_ready:
+            return
+
         payload = base64.b64encode(frame.audio).decode("utf-8")
         await self.send_client_event(events.InputAudioBufferAppendEvent(audio=payload))
 

--- a/tests/test_openai_realtime_user_audio.py
+++ b/tests/test_openai_realtime_user_audio.py
@@ -69,6 +69,7 @@ def _make_service(*, manual_turn_detection: bool, preroll_secs: float | None = N
         settings=settings,
         user_audio_preroll_secs=preroll_secs,
     )
+    service._api_session_ready = True
 
     recorder = _EventRecorder()
     service.send_client_event = recorder  # type: ignore[method-assign]
@@ -202,6 +203,20 @@ async def test_server_mode_appends_without_buffering():
 
     assert recorder.kinds() == ["InputAudioBufferAppendEvent", "InputAudioBufferAppendEvent"]
     assert bytes(service._user_audio_preroll_buffer) == b""
+
+
+@pytest.mark.asyncio
+async def test_user_audio_is_dropped_until_session_ready():
+    """Audio must not reach the server before session.update is acknowledged."""
+    service, recorder = _make_service(manual_turn_detection=False)
+    service._api_session_ready = False
+
+    await service._send_user_audio(_audio_frame(data=b"\xaa\xbb"))
+    assert recorder.kinds() == []
+
+    service._api_session_ready = True
+    await service._send_user_audio(_audio_frame(data=b"\xcc\xdd"))
+    assert recorder.append_payloads() == [base64.b64encode(b"\xcc\xdd").decode()]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #5354

## Summary
- Gate user audio until the OpenAI Realtime session configuration is acknowledged.
- Prevent server-side VAD from starting the first response before the configured instructions apply.

## Root Cause
`_api_session_ready` is set after the server acknowledges `session.update`, but
`_send_user_audio` appended audio immediately. The first audio turn could
therefore reach server-side VAD before the initial session settings took effect.

## Verification
- `uv run pytest tests/test_openai_realtime_audio_frames.py tests/test_openai_realtime_reasoning.py tests/test_openai_realtime_user_audio.py tests/test_realtime_tool_result_encoding.py tests/test_realtime_tool_sync.py` -> 30 passed.
- `uv run ruff format --check` -> passed.
- `uv run ruff check` -> passed.
- `uv run pyright src/pipecat/services/openai/realtime/llm.py tests/test_openai_realtime_user_audio.py` -> passed.
- Full provider-matrix tests, coverage, and registry checks remain for repository CI because optional provider dependencies are not installed in this checkout.

## Notes for Reviewers
The change is limited to the audio send boundary and preserves the existing
manual-turn pre-roll behavior after the session becomes ready.
