### PR TITLE
fix(tavus): use the caller's bot_name as the display name

### DIFF
--- a/changelog/5392.fixed.md
+++ b/changelog/5392.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `TavusTransport` ignoring its `bot_name` argument, so every Tavus bot joined the room named "Pipecat".

--- a/src/pipecat/transports/tavus/transport.py
+++ b/src/pipecat/transports/tavus/transport.py
@@ -281,7 +281,7 @@ class TavusTransportClient:
                 on_transcription_error=partial(self._on_handle_callback, "on_transcription_error"),
             )
             self._client = DailyTransportClient(
-                room_url, None, "Pipecat", self._params, daily_callbacks, self._bot_name
+                room_url, None, self._bot_name, self._params, daily_callbacks, "TavusPipecat"
             )
             await self._client.setup(setup)
         except Exception as e:
@@ -936,7 +936,7 @@ class TavusTransport(BaseTransport):
             on_participant_left=self._on_participant_left,
         )
         self._client = TavusTransportClient(
-            bot_name="Pipecat",
+            bot_name=bot_name,
             callbacks=callbacks,
             api_key=api_key,
             replica_id=replica_id,

--- a/tests/test_tavus_transport.py
+++ b/tests/test_tavus_transport.py
@@ -15,6 +15,7 @@ from pipecat.frames.frames import OutputAudioRawFrame
 from pipecat.transports.tavus.transport import (
     TavusOutputTransport,
     TavusParams,
+    TavusTransport,
     TavusTransportClient,
 )
 from pipecat.utils.asyncio.task_manager import TaskManager
@@ -157,3 +158,35 @@ async def test_the_conversation_outlives_the_first_transport_to_stop(monkeypatch
     await client.stop()
     daily.leave.assert_awaited_once()
     client._api.end_conversation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_the_bot_name_reaches_the_daily_client(monkeypatch):
+    """The name the caller picks is the bot's display name in the room."""
+    import pipecat.transports.tavus.transport as tavus
+
+    captured = {}
+
+    def fake_daily_client(room_url, token, bot_name, params, callbacks, transport_name):
+        captured["bot_name"] = bot_name
+        daily = MagicMock()
+        daily.setup = AsyncMock()
+        return daily
+
+    monkeypatch.setattr(tavus, "DailyTransportClient", fake_daily_client)
+
+    transport = TavusTransport(
+        bot_name="Ada",
+        session=MagicMock(),
+        api_key="test-key",
+        replica_id="replica",
+    )
+
+    async def fake_initialize():
+        return "https://example.daily.co/room"
+
+    monkeypatch.setattr(transport._client, "_initialize", fake_initialize)
+
+    await transport._client.setup(frame_processor_setup(TaskManager()))
+
+    assert captured["bot_name"] == "Ada"


### PR DESCRIPTION
`TavusTransport(bot_name=...)` never reached the room. Two things had to line up: `TavusTransport` passed the literal `"Pipecat"` into `TavusTransportClient`, and the client passed its `bot_name` into `DailyTransportClient`'s `transport_name` slot with `"Pipecat"` in the `bot_name` slot. Fixing either one alone leaves the display name as `"Pipecat"`. `examples/video-avatar/video-avatar-tavus-transport.py` passes `"Pipecat bot"` and shows up as `"Pipecat"`.

`transport_name` now gets `"TavusPipecat"`, matching `LemonSliceTransportClient`'s `"LemonSlicePipecat"`. It only feeds `DailyTransportClient.__str__`, so the visible effect is a log prefix moving off `Pipecat::DailyTransportClient`.

`TavusVideoService` builds the same client with a hardcoded name, but exposes no `bot_name` to callers, so I left it alone.

The new test asserts the name the caller picks is what `DailyTransportClient` receives. On main it fails with `Pipecat` where `Ada` is expected, and it fails with either half of the fix reverted. `tests/test_tavus_transport.py`: 7 passed. `ruff check` and `ruff format --check` clean.
