### PR TITLE
ci: stop the test jobs stalling on apt and an unintended index build

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,6 +15,7 @@ jobs:
   coverage:
     name: "Coverage"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,7 +15,7 @@ jobs:
   coverage:
     name: "Coverage"
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -28,12 +28,6 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install system packages
-        timeout-minutes: 10
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev
-
       - name: Install dependencies
         run: |
           uv sync --group dev \

--- a/.github/workflows/python-compatibility.yaml
+++ b/.github/workflows/python-compatibility.yaml
@@ -25,19 +25,14 @@ jobs:
       - name: Install system dependencies
         timeout-minutes: 10
         run: |
-          # The runner's default mirror can stall mid-fetch; cap the wait so a
-          # dead connection fails fast and a fresh attempt can pick a new one.
-          for attempt in 1 2 3; do
-            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update \
-              && sudo apt-get install -y \
-                portaudio19-dev \
-                libcairo2-dev \
-                libgirepository1.0-dev \
-                pkg-config \
-              && exit 0
-            echo "apt attempt $attempt failed; retrying"
-          done
-          exit 1
+          # The runner's mirror can stall mid-fetch; cap the wait so a dead
+          # connection fails instead of hanging on a silent socket.
+          sudo apt-get -o Acquire::http::Timeout=20 update
+          sudo apt-get install -y \
+            portaudio19-dev \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            pkg-config
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/python-compatibility.yaml
+++ b/.github/workflows/python-compatibility.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-compatibility:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
+        timeout-minutes: 10
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/python-compatibility.yaml
+++ b/.github/workflows/python-compatibility.yaml
@@ -25,12 +25,19 @@ jobs:
       - name: Install system dependencies
         timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            portaudio19-dev \
-            libcairo2-dev \
-            libgirepository1.0-dev \
-            pkg-config
+          # The runner's default mirror can stall mid-fetch; cap the wait so a
+          # dead connection fails fast and a fresh attempt can pick a new one.
+          for attempt in 1 2 3; do
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update \
+              && sudo apt-get install -y \
+                portaudio19-dev \
+                libcairo2-dev \
+                libgirepository1.0-dev \
+                pkg-config \
+              && exit 0
+            echo "apt attempt $attempt failed; retrying"
+          done
+          exit 1
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: "Unit Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -32,6 +33,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: "Unit Tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,12 +32,6 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install system packages
-        timeout-minutes: 10
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev
-
       - name: Install dependencies
         run: |
           uv sync --group dev \

--- a/tests/cli/test_init_agent_ready.py
+++ b/tests/cli/test_init_agent_ready.py
@@ -31,6 +31,20 @@ class _StubAsk:
         return self._value
 
 
+def _confirm_matching(*phrases):
+    """Stub ``questionary.confirm`` to say yes only to prompts naming ``phrases``.
+
+    ``init`` asks several questions, and one of them offers to build the Context Hub
+    index — a subprocess that downloads and indexes the corpus. Matching on the prompt
+    text keeps a test from answering a question it did not mean to.
+    """
+
+    def _confirm(message, *args, **kwargs):
+        return _StubAsk(any(phrase in message for phrase in phrases))
+
+    return _confirm
+
+
 class TestInitAgentReady:
     """Behavior of the `pipecat init` file-drop command."""
 
@@ -177,7 +191,7 @@ class TestInitAgentReady:
         monkeypatch.setattr(init_mod, "_is_interactive", lambda: True)
         import questionary
 
-        monkeypatch.setattr(questionary, "confirm", lambda *a, **k: _StubAsk(True))
+        monkeypatch.setattr(questionary, "confirm", _confirm_matching("Refresh the guide files"))
         monkeypatch.setattr(questionary, "select", lambda *a, **k: _StubAsk("agent"))
         result = runner.invoke(app, ["init", str(tmp_path)])
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
Jobs wedged on `apt-get` were holding runner slots until GitHub's six-hour job limit. Job concurrency is a pool shared across the whole org, so a handful of stalled jobs blocked unrelated PRs. Two independent causes turned up.

## Summary

- Drop the `apt-get` step from `tests` and `coverage` — neither installs the `local` extra, so `portaudio19-dev` had nothing to build against
- Bound the connection wait on the one remaining `apt-get`, in `python-compatibility`, which syncs every extra and does need system packages
- Give all three jobs a 30-minute ceiling, so a hang costs 30 minutes of a runner slot rather than six hours
- Stop `test_stale_guide_offers_refresh_interactively` from building the Context Hub index

## The apt stall

`apt-get` has no default timeout. The runner's default mirror was failing every request; apt fell back to the public archive, which then stalled mid-fetch:

```
19:36:55  Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist
19:37:26  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease   <- 31s, then 3 retries
19:37:33  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease        <- fallback
19:37:33  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
19:42:08  ##[error] timed out after 5 minutes                            <- 4m35s of silence
```

`Acquire::http::Timeout=20` bounds that silence — per apt's docs the value "applies to the connection as well as the data timeout". apt retries failed fetches on its own, so no retry wrapper is needed.

## The stray index build

`test_stale_guide_offers_refresh_interactively` stubbed `questionary.confirm` to return `True` for every prompt. `init` asks two, and the second offers to build the Context Hub index — a subprocess that downloads and indexes the corpus. The test accepted it.

That one test was **790s of the 984s** unit-test run: 80% of the job, with the other ~4,459 tests sharing the rest. It passed throughout, and it is invisible locally, because `_offer_context_hub_index` returns early when an index already exists.

## Testing

Simulating a fresh runner (no index on disk) and recording whether the build is spawned:

| | Index build spawned | Result |
| --- | --- | --- |
| Before | 1 — `python -m pipecat_context_hub --log-level INFO refresh` | passed |
| After | 0 | passed |

`tests/cli/test_init_agent_ready.py` — 26 passed.

## On the 30-minute ceiling

The unit suite runs in ~3.2 minutes once the stray build is gone, so the ceiling guards against a hang rather than bounding normal work. It matters because the suite has no `pytest-timeout` — nothing bounds an individual test, and there are `wait_for(...)` and `await ....wait()` calls with no timeout that can block indefinitely.

## Note for reviewers

Not addressed here, each worth its own change:

- `init.py` polls the index build with `while process.poll() is None` and no timeout
- The suite has no `pytest-timeout`, so a hang is bounded only by the job ceiling, which kills the run without naming the test responsible
