### PR TITLE
Apply Google's thinking defaults in run_inference too

### DIFF
--- a/changelog/5368.fixed.md
+++ b/changelog/5368.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GoogleLLMService` not applying its low-latency thinking defaults in `run_inference()`. Now both in-pipeline and `run_inference()` code paths build their request the same way. An explicit `thinking` setting still wins.

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -411,7 +411,8 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
             tool_config: Optional tool configuration.
 
         Returns:
-            Dictionary of generation parameters with None values filtered out.
+            Dictionary of generation parameters with None values filtered out,
+            carrying the low-latency thinking default when none is configured.
         """
         # Filter out None values and create GenerationContentConfig
         generation_params = {
@@ -437,6 +438,10 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
 
         if self._settings.extra:
             generation_params.update(self._settings.extra)
+
+        # Applied last, so an explicit thinking config from the settings or from
+        # extra wins over the low-latency default.
+        self._maybe_unset_thinking_budget(generation_params)
 
         return generation_params
 
@@ -534,9 +539,6 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
             tools=tools,
             tool_config=tool_config,
         )
-
-        # possibly modify generation_params (in place) to set thinking to off by default
-        self._maybe_unset_thinking_budget(generation_params)
 
         generation_config = GenerateContentConfig(**generation_params)
 

--- a/tests/test_google_thinking_defaults.py
+++ b/tests/test_google_thinking_defaults.py
@@ -8,12 +8,15 @@
 
 import io
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from google.genai.types import ThinkingLevel
 from loguru import logger
 
+from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.google.llm import GoogleLLMService
 from pipecat.services.google.vertex.llm import GoogleVertexLLMService
 
@@ -23,7 +26,6 @@ def _applied_thinking_config(model: str) -> dict[str, Any] | None:
     service = GoogleLLMService(api_key="test-key", settings=GoogleLLMService.Settings(model=model))
 
     params = service._build_generation_params()
-    service._maybe_unset_thinking_budget(params)
 
     return params.get("thinking_config")
 
@@ -83,9 +85,31 @@ def test_a_configured_thinking_config_is_left_alone():
     )
 
     params = service._build_generation_params()
-    service._maybe_unset_thinking_budget(params)
 
     assert params["thinking_config"] == {"thinking_level": "high"}
+
+
+# --- every inference path ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_inference_applies_the_thinking_default():
+    """Out-of-band inference gets the same default as the in-pipeline path."""
+    service = GoogleLLMService(
+        api_key="test-key",
+        settings=GoogleLLMService.Settings(
+            model="gemini-3.6-flash", system_instruction="You are helpful."
+        ),
+    )
+    response = SimpleNamespace(candidates=[])
+
+    with patch.object(
+        service._client.aio.models, "generate_content", return_value=response
+    ) as generate:
+        await service.run_inference(LLMContext(messages=[{"role": "user", "content": "hi"}]))
+
+    config = generate.call_args.kwargs["config"]
+    assert config.thinking_config.thinking_level == ThinkingLevel.MINIMAL
 
 
 # --- warning on a budget that may not control thinking ----------------------
@@ -183,7 +207,6 @@ def test_vertex_shares_the_thinking_defaults():
     service = _vertex_service(settings=GoogleVertexLLMService.Settings(model="gemini-3.7-flash"))
 
     params = service._build_generation_params()
-    service._maybe_unset_thinking_budget(params)
 
     assert params["thinking_config"] == {"thinking_level": "low"}
 


### PR DESCRIPTION
## The bug

`GoogleLLMService` lowers thinking by default for real-time voice, but `run_inference()` never applied those defaults — so out-of-band inference sent whatever the model reasons by default. It affects context summarization, pipecat-flows conversation summaries, and the eval judge.

**`run_inference()` on `gemini-3.6-flash`: 1.307s → 0.922s median** (p90 1.453s → 1.108s, 8 calls each).

## The fix

The defaults were applied *beside* `_build_generation_params` rather than inside it, so only `_stream_content` picked them up. Moving the call into the builder gives both paths — the only two — the same request. It runs last, so an explicit `thinking` setting still wins.

## Why

Consistency: `run_inference()` should behave as closely as possible to in-pipeline inference, which is how it's treated elsewhere. `OpenAIResponsesLLMService` applies its reasoning default inside its shared builder for exactly this reason (its docstring says it mirrors Gemini's version). Anthropic passes its model-conditional prefill fix-up on both paths. And `LLMService` composes async-tool instructions into the system prompt that Google's `run_inference()` already reads.

Thinking was the one automatic adjustment that stopped at the pipeline boundary.
