### PR TITLE
Resolve the ElevenLabs STT detected language to a Language enum

### DIFF
--- a/changelog/5396.fixed.md
+++ b/changelog/5396.fixed.md
@@ -1,0 +1,4 @@
+`ElevenLabsSTTService` and `ElevenLabsRealtimeSTTService` now resolve the
+detected language to a `Language` before emitting it, instead of forwarding
+ElevenLabs' raw ISO-639-3 code. Comparing `frame.language == Language.PT` works
+on these services as it already did on Deepgram and Soniox.

--- a/src/pipecat/services/elevenlabs/stt.py
+++ b/src/pipecat/services/elevenlabs/stt.py
@@ -44,6 +44,113 @@ from pipecat.utils.tracing.service_decorators import traced_stt
 from pipecat.utils.types import NOT_GIVEN, NotGiven, is_given
 
 
+#: Language -> the ISO-639-3 code ElevenLabs uses.
+#:
+#: Module level so the reverse direction can be derived from it rather than
+#: hand-written; the two cannot then drift apart.
+LANGUAGE_MAP = {
+    Language.AF: "afr",  # Afrikaans
+    Language.AM: "amh",  # Amharic
+    Language.AR: "ara",  # Arabic
+    Language.HY: "hye",  # Armenian
+    Language.AS: "asm",  # Assamese
+    Language.AST: "ast",  # Asturian
+    Language.AZ: "aze",  # Azerbaijani
+    Language.BE: "bel",  # Belarusian
+    Language.BN: "ben",  # Bengali
+    Language.BS: "bos",  # Bosnian
+    Language.BG: "bul",  # Bulgarian
+    Language.MY: "mya",  # Burmese
+    Language.YUE: "yue",  # Cantonese
+    Language.CA: "cat",  # Catalan
+    Language.CEB: "ceb",  # Cebuano
+    Language.NY: "nya",  # Chichewa
+    Language.HR: "hrv",  # Croatian
+    Language.CS: "ces",  # Czech
+    Language.DA: "dan",  # Danish
+    Language.NL: "nld",  # Dutch
+    Language.EN: "eng",  # English
+    Language.ET: "est",  # Estonian
+    Language.FIL: "fil",  # Filipino
+    Language.FI: "fin",  # Finnish
+    Language.FR: "fra",  # French
+    Language.FF: "ful",  # Fulah
+    Language.GL: "glg",  # Galician
+    Language.LG: "lug",  # Ganda
+    Language.KA: "kat",  # Georgian
+    Language.DE: "deu",  # German
+    Language.EL: "ell",  # Greek
+    Language.GU: "guj",  # Gujarati
+    Language.HA: "hau",  # Hausa
+    Language.HE: "heb",  # Hebrew
+    Language.HI: "hin",  # Hindi
+    Language.HU: "hun",  # Hungarian
+    Language.IS: "isl",  # Icelandic
+    Language.IG: "ibo",  # Igbo
+    Language.ID: "ind",  # Indonesian
+    Language.GA: "gle",  # Irish
+    Language.IT: "ita",  # Italian
+    Language.JA: "jpn",  # Japanese
+    Language.JV: "jav",  # Javanese
+    Language.KEA: "kea",  # Kabuverdianu
+    Language.KN: "kan",  # Kannada
+    Language.KK: "kaz",  # Kazakh
+    Language.KM: "khm",  # Khmer
+    Language.KO: "kor",  # Korean
+    Language.KU: "kur",  # Kurdish
+    Language.KY: "kir",  # Kyrgyz
+    Language.LO: "lao",  # Lao
+    Language.LV: "lav",  # Latvian
+    Language.LN: "lin",  # Lingala
+    Language.LT: "lit",  # Lithuanian
+    Language.LUO: "luo",  # Luo
+    Language.LB: "ltz",  # Luxembourgish
+    Language.MK: "mkd",  # Macedonian
+    Language.MS: "msa",  # Malay
+    Language.ML: "mal",  # Malayalam
+    Language.MT: "mlt",  # Maltese
+    Language.ZH: "zho",  # Mandarin Chinese
+    Language.MI: "mri",  # Māori
+    Language.MR: "mar",  # Marathi
+    Language.MN: "mon",  # Mongolian
+    Language.NE: "nep",  # Nepali
+    Language.NSO: "nso",  # Northern Sotho
+    Language.NO: "nor",  # Norwegian
+    Language.OC: "oci",  # Occitan
+    Language.OR: "ori",  # Odia
+    Language.PS: "pus",  # Pashto
+    Language.FA: "fas",  # Persian
+    Language.PL: "pol",  # Polish
+    Language.PT: "por",  # Portuguese
+    Language.PA: "pan",  # Punjabi
+    Language.RO: "ron",  # Romanian
+    Language.RU: "rus",  # Russian
+    Language.SR: "srp",  # Serbian
+    Language.SN: "sna",  # Shona
+    Language.SD: "snd",  # Sindhi
+    Language.SK: "slk",  # Slovak
+    Language.SL: "slv",  # Slovenian
+    Language.SO: "som",  # Somali
+    Language.ES: "spa",  # Spanish
+    Language.SW: "swa",  # Swahili
+    Language.SV: "swe",  # Swedish
+    Language.TA: "tam",  # Tamil
+    Language.TG: "tgk",  # Tajik
+    Language.TE: "tel",  # Telugu
+    Language.TH: "tha",  # Thai
+    Language.TR: "tur",  # Turkish
+    Language.UK: "ukr",  # Ukrainian
+    Language.UMB: "umb",  # Umbundu
+    Language.UR: "urd",  # Urdu
+    Language.UZ: "uzb",  # Uzbek
+    Language.VI: "vie",  # Vietnamese
+    Language.CY: "cym",  # Welsh
+    Language.WO: "wol",  # Wolof
+    Language.XH: "xho",  # Xhosa
+    Language.ZU: "zul",  # Zulu
+}
+
+
 def language_to_elevenlabs_language(language: Language) -> str:
     """Convert a Language enum to ElevenLabs language code.
 
@@ -58,109 +165,44 @@ def language_to_elevenlabs_language(language: Language) -> str:
         the verified mapping, falls back to the full language code string and
         logs a warning (via ``resolve_language(..., use_base_code=False)``).
     """
-    LANGUAGE_MAP = {
-        Language.AF: "afr",  # Afrikaans
-        Language.AM: "amh",  # Amharic
-        Language.AR: "ara",  # Arabic
-        Language.HY: "hye",  # Armenian
-        Language.AS: "asm",  # Assamese
-        Language.AST: "ast",  # Asturian
-        Language.AZ: "aze",  # Azerbaijani
-        Language.BE: "bel",  # Belarusian
-        Language.BN: "ben",  # Bengali
-        Language.BS: "bos",  # Bosnian
-        Language.BG: "bul",  # Bulgarian
-        Language.MY: "mya",  # Burmese
-        Language.YUE: "yue",  # Cantonese
-        Language.CA: "cat",  # Catalan
-        Language.CEB: "ceb",  # Cebuano
-        Language.NY: "nya",  # Chichewa
-        Language.HR: "hrv",  # Croatian
-        Language.CS: "ces",  # Czech
-        Language.DA: "dan",  # Danish
-        Language.NL: "nld",  # Dutch
-        Language.EN: "eng",  # English
-        Language.ET: "est",  # Estonian
-        Language.FIL: "fil",  # Filipino
-        Language.FI: "fin",  # Finnish
-        Language.FR: "fra",  # French
-        Language.FF: "ful",  # Fulah
-        Language.GL: "glg",  # Galician
-        Language.LG: "lug",  # Ganda
-        Language.KA: "kat",  # Georgian
-        Language.DE: "deu",  # German
-        Language.EL: "ell",  # Greek
-        Language.GU: "guj",  # Gujarati
-        Language.HA: "hau",  # Hausa
-        Language.HE: "heb",  # Hebrew
-        Language.HI: "hin",  # Hindi
-        Language.HU: "hun",  # Hungarian
-        Language.IS: "isl",  # Icelandic
-        Language.IG: "ibo",  # Igbo
-        Language.ID: "ind",  # Indonesian
-        Language.GA: "gle",  # Irish
-        Language.IT: "ita",  # Italian
-        Language.JA: "jpn",  # Japanese
-        Language.JV: "jav",  # Javanese
-        Language.KEA: "kea",  # Kabuverdianu
-        Language.KN: "kan",  # Kannada
-        Language.KK: "kaz",  # Kazakh
-        Language.KM: "khm",  # Khmer
-        Language.KO: "kor",  # Korean
-        Language.KU: "kur",  # Kurdish
-        Language.KY: "kir",  # Kyrgyz
-        Language.LO: "lao",  # Lao
-        Language.LV: "lav",  # Latvian
-        Language.LN: "lin",  # Lingala
-        Language.LT: "lit",  # Lithuanian
-        Language.LUO: "luo",  # Luo
-        Language.LB: "ltz",  # Luxembourgish
-        Language.MK: "mkd",  # Macedonian
-        Language.MS: "msa",  # Malay
-        Language.ML: "mal",  # Malayalam
-        Language.MT: "mlt",  # Maltese
-        Language.ZH: "zho",  # Mandarin Chinese
-        Language.MI: "mri",  # Māori
-        Language.MR: "mar",  # Marathi
-        Language.MN: "mon",  # Mongolian
-        Language.NE: "nep",  # Nepali
-        Language.NSO: "nso",  # Northern Sotho
-        Language.NO: "nor",  # Norwegian
-        Language.OC: "oci",  # Occitan
-        Language.OR: "ori",  # Odia
-        Language.PS: "pus",  # Pashto
-        Language.FA: "fas",  # Persian
-        Language.PL: "pol",  # Polish
-        Language.PT: "por",  # Portuguese
-        Language.PA: "pan",  # Punjabi
-        Language.RO: "ron",  # Romanian
-        Language.RU: "rus",  # Russian
-        Language.SR: "srp",  # Serbian
-        Language.SN: "sna",  # Shona
-        Language.SD: "snd",  # Sindhi
-        Language.SK: "slk",  # Slovak
-        Language.SL: "slv",  # Slovenian
-        Language.SO: "som",  # Somali
-        Language.ES: "spa",  # Spanish
-        Language.SW: "swa",  # Swahili
-        Language.SV: "swe",  # Swedish
-        Language.TA: "tam",  # Tamil
-        Language.TG: "tgk",  # Tajik
-        Language.TE: "tel",  # Telugu
-        Language.TH: "tha",  # Thai
-        Language.TR: "tur",  # Turkish
-        Language.UK: "ukr",  # Ukrainian
-        Language.UMB: "umb",  # Umbundu
-        Language.UR: "urd",  # Urdu
-        Language.UZ: "uzb",  # Uzbek
-        Language.VI: "vie",  # Vietnamese
-        Language.CY: "cym",  # Welsh
-        Language.WO: "wol",  # Wolof
-        Language.XH: "xho",  # Xhosa
-        Language.ZU: "zul",  # Zulu
-    }
-
     return resolve_language(language, LANGUAGE_MAP, use_base_code=False)
+
+
+#: The ISO-639-3 code ElevenLabs reports -> Language. Derived, never hand-written.
+_REVERSE_LANGUAGE_MAP: dict[str, Language] = {
+    code: language for language, code in LANGUAGE_MAP.items()
+}
+
+
+def elevenlabs_language_to_language(language_code: str | None) -> Language | None:
+    """Convert a language code reported by ElevenLabs into a Language enum.
+
+    ElevenLabs reports the detected language as ISO-639-3 (``por``, ``eng``)
+    while :class:`~pipecat.transcriptions.language.Language` is ISO-639-1
+    (``pt``, ``en``). Handing the raw code to a transcription frame makes this
+    service the odd one out — Deepgram and Soniox both resolve the detected code
+    to the enum — so a consumer comparing ``frame.language == Language.PT``
+    silently never matches on ElevenLabs.
+
+    ISO-639-1 input is accepted too, since the API documents both forms.
+
+    Args:
+        language_code: The code reported by ElevenLabs, or None.
+
+    Returns:
+        The matching Language, or None when the code is absent or unrecognised.
+        An unrecognised code is dropped rather than passed through, because the
+        frame field is typed as a Language.
+    """
+    if not language_code:
+        return None
+    code = language_code.strip().lower()
+    if not code:
+        return None
+    try:
+        return Language(code)
+    except ValueError:
+        return _REVERSE_LANGUAGE_MAP.get(code)
 
 
 class CommitStrategy(StrEnum):
@@ -404,7 +446,9 @@ class ElevenLabsSTTService(SegmentedSTTService):
             text = result.get("text", "").strip()
             if text:
                 # Use the language_code returned by the API
-                detected_language = result.get("language_code", "eng")
+                detected_language = elevenlabs_language_to_language(
+                    result.get("language_code", "eng")
+                )
 
                 await self._handle_transcription(text, True, detected_language)
                 logger.debug(f"Transcription: [{text}]")
@@ -902,7 +946,7 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
             return
 
         # Get language if provided
-        language = data.get("language_code")
+        language = elevenlabs_language_to_language(data.get("language_code"))
 
         logger.trace(f"Partial transcript: [{text}]")
 
@@ -940,7 +984,7 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
             return
 
         # Get language if provided
-        language = data.get("language_code")
+        language = elevenlabs_language_to_language(data.get("language_code"))
 
         logger.debug(f"Committed transcript: [{text}]")
 
@@ -987,7 +1031,7 @@ class ElevenLabsRealtimeSTTService(WebsocketSTTService):
             return
 
         # Get language if provided
-        language = data.get("language_code")
+        language = elevenlabs_language_to_language(data.get("language_code"))
 
         logger.debug(f"Committed transcript with timestamps: [{text}]")
 

--- a/tests/test_elevenlabs_stt.py
+++ b/tests/test_elevenlabs_stt.py
@@ -12,10 +12,12 @@ from aiohttp import web
 
 from pipecat.frames.frames import TranscriptionFrame
 from pipecat.services.elevenlabs.stt import (
+    LANGUAGE_MAP,
     CommitStrategy,
     ElevenLabsRealtimeSTTService,
     ElevenLabsSTTService,
     audio_format_from_sample_rate,
+    elevenlabs_language_to_language,
 )
 from pipecat.transcriptions.language import Language
 
@@ -256,4 +258,88 @@ async def test_elevenlabs_realtime_plain_committed_emitted_without_options():
 
     assert len(captured) == 1
     assert captured[0].text == COMMITTED_TEXT
+    assert captured[0].language is None
+
+
+# --- detected language reaches the frame as a Language ------------------------
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("por", Language.PT),
+        ("eng", Language.EN),
+        ("spa", Language.ES),
+        ("fas", Language.FA),
+        # ISO-639-1 is documented too and must pass straight through.
+        ("pt", Language.PT),
+        ("en", Language.EN),
+        ("POR", Language.PT),
+        (" por ", Language.PT),
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("not-a-language", None),
+    ],
+)
+def test_elevenlabs_language_to_language(code, expected):
+    assert elevenlabs_language_to_language(code) == expected
+
+
+def test_every_code_the_service_can_send_round_trips():
+    """The reverse map is derived from LANGUAGE_MAP, so the two cannot drift."""
+    for language, code in LANGUAGE_MAP.items():
+        assert elevenlabs_language_to_language(code) == language
+
+
+@pytest.mark.asyncio
+async def test_realtime_iso_639_3_becomes_a_language_enum():
+    """ElevenLabs reports ISO-639-3; the frame field is a Language.
+
+    Passing the raw code through made this service the odd one out — Deepgram and
+    Soniox both resolve the detected code — so a consumer asking
+    `frame.language == Language.PT` silently never matched a Portuguese turn.
+    """
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        include_language_detection=True,
+    )
+    captured = _capture_transcriptions(service)
+
+    await service._process_response(
+        {
+            "message_type": "committed_transcript_with_timestamps",
+            "text": "O primeiro slot funciona pra mim.",
+            "language_code": "por",
+            "words": None,
+        }
+    )
+
+    assert len(captured) == 1
+    assert captured[0].language == Language.PT
+    assert captured[0].language != "por"
+
+
+@pytest.mark.asyncio
+async def test_realtime_an_unrecognised_code_is_dropped_not_forwarded():
+    """The frame field is typed as a Language, so a code we cannot map is None
+    rather than a string nothing downstream can compare against."""
+    service = ElevenLabsRealtimeSTTService(
+        api_key="test-key",
+        sample_rate=16000,
+        include_language_detection=True,
+    )
+    captured = _capture_transcriptions(service)
+
+    await service._process_response(
+        {
+            "message_type": "committed_transcript_with_timestamps",
+            "text": "hello",
+            "language_code": "not-a-language",
+            "words": None,
+        }
+    )
+
+    assert len(captured) == 1
     assert captured[0].language is None


### PR DESCRIPTION
Fixes #5396

## The problem

ElevenLabs reports the detected language as **ISO-639-3** (`por`, `eng`), and both STT services forward that string straight onto `TranscriptionFrame.language`, whose type is `Language` — ISO-639-1.

Deepgram and Soniox both resolve the detected code first:

```python
# services/deepgram/stt.py
language = message.channel.alternatives[0].languages[0]
language = Language(language)

# services/soniox/stt.py
language_counts[Language(language)] += 1
```

ElevenLabs is the odd one out, so a consumer comparing `frame.language == Language.PT` **silently never matches** a Portuguese turn. No error, and the field looks populated — `"por"` is simply never equal to `"pt"`.

This is not hypothetical: we route per-turn language off `TranscriptionFrame.language` in a multilingual voice agent, and every ElevenLabs-transcribed turn fell through the comparison while Deepgram and Soniox turns worked.

## The change

`elevenlabs_language_to_language()` does the reverse lookup, applied at all four emission sites — the HTTP `run_stt` plus the realtime partial, committed and committed-with-timestamps handlers.

Its table is **derived from `LANGUAGE_MAP`** rather than hand-written, so the two directions cannot drift apart; that is why `LANGUAGE_MAP` moves from a function local to module scope. A test asserts every code the forward map can emit round-trips.

ISO-639-1 input is accepted too, since the API documents both forms, and it agrees with the table wherever both apply (verified across all 99 entries). An unrecognised code resolves to `None` rather than being passed through as a string the field is not typed to hold.

## Compatibility

Existing assertions of the form `frame.language == "en"` keep passing: `Language` is a str enum, and the 639-1 codes were already correct. Only the 639-3 ones were not.

`tests/test_elevenlabs_stt.py`: **23 passed** (8 existing, 15 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)