### PR TITLE
Honor the seed setting in the Google LLM services

### DIFF
--- a/changelog/5366.fixed.md
+++ b/changelog/5366.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the Google LLM services ignoring the `seed` setting. `GoogleLLMService`, `GoogleVertexLLMService`, `GeminiLiveLLMService`, and `GeminiLiveVertexLLMService` now send it. Gemini treats a seed as best effort, so identical seeds usually but not always produce identical responses.

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -1147,6 +1147,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                     frequency_penalty=assert_given(self._settings.frequency_penalty),
                     max_output_tokens=assert_given(self._settings.max_tokens),
                     presence_penalty=assert_given(self._settings.presence_penalty),
+                    seed=assert_given(self._settings.seed),
                     temperature=assert_given(self._settings.temperature),
                     top_k=assert_given(self._settings.top_k),
                     top_p=assert_given(self._settings.top_p),

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -422,6 +422,7 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
                 "top_p": self._settings.top_p,
                 "top_k": self._settings.top_k,
                 "max_output_tokens": self._settings.max_tokens,
+                "seed": self._settings.seed,
                 "safety_settings": assert_given(self._settings.safety_settings),
                 "tools": tools,
                 "tool_config": tool_config,


### PR DESCRIPTION
`seed` has been part of `LLMSettings` all along — OpenAI and the ~20 services built on it have always sent it — but the Google services stored the value and never put it in the request. Setting it did nothing, and nothing said so.

`GoogleLLMService`, `GoogleVertexLLMService`, `GeminiLiveLLMService`, and `GeminiLiveVertexLLMService` now pass it through. An unset seed is still omitted, so nothing changes for anyone not using it.

Note: Gemini documents a seed as [best effort](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/content-generation-parameters), not a guarantee. It does real work — four unseeded runs of one prompt gave four different answers, four runs at `seed=42` gave one — but 2.5 Flash still varied across identical seeds, which matches what Google documents.
