### PR TITLE
fix(llm): add generic opt-in tool-call text policy for all text LLM providers

### DIFF
--- a/changelog/5369.added.md
+++ b/changelog/5369.added.md
@@ -1,0 +1,1 @@
++- Added an opt-in setting that suppresses text emitted after tool calls by all text-based LLM services (OpenAI-compatible, OpenAI Responses, Anthropic, Google, and AWS Bedrock Converse).

--- a/src/pipecat/services/anthropic/llm.py
+++ b/src/pipecat/services/anthropic/llm.py
@@ -39,7 +39,7 @@ from pipecat.metrics.metrics import LLMTokenUsage
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.utils.deprecation import deprecated
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given, is_given
@@ -218,6 +218,7 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
             thinking=ANTHROPIC_NOT_GIVEN,
+            tool_call_text_policy=ToolCallTextPolicy.PRESERVE,
             extra={},
         )
 
@@ -466,6 +467,7 @@ class AnthropicLLMService(LLMService[AnthropicLLMAdapter]):
                         # the call itself is what the caller gets and TTFAT ends
                         # here rather than going unmeasured.
                         await self.stop_ttfat_metrics()
+                        self._note_tool_call_detected()
                         tool_use_block = event.content_block
                         json_accumulator = ""
                     elif event.content_block.type == "thinking":

--- a/src/pipecat/services/aws/llm.py
+++ b/src/pipecat/services/aws/llm.py
@@ -38,7 +38,7 @@ from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.aws.utils import resolve_credentials
 from pipecat.services.llm_service import LLMService
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.utils.deprecation import deprecated
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
@@ -188,6 +188,7 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
             latency=None,
             enable_prompt_caching=False,
             additional_model_request_fields={},
+            tool_call_text_policy=ToolCallTextPolicy.PRESERVE,
         )
 
         # 2. Apply direct init arg overrides (deprecated)
@@ -559,9 +560,10 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
                         block = event["contentBlockDelta"]
                         delta = block["delta"]
                         if "text" in delta:
-                            await self._push_llm_text(delta["text"])
                             completion_tokens_estimate += self._estimate_tokens(delta["text"])
+                            await self._push_llm_text(delta["text"])
                         elif "toolUse" in delta and "input" in delta["toolUse"]:
+                            self._note_tool_call_detected()
                             # Handle partial JSON for tool use
                             index = block["contentBlockIndex"]
                             json_accumulators[index] = (
@@ -580,6 +582,7 @@ class AWSBedrockLLMService(LLMService[AWSBedrockLLMAdapter]):
                             # so the call itself is what the caller gets and TTFAT
                             # ends here rather than going unmeasured.
                             await self.stop_ttfat_metrics()
+                            self._note_tool_call_detected()
                             index = block["contentBlockIndex"]
                             tool_use_blocks[index] = {
                                 "id": content_block_start["toolUse"].get("toolUseId", ""),

--- a/src/pipecat/services/aws/nova_sonic/llm.py
+++ b/src/pipecat/services/aws/nova_sonic/llm.py
@@ -368,6 +368,7 @@ class AWSNovaSonicLLMService(LLMService[AWSNovaSonicLLMAdapter]):
             seed=None,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
+            tool_call_text_policy=None,
             endpointing_sensitivity=None,
         )
 

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -531,6 +531,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             thinking={},
             enable_affective_dialog=False,
             proactivity={},
+            tool_call_text_policy=None,
             extra={},
         )
 

--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -42,7 +42,7 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.google.frames import LLMSearchResponseFrame
 from pipecat.services.google.utils import update_google_client_http_options
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.utils.deprecation import deprecated
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given, is_given
@@ -280,6 +280,7 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
             user_turn_completion_config=None,
             thinking=None,
             safety_settings=None,
+            tool_call_text_policy=ToolCallTextPolicy.PRESERVE,
             extra={},
         )
 
@@ -716,6 +717,7 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
                                 # text, so the call itself is what the caller gets
                                 # and TTFAT ends here rather than going unmeasured.
                                 await self.stop_ttfat_metrics()
+                                self._note_tool_call_detected()
                                 function_call = part.function_call
                                 function_call_id = function_call.id or str(uuid.uuid4())
                                 logger.debug(

--- a/src/pipecat/services/inworld/realtime/llm.py
+++ b/src/pipecat/services/inworld/realtime/llm.py
@@ -328,6 +328,7 @@ class InworldRealtimeLLMService(LLMService[InworldRealtimeLLMAdapter]):
                     ),
                 ),
             ),
+            tool_call_text_policy=None,
         )
 
         self.Settings._sync_top_level_to_sp(default_settings)

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -749,14 +749,14 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
 
         Text is suppressed once a tool call has been detected in the current
         response when ``tool_call_text_policy`` is
-        :attr:`ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL`. Providers signal
+        :attr:`ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED`. Providers signal
         detection via :meth:`_note_tool_call_detected`.
 
         Args:
             text: The text content from the LLM to push.
         """
         if (
-            self._settings.tool_call_text_policy == ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL
+            self._settings.tool_call_text_policy == ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED
             and self._tool_call_detected
         ):
             return

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -62,7 +62,7 @@ from pipecat.processors.aggregators.llm_context import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.services.ai_service import AIService
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.services.websocket_service import WebsocketService
 from pipecat.turns.user_turn_completion_mixin import UserTurnCompletionLLMServiceMixin
 from pipecat.utils.async_tool_cancellation import (
@@ -378,6 +378,10 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         # typed for callers that opt into `LLMService[XAdapter]`.
         self._adapter = cast(TAdapter, self._resolve_adapter_class()())
         self._functions: dict[str | None, FunctionCallRegistryItem] = {}
+        # Set by providers mid-stream once a tool call is detected, and reset
+        # per response (see ``push_frame``). Read by ``_push_llm_text`` to drop
+        # text after a tool call when ``tool_call_text_policy`` is SUPPRESS.
+        self._tool_call_detected: bool = False
         # Cleanup callables carried by registered tool handlers, awaited at
         # service teardown (see _record_tool_cleanup).
         self._tool_cleanups: list[Callable[[], Awaitable[None]]] = []
@@ -733,17 +737,29 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             if self._skip_tts is not None:
                 frame.skip_tts = self._skip_tts
 
+        # A new assistant response begins here, so any tool-call detection
+        # from the previous response no longer applies.
+        if isinstance(frame, LLMFullResponseStartFrame):
+            self._tool_call_detected = False
+
         await super().push_frame(frame, direction)
 
     async def _push_llm_text(self, text: str):
         """Push LLM text, using turn completion detection if enabled.
 
-        This helper method simplifies text pushing in LLM implementations by
-        handling the conditional logic for turn completion internally.
+        Text is suppressed once a tool call has been detected in the current
+        response when ``tool_call_text_policy`` is
+        :attr:`ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL`. Providers signal
+        detection via :meth:`_note_tool_call_detected`.
 
         Args:
             text: The text content from the LLM to push.
         """
+        if (
+            self._settings.tool_call_text_policy == ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL
+            and self._tool_call_detected
+        ):
+            return
         # Measured before turn-completion filtering, which can hold text back or
         # drop it entirely — neither says anything about how fast the model
         # answered.
@@ -754,6 +770,15 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             await self._push_turn_text(text)
         else:
             await self.push_frame(LLMTextFrame(text))
+
+    def _note_tool_call_detected(self):
+        """Record that the current response contains a tool call.
+
+        Providers call this from their streaming loop as soon as a tool-call
+        delta/block is observed. It is idempotent within a response and resets
+        automatically at the start of the next response.
+        """
+        self._tool_call_detected = True
 
     async def _handle_interruptions(self, _: InterruptionFrame):
         for function_name, entry in self._functions.items():

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -40,7 +40,7 @@ from pipecat.metrics.metrics import LLMTokenUsage
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.utils.deprecation import deprecated
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
@@ -206,6 +206,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
             top_k=None,
             max_tokens=OPENAI_NOT_GIVEN,
             max_completion_tokens=OPENAI_NOT_GIVEN,
+            tool_call_text_policy=ToolCallTextPolicy.PRESERVE,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
             extra={},
@@ -512,6 +513,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                         # here rather than going unmeasured.
                         await self.stop_ttfat_metrics()
 
+                        self._note_tool_call_detected()
                         # We're streaming the LLM response to enable the fastest response times.
                         # For text, we just yield each chunk as we receive it and count on consumers
                         # to do whatever coalescing they need (eg. to pass full sentences to TTS)

--- a/src/pipecat/services/openai/realtime/llm.py
+++ b/src/pipecat/services/openai/realtime/llm.py
@@ -300,6 +300,7 @@ class OpenAIRealtimeLLMService(LLMService[OpenAIRealtimeLLMAdapter]):
             seed=None,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
+            tool_call_text_policy=None,
             session_properties=events.SessionProperties(),
         )
 

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -63,7 +63,7 @@ from pipecat.services.llm_service import (
     WebsocketLLMService,
     WebsocketReconnectedError,
 )
-from pipecat.services.settings import LLMSettings
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 
@@ -262,6 +262,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
             reasoning=None,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
+            tool_call_text_policy=ToolCallTextPolicy.PRESERVE,
             extra={},
         )
 
@@ -1103,6 +1104,7 @@ class OpenAIResponsesLLMService(
                     # call itself is what the caller gets and TTFAT ends here
                     # rather than going unmeasured.
                     await self.stop_ttfat_metrics()
+                    self._note_tool_call_detected()
                     item_id = item.get("id", "")
                     function_calls[item_id] = {
                         "name": item.get("name", ""),
@@ -1338,6 +1340,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                         # the call itself is what the caller gets and TTFAT ends
                         # here rather than going unmeasured.
                         await self.stop_ttfat_metrics()
+                        self._note_tool_call_detected()
                         item_id = item.id or ""
                         function_calls[item_id] = {
                             "name": item.name,

--- a/src/pipecat/services/settings.py
+++ b/src/pipecat/services/settings.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import copy
 from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 from loguru import logger
@@ -55,6 +56,19 @@ if TYPE_CHECKING:
 # "this service doesn't support this field". Every delta field defaults to it so
 # deltas stay sparse and ``apply_update`` can skip untouched fields. It must
 # never appear in a store-mode object — see ``validate_complete()``.
+
+
+class ToolCallTextPolicy(StrEnum):
+    """Policy for text emitted in the same response as a tool call.
+
+    Parameters:
+        PRESERVE: Preserve streamed text before and after tool-call detection.
+        SUPPRESS_AFTER_TOOL_CALL: Preserve text before tool-call detection and suppress
+            subsequent text in the same response.
+    """
+
+    PRESERVE = "preserve"
+    SUPPRESS_AFTER_TOOL_CALL = "suppress_after_tool_call"
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +345,12 @@ class LLMSettings(ServiceSettings):
                 Pass the config to
                 ``FilterIncompleteUserTurnStrategies(config=...)`` instead. Will
                 be removed in 2.0.0.
+        tool_call_text_policy: Policy for text emitted in the same response as a
+            tool call. ``PRESERVE`` keeps streamed text before and after
+            tool-call detection; ``SUPPRESS_AFTER_TOOL_CALL`` keeps text before
+            the first tool call and suppresses subsequent text in the same
+            response. Set to ``None`` for services that don't stream
+            TTS-bound text (e.g. realtime speech-to-speech services).
     """
 
     system_instruction: str | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -343,6 +363,9 @@ class LLMSettings(ServiceSettings):
     seed: int | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
     filter_incomplete_user_turns: bool | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
     user_turn_completion_config: UserTurnCompletionConfig | None | NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+    tool_call_text_policy: ToolCallTextPolicy | None | NotGiven = field(
         default_factory=lambda: NOT_GIVEN
     )
 

--- a/src/pipecat/services/settings.py
+++ b/src/pipecat/services/settings.py
@@ -63,12 +63,12 @@ class ToolCallTextPolicy(StrEnum):
 
     Parameters:
         PRESERVE: Preserve streamed text before and after tool-call detection.
-        SUPPRESS_AFTER_TOOL_CALL: Preserve text before tool-call detection and suppress
+        SUPPRESS_AFTER_TOOL_CALL_DETECTED: Preserve text before tool-call detection and suppress
             subsequent text in the same response.
     """
 
     PRESERVE = "preserve"
-    SUPPRESS_AFTER_TOOL_CALL = "suppress_after_tool_call"
+    SUPPRESS_AFTER_TOOL_CALL_DETECTED = "suppress_after_tool_call_detected"
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +347,7 @@ class LLMSettings(ServiceSettings):
                 be removed in 2.0.0.
         tool_call_text_policy: Policy for text emitted in the same response as a
             tool call. ``PRESERVE`` keeps streamed text before and after
-            tool-call detection; ``SUPPRESS_AFTER_TOOL_CALL`` keeps text before
+            tool-call detection; ``SUPPRESS_AFTER_TOOL_CALL_DETECTED`` keeps text before
             the first tool call and suppresses subsequent text in the same
             response. Set to ``None`` for services that don't stream
             TTS-bound text (e.g. realtime speech-to-speech services).

--- a/src/pipecat/services/ultravox/llm.py
+++ b/src/pipecat/services/ultravox/llm.py
@@ -227,6 +227,7 @@ class UltravoxRealtimeLLMService(LLMService):
             seed=None,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
+            tool_call_text_policy=None,
             output_medium=None,
         )
 

--- a/src/pipecat/services/xai/realtime/llm.py
+++ b/src/pipecat/services/xai/realtime/llm.py
@@ -258,6 +258,7 @@ class GrokRealtimeLLMService(LLMService[GrokRealtimeLLMAdapter]):
             seed=None,
             filter_incomplete_user_turns=False,
             user_turn_completion_config=None,
+            tool_call_text_policy=None,
             session_properties=events.SessionProperties(),
         )
 

--- a/tests/test_anthropic_tool_call_text.py
+++ b/tests/test_anthropic_tool_call_text.py
@@ -131,7 +131,7 @@ async def test_anthropic_text_after_a_tool_call_can_be_suppressed():
             _message_delta_tool_use(),
             _text_delta("After."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -149,7 +149,7 @@ async def test_anthropic_suppression_state_resets_for_the_next_response():
             _message_delta_tool_use(),
             _text_delta("Suppressed."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed: list[str] = []

--- a/tests/test_anthropic_tool_call_text.py
+++ b/tests/test_anthropic_tool_call_text.py
@@ -1,0 +1,170 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for text handling around streamed Anthropic tool calls.
+
+Suppression is centralized in ``LLMService._push_llm_text``; these tests verify
+the Anthropic streaming loop signals detection at the right time and that the
+end-to-end frame flow matches the configured policy.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.frames.frames import LLMTextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.anthropic.llm import AnthropicLLMService
+from pipecat.services.settings import ToolCallTextPolicy
+
+
+class _FakeStream:
+    def __init__(self, events):
+        self._events = events
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for event in self._events:
+            yield event
+
+
+def _text_delta(text):
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(text=text))
+
+
+def _tool_use_start(*, name="record_name", tool_id="tool_1"):
+    return SimpleNamespace(
+        type="content_block_start",
+        content_block=SimpleNamespace(type="tool_use", id=tool_id, name=name),
+    )
+
+
+def _partial_json(fragment):
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(partial_json=fragment))
+
+
+def _message_delta_tool_use():
+    return SimpleNamespace(type="message_delta", delta=SimpleNamespace(stop_reason="tool_use"))
+
+
+def _service(events, *, policy=ToolCallTextPolicy.PRESERVE):
+    fake_client = SimpleNamespace(
+        beta=SimpleNamespace(messages=SimpleNamespace(create=AsyncMock()))
+    )
+    service = AnthropicLLMService(
+        api_key="test-key",
+        client=fake_client,
+        settings=AnthropicLLMService.Settings(
+            model="claude-sonnet-4-6",
+            tool_call_text_policy=policy,
+        ),
+    )
+    service._create_message_stream = AsyncMock(return_value=_FakeStream(events))
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.start_processing_metrics = AsyncMock()
+    service.stop_processing_metrics = AsyncMock()
+    service.run_function_calls = AsyncMock()
+    service._report_usage_metrics = AsyncMock()
+    return service
+
+
+def _context():
+    return LLMContext(
+        messages=[{"role": "user", "content": "Record Sam"}],
+        tools=[
+            FunctionSchema(
+                name="record_name",
+                description="Record a supplied first name.",
+                properties={"name": {"type": "string"}},
+                required=["name"],
+            )
+        ],
+    )
+
+
+async def _run_and_collect(service, context):
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(context)
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_text_is_preserved_by_default_around_a_tool_call():
+    service = _service(
+        [
+            _text_delta("Before."),
+            _tool_use_start(),
+            _partial_json('{"name":"Sam"}'),
+            _message_delta_tool_use(),
+            _text_delta("After."),
+        ]
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before.", "After."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_text_after_a_tool_call_can_be_suppressed():
+    service = _service(
+        [
+            _text_delta("Before."),
+            _tool_use_start(),
+            _partial_json('{"name":"Sam"}'),
+            _message_delta_tool_use(),
+            _text_delta("After."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_suppression_state_resets_for_the_next_response():
+    service = _service(
+        [
+            _tool_use_start(),
+            _partial_json('{"name":"Sam"}'),
+            _message_delta_tool_use(),
+            _text_delta("Suppressed."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(_context())
+        assert pushed == []
+
+        service._create_message_stream = AsyncMock(
+            return_value=_FakeStream([_text_delta("Final.")])
+        )
+        await service._process_context(_context())
+
+    assert pushed == ["Final."]

--- a/tests/test_bedrock_tool_call_text.py
+++ b/tests/test_bedrock_tool_call_text.py
@@ -1,0 +1,157 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for text handling around streamed Bedrock tool calls.
+
+Suppression is centralized in ``LLMService._push_llm_text``; these tests verify
+the Bedrock streaming loop signals detection at the right time and that the
+end-to-end frame flow matches the configured policy.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.frames.frames import LLMFullResponseStartFrame, LLMTextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.aws.llm import AWSBedrockLLMService
+from pipecat.services.settings import ToolCallTextPolicy
+
+
+class _FakeStream:
+    def __init__(self, events):
+        self._events = events
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for event in self._events:
+            yield event
+
+
+def _text(text):
+    return {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": text}}}
+
+
+def _tool_start():
+    return {
+        "contentBlockStart": {
+            "contentBlockIndex": 1,
+            "start": {"toolUse": {"toolUseId": "tool_1", "name": "record_name"}},
+        }
+    }
+
+
+def _tool_args():
+    return {
+        "contentBlockDelta": {
+            "contentBlockIndex": 1,
+            "delta": {"toolUse": {"input": '{"name":"Sam"}'}},
+        }
+    }
+
+
+def _tool_stop():
+    return {"contentBlockStop": {"contentBlockIndex": 1}}
+
+
+def _service(events, *, policy=ToolCallTextPolicy.PRESERVE):
+    service = AWSBedrockLLMService(
+        settings=AWSBedrockLLMService.Settings(
+            model="us.amazon.nova-lite-v1:0",
+            tool_call_text_policy=policy,
+        )
+    )
+
+    @asynccontextmanager
+    async def fake_client(*args, **kwargs):
+        yield object()
+
+    service._aws_session.create_client = fake_client
+    service._create_converse_stream = AsyncMock(return_value={"stream": _FakeStream(events)})
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.run_function_calls = AsyncMock()
+    return service
+
+
+def _context():
+    return LLMContext(
+        messages=[{"role": "user", "content": "Record Sam"}],
+        tools=[
+            FunctionSchema(
+                name="record_name",
+                description="Record a supplied first name.",
+                properties={"name": {"type": "string"}},
+                required=["name"],
+            )
+        ],
+    )
+
+
+async def _run_and_collect(service, context):
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(context)
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_bedrock_text_is_preserved_by_default_after_a_tool_call():
+    service = _service([_tool_start(), _tool_args(), _tool_stop(), _text("Recorded.")])
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Recorded."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_text_after_a_tool_call_can_be_suppressed():
+    service = _service(
+        [_text("Before."), _tool_start(), _tool_args(), _tool_stop(), _text("After.")],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_suppression_state_resets_for_the_next_response():
+    service = _service(
+        [_tool_start(), _tool_args(), _tool_stop(), _text("Suppressed.")],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(_context())
+        assert pushed == []
+
+        await service.push_frame(LLMFullResponseStartFrame())
+        service._create_converse_stream = AsyncMock(
+            return_value={"stream": _FakeStream([_text("Final.")])}
+        )
+        await service._process_context(_context())
+
+    assert pushed == ["Final."]

--- a/tests/test_bedrock_tool_call_text.py
+++ b/tests/test_bedrock_tool_call_text.py
@@ -122,7 +122,7 @@ async def test_bedrock_text_is_preserved_by_default_after_a_tool_call():
 async def test_bedrock_text_after_a_tool_call_can_be_suppressed():
     service = _service(
         [_text("Before."), _tool_start(), _tool_args(), _tool_stop(), _text("After.")],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -135,7 +135,7 @@ async def test_bedrock_text_after_a_tool_call_can_be_suppressed():
 async def test_bedrock_suppression_state_resets_for_the_next_response():
     service = _service(
         [_tool_start(), _tool_args(), _tool_stop(), _text("Suppressed.")],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed: list[str] = []

--- a/tests/test_google_tool_call_text.py
+++ b/tests/test_google_tool_call_text.py
@@ -1,0 +1,170 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for text handling around streamed Google (Gemini) tool calls.
+
+Suppression is centralized in ``LLMService._push_llm_text``; these tests verify
+the Google streaming loop signals detection at the right time and that the
+end-to-end frame flow matches the configured policy.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.frames.frames import LLMTextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.settings import ToolCallTextPolicy
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _text_part(text):
+    return SimpleNamespace(
+        text=text, thought=False, function_call=None, inline_data=None, thought_signature=None
+    )
+
+
+def _function_call_part(*, name="record_name", call_id="fc_1", args=None):
+    return SimpleNamespace(
+        text=None,
+        thought=False,
+        function_call=SimpleNamespace(id=call_id, name=name, args=args or {"name": "Sam"}),
+        inline_data=None,
+        thought_signature=None,
+    )
+
+
+def _chunk(parts):
+    return SimpleNamespace(
+        usage_metadata=None,
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(parts=parts),
+                finish_reason=None,
+                grounding_metadata=None,
+            )
+        ],
+    )
+
+
+def _service(chunks, *, policy=ToolCallTextPolicy.PRESERVE):
+    with patch.object(GoogleLLMService, "create_client"):
+        service = GoogleLLMService(
+            api_key="test-key",
+            settings=GoogleLLMService.Settings(
+                model="gemini-3.6-flash",
+                tool_call_text_policy=policy,
+            ),
+        )
+    service._stream_response = lambda ctx: _FakeStream(chunks)
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.run_function_calls = AsyncMock()
+    return service
+
+
+def _context():
+    return LLMContext(
+        messages=[{"role": "user", "content": "Record Sam"}],
+        tools=[
+            FunctionSchema(
+                name="record_name",
+                description="Record a supplied first name.",
+                properties={"name": {"type": "string"}},
+                required=["name"],
+            )
+        ],
+    )
+
+
+async def _run_and_collect(service, context):
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with (
+        patch.object(FrameProcessor, "push_frame", fake_push),
+        patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()),
+    ):
+        await service._process_context(context)
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_google_text_is_preserved_by_default_around_a_tool_call():
+    service = _service(
+        [
+            _chunk([_text_part("Before."), _function_call_part()]),
+            _chunk([_text_part("After.")]),
+        ]
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before.", "After."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_google_text_after_a_tool_call_can_be_suppressed():
+    service = _service(
+        [
+            _chunk([_text_part("Before."), _function_call_part()]),
+            _chunk([_text_part("After.")]),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_google_suppression_state_resets_for_the_next_response():
+    service = _service(
+        [
+            _chunk([_function_call_part()]),
+            _chunk([_text_part("Suppressed.")]),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with (
+        patch.object(FrameProcessor, "push_frame", fake_push),
+        patch.object(FrameProcessor, "start_llm_usage_metrics", AsyncMock()),
+    ):
+        await service._process_context(_context())
+        assert pushed == []
+
+        service._stream_response = lambda ctx: _FakeStream([_chunk([_text_part("Final.")])])
+        await service._process_context(_context())
+
+    assert pushed == ["Final."]

--- a/tests/test_google_tool_call_text.py
+++ b/tests/test_google_tool_call_text.py
@@ -132,7 +132,7 @@ async def test_google_text_after_a_tool_call_can_be_suppressed():
             _chunk([_text_part("Before."), _function_call_part()]),
             _chunk([_text_part("After.")]),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -148,7 +148,7 @@ async def test_google_suppression_state_resets_for_the_next_response():
             _chunk([_function_call_part()]),
             _chunk([_text_part("Suppressed.")]),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed: list[str] = []

--- a/tests/test_llm_service_tool_call_text.py
+++ b/tests/test_llm_service_tool_call_text.py
@@ -70,7 +70,7 @@ async def test_text_is_pushed_when_policy_is_preserve_even_after_detection():
 
 @pytest.mark.asyncio
 async def test_text_is_pushed_when_suppress_but_no_tool_call_detected():
-    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
 
     pushed = await _capture_push(service, lambda: service._push_llm_text("before"))
     assert pushed == ["before"]
@@ -78,7 +78,7 @@ async def test_text_is_pushed_when_suppress_but_no_tool_call_detected():
 
 @pytest.mark.asyncio
 async def test_text_is_dropped_when_suppress_and_tool_call_detected():
-    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     service._note_tool_call_detected()
 
     pushed = await _capture_push(service, lambda: service._push_llm_text("after"))
@@ -87,7 +87,7 @@ async def test_text_is_dropped_when_suppress_and_tool_call_detected():
 
 @pytest.mark.asyncio
 async def test_note_tool_call_detected_sets_the_flag():
-    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     assert service._tool_call_detected is False
     service._note_tool_call_detected()
     assert service._tool_call_detected is True
@@ -95,7 +95,7 @@ async def test_note_tool_call_detected_sets_the_flag():
 
 @pytest.mark.asyncio
 async def test_full_response_start_frame_resets_the_flag():
-    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     service._note_tool_call_detected()
     assert service._tool_call_detected is True
 

--- a/tests/test_llm_service_tool_call_text.py
+++ b/tests/test_llm_service_tool_call_text.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Unit tests for the centralized tool-call text suppression mechanism.
+
+``LLMService`` owns the suppression flag and the drop logic in
+``_push_llm_text``; providers only call ``_note_tool_call_detected``. These
+tests exercise that contract directly, independent of any provider's
+streaming loop.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from pipecat.frames.frames import LLMFullResponseStartFrame, LLMTextFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.llm_service import LLMService
+from pipecat.services.settings import LLMSettings, ToolCallTextPolicy
+from tests.frame_processor_helpers import frame_processor_setup
+
+
+class _LLMService(LLMService):
+    """Minimal LLM service for testing the centralized text-suppression logic."""
+
+    def __init__(self, *, policy):
+        super().__init__(
+            settings=LLMSettings(
+                model="test-model",
+                system_instruction=None,
+                temperature=None,
+                max_tokens=None,
+                top_p=None,
+                top_k=None,
+                frequency_penalty=None,
+                presence_penalty=None,
+                seed=None,
+                filter_incomplete_user_turns=False,
+                user_turn_completion_config=None,
+                tool_call_text_policy=policy,
+            )
+        )
+        self._setup = frame_processor_setup(pipeline_worker=SimpleNamespace(app_resources=None))
+
+
+async def _capture_push(service, coro_factory):
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await coro_factory()
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_text_is_pushed_when_policy_is_preserve_even_after_detection():
+    service = _LLMService(policy=ToolCallTextPolicy.PRESERVE)
+    service._note_tool_call_detected()
+
+    pushed = await _capture_push(service, lambda: service._push_llm_text("after"))
+    assert pushed == ["after"]
+
+
+@pytest.mark.asyncio
+async def test_text_is_pushed_when_suppress_but_no_tool_call_detected():
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+
+    pushed = await _capture_push(service, lambda: service._push_llm_text("before"))
+    assert pushed == ["before"]
+
+
+@pytest.mark.asyncio
+async def test_text_is_dropped_when_suppress_and_tool_call_detected():
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service._note_tool_call_detected()
+
+    pushed = await _capture_push(service, lambda: service._push_llm_text("after"))
+    assert pushed == []
+
+
+@pytest.mark.asyncio
+async def test_note_tool_call_detected_sets_the_flag():
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    assert service._tool_call_detected is False
+    service._note_tool_call_detected()
+    assert service._tool_call_detected is True
+
+
+@pytest.mark.asyncio
+async def test_full_response_start_frame_resets_the_flag():
+    service = _LLMService(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service._note_tool_call_detected()
+    assert service._tool_call_detected is True
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        pass
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service.push_frame(LLMFullResponseStartFrame())
+    assert service._tool_call_detected is False

--- a/tests/test_openai_responses_tool_call_text.py
+++ b/tests/test_openai_responses_tool_call_text.py
@@ -151,7 +151,7 @@ async def test_responses_text_is_preserved_by_default_around_a_tool_call():
 
 @pytest.mark.asyncio
 async def test_responses_text_after_a_tool_call_can_be_suppressed():
-    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     pushed = await _run_and_collect(
         service,
         [
@@ -169,7 +169,7 @@ async def test_responses_text_after_a_tool_call_can_be_suppressed():
 
 @pytest.mark.asyncio
 async def test_responses_suppression_state_resets_for_the_next_response():
-    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     pushed: list[str] = []
 
     async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):

--- a/tests/test_openai_responses_tool_call_text.py
+++ b/tests/test_openai_responses_tool_call_text.py
@@ -1,0 +1,194 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for text handling around streamed OpenAI Responses API tool calls.
+
+Suppression is centralized in ``LLMService._push_llm_text``; these tests verify
+the Responses HTTP streaming loop signals detection at the right time and that
+the end-to-end frame flow matches the configured policy.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseTextDeltaEvent,
+)
+
+from pipecat.frames.frames import LLMFullResponseStartFrame, LLMTextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.openai.responses.llm import OpenAIResponsesHttpLLMService
+from pipecat.services.settings import ToolCallTextPolicy
+
+
+class _FakeAsyncStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    async def _iterator(self):
+        for event in self._events:
+            yield event
+
+    def __aiter__(self):
+        return self._iterator()
+
+    async def close(self):
+        pass
+
+
+def _text_delta(text):
+    event = MagicMock(spec=ResponseTextDeltaEvent)
+    event.delta = text
+    return event
+
+
+def _tool_call_added(*, item_id="fc_1", call_id="call_1", name="lookup"):
+    item = MagicMock(spec=ResponseFunctionToolCall)
+    item.id = item_id
+    item.call_id = call_id
+    item.name = name
+    item.arguments = ""
+    event = MagicMock(spec=ResponseOutputItemAddedEvent)
+    event.item = item
+    return event
+
+
+def _tool_call_args_done(*, item_id="fc_1", arguments='{"q":"test"}'):
+    event = MagicMock(spec=ResponseFunctionCallArgumentsDoneEvent)
+    event.item_id = item_id
+    event.arguments = arguments
+    return event
+
+
+def _tool_call_done(*, item_id="fc_1", call_id="call_1", name="lookup", arguments='{"q":"test"}'):
+    item = MagicMock(spec=ResponseFunctionToolCall)
+    item.id = item_id
+    item.call_id = call_id
+    item.name = name
+    item.arguments = arguments
+    event = MagicMock(spec=ResponseOutputItemDoneEvent)
+    event.item = item
+    return event
+
+
+def _completed():
+    response = MagicMock()
+    response.usage = None
+    response.model = "gpt-4.1"
+    response.output = []
+    event = MagicMock(spec=ResponseCompletedEvent)
+    event.response = response
+    return event
+
+
+def _service(*, policy=ToolCallTextPolicy.PRESERVE):
+    with patch.object(OpenAIResponsesHttpLLMService, "_create_client"):
+        service = OpenAIResponsesHttpLLMService(
+            api_key="test-key",
+            settings=OpenAIResponsesHttpLLMService.Settings(
+                model="gpt-4.1",
+                tool_call_text_policy=policy,
+            ),
+        )
+    service._client = AsyncMock()
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.start_llm_usage_metrics = AsyncMock()
+    service.run_function_calls = AsyncMock()
+
+    adapter = MagicMock()
+    adapter.get_messages_for_logging.return_value = []
+    adapter.get_llm_invocation_params.return_value = {}
+    service.get_llm_adapter = MagicMock(return_value=adapter)
+    service._build_response_params = MagicMock(return_value={})
+    return service
+
+
+def _context():
+    return LLMContext(messages=[{"role": "user", "content": "Look it up"}])
+
+
+async def _run_and_collect(service, events):
+    service._create_stream = AsyncMock(return_value=_FakeAsyncStream(events))
+
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(_context())
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_responses_text_is_preserved_by_default_around_a_tool_call():
+    service = _service()
+    pushed = await _run_and_collect(
+        service,
+        [
+            _text_delta("Before."),
+            _tool_call_added(),
+            _tool_call_args_done(),
+            _tool_call_done(),
+            _text_delta("After."),
+            _completed(),
+        ],
+    )
+    assert pushed == ["Before.", "After."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_responses_text_after_a_tool_call_can_be_suppressed():
+    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    pushed = await _run_and_collect(
+        service,
+        [
+            _text_delta("Before."),
+            _tool_call_added(),
+            _tool_call_args_done(),
+            _tool_call_done(),
+            _text_delta("After."),
+            _completed(),
+        ],
+    )
+    assert pushed == ["Before."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_responses_suppression_state_resets_for_the_next_response():
+    service = _service(policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        service._create_stream = AsyncMock(
+            return_value=_FakeAsyncStream(
+                [_tool_call_added(), _tool_call_args_done(), _tool_call_done(), _completed()]
+            )
+        )
+        await service._process_context(_context())
+        assert pushed == []
+
+        await service.push_frame(LLMFullResponseStartFrame())
+        service._create_stream = AsyncMock(
+            return_value=_FakeAsyncStream([_text_delta("Final."), _completed()])
+        )
+        await service._process_context(_context())
+
+    assert pushed == ["Final."]

--- a/tests/test_openai_tool_call_text.py
+++ b/tests/test_openai_tool_call_text.py
@@ -113,7 +113,7 @@ async def test_text_after_a_tool_call_can_be_suppressed():
             _chunk(tool_calls=[_tool_call()]),
             _chunk(content="After."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -133,7 +133,7 @@ async def test_any_tool_call_delta_starts_suppression():
             ),
             _chunk(content="After an id-only tool delta."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -153,7 +153,7 @@ async def test_parallel_tool_calls_are_unchanged_when_text_is_suppressed():
             ),
             _chunk(content="After."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed = await _run_and_collect(service, _context())
@@ -171,7 +171,7 @@ async def test_suppression_state_resets_for_the_next_response():
             _chunk(tool_calls=[_tool_call()]),
             _chunk(content="Suppressed."),
         ],
-        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     )
 
     pushed: list[str] = []
@@ -206,7 +206,7 @@ async def test_policy_can_be_updated_between_responses():
     assert pushed == ["After."]
 
     await service._update_settings(
-        OpenAILLMService.Settings(tool_call_text_policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+        OpenAILLMService.Settings(tool_call_text_policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED)
     )
     service.get_chat_completions = AsyncMock(return_value=_FakeStream(chunks))
     pushed = await _run_and_collect(service, _context())
@@ -218,7 +218,7 @@ async def test_policy_can_be_updated_between_responses():
     "policy",
     [
         ToolCallTextPolicy.PRESERVE,
-        ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+        ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL_DETECTED,
     ],
 )
 async def test_tool_call_takes_precedence_over_content_in_the_same_delta(policy):

--- a/tests/test_openai_tool_call_text.py
+++ b/tests/test_openai_tool_call_text.py
@@ -1,0 +1,233 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for OpenAI-compatible text handling around streamed tool calls.
+
+Suppression is centralized in ``LLMService._push_llm_text``; these tests verify
+the OpenAI streaming loop signals detection at the right time and that the
+end-to-end frame flow matches the configured policy.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipecat.frames.frames import LLMFullResponseStartFrame, LLMTextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.settings import ToolCallTextPolicy
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def close(self):
+        pass
+
+
+def _chunk(*, content=None, tool_calls=None):
+    return SimpleNamespace(
+        usage=None,
+        model=None,
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content, tool_calls=tool_calls),
+            )
+        ],
+    )
+
+
+def _tool_call(*, index=0, call_id="call_1", name="lookup", arguments="{}"):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _service(chunks, *, policy=ToolCallTextPolicy.PRESERVE):
+    with patch.object(OpenAILLMService, "create_client"):
+        service = OpenAILLMService(
+            settings=OpenAILLMService.Settings(
+                model="test-model",
+                tool_call_text_policy=policy,
+            )
+        )
+    service.get_chat_completions = AsyncMock(return_value=_FakeStream(chunks))
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.run_function_calls = AsyncMock()
+    return service
+
+
+def _context():
+    return LLMContext(messages=[{"role": "user", "content": "Look it up"}])
+
+
+async def _run_and_collect(service, context):
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(context)
+    return pushed
+
+
+@pytest.mark.asyncio
+async def test_text_is_preserved_by_default_before_and_after_a_tool_call():
+    service = _service(
+        [
+            _chunk(content="Before."),
+            _chunk(tool_calls=[_tool_call()]),
+            _chunk(content="After."),
+        ]
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before.", "After."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_text_after_a_tool_call_can_be_suppressed():
+    service = _service(
+        [
+            _chunk(content="Before."),
+            _chunk(tool_calls=[_tool_call()]),
+            _chunk(content="After."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == ["Before."]
+    service.run_function_calls.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_any_tool_call_delta_starts_suppression():
+    service = _service(
+        [
+            _chunk(
+                tool_calls=[
+                    _tool_call(call_id="call_1", name=None, arguments=None),
+                ]
+            ),
+            _chunk(content="After an id-only tool delta."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == []
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_calls_are_unchanged_when_text_is_suppressed():
+    service = _service(
+        [
+            _chunk(tool_calls=[_tool_call(call_id="call_1", name="first")]),
+            _chunk(
+                tool_calls=[
+                    _tool_call(index=1, call_id="call_2", name="second"),
+                ]
+            ),
+            _chunk(content="After."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == []
+    function_calls = service.run_function_calls.await_args.args[0]
+    assert [call.function_name for call in function_calls] == ["first", "second"]
+    assert [call.tool_call_id for call in function_calls] == ["call_1", "call_2"]
+
+
+@pytest.mark.asyncio
+async def test_suppression_state_resets_for_the_next_response():
+    service = _service(
+        [
+            _chunk(tool_calls=[_tool_call()]),
+            _chunk(content="Suppressed."),
+        ],
+        policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    )
+
+    pushed: list[str] = []
+
+    async def fake_push(self_, frame, direction=FrameDirection.DOWNSTREAM):
+        if isinstance(frame, LLMTextFrame):
+            pushed.append(frame.text)
+
+    with patch.object(FrameProcessor, "push_frame", fake_push):
+        await service._process_context(_context())
+        assert pushed == []
+
+        # The next response's start frame resets suppression state.
+        await service.push_frame(LLMFullResponseStartFrame())
+        service.get_chat_completions = AsyncMock(
+            return_value=_FakeStream([_chunk(content="Final answer.")])
+        )
+        await service._process_context(_context())
+
+    assert pushed == ["Final answer."]
+
+
+@pytest.mark.asyncio
+async def test_policy_can_be_updated_between_responses():
+    chunks = [
+        _chunk(tool_calls=[_tool_call()]),
+        _chunk(content="After."),
+    ]
+    service = _service(chunks)
+
+    pushed = await _run_and_collect(service, _context())
+    assert pushed == ["After."]
+
+    await service._update_settings(
+        OpenAILLMService.Settings(tool_call_text_policy=ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL)
+    )
+    service.get_chat_completions = AsyncMock(return_value=_FakeStream(chunks))
+    pushed = await _run_and_collect(service, _context())
+    assert pushed == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "policy",
+    [
+        ToolCallTextPolicy.PRESERVE,
+        ToolCallTextPolicy.SUPPRESS_AFTER_TOOL_CALL,
+    ],
+)
+async def test_tool_call_takes_precedence_over_content_in_the_same_delta(policy):
+    service = _service(
+        [_chunk(content="Same delta.", tool_calls=[_tool_call()])],
+        policy=policy,
+    )
+
+    pushed = await _run_and_collect(service, _context())
+
+    assert pushed == []
+    service.run_function_calls.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Adds an opt-in `ToolCallTextPolicy` setting (`PRESERVE` / `SUPPRESS_AFTER_TOOL_CALL_DETECTED`) that suppresses streamed text after a tool call is detected in the same response.
- The setting lives on base `LLMSettings`, so every LLM service accepts it uniformly and it's runtime-updatable via `LLMUpdateSettingsFrame`.
- Suppression is centralized in `LLMService._push_llm_text`: the base class owns a `_tool_call_detected` flag (reset per response via `LLMFullResponseStartFrame` in `push_frame`) and drops text when the policy is `SUPPRESS_AFTER_TOOL_CALL_DETECTED`. Providers call `_note_tool_call_detected()` at their tool-call detection site — one line per streaming loop.
- Covers all text-bearing LLM services: OpenAI-compatible (20+ subclasses via `BaseOpenAILLMService`), OpenAI Responses (WebSocket + HTTP), Anthropic, Google (Gemini + Vertex), and AWS Bedrock Converse. Realtime speech-to-speech services set `tool_call_text_policy=None` (unsupported — they don't stream TTS-bound text).
- Default is `PRESERVE` everywhere — non-breaking; no behavior changes unless users explicitly opt in.

## Testing

- `uv run pytest tests/test_llm_service_tool_call_text.py tests/test_openai_tool_call_text.py tests/test_bedrock_tool_call_text.py tests/test_anthropic_tool_call_text.py tests/test_google_tool_call_text.py tests/test_openai_responses_tool_call_text.py`
- `uv run ruff check src/pipecat/services/ tests/test_*tool_call_text.py`
- Validated end-to-end with real API calls: OpenAI chat completions, OpenAI Responses, and AWS Bedrock Converse (nova-lite + claude). Function calls execute with correct args in both policies; pre-tool-call text (narration, thinking) is preserved; post-tool-call text is suppressed when the policy is `SUPPRESS_AFTER_TOOL_CALL_DETECTED`; suppression state resets between responses.

## Documentation

- [Docs PR #1112](https://github.com/pipecat-ai/docs/pull/1112)
