### PR TITLE
Warm deferred imports before frames flow

### DIFF
--- a/changelog/5417.fixed.md
+++ b/changelog/5417.fixed.md
@@ -1,0 +1,1 @@
+- Fixed a glitch in the opening audio. Pipecat warms its deferred imports in a thread so a pipeline doesn't pay for them when it first needs them, but that started once the worker had started, putting a stretch of CPU-bound importing right where the pipeline begins pushing frames. It now runs while the processors are being set up, and finishes before any frame flows.

--- a/src/pipecat/pipeline/worker.py
+++ b/src/pipecat/pipeline/worker.py
@@ -1135,6 +1135,10 @@ class PipelineWorker(BaseWorker):
         # Start worker observer.
         await self._observer.setup(self.task_manager)
 
+        # Services spend most of the start sequence waiting on the network, which
+        # leaves room to load the imports while setup is happening.
+        lazy_imports_task = self.create_task(asyncio.to_thread(warm_deferred_imports))
+
         # Setup processors
         setup = FrameProcessorSetup(
             audio_in_sample_rate=self._params.audio_in_sample_rate,
@@ -1156,6 +1160,9 @@ class PipelineWorker(BaseWorker):
             tool_resources=self._app_resources,
         )
         await self.create_task(self._pipeline.setup(setup))
+
+        # Make sure lazy imports are done at this point.
+        await lazy_imports_task
 
     async def _cleanup(self, cleanup_pipeline: bool):
         """Clean up the pipeline worker and processors."""
@@ -1203,12 +1210,6 @@ class PipelineWorker(BaseWorker):
         until the worker is cancelled or stopped (e.g. with an EndFrame).
         """
         self._maybe_start_idle_task()
-
-        # Services spend most of the start sequence waiting on the network, which
-        # leaves room to load the imports deferred out of pipeline construction.
-        self.create_task(
-            asyncio.to_thread(warm_deferred_imports), name=f"{self}::warm_deferred_imports"
-        )
 
         # Processors read the pipeline configuration from FrameProcessorSetup,
         # but the deprecated StartFrame fields carry it until they are removed,


### PR DESCRIPTION
Warming the deferred imports used to start after the worker had started, so the import competed with the first frames and glitched the opening audio.

It now starts before the processors are set up, overlapping `_pipeline.setup()`, and is awaited so it cannot still be running when frames arrive.

## Testing

`uv run pytest`, 4707 passed.
