### PR TITLE
fix(daily): propagate pinless dial-in update failures

### DIFF
--- a/changelog/5358.fixed.md
+++ b/changelog/5358.fixed.md
@@ -1,0 +1,1 @@
+- Pinless dial-in update failures now trigger the Daily transport's `on_error` event instead of only being logged.

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -2945,16 +2945,16 @@ class DailyTransport(BaseTransport):
                 ) as r:
                     if r.status != 200:
                         text = await r.text()
-                        logger.error(
+                        await self._on_dialin_error(
                             f"Unable to handle dialin-ready event (status: {r.status}, error: {text})"
                         )
                         return
 
                     logger.debug("Event dialin-ready was handled successfully")
             except TimeoutError:
-                logger.error(f"Timeout handling dialin-ready event ({url})")
+                await self._on_dialin_error(f"Timeout handling dialin-ready event ({url})")
             except Exception as e:
-                logger.error(f"Error handling dialin-ready event ({url}): {e}")
+                await self._on_dialin_error(f"Error handling dialin-ready event ({url}): {e}")
 
     async def _on_dialin_connected(self, data):
         """Handle dial-in connected events."""

--- a/src/pipecat/transports/daily/transport.py
+++ b/src/pipecat/transports/daily/transport.py
@@ -2945,16 +2945,16 @@ class DailyTransport(BaseTransport):
                 ) as r:
                     if r.status != 200:
                         text = await r.text()
-                        await self._on_dialin_error(
+                        await self._on_error(
                             f"Unable to handle dialin-ready event (status: {r.status}, error: {text})"
                         )
                         return
 
                     logger.debug("Event dialin-ready was handled successfully")
             except TimeoutError:
-                await self._on_dialin_error(f"Timeout handling dialin-ready event ({url})")
+                await self._on_error(f"Timeout handling dialin-ready event ({url})")
             except Exception as e:
-                await self._on_dialin_error(f"Error handling dialin-ready event ({url}): {e}")
+                await self._on_error(f"Error handling dialin-ready event ({url}): {e}")
 
     async def _on_dialin_connected(self, data):
         """Handle dial-in connected events."""

--- a/tests/test_daily_transport.py
+++ b/tests/test_daily_transport.py
@@ -6,7 +6,7 @@
 
 """Tests for the Daily transport."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -23,6 +23,33 @@ def _make_transport(**params_kwargs) -> DailyTransport:
         return DailyTransport(
             "https://mock.daily.co/mock", None, "bot", params=DailyParams(**params_kwargs)
         )
+
+
+def _make_client_session(
+    *, status: int = 200, body: str = "", error: Exception | None = None
+) -> MagicMock:
+    response = MagicMock(status=status)
+    response.text = AsyncMock(return_value=body)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+
+    session = MagicMock()
+    if error:
+        session.post.side_effect = error
+    else:
+        session.post.return_value = response
+
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=None)
+    return context
+
+
+def _make_dialin_transport() -> DailyTransport:
+    return _make_transport(
+        api_key="test-api-key",
+        dialin_settings={"call_id": "test-call", "call_domain": "test-domain"},
+    )
 
 
 @pytest.mark.asyncio
@@ -79,3 +106,62 @@ async def test_push_stt_metadata_frame_contents():
         service_name=input_transport.name,
         ttfs_p99_latency=DEEPGRAM_TTFS_P99,
     )
+
+
+@pytest.mark.asyncio
+async def test_on_dialin_ready_reports_http_error_and_ready_event():
+    transport = _make_dialin_transport()
+    transport._on_dialin_error = AsyncMock()
+    transport._call_event_handler = AsyncMock()
+    session = _make_client_session(status=503, body="service unavailable")
+
+    with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
+        await transport._on_dialin_ready("sip:test@example.com")
+
+    transport._on_dialin_error.assert_awaited_once_with(
+        "Unable to handle dialin-ready event (status: 503, error: service unavailable)"
+    )
+    transport._call_event_handler.assert_awaited_once_with(
+        "on_dialin_ready", "sip:test@example.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_dialin_ready_reports_timeout():
+    transport = _make_dialin_transport()
+    transport._on_dialin_error = AsyncMock()
+    session = _make_client_session(error=TimeoutError())
+
+    with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
+        await transport._handle_dialin_ready("sip:test@example.com")
+
+    transport._on_dialin_error.assert_awaited_once_with(
+        "Timeout handling dialin-ready event (https://api.daily.co/v1/dialin/pinlessCallUpdate)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_dialin_ready_reports_unexpected_error():
+    transport = _make_dialin_transport()
+    transport._on_dialin_error = AsyncMock()
+    session = _make_client_session(error=RuntimeError("connection failed"))
+
+    with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
+        await transport._handle_dialin_ready("sip:test@example.com")
+
+    transport._on_dialin_error.assert_awaited_once_with(
+        "Error handling dialin-ready event "
+        "(https://api.daily.co/v1/dialin/pinlessCallUpdate): connection failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_dialin_ready_does_not_report_success_as_error():
+    transport = _make_dialin_transport()
+    transport._on_dialin_error = AsyncMock()
+    session = _make_client_session()
+
+    with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
+        await transport._handle_dialin_ready("sip:test@example.com")
+
+    transport._on_dialin_error.assert_not_awaited()

--- a/tests/test_daily_transport.py
+++ b/tests/test_daily_transport.py
@@ -111,14 +111,14 @@ async def test_push_stt_metadata_frame_contents():
 @pytest.mark.asyncio
 async def test_on_dialin_ready_reports_http_error_and_ready_event():
     transport = _make_dialin_transport()
-    transport._on_dialin_error = AsyncMock()
+    transport._on_error = AsyncMock()
     transport._call_event_handler = AsyncMock()
     session = _make_client_session(status=503, body="service unavailable")
 
     with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
         await transport._on_dialin_ready("sip:test@example.com")
 
-    transport._on_dialin_error.assert_awaited_once_with(
+    transport._on_error.assert_awaited_once_with(
         "Unable to handle dialin-ready event (status: 503, error: service unavailable)"
     )
     transport._call_event_handler.assert_awaited_once_with(
@@ -129,13 +129,13 @@ async def test_on_dialin_ready_reports_http_error_and_ready_event():
 @pytest.mark.asyncio
 async def test_on_dialin_ready_reports_timeout():
     transport = _make_dialin_transport()
-    transport._on_dialin_error = AsyncMock()
+    transport._on_error = AsyncMock()
     session = _make_client_session(error=TimeoutError())
 
     with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
         await transport._handle_dialin_ready("sip:test@example.com")
 
-    transport._on_dialin_error.assert_awaited_once_with(
+    transport._on_error.assert_awaited_once_with(
         "Timeout handling dialin-ready event (https://api.daily.co/v1/dialin/pinlessCallUpdate)"
     )
 
@@ -143,13 +143,13 @@ async def test_on_dialin_ready_reports_timeout():
 @pytest.mark.asyncio
 async def test_on_dialin_ready_reports_unexpected_error():
     transport = _make_dialin_transport()
-    transport._on_dialin_error = AsyncMock()
+    transport._on_error = AsyncMock()
     session = _make_client_session(error=RuntimeError("connection failed"))
 
     with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
         await transport._handle_dialin_ready("sip:test@example.com")
 
-    transport._on_dialin_error.assert_awaited_once_with(
+    transport._on_error.assert_awaited_once_with(
         "Error handling dialin-ready event "
         "(https://api.daily.co/v1/dialin/pinlessCallUpdate): connection failed"
     )
@@ -158,10 +158,10 @@ async def test_on_dialin_ready_reports_unexpected_error():
 @pytest.mark.asyncio
 async def test_on_dialin_ready_does_not_report_success_as_error():
     transport = _make_dialin_transport()
-    transport._on_dialin_error = AsyncMock()
+    transport._on_error = AsyncMock()
     session = _make_client_session()
 
     with patch("pipecat.transports.daily.transport.aiohttp.ClientSession", return_value=session):
         await transport._handle_dialin_ready("sip:test@example.com")
 
-    transport._on_dialin_error.assert_not_awaited()
+    transport._on_error.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Propagate automatic pinless dial-in update failures through the Daily transport's existing `on_error` event
- Preserve the `on_dialin_ready` event emitted by Daily after reporting an update failure
- Cover successful updates, HTTP failures, timeouts, and unexpected exceptions

## Testing

- `uv run pytest tests/test_daily_transport.py -q`
- `uv run ruff check src/pipecat/transports/daily/transport.py tests/test_daily_transport.py`
- `uv run ruff format --check src/pipecat/transports/daily/transport.py tests/test_daily_transport.py`
- `uv run pyright src/pipecat/transports/daily/transport.py tests/test_daily_transport.py`
- `uv run pre-commit run --files src/pipecat/transports/daily/transport.py tests/test_daily_transport.py`
