### PR TITLE
test(cli): answer only the prompt the stale-guide test is about

### DIFF
--- a/tests/cli/test_init_agent_ready.py
+++ b/tests/cli/test_init_agent_ready.py
@@ -31,6 +31,20 @@ class _StubAsk:
         return self._value
 
 
+def _confirm_matching(*phrases):
+    """Stub ``questionary.confirm`` to say yes only to prompts naming ``phrases``.
+
+    ``init`` asks several questions, and one of them offers to build the Context Hub
+    index — a subprocess that downloads and indexes the corpus. Matching on the prompt
+    text keeps a test from answering a question it did not mean to.
+    """
+
+    def _confirm(message, *args, **kwargs):
+        return _StubAsk(any(phrase in message for phrase in phrases))
+
+    return _confirm
+
+
 class TestInitAgentReady:
     """Behavior of the `pipecat init` file-drop command."""
 
@@ -177,7 +191,7 @@ class TestInitAgentReady:
         monkeypatch.setattr(init_mod, "_is_interactive", lambda: True)
         import questionary
 
-        monkeypatch.setattr(questionary, "confirm", lambda *a, **k: _StubAsk(True))
+        monkeypatch.setattr(questionary, "confirm", _confirm_matching("Refresh the guide files"))
         monkeypatch.setattr(questionary, "select", lambda *a, **k: _StubAsk("agent"))
         result = runner.invoke(app, ["init", str(tmp_path)])
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

- `test_stale_guide_offers_refresh_interactively` stubbed `questionary.confirm` to return `True` for every prompt, which also accepted `init`'s offer to build the Context Hub index — a subprocess that downloads and indexes the corpus
- The stub now matches on the prompt text, so only the guide refresh is confirmed

## Impact

That one test was **790s of the 984s** unit-test run — 80% of the job, with the other ~4,459 tests sharing the remaining three minutes.

It passed the whole time, so nothing flagged it. It is also invisible locally: `_offer_context_hub_index` returns early when an index already exists, so only a fresh runner reaches the prompt.

## Verification

Simulating a fresh runner (no index on disk) and recording whether the build is spawned:

| | Index build spawned | Result |
| --- | --- | --- |
| Before | 1 — `python -m pipecat_context_hub --log-level INFO refresh` | passed |
| After | 0 | passed |

`tests/cli/test_init_agent_ready.py` — 26 passed.

## Note for reviewers

Two things this does not address, both worth their own change:

- `init.py:348` polls the index build with `while process.poll() is None` and no timeout, so a hung build waits forever.
- The suite has no `pytest-timeout`, so a hanging test is bounded only by the job-level timeout — which kills the run without naming the test responsible.
