### PR TITLE
Update OpenAI Realtime default to gpt-realtime-2.1

### DIFF
--- a/changelog/5362.changed.md
+++ b/changelog/5362.changed.md
@@ -1,0 +1,1 @@
+- OpenAI Realtime sessions now use `gpt-realtime-2.1` as the default model.

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -289,7 +289,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="gpt-realtime-2",
+            model="gpt-realtime-2.1",
             system_instruction=None,
             temperature=None,
             max_tokens=None,
@@ -772,7 +772,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
     # match (rather than exact equality) so date-versioned variants of the same
     # base model also match without code changes. Extend this tuple as OpenAI
     # ships more reasoning-capable Realtime models.
-    _REASONING_CAPABLE_MODEL_SUBSTRINGS = ("gpt-realtime-2",)
+    _REASONING_CAPABLE_MODEL_SUBSTRINGS = ("gpt-realtime-2", "gpt-realtime-2.1")
 
     def _strip_unsupported_reasoning(
         self, settings: events.SessionProperties


### PR DESCRIPTION
## Summary

- Update the OpenAI Realtime service default model to gpt-realtime-2.1.
- Preserve reasoning settings when using the new default model.

## Testing

- uv run pytest tests/test_openai_realtime_reasoning.py tests/test_settings.py
- uv run ruff check src/pipecat/services/openai/realtime/llm.py
- uv run ruff format --check src/pipecat/services/openai/realtime/llm.py