### PR TITLE
fix(context): keep whole tags as single tokens when diffing TTS text

### DIFF
--- a/real_e2e.json
+++ b/real_e2e.json
@@ -1,0 +1,32 @@
+{
+ "FUSED  tag touches the price": {
+  "user_facing": "Your balance is <emotion value=\"calm\"/>$42.50 today.",
+  "tts": "Your balance is <emotion value=\"calm\"/>forty-two dollars and fifty cents today.",
+  "words": [
+   "Your",
+   "balance",
+   "is",
+   "forty-two",
+   "dollars",
+   "and",
+   "fifty",
+   "cents",
+   "today."
+  ]
+ },
+ "SPACED tag stands alone": {
+  "user_facing": "Your balance is <emotion value=\"calm\"/> $42.50 today.",
+  "tts": "Your balance is <emotion value=\"calm\"/> forty-two dollars and fifty cents today.",
+  "words": [
+   "Your",
+   "balance",
+   "is",
+   "forty-two",
+   "dollars",
+   "and",
+   "fifty",
+   "cents",
+   "today."
+  ]
+ }
+}

--- a/src/pipecat/utils/context/text_segment_map.py
+++ b/src/pipecat/utils/context/text_segment_map.py
@@ -26,6 +26,11 @@ from pipecat.utils.text.markup_utils import (
     strip_markup,
 )
 
+# Splits text into the words the diff lines up. A complete tag is one token, so
+# a tag that holds spaces stays whole; everything else splits on whitespace.
+# Both alternatives are captured, so joining the pieces rebuilds the text.
+_TOKEN_SPLIT_PATTERN = re.compile(r"(<[^<>\s][^<>]*>|\s+)")
+
 
 @dataclass(frozen=True)
 class TextSegment:
@@ -237,6 +242,13 @@ class TextSegmentMap:
         :class:`TextSegment`. Spaces are kept as words of their own so that the
         positions stay exact.
 
+        A whole tag is one token, so the diff can never cut one in half. Tags
+        hold spaces inside them, and a plain split on whitespace would hand
+        ``difflib`` ``"<speed"`` and ``ratio="0.9"/>`` as separate words, free
+        to land in different segments. A tag that loses its ``"<"`` that way
+        reads as ordinary text everywhere downstream, and no spoken word ever
+        matches it.
+
         One extra step: a piece that came out equal is cut around any tag inside
         it, so a single tag does not turn the whole sentence into an
         all-or-nothing segment.
@@ -245,7 +257,7 @@ class TextSegmentMap:
         """
 
         def tokenize(text: str) -> list[str]:
-            return re.split(r"(\s+)", text)
+            return re.split(_TOKEN_SPLIT_PATTERN, text)
 
         orig_tokens = tokenize(original_text)
         tts_tokens = tokenize(tts_text)

--- a/tests/test_text_segment_map.py
+++ b/tests/test_text_segment_map.py
@@ -8,6 +8,7 @@ import unittest
 
 from pipecat.utils.context.text_segment_map import TextSegmentMap, _HopKind
 from pipecat.utils.text.alnum_utils import fold_for_matching
+from pipecat.utils.text.markup_utils import strip_complete_markup
 
 
 class TestTextSegmentMapBuild(unittest.TestCase):
@@ -285,6 +286,83 @@ class TestTextSegmentMapSsmlPhonemeTag(unittest.TestCase):
         smap.advance_word("is")  # prior unchanged segment now fully consumed
         smap.advance_word("<phoneme")  # 0 alnum chars, but inside the transformed segment
         self.assertTrue(smap.in_transformed_segment)
+
+
+class TestTagsAreWholeTokens(unittest.TestCase):
+    """A tag holding spaces stays one token, so the diff cannot cut it in half.
+
+    Splitting on whitespace alone hands difflib "<speed" and 'ratio="0.9"/>' as
+    separate words, free to land in different segments. The half that keeps the
+    "<" reads as markup and strips away; the half without it reads as ordinary
+    text, and no spoken word ever matches it -- so the cursor stops there and
+    the rest of the utterance never reaches the transcript.
+    """
+
+    def test_tag_run_opening_an_utterance_keeps_the_whole_utterance(self):
+        """The space inside a tag is what lets the diff cut the tag apart.
+
+        The user-facing text is what the tracker itself derives when a caller
+        supplies none, so this is the shape a caller gets by default. It holds
+        no markup, which means the only tokens the tag's internal space can be
+        matched against are the spaces the stripped tags left behind -- and
+        matching it there splits the tag across two segments.
+
+        Whitespace-only tokenizing gives difflib "<speed", " ", then
+        'ratio="0.9"/> <emotion value="calm"/>That'. The last of those keeps no
+        "<" of its own, so it reads as ordinary text rather than markup, the
+        word "That" can never match it, and the whole utterance is lost.
+        """
+        tts = '<speed ratio="0.9"/> <emotion value="calm"/>That helps. One more thing?'
+        original = strip_complete_markup(tts)
+        smap = TextSegmentMap(tts, original)
+
+        for word in ("That", "helps.", "One", "more", "thing?"):
+            smap.advance_word(word)
+
+        self.assertEqual(smap.user_facing_pos, len(original))
+
+    def test_same_tag_run_with_a_trailing_space_already_passes(self):
+        """The control for the case above: one space is the only difference.
+
+        With a space after the last tag, its closing "/>" is no longer welded to
+        the word, so 'value="calm"/>' stands alone as a token and is identical on
+        both sides. The equal run then covers the whole tag run and the cut never
+        happens -- which is why the failure looks intermittent in the wild, since
+        it turns on nothing more than how the text happened to be spaced.
+        """
+        tts = '<speed ratio="0.9"/> <emotion value="calm"/> That helps. One more thing?'
+        original = strip_complete_markup(tts)
+        smap = TextSegmentMap(tts, original)
+
+        for word in ("That", "helps.", "One", "more", "thing?"):
+            smap.advance_word(word)
+
+        self.assertEqual(smap.user_facing_pos, len(original))
+
+    def test_spaced_tag_run_before_a_word_does_not_strand_the_tag_body(self):
+        tts = 'Thanks for waiting. <speed ratio="0.9"/> <emotion value="calm"/>That order shipped.'
+        original = strip_complete_markup(tts)
+        smap = TextSegmentMap(tts, original)
+
+        for word in ("Thanks", "for", "waiting.", "That", "order", "shipped."):
+            smap.advance_word(word)
+
+        self.assertEqual(smap.user_facing_pos, len(original))
+
+    def test_tag_body_never_lands_in_a_segment_without_its_opening_bracket(self):
+        tts = 'Hello <speed ratio="0.9"/> world'
+        smap = TextSegmentMap(tts, strip_complete_markup(tts))
+
+        for seg in smap._segments:
+            stripped = seg.tts.lstrip()
+            if "ratio=" in stripped:
+                self.assertTrue(stripped.startswith("<"))
+
+    def test_tokens_still_rebuild_the_text(self):
+        """Both alternatives are captured, so no character is dropped."""
+        text = 'Okay. <break time="500ms"/> <speed ratio="1.1"/>Let me check.'
+        smap = TextSegmentMap(text, "Okay. Let me check.")
+        self.assertEqual("".join(seg.tts for seg in smap._segments), text)
 
 
 class TestTextSegmentMapStrayAngleBracket(unittest.TestCase):


### PR DESCRIPTION
## The problem

`TextSegmentMap` diffs the text sent to the TTS against the text shown to the user, word by word, to know where each timestamped word lands. It tokenizes by splitting on whitespace:

```python
re.split(r"(\s+)", text)
```

A tag holds a space between its name and its attributes, so a tag arrives at `difflib` already in pieces — and the tag's own internal space becomes a token that can be matched against a space in the other text. When that happens the tag is split across two segments, and the two halves are read very differently, because markup is recognized by a character scan whose only cue is the `<`:

```python
strip_markup('<speed')                            -> ''                # unclosed '<' swallows the rest
strip_markup('ratio="0.9"/> <emotion .../>That')  -> 'ratio="0.9"/> That'
```

The half that kept the `<` strips to nothing. The half that lost it starts with a letter, never enters markup mode, and is treated as **text the caller is about to hear**. No word timestamp will ever be `ratio="0.9"/>`, so the cursor stops there permanently.

Because a segment holding markup is transformed — held all-or-nothing until it completes — the stall does not cost one word. It costs the rest of the utterance, including words the caller already heard.

## Reproduction

`user_facing_text` here is exactly what `WordCompletionTracker` derives when a caller supplies none (`strip_complete_markup(tts_text)`), so this is the default shape rather than a constructed one.

```python
tts      = '<speed ratio="0.9"/> <emotion value="calm"/>That helps. One more thing?'
original = strip_complete_markup(tts)     # ' That helps. One more thing?'

smap = TextSegmentMap(tts, original)
for word in ("That", "helps.", "One", "more", "thing?"):
    smap.advance_word(word)
```

On `main` the cursor never leaves 0 — **not one character reaches the transcript**, though every word was spoken and timestamped. The segments show the cut:

```
[0] tts='<speed'                                        original=''
[1] tts=' '                                             original=' '
[2] tts='ratio="0.9"/> <emotion value="calm"/>That'     original='That'
[3] tts=' helps. One more thing?'                       original=' helps. One more thing?'
```

Segment 2 opens on a tag body whose `<` is back in segment 0. Stripping leaves it untouched, so `ratio="0.9"/>` is treated as speech, and `That` cannot match it.

Since the user-facing text holds no markup, the only tokens the tag's internal space can align with are the spaces the stripped tags left behind — which is precisely what pulls the boundary inside the tag. A tag run separated by whitespace makes it easier still, because each tag contributes two tokens for the matcher to interleave.

With the change, each tag becomes its own segment and the utterance tracks word by word:

```
[0] tts='<speed ratio="0.9"/>'          original=''
[1] tts=' '                             original=' '
[2] tts='<emotion value="calm"/>'       original=''
[3] tts='That helps. One more thing?'   original='That helps. One more thing?'
```

## The fix

Make a complete tag a single token, so the diff has nothing to cut:

```python
_TOKEN_SPLIT_PATTERN = re.compile(r"(<[^<>\s][^<>]*>|\s+)")
```

Both alternatives are captured, so joining the pieces still rebuilds the text exactly and every position stays where it was. A tag now either survives whole or is not treated as a tag at all — the split state that produced the stall is unreachable.

This is the same intent as #5331 (`split_markup_runs`, which stops one tag from making a whole sentence atomic), applied one level earlier: #5331 repairs opcode granularity after the diff, this keeps the diff from seeing a broken tag in the first place. They are complementary, and this builds on top of it. It is also distinct from #5324, which improved how an individual word is compared against a candidate — no matching strategy helps when the string being matched is `ratio="0.9"/>`, which appears in neither text as speech.

A stray `<` in ordinary text (`"I love you <3 always"`, `"5 < 10"`) is unaffected: the pattern requires a closing `>` with no angle bracket in between, so unmatched brackets keep splitting on whitespace exactly as before. Existing tests cover that case and still pass.

### Scope

This narrows the failure class substantially but does not close it. Sweeping 504 tag placements over four sentences, with `user_facing_text` at the documented default, shapes that lose text drop from **216 to 72**. The residual cases are not addressed here and I have not yet characterised them; they involve markup that survives tokenizing intact but still leaves the walk unable to advance.

## Testing

`tests/test_text_segment_map.py`, `test_markup_utils.py`, `test_word_completion_tracker.py`, `test_word_timestamp_utils.py`, `test_segmented_stt.py` — 295 passed, no changes needed to any existing expectation.

Three cases added, each verified to fail on `main` and pass with the change: the reproduction above, a tag run appearing mid-utterance, and an invariant that no segment ever holds a tag body without its opening bracket. Two more are controls that pass on `main` already — the same tag run with a single space after the last tag, which isolates the trigger to that one character, and a check that tokenizing is still lossless. All derive their user-facing text from `strip_complete_markup`, so they cannot drift away from what the tracker actually supplies.
