### PR TITLE
Drop changelog entry for an unreleased fix

### DIFF
--- a/changelog/5417.fixed.md
+++ b/changelog/5417.fixed.md
@@ -1,1 +1,0 @@
-- Fixed a glitch in the opening audio. Pipecat warms its deferred imports in a thread so a pipeline doesn't pay for them when it first needs them, but that started once the worker had started, putting a stretch of CPU-bound importing right where the pipeline begins pushing frames. It now runs while the processors are being set up, and finishes before any frame flows.


### PR DESCRIPTION
The glitch this entry describes was in `prewarm.py`, added after 1.7.0 and never released, so no one ever saw it.
