### PR TITLE
style: format Markdown code blocks with ruff

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -165,7 +165,6 @@ Validated against `examples/07-interruptible.py`:
 
 ```python
 class ExampleTTSService(TTSService):
-
     def __init__(self, *, api_key: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self._api_key = api_key or os.getenv("SERVICE_API_KEY")
@@ -196,6 +195,7 @@ transport_params = {
     "webrtc": lambda: TransportParams(...),
 }
 
+
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     stt = DeepgramSTTService(...)
     tts = SomeTTSService(...)
@@ -220,6 +220,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await runner.cancel()
 
     await runner.run()
+
 
 async def bot(runner_args: RunnerArguments):
     """Main bot entry point compatible with Pipecat Cloud."""
@@ -267,6 +268,7 @@ class AudioInfo:
 
     sample_rate: int
     num_channels: int
+
 
 def get_audio_info(self) -> AudioInfo:
     return AudioInfo(sample_rate=48000, num_channels=1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3630,11 +3630,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     ```python
     params = DailyParams(
-          video_out_enabled=True,
-          video_out_is_live=True,
-          video_out_width=1280,
-          video_out_height=720,
-          video_out_destinations=["screenVideo"]
+        video_out_enabled=True,
+        video_out_is_live=True,
+        video_out_width=1280,
+        video_out_height=720,
+        video_out_destinations=["screenVideo"],
     )
 
     ...
@@ -3652,9 +3652,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     params = DailyParams(
         camera_out_send_settings={
             "maxQuality": "high",
-            "encodings": {
-                "high": {"maxBitrate": 2_000_000, "maxFramerate": 30}
-            },
+            "encodings": {"high": {"maxBitrate": 2_000_000, "maxFramerate": 30}},
         },
     )
     ```
@@ -5218,6 +5216,7 @@ Migration guide: https://docs.pipecat.ai/pipecat/migration/migration-1.0
 
     context = LLMContext()
 
+
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):
         context.add_message({"role": "user", "content": "Please introduce yourself."})
@@ -5455,17 +5454,13 @@ Migration guide: https://docs.pipecat.ai/pipecat/migration/migration-1.0
     Instead of, say:
 
     ```python
-    await task.queue_frame(
-        STTUpdateSettingsFrame(settings={"language": Language.ES})
-    )
+    await task.queue_frame(STTUpdateSettingsFrame(settings={"language": Language.ES}))
     ```
 
     you'd do:
 
     ```python
-    await task.queue_frame(
-        STTUpdateSettingsFrame(delta=DeepgramSTTSettings(language=Language.ES))
-    )
+    await task.queue_frame(STTUpdateSettingsFrame(delta=DeepgramSTTSettings(language=Language.ES)))
     ```
 
   Each service now vends strongly-typed classes like `DeepgramSTTSettings`
@@ -6798,7 +6793,8 @@ Migration guide: https://docs.pipecat.ai/pipecat/migration/migration-1.0
       user_params=LLMUserAggregatorParams(
           user_turn_strategies=UserTurnStrategies(
               stop=[
-                  TurnAnalyzerUserTurnStopStrategy(turn_analyzer=LocalSmartTurnAnalyzerV3(params=SmartTurnParams())
+                  TurnAnalyzerUserTurnStopStrategy(
+                      turn_analyzer=LocalSmartTurnAnalyzerV3(params=SmartTurnParams())
                   )
               ],
           )
@@ -6957,8 +6953,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
   function with the following signature:
 
   ```python
-  async def setup_pipeline_task(task: PipelineTask):
-      ...
+  async def setup_pipeline_task(task: PipelineTask): ...
   ```
 
   (PR [#3397](https://github.com/pipecat-ai/pipecat/pull/3397))
@@ -6992,10 +6987,9 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
   `include_language_detection` parameter to detect language.
 
   ```python
-    stt = ElevenLabsRealtimeSTTService(
-        api_key=os.getenv("ELEVENLABS_API_KEY"),
-        include_language_detection=True
-    )
+  stt = ElevenLabsRealtimeSTTService(
+      api_key=os.getenv("ELEVENLABS_API_KEY"), include_language_detection=True
+  )
   ```
 
   (PR [#3216](https://github.com/pipecat-ai/pipecat/pull/3216))
@@ -7807,7 +7801,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
     ```python
     aggregation = myAggregator.aggregate(text)
     if aggregation:
-      print(f"successfully aggregated text: {aggregation.text}")
+        print(f"successfully aggregated text: {aggregation.text}")
     ```
 
   - `SimpleTextAggregator`, `SkipTagsAggregator`, `PatternPairAggregator`
@@ -8074,8 +8068,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
   file must define a function with the following signature:
 
   ```python
-  async def create_observers(task: PipelineTask) -> Iterable[BaseObserver]:
-      ...
+  async def create_observers(task: PipelineTask) -> Iterable[BaseObserver]: ...
   ```
 
 - Added support for new sonic-3 languages in `CartesiaTTSService` and
@@ -8195,7 +8188,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
   example, when creating `LLMMessagesAppendFrame`:
 
   ```python
-  message = LLMContext.create_image_message(image=..., size= ...)
+  message = LLMContext.create_image_message(image=..., size=...)
   await self.push_frame(LLMMessagesAppendFrame(messages=[message], run_llm=True))
   ```
 
@@ -8226,22 +8219,19 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
 
   ```python
   pipeline = Pipeline(
-    [
-      transport.input(),
-      context_aggregator.user(),
-
-      # BEFORE
-      llm,
-      transcript.user(),
-
-      # AFTER
-      transcript.user(),
-      llm,
-
-      transport.output(),
-      transcript.assistant(),
-      context_aggregator.assistant(),
-    ]
+      [
+          transport.input(),
+          context_aggregator.user(),
+          # BEFORE
+          llm,
+          transcript.user(),
+          # AFTER
+          transcript.user(),
+          llm,
+          transport.output(),
+          transcript.assistant(),
+          context_aggregator.assistant(),
+      ]
   )
   ```
 
@@ -8608,8 +8598,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
 
   ```python
   @task.event_handler("on_pipeline_error")
-  async def on_pipeline_error(task: PipelineTask, frame: ErrorFrame):
-      ...
+  async def on_pipeline_error(task: PipelineTask, frame: ErrorFrame): ...
   ```
 
 - Added a `service_tier` `InputParam` to the `BaseOpenAILLMService`. This
@@ -8803,8 +8792,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
 
   ```python
   @task.event_handler("on_pipeline_finished")
-  async def on_pipeline_finished(task: PipelineTask, frame: Frame):
-      ...
+  async def on_pipeline_finished(task: PipelineTask, frame: Frame): ...
   ```
 
 - Added support for new RTVI `send-text` event, along with the ability to toggle
@@ -9205,6 +9193,7 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
 
   # ...
 
+
   @transport.event_handler("on_client_connected")
   async def on_client_connected(transport, client):
       # Kick off the conversation.
@@ -9290,15 +9279,15 @@ PIPECAT_SETUP_FILES="setup1.py:setup.py:..."`). Each file must define a
 
   # Create your pipeline
   pipeline = Pipeline(
-    [
-        transport.input(),
-        stt,
-        context_aggregator.user(),
-        llm_switcher,
-        tts,
-        transport.output(),
-        context_aggregator.assistant(),
-    ]
+      [
+          transport.input(),
+          stt,
+          context_aggregator.user(),
+          llm_switcher,
+          tts,
+          transport.output(),
+          context_aggregator.assistant(),
+      ]
   )
   task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
 
@@ -10033,16 +10022,17 @@ quality and critical bugs impacting `ParallelPipelines` functionality.**
   # "Direct" function
   # `params` must be the first parameter
   async def do_something(params: FunctionCallParams, foo: int, bar: str = ""):
-    """
-    Do something interesting.
+      """
+      Do something interesting.
 
-    Args:
-      foo (int): The foo to do something interesting with.
-      bar (string): The bar to do something interesting with.
-    """
+      Args:
+        foo (int): The foo to do something interesting with.
+        bar (string): The bar to do something interesting with.
+      """
 
-    result = await process(foo, bar)
-    await params.result_callback({"result": result})
+      result = await process(foo, bar)
+      await params.result_callback({"result": result})
+
 
   # ...
 
@@ -10735,11 +10725,13 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
   provide a mixer per destination. For example:
 
 ```python
-  audio_out_mixer={
-      "track-1": SoundfileMixer(...),
-      "track-2": SoundfileMixer(...),
-      "track-N": SoundfileMixer(...),
-  },
+audio_out_mixer = (
+    {
+        "track-1": SoundfileMixer(...),
+        "track-2": SoundfileMixer(...),
+        "track-N": SoundfileMixer(...),
+    },
+)
 ```
 
 - The `STTMuteFilter` now mutes `InterimTranscriptionFrame` and
@@ -11347,11 +11339,11 @@ https://en.wikipedia.org/wiki/Saint_George%27s_Day_in_Catalonia
 
     ```python
     session_properties = SessionProperties(
-      # ...
-      input_audio_noise_reduction=InputAudioNoiseReduction(
-        type="near_field" # also supported: "far_field"
-      )
-      # ...
+        # ...
+        input_audio_noise_reduction=InputAudioNoiseReduction(
+            type="near_field"  # also supported: "far_field"
+        )
+        # ...
     )
     ```
 

--- a/COMMUNITY_INTEGRATIONS.md
+++ b/COMMUNITY_INTEGRATIONS.md
@@ -292,6 +292,7 @@ from dataclasses import dataclass, field
 
 from pipecat.services.settings import TTSSettings, NOT_GIVEN
 
+
 @dataclass
 class MyTTSSettings(TTSSettings):
     """Settings for MyTTS service.
@@ -322,6 +323,7 @@ Add a `Settings` **class attribute** that points to your settings dataclass. Thi
 
 ```python
 from typing import Optional
+
 
 class MyTTSService(TTSService):
     Settings = MyTTSSettings
@@ -429,6 +431,7 @@ The base `STTService` and `LLMService` already return a sensible frame, so most 
 ```python
 from pipecat.frames.frames import STTMetadataFrame
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
+
 
 def service_metadata_frame(self) -> STTMetadataFrame:
     # This service defines turn boundaries server-side and emits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,8 +285,7 @@ from pipecat.utils.deprecation import deprecated
 
 
 @deprecated(
-    "`OldService` is deprecated since 1.3.0 and will be removed in 2.0.0. "
-    "Use `NewService` instead."
+    "`OldService` is deprecated since 1.3.0 and will be removed in 2.0.0. Use `NewService` instead."
 )
 class OldService(NewService):
     """Deprecated alias for :class:`NewService`.
@@ -328,6 +327,7 @@ class MyService(BaseService):
         """
         if old_param is not None:
             import warnings
+
             warnings.warn(
                 "`old_param` is deprecated since 1.2.0 and will be removed in 2.0.0. "
                 "No replacement.",
@@ -355,6 +355,7 @@ class MyService(BaseService):
         """
         pass
 
+
 # Dataclass with code examples
 @dataclass
 class MessageFrame:
@@ -374,6 +375,7 @@ class MessageFrame:
     """
 
     messages: List[dict]
+
 
 # Enum class
 class Status(Enum):

--- a/changelog/5304.deprecated.md
+++ b/changelog/5304.deprecated.md
@@ -6,14 +6,15 @@
     # Before
     llm = OpenAILLMService(api_key=..., enable_async_tool_cancellation=True)
 
+
     @tool_options(cancel_on_interruption=False)
-    async def write_report(params: FunctionCallParams, topic: str):
-        ...
+    async def write_report(params: FunctionCallParams, topic: str): ...
+
 
     # After
     llm = OpenAILLMService(api_key=...)
 
+
     @tool_options(cancel_on_interruption=False, cancellable_by_llm=True)
-    async def write_report(params: FunctionCallParams, topic: str):
-        ...
+    async def write_report(params: FunctionCallParams, topic: str): ...
     ```


### PR DESCRIPTION
## Summary

- Format the five Markdown files that `ruff format` now rewrites, so `main` passes the `Code quality checks` job again
- Changes are cosmetic and confined to fenced code blocks: blank lines around top-level definitions, and string literals rejoined onto one line

## Why

ruff 0.16 formats Python code blocks inside Markdown by default. Under 0.15 the same files were skipped with *"Markdown formatting is experimental, enable preview mode"*, so they were never brought in line with the formatter.

With the lockfile now on 0.16.3, `uv run ruff format --diff` reports `5 files would be reformatted` on a clean checkout of `main`. Because the `format` workflow runs on every PR, this fails `Code quality checks` on **all** open PRs, including branches already even with `main`.

## Files

| File | Changed lines |
| --- | --- |
| `CHANGELOG.md` | 136 |
| `changelog/5304.deprecated.md` | 9 |
| `CONTRIBUTING.md` | 6 |
| `.claude/skills/cleanup/SKILL.md` | 4 |
| `COMMUNITY_INTEGRATIONS.md` | 3 |

## Testing

```
uv run ruff format --check .
```

Reports `1416 files already formatted` on this branch; the same command on `main` reports `5 files would be reformatted`.

## Note for reviewers

Formatting Markdown prose files is new ruff behavior worth an explicit decision. If rewriting `CHANGELOG.md` on each release is unwanted, the alternative is excluding `*.md` (or just `changelog/`) via `extend-exclude` in `pyproject.toml` instead of accepting the reformat.
