### PR TITLE
Add the changelog fragment for #5431

### DIFF
--- a/changelog/5431.fixed.md
+++ b/changelog/5431.fixed.md
@@ -1,0 +1,1 @@
+- `ElevenLabsTTSService` and `ElevenLabsHttpTTSService` no longer send `previous_text`/`next_text` to `eleven_v3_conversational`, which rejects them.


### PR DESCRIPTION
#5431 (`eleven_v3_conversational` added to the context-unsupported set) merged without a changelog fragment; this adds its entry.