### PR TITLE
Close Text-to-Dialogue contexts at end of turn

### DIFF
--- a/src/pipecat/services/elevenlabs/dialogue/tts.py
+++ b/src/pipecat/services/elevenlabs/dialogue/tts.py
@@ -121,21 +121,12 @@ class _DialogueContext:
             It rejects any message for a context that has no ``voices``
             registration, and a closed context counts as unregistered.
         new_turn_pending: Whether the next input should reset prosody.
-        has_unflushed_text: Whether text has been sent since the last flush.
-            Flushing without new text would add a batch the server never
-            acknowledges, unbalancing ``outstanding_batches``.
-        outstanding_batches: Flushed generation batches not yet acknowledged.
-        close_when_drained: Whether the turn has ended and the context should
-            close once its batches are done.
         alignment_started: Whether an alignment message has been seen, so
             leading spaces are only stripped from the first one.
     """
 
     registered: bool = True
     new_turn_pending: bool = True
-    has_unflushed_text: bool = False
-    outstanding_batches: int = 0
-    close_when_drained: bool = False
     alignment_started: bool = False
 
 
@@ -241,11 +232,6 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
         point the server starts generating on its own, so a turn is usually
         under way before the end-of-turn flush covers what is left.
 
-        Each flush starts one generation batch, which the server acknowledges
-        with an ``is_final_audio_for_turn``. A flush with no new text behind it
-        is skipped so that batches sent and batches acknowledged stay in step —
-        :meth:`_maybe_close_drained_context` relies on that balance.
-
         Args:
             context_id: The specific context to flush. If None, falls back to the
                 currently active context.
@@ -254,14 +240,10 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
         if not flush_id or not self._websocket:
             return
         context = self._contexts.get(flush_id)
-        if not context or not context.registered or not context.has_unflushed_text:
+        if not context or not context.registered:
             return
 
-        context.has_unflushed_text = False
-        context.outstanding_batches += 1
-        logger.trace(
-            f"{self}: flushing context {flush_id} ({context.outstanding_batches} outstanding)"
-        )
+        logger.trace(f"{self}: flushing context {flush_id}")
         await self._websocket.send(json.dumps({"context_id": flush_id, "flush": True}))
 
     def _build_websocket_url(self) -> str:
@@ -294,14 +276,10 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
     async def _close_context(self, context_id: str):
         """Close a server-side context to free its slot.
 
-        A close discards flushed batches the server hasn't started generating,
-        so it is only safe once the turn has drained — see
-        :meth:`on_turn_context_completed`. On an interruption that discarding is
-        the point.
-
-        Generation already under way cannot be cancelled, so a context closed
-        mid-generation still drains audio for the text it has — one aggregated
-        chunk at most. Removing the audio context discards it.
+        A close generates whatever text the context still holds, streams that
+        audio, and ends with an ``is_final``. A context closed on an
+        interruption therefore keeps producing audio for a while; removing the
+        audio context discards it.
         """
         context = self._contexts.get(context_id)
         if not context or not context.registered:
@@ -324,32 +302,11 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
         self._contexts.pop(context_id, None)
 
     async def on_turn_context_completed(self):
-        """Close the turn's context once the server has generated all of its text.
-
-        The base class flushes whatever text is left as part of completing the
-        turn. Closing then has to wait for the server to work through every
-        batch: a close discards batches that haven't started generating, which
-        would truncate the turn to the audio produced so far.
-        """
+        """Close the turn's context, which generates any text still buffered in it."""
         context_id = self._turn_context_id
         await super().on_turn_context_completed()
-        if not context_id:
-            return
-
-        context = self._contexts.get(context_id)
-        if not context:
-            return
-        context.close_when_drained = True
-        await self._maybe_close_drained_context(context_id)
-
-    async def _maybe_close_drained_context(self, context_id: str):
-        """Close a finished context once its flushed batches have all come back."""
-        context = self._contexts.get(context_id)
-        if not context or not context.close_when_drained or context.outstanding_batches > 0:
-            return
-
-        context.close_when_drained = False
-        await self._close_context(context_id)
+        if context_id:
+            await self._close_context(context_id)
 
     async def _receive_messages(self):
         """Handle incoming WebSocket messages from ElevenLabs Text-to-Dialogue."""
@@ -372,19 +329,9 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
         if received_ctx_id == _KEEPALIVE_CONTEXT_ID:
             return
 
-        # One acknowledgement per explicit flush. Batches the server starts
-        # on its own, once enough text has accumulated, are not acknowledged,
-        # so the count only ever tracks flushes we sent.
-        if msg.get("is_final_audio_for_turn") is True:
-            context = self._contexts.get(received_ctx_id)
-            if context:
-                context.outstanding_batches = max(0, context.outstanding_batches - 1)
-                await self._maybe_close_drained_context(received_ctx_id)
-            return
-
         # `is_final` marks the end of a context. `is_final_audio_for_turn`
-        # arrives repeatedly within a turn — once per generation batch — so
-        # it can't be used to end one.
+        # arrives each time the server finishes a batch of generation, several
+        # times within a turn, so it can't be used to end one.
         if msg.get("is_final") is True:
             logger.debug(f"Received final message for context {received_ctx_id}")
             self._contexts.pop(received_ctx_id, None)
@@ -510,7 +457,6 @@ class ElevenLabsDialogueTTSService(ElevenLabsTTSBase):
 
         new_turn = context.new_turn_pending
         context.new_turn_pending = False
-        context.has_unflushed_text = True
         logger.trace(f"{self}: input for context {context_id} (new_turn={new_turn}): {text!r}")
         msg = {
             "context_id": context_id,

--- a/tests/test_elevenlabs_dialogue_tts.py
+++ b/tests/test_elevenlabs_dialogue_tts.py
@@ -181,61 +181,29 @@ async def test_dialogue_keepalive_context_messages_are_ignored():
 
 
 @pytest.mark.asyncio
-async def test_dialogue_flush_skipped_when_nothing_new_was_sent():
-    """Batches sent and batches acknowledged have to stay in step."""
+async def test_dialogue_flush_targets_registered_contexts_only():
+    """The server rejects any message naming a context it has closed."""
     service = _make_dialogue_service()
     ws = _FakeWebSocket()
     await _open_dialogue_context(service, ws)
 
     await service.flush_audio("ctx-1")
-    assert ws.sent == []
+    assert ws.sent == [{"context_id": "ctx-1", "flush": True}]
 
-    await service._send_text("Hello there.", "ctx-1")
-    await service.flush_audio("ctx-1")
+    service._contexts["ctx-1"].registered = False
     await service.flush_audio("ctx-1")
 
     assert ws.sent.count({"context_id": "ctx-1", "flush": True}) == 1
-    assert service._contexts["ctx-1"].outstanding_batches == 1
 
 
 @pytest.mark.asyncio
-async def test_dialogue_turn_end_waits_for_every_flushed_batch():
-    """A close discards batches that haven't started, truncating the turn."""
-    service = _make_dialogue_service()
-    ws = _FakeWebSocket()
-    await _open_dialogue_context(service, ws)
-
-    for sentence in ("First sentence.", "Second sentence."):
-        await service._send_text(sentence, "ctx-1")
-        await service.flush_audio("ctx-1")
-    assert service._contexts["ctx-1"].outstanding_batches == 2
-
-    service._turn_context_id = "ctx-1"
-    await service.on_turn_context_completed()
-
-    def closes():
-        return ws.sent.count({"context_id": "ctx-1", "close_context": True})
-
-    assert closes() == 0, "closed before any batch was acknowledged"
-    assert service._contexts["ctx-1"].close_when_drained is True
-
-    await service._handle_message({"context_id": "ctx-1", "is_final_audio_for_turn": True})
-    assert closes() == 0, "closed while a batch was still outstanding"
-
-    await service._handle_message({"context_id": "ctx-1", "is_final_audio_for_turn": True})
-    assert closes() == 1
-
-
-@pytest.mark.asyncio
-async def test_dialogue_turn_end_closes_once_batches_already_acknowledged():
-    """Generation can finish before the turn does; then the close is immediate."""
+async def test_dialogue_turn_end_closes_the_context():
+    """Ending a turn sends the close, which is what generates the turn's tail."""
     service = _make_dialogue_service()
     ws = _FakeWebSocket()
     await _open_dialogue_context(service, ws)
 
     await service._send_text("Sure.", "ctx-1")
-    await service.flush_audio("ctx-1")
-    await service._handle_message({"context_id": "ctx-1", "is_final_audio_for_turn": True})
 
     service._turn_context_id = "ctx-1"
     await service.on_turn_context_completed()
@@ -245,7 +213,7 @@ async def test_dialogue_turn_end_closes_once_batches_already_acknowledged():
 
 @pytest.mark.asyncio
 async def test_dialogue_turn_final_does_not_end_the_audio_context():
-    """Turn finals arrive per batch; only is_final ends a context."""
+    """Turn finals arrive per generation batch; only is_final ends a context."""
     service = _make_dialogue_service()
     ws = _FakeWebSocket()
     await _open_dialogue_context(service, ws)


### PR DESCRIPTION
The ElevenLabs teams fixed an API bug with the text-to-dialogue endpoint, so we can remove the workaround which help the context open to drain.

## Summary

- `ElevenLabsDialogueTTSService` closes a Text-to-Dialogue context as soon as its turn ends, freeing the server-side context slot sooner
- The endpoint generates whatever text a context still holds before emitting `is_final`, so the close carries the tail of the turn with it
- A context closed on an interruption keeps streaming audio for the text it was holding; the service discards it

## Testing

```
uv run pytest tests/test_elevenlabs_dialogue_tts.py
```

A truncated end of turn is invisible to unit tests, so this also needs a run against the live endpoint:

```
pipecat eval suite scripts/release-evals/manifest.yaml -p elevenlabs-dialogue
```

with a long multi-sentence final turn, plus an interruption case.