### PR TITLE
Deprecating pause_watchdog_timeout_s and removing the watchdog entirely.

### DIFF
--- a/changelog/5394.changed.md
+++ b/changelog/5394.changed.md
@@ -1,0 +1,1 @@
+- `TTSService` with `pause_frame_processing=True` now pauses only while there is audio to wait for: the bot speaking, or an audio context still open that may yet produce audio. Previously a turn that produced no audio could stall the pipeline for a few seconds until a watchdog force-resumed it and reported a non-fatal error.

--- a/changelog/5394.deprecated.md
+++ b/changelog/5394.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated the `pause_watchdog_timeout_s` parameter of `TTSService`, which will be removed in 2.0.0. Passing it warns and does nothing: a pause is now only taken while audio is playing or still on its way, so it is always lifted by the `BotStoppedSpeakingFrame` that follows playback or by the audio context completing in silence — no timer is needed to break it.

--- a/scripts/deprecations/deprecations.json
+++ b/scripts/deprecations/deprecations.json
@@ -3611,6 +3611,17 @@
       "location": "pipecat/services/tts_service.py"
     },
     {
+      "subject": "TTSService.pause_watchdog_timeout_s",
+      "module": "pipecat.services.tts_service",
+      "kind": "parameter",
+      "deprecated_in": "1.8.0",
+      "removed_in": "2.0.0",
+      "relation": "none",
+      "replacement": null,
+      "message": "No replacement. Frame processing is now paused only while there is audio still to be played, so the pause is lifted by the ``BotStoppedSpeakingFrame`` that follows playback or by the audio context completing in silence, and no timer is needed to break it. Will be removed in 2.0.0.",
+      "location": "pipecat/services/tts_service.py"
+    },
+    {
       "subject": "TTSService.set_model",
       "module": "pipecat.services.tts_service",
       "kind": "method",

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -308,10 +308,10 @@ class TTSService(AIService):
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 warnings.warn(
-                    "The `pause_watchdog_timeout_s` parameter is deprecated since 1.8.0 and "
-                    "will be removed in 2.0.0. It no longer does anything: frame processing "
-                    "is paused only while there is audio still to be played, so the pause "
-                    "cannot outlive what it waits for.",
+                    "`pause_watchdog_timeout_s` is deprecated since 1.8.0 and will be "
+                    "removed in 2.0.0. No replacement. Frame processing is paused only "
+                    "while there is audio still to be played, so the pause cannot "
+                    "outlive what it waits for.",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -162,9 +162,7 @@ class TTSService(AIService):
         silence_time_s: float = 2.0,
         # if True, we will pause processing frames while we are receiving audio
         pause_frame_processing: bool = False,
-        # if pause_frame_processing is True, force-resume if no BotStartedSpeakingFrame
-        # arrives within this many seconds of pausing
-        pause_watchdog_timeout_s: float = 3.0,
+        pause_watchdog_timeout_s: float | None = None,
         # number of consecutive TTS contexts that may complete with no audio before the
         # service is reported unable to do its job; 0 disables the check
         max_consecutive_zero_audio_contexts: int = 3,
@@ -214,15 +212,15 @@ class TTSService(AIService):
             push_silence_after_stop: Whether to push silence audio after TTSStoppedFrame.
             silence_time_s: Duration of silence to push when push_silence_after_stop is True.
             pause_frame_processing: Whether to pause frame processing during audio generation.
-            pause_watchdog_timeout_s: When pause_frame_processing is True, force-resume frame
-                processing (and report a non-fatal error) if no BotStartedSpeakingFrame confirms
-                audio is playing for the current turn within this many seconds of pausing. Not
-                armed when audio was already confirmed before the pause (the common case for
-                streaming TTS, where playback starts while the LLM is still generating). A
-                context that completes with no audio lifts the pause itself, so this covers
-                what that completion can't: a BotStoppedSpeakingFrame race that leaves the
-                pause latched after audio did play, and a context that completed in silence
-                before the pause was taken.
+            pause_watchdog_timeout_s: Unused.
+
+                .. deprecated:: 1.8.0
+                    No replacement. Frame processing is now paused only while there is
+                    audio still to be played, so the pause is lifted by the
+                    ``BotStoppedSpeakingFrame`` that follows playback or by the audio
+                    context completing in silence, and no timer is needed to break it.
+                    Will be removed in 2.0.0.
+
             max_consecutive_zero_audio_contexts: How many consecutive TTS contexts may
                 complete without producing any audio before the service is reported unable
                 to do its job. Catches a provider that accepts requests and stays silent —
@@ -279,8 +277,6 @@ class TTSService(AIService):
 
         # Resolve text_aggregation_mode from the new param or deprecated aggregate_sentences
         if aggregate_sentences is not None:
-            import warnings
-
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 warnings.warn(
@@ -308,13 +304,20 @@ class TTSService(AIService):
         self._push_silence_after_stop: bool = push_silence_after_stop
         self._silence_time_s: float = silence_time_s
         self._pause_frame_processing: bool = pause_frame_processing
-        self._pause_watchdog_timeout_s: float = pause_watchdog_timeout_s
-        self._pause_watchdog_task: asyncio.Task | None = None
+        if pause_watchdog_timeout_s is not None:
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "The `pause_watchdog_timeout_s` parameter is deprecated since 1.8.0 and "
+                    "will be removed in 2.0.0. It no longer does anything: frame processing "
+                    "is paused only while there is audio still to be played, so the pause "
+                    "cannot outlive what it waits for.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         # Whether the bot is currently speaking. Set on BotStartedSpeakingFrame,
-        # cleared on BotStoppedSpeakingFrame and InterruptionFrame. Lets
-        # _maybe_pause_frame_processing() know this turn's audio already
-        # started before skipping the watchdog — see its docstring. Also used
-        # by InterruptibleTTSService to decide whether an interruption needs a
+        # cleared on BotStoppedSpeakingFrame and InterruptionFrame. Used by
+        # InterruptibleTTSService to decide whether an interruption needs a
         # reconnect.
         self._bot_speaking: bool = False
         self._max_consecutive_zero_audio_contexts: int = max_consecutive_zero_audio_contexts
@@ -602,7 +605,6 @@ class TTSService(AIService):
         """Release TTS resources at teardown."""
         await super().cleanup()
         await self._stop_audio_context_task()
-        await self._cancel_pause_watchdog()
 
     async def start(self, frame: StartFrame):
         """Start the TTS service.
@@ -890,11 +892,7 @@ class TTSService(AIService):
                 delta = type(self._settings).from_mapping(frame.settings)
                 await self._update_settings(delta)
         elif isinstance(frame, BotStartedSpeakingFrame):
-            # Audio is confirmed playing for this turn, so no watchdog is
-            # needed — the ordinary BotStoppedSpeakingFrame path below will
-            # resume once playback finishes.
             self._bot_speaking = True
-            await self._cancel_pause_watchdog()
             await self.push_frame(frame, direction)
         elif isinstance(frame, BotStoppedSpeakingFrame):
             self._bot_speaking = False
@@ -1068,47 +1066,28 @@ class TTSService(AIService):
         await self._maybe_resume_frame_processing()
 
     async def _maybe_pause_frame_processing(self):
-        if self._processing_text and self._pause_frame_processing:
-            await self.pause_processing_frames()
-            await self._cancel_pause_watchdog()
-            if not self._bot_speaking:
-                # Streaming TTS (e.g. ElevenLabs, Deepgram) usually starts
-                # playback — and so BotStartedSpeakingFrame — while the LLM is
-                # still generating, i.e. before this pause happens. In that
-                # case audio for this turn is already confirmed and the
-                # ordinary BotStoppedSpeakingFrame path will resume once
-                # playback finishes.
-                #
-                # Otherwise, force-resume if no BotStartedSpeakingFrame
-                # confirms audio is actually playing (e.g. a context completes
-                # with zero audio, or a BotStoppedSpeakingFrame race left this
-                # pause permanently latched), so the pause can never deadlock
-                # the pipeline.
-                self._pause_watchdog_task = self.create_task(
-                    self._pause_watchdog_handler(), name="pause_watchdog"
-                )
+        """Hold incoming frames until the audio for this turn has been played.
+
+        Pausing waits for the ``BotStoppedSpeakingFrame`` that follows playback,
+        so it is only taken while there is playback to wait for: the bot
+        speaking, or an audio context still open that may yet produce audio. A
+        turn with neither — one whose contexts all completed in silence, or
+        whose playback finished before the turn's text ran out — has nothing
+        left to resume it, and pausing would latch frame processing for good.
+        """
+        if not (self._processing_text and self._pause_frame_processing):
+            return
+
+        # With no audio playing or on its way, no BotStoppedSpeakingFrame is
+        # coming to lift the pause and it would latch for good.
+        if not (self._bot_speaking or self._audio_contexts):
+            return
+
+        await self.pause_processing_frames()
 
     async def _maybe_resume_frame_processing(self):
-        await self._cancel_pause_watchdog()
         if self._pause_frame_processing:
             await self.resume_processing_frames()
-
-    async def _cancel_pause_watchdog(self):
-        if self._pause_watchdog_task:
-            await self.cancel_task(self._pause_watchdog_task)
-            self._pause_watchdog_task = None
-
-    async def _pause_watchdog_handler(self):
-        await asyncio.sleep(self._pause_watchdog_timeout_s)
-        self._pause_watchdog_task = None
-        msg = (
-            f"{self} no BotStartedSpeakingFrame within "
-            f"{self._pause_watchdog_timeout_s}s of pausing frame processing "
-            f"(e.g. a TTS context completed with no audio) — force-resuming"
-        )
-        logger.warning(msg)
-        await self.resume_processing_frames()
-        await self.push_error(msg)
 
     async def _process_text_frame(self, frame: TextFrame):
         async for aggregate in self._text_aggregator.aggregate(frame.text):
@@ -1824,8 +1803,8 @@ class TTSService(AIService):
             return
 
         # This context played nothing, so the transport will never send the
-        # BotStoppedSpeakingFrame that lifts a pause taken for it. Resume as
-        # soon as that is known rather than waiting out the pause watchdog. A
+        # BotStoppedSpeakingFrame that lifts a pause taken for it, which can
+        # happen when the pause was taken while the context was still open. A
         # bot still speaking is playing audio from another context, whose own
         # BotStoppedSpeakingFrame is still to come.
         if not self._bot_speaking:
@@ -2005,10 +1984,9 @@ class InterruptibleTTSService(WebsocketTTSService):
         # True once run_tts has been invoked (TTSStartedFrame pushed) for the
         # current turn but before BotStartedSpeakingFrame confirms playback —
         # the narrow window where _bot_speaking (which only reflects confirmed
-        # playback, and also gates TTSService's pause watchdog) can't yet tell
-        # a reconnect is needed. Kept separate from _bot_speaking so this
-        # early, unconfirmed marker never suppresses the watchdog for a turn
-        # that ends up producing no audio.
+        # playback) can't yet tell a reconnect is needed. Kept separate from
+        # _bot_speaking so this early, unconfirmed marker never makes a turn
+        # that produces no audio look like one that played.
         self._tts_started: bool = False
 
     async def _handle_interruption(self, frame: InterruptionFrame, direction: FrameDirection):
@@ -2050,8 +2028,7 @@ class InterruptibleTTSService(WebsocketTTSService):
             # The turn ended normally; nothing left to reconnect for.
             self._tts_started = False
         elif isinstance(frame, LLMFullResponseStartFrame):
-            # Safety net for a previous turn that never produced audio (e.g.
-            # force-resumed by TTSService's pause watchdog), so
+            # Safety net for a previous turn that never produced audio, so
             # BotStoppedSpeakingFrame never arrived to clear it above.
             self._tts_started = False
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -960,11 +960,10 @@ class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
         test has no transport, so no BotStoppedSpeakingFrame or
         BotStartedSpeakingFrame is ever sent, modeling that gap directly.
 
-        The terminal EndFrame is a ControlFrame, so it queues behind the pause
-        and never reaches the sink, and _wait_for_pipeline_end's EndFrame
-        branch has no timeout (unlike the CancelFrame branch) — so
-        TTSService's pause watchdog must force-resume after
-        pause_watchdog_timeout_s for PipelineWorker.run() to return.
+        The terminal EndFrame is a ControlFrame, so a pause left latched would
+        queue it behind the pause and it would never reach the sink —
+        _wait_for_pipeline_end's EndFrame branch has no timeout (unlike the
+        CancelFrame branch), so PipelineWorker.run() would never return.
         """
 
         class TTSZeroAudioNoResume(TTSService):
@@ -973,7 +972,6 @@ class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
                     push_start_frame=True,
                     push_text_frames=False,
                     pause_frame_processing=True,
-                    pause_watchdog_timeout_s=0.2,
                     sample_rate=16000,
                     **kwargs,
                 )

--- a/tests/test_tts_frame_ordering.py
+++ b/tests/test_tts_frame_ordering.py
@@ -311,9 +311,8 @@ class MockWebSocketPauseTTSServiceZeroAudioCompletion(TTSService):
     ElevenLabsTTSService's actual override: it resets alignment state but never
     calls _maybe_resume_frame_processing(). Because no TTSAudioRawFrame is ever
     produced, the output transport's BotStartedSpeakingFrame/
-    BotStoppedSpeakingFrame never fire in production either, so nothing resumes
-    frame processing after pause_processing_frames() latches — until
-    TTSService's own pause watchdog force-resumes after pause_watchdog_timeout_s.
+    BotStoppedSpeakingFrame never fire in production either, so the context
+    completing in silence is the only thing that can lift the pause.
     """
 
     def __init__(self, **kwargs):
@@ -321,7 +320,6 @@ class MockWebSocketPauseTTSServiceZeroAudioCompletion(TTSService):
             push_start_frame=True,
             push_text_frames=False,
             pause_frame_processing=True,
-            pause_watchdog_timeout_s=0.2,
             sample_rate=_SAMPLE_RATE,
             **kwargs,
         )
@@ -348,8 +346,8 @@ class MockWebSocketPauseTTSServiceLongPlayback(TTSService):
     whose audio context completes quickly (as ElevenLabs-style providers
     typically report isFinal shortly after the last text is sent), but whose
     actual playback — tracked independently by the output transport — keeps
-    going past pause_watchdog_timeout_s after the turn's LLMFullResponseEndFrame
-    pauses frame processing.
+    going well after the turn's LLMFullResponseEndFrame pauses frame
+    processing.
 
     Does NOT override on_audio_context_completed(), matching
     ElevenLabsTTSService's actual override (resets alignment state but never
@@ -364,7 +362,6 @@ class MockWebSocketPauseTTSServiceLongPlayback(TTSService):
             push_start_frame=True,
             push_text_frames=False,
             pause_frame_processing=True,
-            pause_watchdog_timeout_s=0.2,
             sample_rate=_SAMPLE_RATE,
             **kwargs,
         )
@@ -1593,8 +1590,8 @@ async def test_no_deadlock_on_zero_audio_context_completion():
 
     Timeline:
     1. LLM response -> _processing_text=True.
-    2. LLMFullResponseEndFrame -> pause_processing_frames() called, starting
-       the pause watchdog.
+    2. LLMFullResponseEndFrame -> pause_processing_frames() called, the context
+       still being open and able to produce audio.
     3. Provider reports the context finished with no audio (TTSStoppedFrame,
        zero TTSAudioRawFrame). on_audio_context_completed() is a no-op here,
        matching ElevenLabsTTSService's actual override.
@@ -1602,10 +1599,8 @@ async def test_no_deadlock_on_zero_audio_context_completion():
        production the output transport only sends them once TTS audio was
        actually received, and this test models that absence directly by never
        sending either.
-    5. The pause watchdog (pause_watchdog_timeout_s=0.2 here) fires with no
-       BotStartedSpeakingFrame seen, force-resumes frame processing, and
-       reports a non-fatal error. FooFrame must arrive downstream within the
-       timeout.
+    5. The context completing with no audio resumes frame processing, so
+       FooFrame must arrive downstream.
     """
     tts = MockWebSocketPauseTTSServiceZeroAudioCompletion()
 
@@ -1676,20 +1671,19 @@ async def test_filter_stripped_text_does_not_pause_frame_processing():
 
 
 @pytest.mark.asyncio
-async def test_no_spurious_watchdog_on_long_streaming_turn():
-    """A long streaming turn whose audio is still playing past
-    pause_watchdog_timeout_s after the pause must not trip the watchdog.
+async def test_no_early_resume_on_long_streaming_turn():
+    """A long streaming turn whose audio is still playing must stay paused.
 
     Timeline:
     1. LLM response -> _processing_text=True.
     2. BotStartedSpeakingFrame arrives *before* LLMFullResponseEndFrame —
        streaming TTS starts playback while the LLM is still generating, and
        the output transport only sends this frame once per turn.
-    3. LLMFullResponseEndFrame -> pause_processing_frames() called. Audio for
-       this turn was already confirmed, so no watchdog should be armed.
-    4. More than pause_watchdog_timeout_s (0.2s here) elapses with no
-       BotStoppedSpeakingFrame yet — this must NOT force-resume or push an
-       ErrorFrame; playback is still legitimately in progress.
+    3. LLMFullResponseEndFrame -> pause_processing_frames() called, this turn's
+       audio being on its way to the transport.
+    4. Time passes with no BotStoppedSpeakingFrame yet — nothing must resume
+       frame processing or push an ErrorFrame; playback is still legitimately
+       in progress.
     5. BotStoppedSpeakingFrame finally arrives (playback finished) and
        resumes frame processing normally; FooFrame must arrive afterward.
     """
@@ -1711,7 +1705,7 @@ async def test_no_spurious_watchdog_on_long_streaming_turn():
         BotStartedSpeakingFrame(),
         SleepFrame(sleep=0.05),
         LLMFullResponseEndFrame(),
-        SleepFrame(sleep=0.3),  # longer than pause_watchdog_timeout_s=0.2
+        SleepFrame(sleep=0.3),  # playback still in progress
         BotStoppedSpeakingFrame(),
         FooFrame(label="after_stop"),
     ]
@@ -1723,10 +1717,7 @@ async def test_no_spurious_watchdog_on_long_streaming_turn():
 
     down, up = frames_received
     error_frames = [f for f in up if isinstance(f, ErrorFrame)]
-    assert not error_frames, (
-        f"Spurious pause-watchdog ErrorFrame(s) during in-progress playback: {error_frames} — "
-        "the watchdog must not arm when audio was already confirmed before the pause"
-    )
+    assert not error_frames, f"Spurious ErrorFrame(s) during in-progress playback: {error_frames}"
 
     foo_frames = [f for f in down if isinstance(f, FooFrame)]
     assert any(f.label == "after_stop" for f in foo_frames), (

--- a/tests/test_tts_interruptible_service.py
+++ b/tests/test_tts_interruptible_service.py
@@ -11,9 +11,9 @@ was speaking (or about to start speaking) for the turn being interrupted. It
 tracks this with two flags:
 
 - ``_bot_speaking`` (on the base TTSService): true only once BotStartedSpeakingFrame
-  confirms the output transport actually received audio; also gates
-  TTSService's pause watchdog (see test_no_spurious_watchdog_on_long_streaming_turn
-  and test_no_deadlock_on_zero_audio_context_completion in test_tts_frame_ordering.py).
+  confirms the output transport actually received audio (see
+  test_no_early_resume_on_long_streaming_turn and
+  test_no_deadlock_on_zero_audio_context_completion in test_tts_frame_ordering.py).
 - ``_tts_started`` (InterruptibleTTSService only): true from the moment
   run_tts is invoked (TTSStartedFrame pushed) until consumed by an
   interruption, or cleared by BotStoppedSpeakingFrame (turn ended normally) or
@@ -177,9 +177,9 @@ async def test_tts_started_cleared_on_new_turn():
     """_tts_started must not leak into a new turn.
 
     Models a turn that invoked run_tts (TTSStartedFrame) but never got a
-    BotStartedSpeakingFrame or BotStoppedSpeakingFrame — e.g. force-resumed by
-    TTSService's own pause watchdog after a zero-audio completion, so nothing
-    ever clears _tts_started via the normal BotStoppedSpeakingFrame path.
+    BotStartedSpeakingFrame or BotStoppedSpeakingFrame — a turn that completed
+    with no audio, say — so nothing ever clears _tts_started via the normal
+    BotStoppedSpeakingFrame path.
     Without the LLMFullResponseStartFrame reset, an interruption during the
     *next* turn (before it has invoked run_tts itself) would incorrectly
     reconnect because of the stale flag.
@@ -219,17 +219,14 @@ async def test_silent_turn_resumes_frame_processing():
     A context completes (TTSStoppedFrame) with zero TTSAudioRawFrames, and no
     BotStartedSpeakingFrame/BotStoppedSpeakingFrame ever arrives — as in
     production, where the output transport never receives audio to react to.
-    Both recoveries from this are gated on _bot_speaking: the resume when a
-    context completes in silence, and the pause watchdog behind it. Which one
-    gets there first depends on how long the provider holds the context open,
-    so this asserts only that the pipeline keeps moving.
+    Whether the pause is taken at all depends on how long the provider holds
+    the context open, so this asserts only that the pipeline keeps moving.
     """
 
     class FakeInterruptiblePauseTTSService(FakeInterruptibleTTSService):
         def __init__(self, **kwargs):
             super().__init__(
                 pause_frame_processing=True,
-                pause_watchdog_timeout_s=0.2,
                 **kwargs,
             )
 
@@ -250,7 +247,7 @@ async def test_silent_turn_resumes_frame_processing():
         LLMFullResponseStartFrame(),
         TextFrame(text="Hello."),
         LLMFullResponseEndFrame(),
-        SleepFrame(sleep=0.4),  # longer than pause_watchdog_timeout_s=0.2
+        SleepFrame(sleep=0.4),  # let the silent context complete
         MarkerFrame(label="after_silence"),
     ]
 

--- a/tests/test_tts_zero_audio_contexts.py
+++ b/tests/test_tts_zero_audio_contexts.py
@@ -246,14 +246,10 @@ async def test_becoming_usable_again_clears_the_count():
 async def test_a_silent_context_resumes_frame_processing():
     """A context known to have played nothing lifts the pause it took.
 
-    The watchdog would eventually force-resume, so it is given a timeout far
-    longer than the test: the frames only get through if completing in silence
-    resumes frame processing on its own.
+    The pause is taken while the context is still open and might yet produce
+    audio; nothing else will resume it once the context completes in silence.
     """
-    tts = MockPausingTTSService(
-        pause_watchdog_timeout_s=30.0,
-        max_consecutive_zero_audio_contexts=0,
-    )
+    tts = MockPausingTTSService(max_consecutive_zero_audio_contexts=0)
 
     frames_to_send: list[Frame] = [
         LLMFullResponseStartFrame(),
@@ -272,5 +268,4 @@ async def test_a_silent_context_resumes_frame_processing():
     assert any(marker.label == "after_silence" for marker in markers), (
         "frame processing stayed paused after a context completed with no audio"
     )
-    # The watchdog never fired, so the error it reports is absent too.
     assert _errors(up) == []


### PR DESCRIPTION
  ## Summary

  - `TTSService` with `pause_frame_processing=True` now takes the pause only while there is audio to wait for — the bot speaking, or an audio context still open that may yet produce audio. A turn with neither has nothing coming to lift the pause, so it is not taken at all.
  - This removes the failure mode the pause watchdog existed to break: a pause latched with no `BotStoppedSpeakingFrame` on its way. With the pause never outliving what it waits for, the timer has nothing left to do.
  - Deprecated `TTSService(pause_watchdog_timeout_s=...)` (removed in 2.0.0). Passing it warns and does nothing; a turn that produces no audio no longer stalls for a few seconds or reports the non-fatal error the watchdog raised on force-resume.

  ## Breaking Changes
  
  None. `pause_watchdog_timeout_s` still accepts a value and only warns.   