### PR TITLE
docs(examples): fix broken thinking-and-mcp link in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -105,9 +105,13 @@ Changing service settings at runtime, organized by service type:
 
 Turn detection, interruption handling, and user input management.
 
-### [`thinking-and-mcp/`](./thinking-and-mcp/)
+### [`thinking/`](./thinking/)
 
-LLM thinking/reasoning modes and MCP (Model Context Protocol) tool server integration.
+LLM thinking/reasoning modes.
+
+### [`mcp/`](./mcp/)
+
+MCP (Model Context Protocol) tool server integration.
 
 ### [`transports/`](./transports/)
 


### PR DESCRIPTION
### Problem

The examples index (`examples/README.md`) has a section linking to `./thinking-and-mcp/`:

```
### [`thinking-and-mcp/`](./thinking-and-mcp/)
```

That directory does not exist in the repo, so the link 404s. The examples were split into two separate top-level directories that both exist today:

- `examples/thinking/` — `thinking-anthropic.py`, `thinking-google.py`, `thinking-openai-responses.py`, etc.
- `examples/mcp/` — `mcp-stdio.py`, `mcp-streamable-http.py`, `mcp-multiple-mcp.py`, etc.

`grep -rn "thinking-and-mcp"` returns only this one README line, confirming the path is dangling.

### Fix

Split the stale section into two entries that point at the actual directories, keeping the original one-line description split across the two (thinking / MCP). No content beyond `examples/README.md` is touched.

### How to verify

- Before: `ls examples/thinking-and-mcp` → No such file or directory.
- After: both `examples/thinking/` and `examples/mcp/` exist and the two links resolve.
- Docs-only change, so per CONTRIBUTING no changelog fragment is required.