### PR TITLE
test(observers): buy the startup span assertion its headroom from the count

### DIFF
--- a/tests/test_startup_timing_observer.py
+++ b/tests/test_startup_timing_observer.py
@@ -129,12 +129,21 @@ class TestStartupTimingObserver(unittest.IsolatedAsyncioTestCase):
     async def test_total_is_the_span_rather_than_the_sum(self):
         """Processors are set up concurrently, so their cost does not add up.
 
-        Summing what each cost would report three concurrent 0.1s connections
-        as 0.3s, so a pipeline reads as slower the more it overlaps.
+        Summing what each cost would report ten concurrent 0.1s connections as
+        1.0s, so a pipeline reads as slower the more it overlaps.
+
+        The gap between the sum and the span is what the span has to spend on
+        the rest of startup before the assertion stops holding, and it is
+        ``(count - 1) * delay``. The count buys that headroom for free, since
+        the setups overlap and the span stays at one delay however many there
+        are; the delay buys it at the cost of the same time again in every run.
         """
+        delay = 0.1
+        count = 10
+
         observer = StartupTimingObserver()
         pipeline = Pipeline(
-            [SlowSetupProcessor(delay=0.1) for _ in range(3)],
+            [SlowSetupProcessor(delay=delay) for _ in range(count)],
         )
 
         reports = []
@@ -153,11 +162,11 @@ class TestStartupTimingObserver(unittest.IsolatedAsyncioTestCase):
         report = reports[0]
         summed = sum(t.duration_secs for t in report.processor_timings)
 
-        self.assertGreaterEqual(summed, 0.25, "each processor should be measured")
+        self.assertGreaterEqual(summed, count * delay * 0.8, "each processor should be measured")
         self.assertLess(
             report.total_duration_secs,
             summed,
-            "the three setups overlapped, so the span is shorter than the sum",
+            "the setups overlapped, so the span is shorter than the sum",
         )
 
     async def test_processor_types_filter(self):


### PR DESCRIPTION
`coverage` on main went red at [32495397494](https://github.com/pipecat-ai/pipecat/actions/runs/32495397494): `total_duration_secs` 0.4949 against a summed 0.3072. `tests` passed on the same commit. Under `coverage run` the tracing tax falls on pipeline startup but not on `asyncio.sleep`, so the span grows while the sum it is measured against does not.

Three 0.1s setups leave the span 0.20s for the rest of startup. Coverage alone spends 0.135s of that on my laptop; the runner spent 0.392s.

Headroom is `(count - 1) * delay`. The count buys it for free, because the setups overlap and the span stays at one delay:

| | summed | span | headroom | wall time |
|---|---|---|---|---|
| 3 x 0.1 | 0.31 | 0.10 | 0.20 | 0.11s |
| 10 x 0.1 | 1.02 | 0.10 | 0.90 | 0.11s |
| 3 x 0.5 | 1.51 | 0.50 | 1.00 | 0.51s |

The delay reaches the same headroom at 5x the runtime, so I moved the count.

This stays a wall-clock comparison, and a runner spending over 0.9s on the rest of startup will fail it again. I did not reproduce the red run locally.

The assertion keeps its teeth: it fails with `_emit_report` summing `_timings`, and fails again with `_setup_processors` looping where it gathers.

Test-only, so no changelog fragment (CONTRIBUTING.md, "When to Skip Changelog Entries").
