### PR TITLE
fix(krisp): keep SDK process-lifetime and drain VAD executor on cleanup

### DIFF
--- a/src/pipecat/audio/filters/krisp_viva_filter.py
+++ b/src/pipecat/audio/filters/krisp_viva_filter.py
@@ -84,70 +84,62 @@ class KrispVivaFilter(BaseAudioFilter):
 
         self._api_key = api_key
 
-        try:
-            # Set model path, checking environment if not specified
-            if model_path:
-                self._model_path = model_path
-            else:
-                # Check new environment variable first
-                self._model_path = os.getenv("KRISP_VIVA_FILTER_MODEL_PATH")
-                # Fall back to old environment variable for backward compatibility
-                if not self._model_path:
-                    self._model_path = os.getenv("KRISP_VIVA_MODEL_PATH")
-                    if self._model_path:
-                        logger.warning(
-                            "KRISP_VIVA_MODEL_PATH is deprecated. "
-                            "Please use KRISP_VIVA_FILTER_MODEL_PATH instead."
-                        )
+        # Set model path, checking environment if not specified
+        if model_path:
+            self._model_path = model_path
+        else:
+            # Check new environment variable first
+            self._model_path = os.getenv("KRISP_VIVA_FILTER_MODEL_PATH")
+            # Fall back to old environment variable for backward compatibility
             if not self._model_path:
-                logger.error(
-                    "Model path is not provided and KRISP_VIVA_FILTER_MODEL_PATH is not set."
-                )
-                raise ValueError("Model path for KrispAudioProcessor must be provided.")
+                self._model_path = os.getenv("KRISP_VIVA_MODEL_PATH")
+                if self._model_path:
+                    logger.warning(
+                        "KRISP_VIVA_MODEL_PATH is deprecated. "
+                        "Please use KRISP_VIVA_FILTER_MODEL_PATH instead."
+                    )
+        if not self._model_path:
+            logger.error("Model path is not provided and KRISP_VIVA_FILTER_MODEL_PATH is not set.")
+            raise ValueError("Model path for KrispAudioProcessor must be provided.")
 
-            if not self._model_path.endswith(".kef"):
-                raise Exception("Model is expected with .kef extension")
+        if not self._model_path.endswith(".kef"):
+            raise Exception("Model is expected with .kef extension")
 
-            if not os.path.isfile(self._model_path):
-                raise FileNotFoundError(f"Model file not found: {self._model_path}")
+        if not os.path.isfile(self._model_path):
+            raise FileNotFoundError(f"Model file not found: {self._model_path}")
 
-            # Resolve TTS detection model path (optional)
-            if tts_model_path:
-                self._tts_model_path = tts_model_path
-            else:
-                self._tts_model_path = os.getenv("KRISP_VIVA_TTS_MODEL_PATH")
-            if self._tts_model_path:
-                if not self._tts_model_path.endswith(".kef"):
-                    raise Exception("TTS model is expected with .kef extension")
-                if not os.path.isfile(self._tts_model_path):
-                    raise FileNotFoundError(f"TTS model file not found: {self._tts_model_path}")
+        # Resolve TTS detection model path (optional)
+        if tts_model_path:
+            self._tts_model_path = tts_model_path
+        else:
+            self._tts_model_path = os.getenv("KRISP_VIVA_TTS_MODEL_PATH")
+        if self._tts_model_path:
+            if not self._tts_model_path.endswith(".kef"):
+                raise Exception("TTS model is expected with .kef extension")
+            if not os.path.isfile(self._tts_model_path):
+                raise FileNotFoundError(f"TTS model file not found: {self._tts_model_path}")
 
-            self._session = None
-            self._tts_detector = None
-            self._sdk_acquired = False
-            self._samples_per_frame = None
-            self._uses_nanobind_bindings = krisp_sdk_uses_nanobind_bindings()
-            self._noise_suppression_level = (
-                float(noise_suppression_level)
-                if self._uses_nanobind_bindings
-                else int(noise_suppression_level)
-            )
-            self._frame_duration_ms = frame_duration
-            self._audio_buffer = bytearray()
-            self._filtering = True
+        self._session = None
+        self._tts_detector = None
+        self._sdk_acquired = False
+        self._samples_per_frame = None
+        self._uses_nanobind_bindings = krisp_sdk_uses_nanobind_bindings()
+        self._noise_suppression_level = (
+            float(noise_suppression_level)
+            if self._uses_nanobind_bindings
+            else int(noise_suppression_level)
+        )
+        self._frame_duration_ms = frame_duration
+        self._audio_buffer = bytearray()
+        self._filtering = True
 
-            # TTS detection state (active only when tts_model_path is set)
-            self._tts_threshold = tts_threshold
-            self._tts_detection_timeout = tts_detection_timeout
-            self._tts_detection_active = False
-            self._tts_elapsed_s: float = 0.0
-            self._tts_ever_detected = False
-            self._tts_last_detected_s: float | None = None
-
-        except Exception:
-            # If initialization fails, release the SDK reference
-            KrispVivaSDKManager.release()
-            raise
+        # TTS detection state (active only when tts_model_path is set)
+        self._tts_threshold = tts_threshold
+        self._tts_detection_timeout = tts_detection_timeout
+        self._tts_detection_active = False
+        self._tts_elapsed_s: float = 0.0
+        self._tts_ever_detected = False
+        self._tts_last_detected_s: float | None = None
 
     def _create_session(self, sample_rate: int, frame_duration: int):
         """Create a Krisp session with a specific sample rate.

--- a/src/pipecat/audio/krisp_instance.py
+++ b/src/pipecat/audio/krisp_instance.py
@@ -97,11 +97,18 @@ def krisp_sdk_uses_nanobind_bindings() -> bool:
 
 
 class KrispVivaSDKManager:
-    """Singleton manager for Krisp VIVA SDK with reference counting."""
+    """Singleton manager for the process-lifetime Krisp VIVA SDK.
+
+    ``globalInit`` runs on the first ``acquire()``. ``globalDestroy`` is deferred
+    to process exit (``atexit``). Per-call teardown only drops the reference
+    count — destroying the SDK while native ``process()`` or session destructors
+    are still running segfaults in ``libkrisp-audio-sdk``.
+    """
 
     _initialized = False
     _lock = Lock()
     _reference_count = 0
+    _atexit_registered = False
 
     @staticmethod
     def _license_callback(error, error_message):
@@ -127,8 +134,10 @@ class KrispVivaSDKManager:
             Exception: If SDK initialization fails (propagated from krisp_audio)
         """
         with cls._lock:
-            # Initialize SDK on first acquire
-            if cls._reference_count == 0:
+            # Initialize once per process. Subsequent acquire/release cycles at
+            # refcount 0 must not call globalInit/globalDestroy — Krisp's
+            # contract is one init/destroy pair per process.
+            if not cls._initialized:
                 try:
                     key = api_key or os.environ.get("KRISP_VIVA_API_KEY", "")
                     try:
@@ -152,8 +161,9 @@ class KrispVivaSDKManager:
                         f"{SDK_VERSION.major}.{SDK_VERSION.minor}.{SDK_VERSION.patch}"
                     )
 
-                    # Register cleanup on program exit (failsafe)
-                    atexit.register(cls._force_cleanup)
+                    if not cls._atexit_registered:
+                        atexit.register(cls._force_cleanup)
+                        cls._atexit_registered = True
 
                 except Exception as e:
                     cls._initialized = False
@@ -165,24 +175,15 @@ class KrispVivaSDKManager:
 
     @classmethod
     def release(cls):
-        """Release a reference to the SDK (destroys if last reference).
+        """Release a reference to the SDK.
 
-        Call this when destroying a filter instance.
+        Call this when destroying a filter or analyzer instance. Does not call
+        ``globalDestroy``; the native SDK stays initialized until process exit.
         """
         with cls._lock:
             if cls._reference_count > 0:
                 cls._reference_count -= 1
                 logger.debug(f"Krisp SDK reference count: {cls._reference_count}")
-
-                # Destroy SDK when last reference is released
-                if cls._reference_count == 0 and cls._initialized:
-                    try:
-                        krisp_audio.globalDestroy()
-                        cls._initialized = False
-                        logger.debug("Krisp Audio SDK destroyed (all references released)")
-                    except Exception as e:
-                        logger.error(f"Error during Krisp SDK cleanup: {e}")
-                        cls._initialized = False
 
     @classmethod
     def get_reference_count(cls) -> int:
@@ -208,12 +209,19 @@ class KrispVivaSDKManager:
     def _force_cleanup(cls):
         """Force cleanup on program exit (failsafe)."""
         with cls._lock:
-            if cls._initialized:
-                try:
+            if not cls._initialized:
+                return
+            try:
+                if cls._reference_count > 0:
                     logger.warning(
                         f"Force cleaning up Krisp SDK at exit (ref count: {cls._reference_count})"
                     )
-                    krisp_audio.globalDestroy()
-                    cls._initialized = False
-                except Exception as e:
+                krisp_audio.globalDestroy()
+            except Exception as e:
+                try:
                     logger.error(f"Error during forced Krisp SDK cleanup: {e}")
+                except Exception:
+                    pass
+            finally:
+                cls._initialized = False
+                cls._reference_count = 0

--- a/src/pipecat/audio/vad/krisp_viva_vad.py
+++ b/src/pipecat/audio/vad/krisp_viva_vad.py
@@ -61,40 +61,31 @@ class KrispVivaVadAnalyzer(VADAnalyzer):
 
         logger.debug("Loading Krisp VIVA VAD model...")
 
-        try:
-            # Set model path, checking environment if not specified
-            if model_path:
-                self._model_path = model_path
-            else:
-                self._model_path = os.getenv("KRISP_VIVA_VAD_MODEL_PATH")
-                if not self._model_path:
-                    logger.error(
-                        "Model path is not provided and KRISP_VIVA_VAD_MODEL_PATH is not set."
-                    )
-                    raise ValueError("Model path for KrispVivaVADAnalyzer must be provided.")
+        # Set model path, checking environment if not specified
+        if model_path:
+            self._model_path = model_path
+        else:
+            self._model_path = os.getenv("KRISP_VIVA_VAD_MODEL_PATH")
+            if not self._model_path:
+                logger.error("Model path is not provided and KRISP_VIVA_VAD_MODEL_PATH is not set.")
+                raise ValueError("Model path for KrispVivaVADAnalyzer must be provided.")
 
-            if not self._model_path.endswith(".kef"):
-                raise Exception("Model is expected with .kef extension")
+        if not self._model_path.endswith(".kef"):
+            raise Exception("Model is expected with .kef extension")
 
-            if not os.path.isfile(self._model_path):
-                raise FileNotFoundError(f"Model file not found: {self._model_path}")
+        if not os.path.isfile(self._model_path):
+            raise FileNotFoundError(f"Model file not found: {self._model_path}")
 
-            self._session = None
-            self._frame_duration_ms = frame_duration
-            self._samples_per_frame = None
-            # Calculate samples per frame if sample_rate is provided
-            if sample_rate is not None:
-                self._samples_per_frame = int((sample_rate * frame_duration) / 1000)
+        self._session = None
+        self._frame_duration_ms = frame_duration
+        self._samples_per_frame = None
+        # Calculate samples per frame if sample_rate is provided
+        if sample_rate is not None:
+            self._samples_per_frame = int((sample_rate * frame_duration) / 1000)
 
-            # Acquire SDK reference (will initialize on first call)
-            KrispVivaSDKManager.acquire()
+        KrispVivaSDKManager.acquire()
 
-            logger.debug("Loaded Krisp VIVA VAD")
-
-        except Exception:
-            # If initialization fails, release the SDK reference
-            KrispVivaSDKManager.release()
-            raise
+        logger.debug("Loaded Krisp VIVA VAD")
 
     def _create_session(self, sample_rate: int, frame_duration: int):
         """Create a Krisp VAD session with a specific sample rate.
@@ -207,7 +198,11 @@ class KrispVivaVadAnalyzer(VADAnalyzer):
             return 0.0
 
     async def cleanup(self):
-        """Cleanup analyzer resources."""
+        """Cleanup analyzer resources.
+
+        Drops the native session only after the executor has drained, so an
+        in-flight ``session.process()`` cannot race destructor / SDK teardown.
+        """
         await super().cleanup()
         try:
             self._session = None

--- a/src/pipecat/audio/vad/vad_analyzer.py
+++ b/src/pipecat/audio/vad/vad_analyzer.py
@@ -250,6 +250,8 @@ class VADAnalyzer(ABC):
     async def cleanup(self):
         """Release the analyzer's resources, including the thread it runs the model on.
 
-        This method should be called when the object is no longer needed.
+        Waits for any in-flight ``voice_confidence()`` call to finish. Futures
+        cannot cancel a running native ``process()``; dropping the session
+        while that call is still on the executor races the SDK.
         """
-        self._executor.shutdown(wait=False)
+        await asyncio.to_thread(self._executor.shutdown, wait=True, cancel_futures=True)

--- a/tests/test_krisp_sdk_manager.py
+++ b/tests/test_krisp_sdk_manager.py
@@ -108,15 +108,16 @@ class TestKrispVivaSDKManager:
         # globalDestroy should NOT be called yet
         mock_krisp_audio.globalDestroy.assert_not_called()
 
-        # Release second reference
+        # Release second (last) reference. The SDK is process-lifetime: last
+        # release must not call globalDestroy while other native work may still
+        # be in flight on Krisp's own threads.
         KrispVivaSDKManager.release()
         assert KrispVivaSDKManager.get_reference_count() == initial_count
-
-        # globalDestroy should be called now
-        mock_krisp_audio.globalDestroy.assert_called_once()
+        assert KrispVivaSDKManager.is_initialized()
+        mock_krisp_audio.globalDestroy.assert_not_called()
 
     def test_multiple_acquire_release_cycles(self):
-        """Test multiple acquire/release cycles."""
+        """Test multiple acquire/release cycles keep a single process-lifetime init."""
         initial_count = KrispVivaSDKManager.get_reference_count()
 
         for i in range(3):
@@ -125,10 +126,54 @@ class TestKrispVivaSDKManager:
             assert KrispVivaSDKManager.is_initialized()
             KrispVivaSDKManager.release()
             assert KrispVivaSDKManager.get_reference_count() == initial_count
+            assert KrispVivaSDKManager.is_initialized()
 
-        # Verify globalInit/globalDestroy were called for each cycle
-        assert mock_krisp_audio.globalInit.call_count == 3
-        assert mock_krisp_audio.globalDestroy.call_count == 3
+        # globalInit once for the process; globalDestroy is deferred to atexit
+        assert mock_krisp_audio.globalInit.call_count == 1
+        mock_krisp_audio.globalDestroy.assert_not_called()
+
+    def test_last_release_does_not_call_global_destroy(self):
+        """Dropping the last live session must not tear down the native SDK."""
+        KrispVivaSDKManager.acquire()
+        KrispVivaSDKManager.release()
+
+        mock_krisp_audio.globalDestroy.assert_not_called()
+        assert KrispVivaSDKManager.is_initialized()
+        assert KrispVivaSDKManager.get_reference_count() == 0
+
+    def test_reacquire_does_not_reinitialize(self):
+        """A later call after refcount 0 reuses the already-initialized SDK."""
+        KrispVivaSDKManager.acquire()
+        KrispVivaSDKManager.release()
+        mock_krisp_audio.globalInit.reset_mock()
+
+        KrispVivaSDKManager.acquire()
+
+        mock_krisp_audio.globalInit.assert_not_called()
+        assert KrispVivaSDKManager.get_reference_count() == 1
+        assert KrispVivaSDKManager.is_initialized()
+
+    def test_force_cleanup_destroys_initialized_sdk(self):
+        """Process-exit cleanup is the only path that calls globalDestroy."""
+        KrispVivaSDKManager.acquire()
+        KrispVivaSDKManager.release()
+        mock_krisp_audio.globalDestroy.assert_not_called()
+
+        KrispVivaSDKManager._force_cleanup()
+
+        mock_krisp_audio.globalDestroy.assert_called_once()
+        assert not KrispVivaSDKManager.is_initialized()
+
+    def test_acquire_after_force_cleanup_reinitializes(self):
+        """After process-exit cleanup, a new acquire may initialize again."""
+        KrispVivaSDKManager.acquire()
+        KrispVivaSDKManager._force_cleanup()
+        mock_krisp_audio.globalInit.reset_mock()
+
+        KrispVivaSDKManager.acquire()
+
+        mock_krisp_audio.globalInit.assert_called_once()
+        assert KrispVivaSDKManager.is_initialized()
 
     def test_sdk_initialization_failure(self):
         """Test that SDK initialization failures are handled properly."""
@@ -163,9 +208,9 @@ class TestKrispVivaSDKManager:
         KrispVivaSDKManager.acquire()
         assert KrispVivaSDKManager.is_initialized()
 
-        # After release, should not be initialized
+        # After release, the process-lifetime SDK stays initialized
         KrispVivaSDKManager.release()
-        assert not KrispVivaSDKManager.is_initialized()
+        assert KrispVivaSDKManager.is_initialized()
 
 
 class TestSampleRateConversion:

--- a/tests/test_krisp_viva_filter.py
+++ b/tests/test_krisp_viva_filter.py
@@ -134,10 +134,10 @@ class TestKrispVivaFilter(unittest.IsolatedAsyncioTestCase):
                 KrispVivaFilter()
 
             self.assertIn("Model path", str(context.exception))
-            # SDK acquire not called during initialization (happens in start())
-            # But release() is called in exception handler even though acquire() wasn't called
+            # Constructor never acquires, so a failed init must not release
+            # a reference owned by another live instance.
             self.mock_sdk_manager.acquire.assert_not_called()
-            self.mock_sdk_manager.release.assert_called_once()
+            self.mock_sdk_manager.release.assert_not_called()
 
     async def test_initialization_with_invalid_extension(self):
         """Test filter initialization fails with non-.kef file."""
@@ -150,10 +150,8 @@ class TestKrispVivaFilter(unittest.IsolatedAsyncioTestCase):
                 KrispVivaFilter(model_path=tmp_path)
 
             self.assertIn(".kef extension", str(context.exception))
-            # SDK acquire not called during initialization (happens in start())
-            # But release() is called in exception handler even though acquire() wasn't called
             self.mock_sdk_manager.acquire.assert_not_called()
-            self.mock_sdk_manager.release.assert_called_once()
+            self.mock_sdk_manager.release.assert_not_called()
         finally:
             os.unlink(tmp_path)
 
@@ -162,10 +160,8 @@ class TestKrispVivaFilter(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(FileNotFoundError):
             KrispVivaFilter(model_path="/nonexistent/path/model.kef")
 
-        # SDK acquire not called during initialization (happens in start())
-        # But release() is called in exception handler even though acquire() wasn't called
         self.mock_sdk_manager.acquire.assert_not_called()
-        self.mock_sdk_manager.release.assert_called_once()
+        self.mock_sdk_manager.release.assert_not_called()
 
     async def test_initialization_with_custom_noise_level(self):
         """Test filter initialization with custom noise suppression level."""

--- a/tests/test_krisp_viva_vad.py
+++ b/tests/test_krisp_viva_vad.py
@@ -10,6 +10,7 @@ import asyncio
 import os
 import sys
 import tempfile
+import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -129,10 +130,10 @@ class TestKrispVivaVadAnalyzer(unittest.TestCase):
                 KrispVivaVadAnalyzer()
 
             self.assertIn("Model path", str(context.exception))
-            # acquire() is not called because exception is raised before it
+            # acquire() is not called because exception is raised before it,
+            # so release() must not decrement a reference owned by another instance.
             self.mock_sdk_manager.acquire.assert_not_called()
-            # release() is called in the initialization exception handler
-            self.assertGreaterEqual(self.mock_sdk_manager.release.call_count, 1)
+            self.mock_sdk_manager.release.assert_not_called()
 
     def test_initialization_with_invalid_extension(self):
         """Test analyzer initialization fails with non-.kef file."""
@@ -145,10 +146,8 @@ class TestKrispVivaVadAnalyzer(unittest.TestCase):
                 KrispVivaVadAnalyzer(model_path=tmp_path)
 
             self.assertIn(".kef extension", str(context.exception))
-            # acquire() is not called because exception is raised before it
             self.mock_sdk_manager.acquire.assert_not_called()
-            # release() is called in the initialization exception handler
-            self.assertGreaterEqual(self.mock_sdk_manager.release.call_count, 1)
+            self.mock_sdk_manager.release.assert_not_called()
         finally:
             os.unlink(tmp_path)
 
@@ -157,10 +156,8 @@ class TestKrispVivaVadAnalyzer(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             KrispVivaVadAnalyzer(model_path="/nonexistent/path/model.kef")
 
-        # acquire() is not called because exception is raised before it
         self.mock_sdk_manager.acquire.assert_not_called()
-        # release() is called in the initialization exception handler
-        self.assertGreaterEqual(self.mock_sdk_manager.release.call_count, 1)
+        self.mock_sdk_manager.release.assert_not_called()
 
     def test_initialization_with_custom_frame_duration(self):
         """Test analyzer initialization with custom frame duration."""
@@ -360,6 +357,62 @@ class TestKrispVivaVadAnalyzer(unittest.TestCase):
         # Verify SDK was released and session was cleared
         self.mock_sdk_manager.release.assert_called_once()
         self.assertIsNone(analyzer._session)
+
+    def test_cleanup_drains_executor_before_dropping_session(self):
+        """cleanup() must wait for in-flight session.process() before dropping the session.
+
+        VAD analysis runs on a single-worker executor. Pipeline cancel does not
+        abort a running native process() call; dropping the session (or calling
+        globalDestroy) while that call is in flight segfaults in the SDK.
+        """
+        analyzer = KrispVivaVadAnalyzer(model_path=self.model_path)
+        analyzer.set_sample_rate(16000)
+
+        started = threading.Event()
+        finish = threading.Event()
+        cleanup_done = threading.Event()
+        session_alive_in_process = []
+
+        def slow_process(audio):
+            started.set()
+            finish.wait(timeout=5)
+            session_alive_in_process.append(analyzer._session is not None)
+            return 0.75
+
+        self.mock_session.process.side_effect = slow_process
+
+        samples = np.zeros(160, dtype=np.int16).tobytes()
+        future = analyzer._executor.submit(analyzer.voice_confidence, samples)
+        self.assertTrue(started.wait(timeout=2))
+
+        def run_cleanup():
+            asyncio.run(analyzer.cleanup())
+            cleanup_done.set()
+
+        cleanup_thread = threading.Thread(target=run_cleanup)
+        cleanup_thread.start()
+
+        # wait=False returns immediately and drops the session while process()
+        # is still blocked. A correct drain keeps cleanup parked in shutdown().
+        finished_early = cleanup_done.wait(timeout=0.2)
+        session_while_blocked = analyzer._session is not None
+
+        finish.set()
+        cleanup_thread.join(timeout=5)
+        confidence = future.result(timeout=2)
+
+        self.assertFalse(
+            finished_early,
+            "cleanup returned while executor process() was still running",
+        )
+        self.assertTrue(
+            session_while_blocked,
+            "session was dropped while executor process() was still running",
+        )
+        self.assertEqual(session_alive_in_process, [True])
+        self.assertEqual(confidence, 0.75)
+        self.assertIsNone(analyzer._session)
+        self.mock_sdk_manager.release.assert_called()
 
     def test_initialization_with_vad_params(self):
         """Test analyzer initialization with VAD parameters."""


### PR DESCRIPTION
Closes #5408

`KrispVivaSDKManager.release()` was calling `globalDestroy()` whenever the last live filter/VAD dropped its refcount. That happens at the end of every call in a serving worker, while Krisp still has native `process()` work (and its own threads) in flight. Combined with `VADAnalyzer.cleanup()` shutting down the executor with `wait=False`, an abandoned `session.process()` races destructor/`globalDestroy` and SIGSEGVs in `libkrisp-audio-sdk`.

- Keep `globalInit` once per process; `globalDestroy` only from `atexit`.
- Drain the VAD executor (`shutdown(wait=True, cancel_futures=True)`) before dropping the session.
- Stop constructor exception paths from `release()`-ing a ref they never acquired.

Regression tests mock `krisp_audio` (no native `.kef` models).

Used Grok (xAI) while reproducing and implementing this.