### PR TITLE
Regenerate llms.txt in the docs update workflow

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -287,7 +287,43 @@ To determine the correct values:
 
 Insert the new row **alphabetically** within the table. Match the column alignment of the existing rows.
 
-### Step 9: Output summary
+#### 8d: Frontmatter conventions
+
+A new page's `title` and `description` become its `llms.txt` entry and its
+citation label in AI tools, and the docs repo's metadata lint enforces them:
+
+- **title**: 50 chars max, no `- Pipecat` suffix (Mintlify appends it). Add a
+  `sidebarTitle` when the title runs past 30 chars.
+- **description**: 110-140 chars, naming the classes the page documents and the
+  modality acronym (STT/TTS/LLM/VAD) where relevant. Must be unique site-wide,
+  as must the effective unfurl title (`og:title` if set, else `title`) — add an
+  `og:title` when another page already uses the same short title.
+
+### Step 9: Format and regenerate llms.txt
+
+The docs repo checks in `llms.txt` (a navigation-ordered index built from each
+page's frontmatter) and `llms-full.txt` (every page's full body). Its metadata
+lint fails when either is stale, so regenerate them after any page edit,
+`docs.json` navigation change, or new page.
+
+Prettier reflows MDX and `llms-full.txt` embeds the page bodies verbatim, so
+formatting has to settle before generation:
+
+```bash
+cd DOCS_PATH
+npx prettier --ignore-unknown --write <edited files>
+node scripts/gen-llms-txt.mjs
+```
+
+Commit the doc edits together with the regenerated `llms.txt` and
+`llms-full.txt`. Generating before formatting leaves them stale — as does
+relying on the repo's pre-commit hook, which formats pages after generation has
+already run.
+
+`node scripts/docs-meta-lint.mjs` reports the same staleness and frontmatter
+findings CI will.
+
+### Step 10: Output summary
 
 After all edits are complete, print a summary:
 
@@ -338,4 +374,5 @@ Before finishing, verify:
 - [ ] Guides referencing changed APIs were checked and updated
 - [ ] New service pages were added to `docs.json` in the correct group, alphabetically
 - [ ] New service pages were added to `supported-services.mdx` in the correct table, alphabetically
+- [ ] Edited pages were formatted, then `llms.txt` and `llms-full.txt` regenerated and committed
 - [ ] Unmapped files were reported to the user

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -124,7 +124,7 @@ jobs:
 
             ## Follow the skill instructions
 
-            Apply the SKILL.md workflow (Steps 3-9) with these adaptations for automation:
+            Apply the SKILL.md workflow (Steps 3-10) with these adaptations for automation:
 
             ### Docs path
             Use `./_docs/` — it's already checked out. Do not ask for a path.
@@ -181,6 +181,11 @@ jobs:
             (e.g., only skip-listed files changed, or changes don't affect public API docs),
             exit cleanly without creating a branch or PR. Output "No documentation changes needed."
 
+            ### Formatting and llms.txt
+            Skip SKILL.md Step 9. A later workflow step runs Prettier over the pages
+            this branch touches and regenerates `llms.txt` / `llms-full.txt`, so leave
+            both to it rather than running them yourself.
+
             ## Important rules
             - Only modify files inside `./_docs/` — never modify pipecat source code
             - Follow the conservative editing rules from SKILL.md Step 6
@@ -192,20 +197,21 @@ jobs:
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash"
 
       # Pinned from the docs repo's own .nvmrc rather than left to whatever the
-      # runner image ships, so formatting matches what contributors produce.
+      # runner image ships, so formatting and generated files match what
+      # contributors produce.
       - name: Set up Node
         if: always()
         uses: actions/setup-node@v4
         with:
           node-version-file: _docs/.nvmrc
 
-      - name: Format docs with Prettier
+      - name: Format docs and regenerate llms.txt
         if: always()
         working-directory: _docs
         run: |
           BRANCH="docs/pr-${{ steps.pr.outputs.number }}"
           if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then
-            echo "No docs branch checked out; nothing to format."
+            echo "No docs branch checked out; nothing to do."
             exit 0
           fi
 
@@ -224,14 +230,19 @@ jobs:
           npm ci --no-audit --no-fund
           xargs -0 npx prettier --ignore-unknown --write < "$CHANGED"
 
+          # The docs repo checks in llms.txt and llms-full.txt, and its metadata
+          # lint fails when either is stale. llms-full.txt embeds page bodies
+          # verbatim, so generation runs after Prettier has settled them.
+          node scripts/gen-llms-txt.mjs
+
           if git diff --quiet; then
-            echo "Doc changes are already formatted."
+            echo "Doc changes are already formatted and llms.txt is current."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore: format with Prettier"
+          git commit -am "chore: format docs and regenerate llms.txt"
           git push origin "$BRANCH"
 
       - name: Assign docs PR


### PR DESCRIPTION
Aligning the update-docs workflow and skill to comply with the latest docs repo updates:
- create llms.txt, llms-full.txt
- generate frontmatter

## Summary

- The docs update workflow regenerates `llms.txt` and `llms-full.txt` and commits them with the doc edits, so its auto-docs PRs pass the docs repo's metadata lint
- Generation runs after the Prettier pass, since reflowed MDX changes the page bodies `llms-full.txt` copies verbatim
- `SKILL.md` carries the same step for local `/update-docs` runs, plus the frontmatter conventions (title and description length, `sidebarTitle`, uniqueness) the lint enforces on new pages

The docs repo builds both files from page frontmatter and MDX bodies with its `scripts/gen-llms-txt.mjs`. Its metadata lint regenerates them and fails when the checked-in copies differ — and because `llms-full.txt` embeds every page's full body, any doc edit makes it stale.

## Testing

In a docs checkout: after the workflow's docs PR lands its edits, `node scripts/docs-meta-lint.mjs` reports no check 13 findings.