### PR TITLE
Add optional prompt_cache_key passthrough for OpenAI LLM services

### DIFF
--- a/changelog/5391.added.md
+++ b/changelog/5391.added.md
@@ -1,0 +1,1 @@
+- Added optional `prompt_cache_key` to `BaseOpenAILLMService` and the OpenAI Responses services (HTTP and WebSocket), passed through to OpenAI's prompt caching when set and omitted when unset.

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -157,6 +157,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
         project=None,
         default_headers: Mapping[str, str] | None = None,
         service_tier: str | None = None,
+        prompt_cache_key: str | None = None,
         params: InputParams | None = None,
         settings: Settings | None = None,
         retry_timeout_secs: float | None = 5.0,
@@ -178,6 +179,11 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
             project: OpenAI project ID.
             default_headers: Additional HTTP headers to include in requests.
             service_tier: Service tier to use (e.g., "auto", "flex", "priority").
+            prompt_cache_key: Optional cache-routing key passed through to OpenAI's
+                prompt caching (see OpenAI's prompt caching guide). Reusing the same
+                key for requests that share a long common prompt prefix improves
+                cache hit rates. Only sent when set; requires an ``openai`` SDK
+                version that supports ``prompt_cache_key``.
             params: Input parameters for model configuration and behavior.
 
                 .. deprecated:: 0.0.105
@@ -236,6 +242,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
             **kwargs,
         )
         self._service_tier = service_tier
+        self._prompt_cache_key = prompt_cache_key
         self._retry_timeout_secs = retry_timeout_secs
         self._retry_on_timeout = retry_on_timeout
         self._full_model_name: str = ""
@@ -376,6 +383,12 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
             if self._service_tier is not None
             else OPENAI_NOT_GIVEN,
         }
+
+        # Only include prompt_cache_key when set: the parameter requires a newer
+        # openai SDK than this package's minimum, so an unconditional (even
+        # NOT_GIVEN) kwarg would break older installs.
+        if self._prompt_cache_key is not None:
+            params["prompt_cache_key"] = self._prompt_cache_key
 
         # Messages, tools, tool_choice
         params.update(params_from_context)

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -225,6 +225,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
         project=None,
         default_headers: Mapping[str, str] | None = None,
         service_tier: str | None = None,
+        prompt_cache_key: str | None = None,
         settings: Settings | None = None,
         retry_timeout_secs: float | None = 5.0,
         retry_on_timeout: bool | None = False,
@@ -239,6 +240,11 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
             project: OpenAI project ID.
             default_headers: Additional HTTP headers to include in requests.
             service_tier: Service tier to use (e.g., "auto", "flex", "priority").
+            prompt_cache_key: Optional cache-routing key passed through to OpenAI's
+                prompt caching (see OpenAI's prompt caching guide). Reusing the same
+                key for requests that share a long common prompt prefix improves
+                cache hit rates. Only sent when set; requires an ``openai`` SDK
+                version that supports ``prompt_cache_key``.
             settings: Runtime-updatable settings.
             retry_timeout_secs: How long an inference may go without producing
                 output before it is abandoned and re-issued, when
@@ -278,6 +284,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
         # variant connects via raw websockets and needs the key explicitly.
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self._service_tier = service_tier
+        self._prompt_cache_key = prompt_cache_key
         self._retry_timeout_secs = retry_timeout_secs
         self._retry_on_timeout = retry_on_timeout
         # Tracks the model we've already warned about (reasoning configured on a
@@ -367,6 +374,12 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
 
         if self._service_tier is not None:
             params["service_tier"] = self._service_tier
+
+        # Only include prompt_cache_key when set: the parameter requires a newer
+        # openai SDK than this package's minimum, so setting it unconditionally
+        # would break older installs.
+        if self._prompt_cache_key is not None:
+            params["prompt_cache_key"] = self._prompt_cache_key
 
         # Tools
         tools = invocation_params.get("tools")
@@ -586,7 +599,7 @@ class OpenAIResponsesLLMService(
                 Defaults to ``wss://api.openai.com/v1/responses``.
             **kwargs: Additional arguments passed to the base class (api_key,
                 base_url, organization, project, default_headers, service_tier,
-                settings, etc.).
+                prompt_cache_key, settings, etc.).
         """
         super().__init__(**kwargs)
 

--- a/tests/test_openai_prompt_cache_key.py
+++ b/tests/test_openai_prompt_cache_key.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the optional ``prompt_cache_key`` passthrough on OpenAI services.
+
+Covers request-shape only: the supplied key must appear unchanged in the
+request parameters, and an unset key must be omitted entirely (not sent as a
+sentinel), since ``prompt_cache_key`` requires a newer ``openai`` SDK than
+this package's minimum.
+"""
+
+from unittest.mock import patch
+
+from pipecat.services.openai.base_llm import BaseOpenAILLMService
+from pipecat.services.openai.responses.llm import OpenAIResponsesHttpLLMService
+
+
+def _make_chat_service(**kwargs):
+    with patch.object(BaseOpenAILLMService, "create_client"):
+        return BaseOpenAILLMService(api_key="test-key", **kwargs)
+
+
+def _make_responses_service(**kwargs):
+    with patch.object(OpenAIResponsesHttpLLMService, "_create_client"):
+        return OpenAIResponsesHttpLLMService(api_key="test-key", **kwargs)
+
+
+_CHAT_INVOCATION_PARAMS = {"messages": [], "tools": [], "tool_choice": None}
+_RESPONSES_INVOCATION_PARAMS = {"input": []}
+
+
+class TestChatCompletionsPromptCacheKey:
+    def test_supplied_key_is_passed_unchanged(self):
+        service = _make_chat_service(prompt_cache_key="session-abc123")
+        params = service.build_chat_completion_params(dict(_CHAT_INVOCATION_PARAMS))
+        assert params["prompt_cache_key"] == "session-abc123"
+
+    def test_unset_key_is_omitted(self):
+        service = _make_chat_service()
+        params = service.build_chat_completion_params(dict(_CHAT_INVOCATION_PARAMS))
+        assert "prompt_cache_key" not in params
+
+
+class TestResponsesPromptCacheKey:
+    def test_supplied_key_is_passed_unchanged(self):
+        service = _make_responses_service(prompt_cache_key="session-abc123")
+        params = service._build_response_params(dict(_RESPONSES_INVOCATION_PARAMS))
+        assert params["prompt_cache_key"] == "session-abc123"
+
+    def test_unset_key_is_omitted(self):
+        service = _make_responses_service()
+        params = service._build_response_params(dict(_RESPONSES_INVOCATION_PARAMS))
+        assert "prompt_cache_key" not in params


### PR DESCRIPTION
## Summary

Adds an optional `prompt_cache_key` passthrough to the OpenAI LLM services — `BaseOpenAILLMService` (Chat Completions) and the OpenAI Responses services (HTTP and WebSocket, via their shared base).

OpenAI's [prompt caching guide](https://developers.openai.com/api/docs/guides/prompt-caching) recommends: "Set `prompt_cache_key` on requests that share long, common prompt prefixes. Reuse the same key for those requests to help improve cache hit rates." Requests are routed using the key with the prompt-prefix hash as a secondary key; the key improves routing but does not make different prefixes match. For voice agents, whose per-turn requests share a long static prefix (system instruction + tools), a stable key measurably improves cached-token hit rates — we run this in production telephony on a patched service and see consistent `cached_tokens` on every turn after the first.

This PR only exposes the provider parameter. It does not alter prompt construction, caching policy, retention, or any default behavior.

## Implementation

- New optional constructor parameter `prompt_cache_key: str | None = None` on `BaseOpenAILLMService` and `_BaseOpenAIResponsesLLMService` (inherited by the HTTP and WebSocket Responses services), mirroring the existing `service_tier` passthrough.
- Included in the request **only when set**: the parameter needs a newer `openai` SDK than this package's `>=1.74.0` floor, so an unconditional (even `NOT_GIVEN`) kwarg would break older installs. Unset → byte-identical requests to today.
- WebSocket Responses variant picks it up automatically since it spreads `_build_response_params` into `response.create`.

## Tests

`tests/test_openai_prompt_cache_key.py` — request-shape tests for both builders:
- supplied key present unchanged;
- unset key omitted entirely.

```
uv run pytest tests/test_openai_prompt_cache_key.py  # 4 passed
uv run pytest tests/test_openai_responses_http.py tests/test_openai_responses_websocket.py  # 80 passed
uv run ruff format --check / ruff check  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMtNtjH8KvX4SpfzfzNyYb
