### PR TITLE
Retire the MoQ audio track on interruption

### DIFF
--- a/changelog/5443.changed.md
+++ b/changelog/5443.changed.md
@@ -1,1 +1,1 @@
-- Changed `MOQOutputTransport` to retire its audio track on interruption and publish a successor, so audio already in flight is discarded along with the track that carried it rather than relying on the client to flush.
+- Changed `MOQOutputTransport` to retire its audio track when an interruption catches audio still to be played, publishing a successor in its place, so that audio is discarded along with the track that carried it rather than relying on the client to flush.

--- a/changelog/5443.changed.md
+++ b/changelog/5443.changed.md
@@ -1,0 +1,1 @@
+- Changed `MOQOutputTransport` to retire its audio track on interruption and publish a successor, so audio already in flight is discarded along with the track that carried it rather than relying on the client to flush.

--- a/src/pipecat/transports/moq/transport.py
+++ b/src/pipecat/transports/moq/transport.py
@@ -22,11 +22,11 @@ subscribes to the peer at ``<namespace>/<peer_id>`` (e.g.
 both peers agree on a namespace up front; when the paths are instead
 assigned externally, ``response_path``/``request_path`` set them
 directly and the namespace is unused. Audio rides on a
-single Opus track, replaced by a fresh one on every interruption so the
-audio already in flight is discarded along with the track that carried it
-(see :meth:`MOQTransportClient.restart_audio_track`); RTVI JSON rides on a
-fixed-name ``transcript.json.z``
-track carried by moq's JSON stream helper (``publish_json_stream`` /
+single Opus track, replaced by a fresh one when an interruption catches
+audio still in flight, so that audio is discarded along with the track
+that carried it (see :meth:`MOQTransportClient.restart_audio_track`);
+RTVI JSON rides on a fixed-name ``transcript.json.z`` track carried by
+moq's JSON stream helper (``publish_json_stream`` /
 ``subscribe_json_stream``). The stream is an ordered, lossless append-log
 of records — every message is delivered in order, unlike the JSON
 *snapshot* helper (``publish_json_snapshot`` / ``subscribe_json_snapshot``)
@@ -226,6 +226,12 @@ DEFAULT_TRANSCRIPT_TRACK = "transcript.json.z"
 # pipeline rate up to this for us.
 OPUS_SAMPLE_RATE = 48000
 
+# Unplayed audio below this doesn't justify retiring the audio track. A
+# lead this small is the client's own jitter buffer, or a mixer writing
+# at real-time pace, rather than the write-ahead frontier of an
+# abandoned utterance. See :meth:`MOQTransportClient.restart_audio_track`.
+AUDIO_IN_FLIGHT_FLOOR_S = 0.3
+
 
 def _downmix_s16_to_mono(pcm: bytes, channels: int) -> bytes:
     """Downmix interleaved S16 PCM to mono by averaging channels.
@@ -294,10 +300,11 @@ class MOQParams(TransportParams):
         request_path: Full broadcast path the bot subscribes to (incoming
             requests), overriding ``<namespace>/<peer_id>``. See
             :attr:`response_path`.
-        audio_out_track: Name of the bot's outgoing audio track. Each
-            interruption retires the track and publishes a successor
-            named ``<audio_out_track>-<n>``; subscribers discover the
-            current one through the catalog rather than by this name.
+        audio_out_track: Name of the bot's outgoing audio track. An
+            interruption that catches audio still to be played retires
+            the track and publishes a successor named
+            ``<audio_out_track>-<n>``; subscribers discover the current
+            one through the catalog rather than by this name.
         transcript_track: Name of the bot's outgoing transcript track. A
             fixed-name JSON stream track carrying RTVI messages as a
             lossless, ordered append-log (moq's ``publish_json_stream`` /
@@ -540,8 +547,9 @@ class MOQTransportClient:
         # future-dated timestamps to buffer and pace playback. Only the
         # first stamp of a track reaches the wire as given: the encoder
         # takes it as that track's epoch and derives every later PTS from
-        # the running sample count.
-        self._publish_pts_us: int = 0
+        # the running sample count. ``None`` means the current track has
+        # no epoch yet — the next write takes one from the timeline.
+        self._publish_pts_us: int | None = None
         # Counter distinguishing successive audio tracks. Bumped per
         # interruption; the name of track 0 is `audio_out_track` itself.
         self._audio_track_epoch: int = 0
@@ -619,10 +627,13 @@ class MOQTransportClient:
     def _open_audio_track(self, sample_rate: int):
         """Publish an audio track for the current epoch.
 
-        The track is anchored at the timeline position it starts playing
-        from, which is what the encoder takes as its epoch.
+        The epoch is left unset for the first write to fill in, so the
+        track anchors at the timeline position it starts playing from
+        rather than where it was opened. The two are seconds apart
+        whenever an utterance waits on the LLM, and the encoder takes
+        that first stamp as the track's epoch.
         """
-        self._publish_pts_us = self._elapsed_us()
+        self._publish_pts_us = None
         self._audio_out = self._publish_broadcast.publish_audio(
             self._audio_track_name,
             moq.AudioEncoderInput(
@@ -660,13 +671,27 @@ class MOQTransportClient:
         one audio track and subscribers follow the swap through normal
         rendition selection.
 
-        The successor anchors at the current position on the broadcast's
-        shared timeline rather than continuing from where the abandoned
-        utterance had written to, so the next utterance plays immediately
-        instead of waiting out the buffer it replaced. The pacing clock
-        re-anchors with it.
+        The successor anchors at its own first write rather than
+        continuing from where the abandoned utterance had written to, so
+        the next utterance plays immediately instead of waiting out the
+        buffer it replaced. The pacing clock re-anchors with it.
+
+        Interruptions are broadcast on every user turn, not only on
+        barge-in, so a swap is worth its cost — a catalog update and a
+        resubscribe for every subscriber — only when the track actually
+        carries audio nobody has heard yet. ``_publish_audio_clock`` is
+        the presentation deadline of the last chunk written, so its lead
+        over wall-clock is exactly what is still to be played.
         """
         if self._audio_out is None or not self._audio_out_sample_rate:
+            return
+
+        in_flight_s = (
+            0.0
+            if self._publish_audio_clock is None
+            else self._publish_audio_clock - time.monotonic()
+        )
+        if in_flight_s <= AUDIO_IN_FLIGHT_FLOOR_S:
             return
 
         old = self._audio_out
@@ -699,7 +724,8 @@ class MOQTransportClient:
         ``audio_out_max_buffer_ms`` of it. Interruptions retire the whole
         track (see :meth:`restart_audio_track`), so the cap bounds how much
         encoded audio a retired track can strand rather than how much can
-        still reach the player.
+        still reach the player. It also bounds how long the lead stays
+        above the floor a retirement needs to be worth making.
         """
         producer = self._audio_out
         if producer is None or not self._audio_out_sample_rate:
@@ -728,6 +754,12 @@ class MOQTransportClient:
         # duration of this chunk. S16 = 2 bytes/sample, mono.
         duration_s = len(audio) / (self._audio_out_sample_rate * 2)
         self._publish_audio_clock += duration_s
+
+        # First write on this track: it decides where the track sits on the
+        # broadcast timeline, so take the position now that audio is
+        # actually going out.
+        if self._publish_pts_us is None:
+            self._publish_pts_us = self._elapsed_us()
 
         producer.write(moq.AudioFrame(timestamp_us=self._publish_pts_us, data=audio))
         self._publish_pts_us += int(duration_s * 1_000_000)
@@ -1413,7 +1445,7 @@ class MOQOutputTransport(BaseOutputTransport):
         await self._client.cleanup()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Publish a fresh audio track on interruption.
+        """Retire the audio track when an interruption strands audio on it.
 
         The base class drains the queued audio and stops the writer first,
         so the track is retired with no writes still racing it. Everything

--- a/src/pipecat/transports/moq/transport.py
+++ b/src/pipecat/transports/moq/transport.py
@@ -22,7 +22,10 @@ subscribes to the peer at ``<namespace>/<peer_id>`` (e.g.
 both peers agree on a namespace up front; when the paths are instead
 assigned externally, ``response_path``/``request_path`` set them
 directly and the namespace is unused. Audio rides on a
-single Opus track; RTVI JSON rides on a fixed-name ``transcript.json.z``
+single Opus track, replaced by a fresh one on every interruption so the
+audio already in flight is discarded along with the track that carried it
+(see :meth:`MOQTransportClient.restart_audio_track`); RTVI JSON rides on a
+fixed-name ``transcript.json.z``
 track carried by moq's JSON stream helper (``publish_json_stream`` /
 ``subscribe_json_stream``). The stream is an ordered, lossless append-log
 of records — every message is delivered in order, unlike the JSON
@@ -291,7 +294,10 @@ class MOQParams(TransportParams):
         request_path: Full broadcast path the bot subscribes to (incoming
             requests), overriding ``<namespace>/<peer_id>``. See
             :attr:`response_path`.
-        audio_out_track: Name of the bot's outgoing audio track.
+        audio_out_track: Name of the bot's outgoing audio track. Each
+            interruption retires the track and publishes a successor
+            named ``<audio_out_track>-<n>``; subscribers discover the
+            current one through the catalog rather than by this name.
         transcript_track: Name of the bot's outgoing transcript track. A
             fixed-name JSON stream track carrying RTVI messages as a
             lossless, ordered append-log (moq's ``publish_json_stream`` /
@@ -360,9 +366,7 @@ class MOQParams(TransportParams):
             past this many milliseconds. Keep it a little under the
             player's buffer ceiling (``MoqTransportOptions.audioBufferMaxMs``,
             30s) so the producer self-limits below the player's drop
-            ceiling and the player never has to drop. On interruption the
-            pacing clock is re-anchored (see :meth:`reset_audio_pacing`) so
-            the next utterance isn't delayed by the previous buffer.
+            ceiling and the player never has to drop.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -524,12 +528,23 @@ class MOQTransportClient:
         # Wall-clock target for the next publish_audio write. ``None``
         # means "reset" — the next write anchors to ``time.monotonic()``.
         self._publish_audio_clock: float | None = None
-        # Monotonic presentation timestamp (microseconds) for the next
-        # audio chunk, advanced by each chunk's duration. The browser
-        # player uses these future-dated timestamps to buffer and pace
-        # playback. Not reset on interruption — the player re-anchors on
-        # its own (reset() on user-started-speaking).
+        # Origin of the broadcast's presentation timeline. Every track the
+        # bot publishes stamps against this one clock, so they stay
+        # mutually synchronizable — the audio track being replaced on
+        # interruption doesn't restart the timescale, it just re-anchors
+        # into it. Monotonic and publisher-local, matching the browser
+        # side's ``performance.now()`` convention.
+        self._clock_origin: float = time.monotonic()
+        # Presentation timestamp (microseconds) for the next audio chunk,
+        # advanced by each chunk's duration. The browser player uses these
+        # future-dated timestamps to buffer and pace playback. Only the
+        # first stamp of a track reaches the wire as given: the encoder
+        # takes it as that track's epoch and derives every later PTS from
+        # the running sample count.
         self._publish_pts_us: int = 0
+        # Counter distinguishing successive audio tracks. Bumped per
+        # interruption; the name of track 0 is `audio_out_track` itself.
+        self._audio_track_epoch: int = 0
 
         # Track consumers we created so disconnect() can cancel them.
         # Each entry has a sync .cancel() method that terminates any
@@ -588,8 +603,28 @@ class MOQTransportClient:
             return
 
         self._audio_out_sample_rate = sample_rate
+        self._open_audio_track(sample_rate)
+
+    @property
+    def _audio_track_name(self) -> str:
+        """Name of the audio track for the current epoch."""
+        if self._audio_track_epoch == 0:
+            return self._params.audio_out_track
+        return f"{self._params.audio_out_track}-{self._audio_track_epoch}"
+
+    def _elapsed_us(self) -> int:
+        """Microseconds elapsed on the broadcast's presentation timeline."""
+        return int((time.monotonic() - self._clock_origin) * 1_000_000)
+
+    def _open_audio_track(self, sample_rate: int):
+        """Publish an audio track for the current epoch.
+
+        The track is anchored at the timeline position it starts playing
+        from, which is what the encoder takes as its epoch.
+        """
+        self._publish_pts_us = self._elapsed_us()
         self._audio_out = self._publish_broadcast.publish_audio(
-            self._params.audio_out_track,
+            self._audio_track_name,
             moq.AudioEncoderInput(
                 format=moq.AudioFormat.S16,
                 sample_rate=sample_rate,
@@ -607,22 +642,47 @@ class MOQTransportClient:
             f"MOQ: publishing audio as Opus "
             f"(pipeline rate={sample_rate}Hz, opus rate={OPUS_SAMPLE_RATE}Hz, "
             f"frame={self._params.audio_out_frame_ms}ms, "
-            f"track={self._params.audio_out_track!r})"
+            f"track={self._audio_track_name!r})"
         )
 
-    def reset_audio_pacing(self):
-        """Re-anchor the publish_audio pacing clock to wall-clock now.
+    def restart_audio_track(self):
+        """Retire the current audio track and publish a fresh one.
 
-        Called from :class:`MOQOutputTransport.process_frame` on
-        InterruptionFrame so the next utterance plays immediately
-        instead of waiting for the (now-cancelled) previous one to
-        finish in pacing time.
+        The bot writes TTS faster than real-time, so when an interruption
+        arrives the previous utterance is already encoded and in flight —
+        seconds of it. Retiring the track is what discards it: the track
+        name identifies the utterance it carries, so anything still
+        arriving on the old one is recognizably stale rather than
+        indistinguishable from the new utterance's first frame.
 
-        Part of the publish_audio pacing workaround; goes away once
-        moq-rs exposes a flush primitive on ``AudioProducer``. See
-        :meth:`publish_audio`.
+        ``finish()`` drops the producer's catalog rendition, and the new
+        track publishes its own, so the catalog always advertises exactly
+        one audio track and subscribers follow the swap through normal
+        rendition selection.
+
+        The successor anchors at the current position on the broadcast's
+        shared timeline rather than continuing from where the abandoned
+        utterance had written to, so the next utterance plays immediately
+        instead of waiting out the buffer it replaced. The pacing clock
+        re-anchors with it.
         """
+        if self._audio_out is None or not self._audio_out_sample_rate:
+            return
+
+        old = self._audio_out
+        # Cleared before finishing so a chunk still paced against the old
+        # track can tell its write is no longer wanted (see publish_audio).
+        self._audio_out = None
+        try:
+            old.finish()
+        except Exception as e:
+            # A peer that already went away fails the flush; the rendition
+            # is gone either way, so the new track is still worth opening.
+            logger.debug(f"MOQ: finishing audio track {self._audio_track_name!r} failed: {e}")
+
+        self._audio_track_epoch += 1
         self._publish_audio_clock = None
+        self._open_audio_track(self._audio_out_sample_rate)
 
     async def publish_audio(self, audio: bytes):
         """Push a PCM chunk to the bot's audio track with real PTS, paced to a cap.
@@ -630,21 +690,19 @@ class MOQTransportClient:
         The library does the Opus encode + resample inside the FFI, so we
         just write S16 PCM bytes.
 
-        Each chunk is stamped with a monotonic presentation timestamp so
-        the browser player (``@moq/watch``) can buffer the future-dated
-        frames and play them at the encoded pace. ``AudioProducer.write()``
-        is fire-and-forget, so to bound how far ahead the bot runs we pace
-        the writes against a virtual clock: each call advances the clock by
-        the chunk's audio duration, and we sleep until wall-clock is within
-        ``audio_out_max_buffer_ms`` (25s) of it. That keeps the in-flight
-        buffer a little under the player's drop ceiling
-        (``MoqTransportOptions.audioBufferMaxMs``, 30s), so the producer
-        self-limits below the consumer's cap. Interruptions are flushed on
-        the browser side (``reset()`` on ``user-started-speaking``); the
-        pacing clock is re-anchored here (see :meth:`reset_audio_pacing`)
-        so the next utterance isn't delayed by the previous buffer.
+        Each chunk is stamped with a presentation timestamp so the browser
+        player (``@moq/watch``) can buffer the future-dated frames and play
+        them at the encoded pace. ``AudioProducer.write()`` is
+        fire-and-forget, so to bound how far ahead the bot runs we pace the
+        writes against a virtual clock: each call advances the clock by the
+        chunk's audio duration, and we sleep until wall-clock is within
+        ``audio_out_max_buffer_ms`` of it. Interruptions retire the whole
+        track (see :meth:`restart_audio_track`), so the cap bounds how much
+        encoded audio a retired track can strand rather than how much can
+        still reach the player.
         """
-        if self._audio_out is None or not self._audio_out_sample_rate:
+        producer = self._audio_out
+        if producer is None or not self._audio_out_sample_rate:
             return
 
         now = time.monotonic()
@@ -659,12 +717,19 @@ class MOQTransportClient:
         if wait > 0:
             await asyncio.sleep(wait)
 
+        # Pacing can sleep for seconds, long enough for an interruption to
+        # retire the track this chunk was destined for. It belongs to the
+        # utterance that was just discarded, so drop it rather than letting
+        # it anchor the successor track's epoch.
+        if producer is not self._audio_out:
+            return
+
         # Advance the virtual clock and the presentation timestamp by the
         # duration of this chunk. S16 = 2 bytes/sample, mono.
         duration_s = len(audio) / (self._audio_out_sample_rate * 2)
         self._publish_audio_clock += duration_s
 
-        self._audio_out.write(moq.AudioFrame(timestamp_us=self._publish_pts_us, data=audio))
+        producer.write(moq.AudioFrame(timestamp_us=self._publish_pts_us, data=audio))
         self._publish_pts_us += int(duration_s * 1_000_000)
 
     async def wait_for_audio_drain(self, jitter_buffer_margin_s: float = 0.3) -> None:
@@ -1348,20 +1413,20 @@ class MOQOutputTransport(BaseOutputTransport):
         await self._client.cleanup()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Reset the publish_audio pacing clock on interruption.
+        """Publish a fresh audio track on interruption.
 
-        The pacing in ``write_audio_frame`` keeps moq's in-flight buffer
-        bounded so InterruptionFrame can actually stop playback in the
-        browser — but the pacing clock needs to be re-anchored to ``now``
-        so the next utterance plays immediately instead of catching up.
+        The base class drains the queued audio and stops the writer first,
+        so the track is retired with no writes still racing it. Everything
+        the retired track carried is discarded with it; the next utterance
+        goes out on the new one.
 
         Args:
             frame: The frame to process.
             direction: The direction of frame flow in the pipeline.
         """
-        if isinstance(frame, InterruptionFrame):
-            self._client.reset_audio_pacing()
         await super().process_frame(frame, direction)
+        if isinstance(frame, InterruptionFrame):
+            self._client.restart_audio_track()
 
     async def send_message(
         self, frame: OutputTransportMessageFrame | OutputTransportMessageUrgentFrame

--- a/tests/test_moq_transport.py
+++ b/tests/test_moq_transport.py
@@ -803,11 +803,29 @@ class TestMOQAudioTrackRestart(unittest.IsolatedAsyncioTestCase):
     def _published_track_names(self):
         return [call.args[0] for call in self.broadcast.publish_audio.call_args_list]
 
+    def _advance_timeline(self, seconds: float):
+        """Fast-forward the broadcast timeline, as an LLM turn does.
+
+        A track opens the moment the interruption lands but doesn't write
+        until STT, the LLM and TTS have all run, so the gap between the two
+        is what distinguishes the two candidate anchors.
+        """
+        self.client._clock_origin -= seconds
+
+    def _leave_audio_in_flight(self, seconds: float = 5.0):
+        """Park the pacing clock ahead of wall-clock, as a live utterance does.
+
+        Unplayed audio on the track is what a restart exists to discard, so
+        it is also what a restart checks for.
+        """
+        self.client._publish_audio_clock = time.monotonic() + seconds
+
     def test_interruption_retires_the_track_and_publishes_a_successor(self):
         """The old producer is finished — which drops its catalog rendition —
         and a differently-named track takes its place, so the catalog still
         advertises exactly one audio track for subscribers to follow."""
         self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
         retired = self.client._audio_out
 
         self.client.restart_audio_track()
@@ -820,38 +838,64 @@ class TestMOQAudioTrackRestart(unittest.IsolatedAsyncioTestCase):
     def test_each_interruption_names_a_further_track(self):
         """Names keep advancing, so no two utterances in a session share one."""
         self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
         self.client.restart_audio_track()
+        self._leave_audio_in_flight()
         self.client.restart_audio_track()
 
         self.assertEqual(self._published_track_names(), ["bot-audio", "bot-audio-1", "bot-audio-2"])
 
-    def test_successor_anchors_into_the_shared_timeline(self):
+    async def test_successor_anchors_where_it_starts_playing(self):
         """Every track the bot publishes stamps against one broadcast clock, so
         a successor re-anchors into that timeline rather than restarting it.
 
-        The anchor is where playback resumes — the elapsed position now — not
-        the write-ahead frontier the abandoned utterance had reached. The
-        encoder takes that first stamp as the track's epoch, so it decides
-        when the new utterance plays."""
+        The anchor is where playback resumes — not the write-ahead frontier
+        the abandoned utterance had reached, and not where the track was
+        opened, which is a whole LLM turn earlier. The encoder takes that
+        first stamp as the track's epoch, so it decides when the new
+        utterance plays."""
         self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
         # Pacing runs ahead of real-time, so the abandoned utterance left the
         # timestamp far in the future.
         self.client._publish_pts_us = self.client._elapsed_us() + 25_000_000
 
         self.client.restart_audio_track()
+        self.assertIsNone(self.client._publish_pts_us, "anchored before any audio")
+        opened_at = self.client._elapsed_us()
+        self._advance_timeline(2.0)
+        await self.client.publish_audio(b"\x00" * 320)
 
-        anchor = self.client._publish_pts_us
-        self.assertLess(anchor, 1_000_000, "successor anchored at the write-ahead frontier")
-        self.assertAlmostEqual(anchor, self.client._elapsed_us(), delta=100_000)
-
-    def test_first_track_anchors_into_the_same_timeline(self):
-        """The first track is not special-cased: it anchors off the same clock,
-        so a successor's stamps are comparable with its own."""
-        self.client.open_audio_track(16000)
-
-        self.assertAlmostEqual(
-            self.client._publish_pts_us, self.client._elapsed_us(), delta=100_000
+        anchor = self.moq.AudioFrame.call_args.kwargs["timestamp_us"]
+        self.assertLess(
+            anchor, opened_at + 25_000_000, "successor anchored at the write-ahead frontier"
         )
+        self.assertAlmostEqual(anchor, opened_at + 2_000_000, delta=100_000)
+
+    async def test_first_track_anchors_into_the_same_timeline(self):
+        """The first track is not special-cased: it anchors off the same clock,
+        so a successor's stamps are comparable with its own, and it waits for
+        its first write the same way."""
+        self.client.open_audio_track(16000)
+        opened_at = self.client._elapsed_us()
+        self._advance_timeline(2.0)
+        await self.client.publish_audio(b"\x00" * 320)
+
+        anchor = self.moq.AudioFrame.call_args.kwargs["timestamp_us"]
+        self.assertAlmostEqual(anchor, opened_at + 2_000_000, delta=100_000)
+
+    def test_restart_without_audio_in_flight_is_a_no_op(self):
+        """Interruptions are broadcast on every user turn, so most of them find
+        nothing left to play. There is no stale audio to disambiguate, and
+        swapping anyway would cost every subscriber a resubscribe."""
+        self.client.open_audio_track(16000)
+        kept = self.client._audio_out
+
+        self.client.restart_audio_track()
+
+        kept.finish.assert_not_called()
+        self.assertIs(self.client._audio_out, kept)
+        self.assertEqual(self._published_track_names(), ["bot-audio"])
 
     def test_restart_before_the_track_opens_is_a_no_op(self):
         """An interruption can land before StartFrame opens the track (the
@@ -877,11 +921,10 @@ class TestMOQAudioTrackRestart(unittest.IsolatedAsyncioTestCase):
         write = asyncio.create_task(self.client.publish_audio(b"\x00" * 320))
         await asyncio.sleep(0)  # let it reach the pacing sleep
         self.client.restart_audio_track()
-        anchor = self.client._publish_pts_us
         await write
 
         retired.write.assert_not_called()
         self.client._audio_out.write.assert_not_called()
-        # The successor's epoch is still the anchor the restart chose, not one
-        # the discarded chunk moved.
-        self.assertEqual(self.client._publish_pts_us, anchor)
+        # The successor is still waiting on its own first write for an epoch,
+        # rather than taking one from the audio that was just discarded.
+        self.assertIsNone(self.client._publish_pts_us)

--- a/tests/test_moq_transport.py
+++ b/tests/test_moq_transport.py
@@ -6,7 +6,7 @@
 
 """Tests for the MoQ (Media over QUIC) transport.
 
-Four areas covered:
+Five areas covered:
 
 1. **``_downmix_s16_to_mono``** — the workaround for ``@moq/publish``'s
    browser-side encoder publishing stereo even when the source mic
@@ -31,9 +31,18 @@ Four areas covered:
    future refactor moves either into ``_run()``, the bot will lose its
    first few hundred ms of audio (this was a real bug PR #4557's
    self-review fixed).
+
+5. **Audio track restart on interruption** — the bot writes TTS ahead of
+   real-time, so an interruption has to discard audio that has already
+   left. Retiring the track is what does it, and these tests pin the
+   properties that makes possible: a successor track, a timeline that
+   restarts with it, and no write from the retired utterance landing on
+   it.
 """
 
 import argparse
+import asyncio
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -758,3 +767,121 @@ class TestIsNormalClose(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ----------------------------------------------------------------------
+# Audio track restart on interruption
+# ----------------------------------------------------------------------
+
+
+class TestMOQAudioTrackRestart(unittest.IsolatedAsyncioTestCase):
+    """An interruption must discard audio the bot has already published.
+
+    Pacing lets the bot run seconds ahead of real-time, so by the time a
+    user barges in the rest of the utterance is encoded and gone. The
+    track it went out on is retired and a successor published in its
+    place: the track name is what marks the audio as belonging to the
+    abandoned utterance, so a straggler can't be mistaken for the first
+    frame of the next one.
+    """
+
+    def setUp(self):
+        patcher = patch("pipecat.transports.moq.transport.moq")
+        self.moq = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.broadcast = MagicMock(name="broadcast")
+        self.broadcast.publish_json_stream.return_value = MagicMock(name="transcript_stream")
+        self.broadcast.publish_audio.side_effect = lambda *a, **k: MagicMock(name="audio_producer")
+        origin = MagicMock(name="publish_origin")
+        origin.create_broadcast.return_value = self.broadcast
+        self.moq.OriginProducer.return_value = origin
+
+        params = MOQParams(audio_in_enabled=True, audio_out_enabled=True)
+        self.client = MOQTransport(params=params, host="localhost", port=4080)._client
+
+    def _published_track_names(self):
+        return [call.args[0] for call in self.broadcast.publish_audio.call_args_list]
+
+    def test_interruption_retires_the_track_and_publishes_a_successor(self):
+        """The old producer is finished — which drops its catalog rendition —
+        and a differently-named track takes its place, so the catalog still
+        advertises exactly one audio track for subscribers to follow."""
+        self.client.open_audio_track(16000)
+        retired = self.client._audio_out
+
+        self.client.restart_audio_track()
+
+        retired.finish.assert_called_once()
+        self.assertIsNotNone(self.client._audio_out)
+        self.assertIsNot(self.client._audio_out, retired)
+        self.assertEqual(self._published_track_names(), ["bot-audio", "bot-audio-1"])
+
+    def test_each_interruption_names_a_further_track(self):
+        """Names keep advancing, so no two utterances in a session share one."""
+        self.client.open_audio_track(16000)
+        self.client.restart_audio_track()
+        self.client.restart_audio_track()
+
+        self.assertEqual(self._published_track_names(), ["bot-audio", "bot-audio-1", "bot-audio-2"])
+
+    def test_successor_anchors_into_the_shared_timeline(self):
+        """Every track the bot publishes stamps against one broadcast clock, so
+        a successor re-anchors into that timeline rather than restarting it.
+
+        The anchor is where playback resumes — the elapsed position now — not
+        the write-ahead frontier the abandoned utterance had reached. The
+        encoder takes that first stamp as the track's epoch, so it decides
+        when the new utterance plays."""
+        self.client.open_audio_track(16000)
+        # Pacing runs ahead of real-time, so the abandoned utterance left the
+        # timestamp far in the future.
+        self.client._publish_pts_us = self.client._elapsed_us() + 25_000_000
+
+        self.client.restart_audio_track()
+
+        anchor = self.client._publish_pts_us
+        self.assertLess(anchor, 1_000_000, "successor anchored at the write-ahead frontier")
+        self.assertAlmostEqual(anchor, self.client._elapsed_us(), delta=100_000)
+
+    def test_first_track_anchors_into_the_same_timeline(self):
+        """The first track is not special-cased: it anchors off the same clock,
+        so a successor's stamps are comparable with its own."""
+        self.client.open_audio_track(16000)
+
+        self.assertAlmostEqual(
+            self.client._publish_pts_us, self.client._elapsed_us(), delta=100_000
+        )
+
+    def test_restart_before_the_track_opens_is_a_no_op(self):
+        """An interruption can land before StartFrame opens the track (the
+        sample rate isn't known until then). There is nothing to retire, and
+        no track should be conjured at an unknown rate."""
+        self.client.restart_audio_track()
+
+        self.assertIsNone(self.client._audio_out)
+        self.broadcast.publish_audio.assert_not_called()
+
+    async def test_a_chunk_paced_against_a_retired_track_is_dropped(self):
+        """Pacing can park a chunk in a sleep for seconds — long enough for the
+        interruption that abandons its utterance. It must not land on the
+        successor track, which would put the discarded audio back at the head
+        of the new timeline."""
+        self.client.open_audio_track(16000)
+        retired = self.client._audio_out
+
+        # Park the pacing clock past the buffer budget so the write waits.
+        budget = self.client._params.audio_out_max_buffer_ms / 1000.0
+        self.client._publish_audio_clock = time.monotonic() + budget + 0.2
+
+        write = asyncio.create_task(self.client.publish_audio(b"\x00" * 320))
+        await asyncio.sleep(0)  # let it reach the pacing sleep
+        self.client.restart_audio_track()
+        anchor = self.client._publish_pts_us
+        await write
+
+        retired.write.assert_not_called()
+        self.client._audio_out.write.assert_not_called()
+        # The successor's epoch is still the anchor the restart chose, not one
+        # the discarded chunk moved.
+        self.assertEqual(self.client._publish_pts_us, anchor)


### PR DESCRIPTION
## Summary

`MOQOutputTransport` retires its audio track when an interruption catches audio still to be played, publishing a successor (`bot-audio`, `bot-audio-1`, ...) in its place. This replaces the pacing-clock re-anchor.

The bot writes TTS up to `audio_out_max_buffer_ms` ahead of real-time, so at barge-in seconds of the abandoned utterance have already left the process. Nothing on the bot side could retract it, so discarding it relied on an out-of-band signal: the bot published RTVI `user-started-speaking` on the transcript track and the browser flushed its buffer. The two tracks have no ordering relative to each other, and the transcript is subscribed at priority 0 against audio's 80, so the flush signal is scheduled behind exactly the data it exists to flush.

Retiring the track makes the discard structural instead. The track name identifies the utterance it carries, so audio still arriving on the retired track is stale by construction rather than indistinguishable from the successor's first frame, and the client drops it at the closed subscription.

`AudioProducer.finish()` drops the producer's catalog rendition, and the successor publishes its own, so the catalog always advertises exactly one audio track and subscribers follow the swap through normal rendition selection.

## When the swap happens

Interruptions are broadcast on every user turn, not only on barge-in, so an unconditional swap would cost every subscriber a catalog update and a resubscribe per turn — for turns where the bot had nothing left to play and there was no stale audio to disambiguate.

`_publish_audio_clock` is the presentation deadline of the last chunk written, so its lead over wall-clock is exactly what is still to be played. A swap happens only when that lead exceeds `AUDIO_IN_FLIGHT_FLOOR_S` (0.3s), which also keeps the client's own jitter buffer and a mixer's real-time write-ahead below the bar.

## Timestamps

PTS is not per-track. Every track stamps against one broadcast-wide monotonic origin, matching the browser side's `performance.now()` convention, so tracks stay mutually synchronizable and a successor re-anchors into that timeline at the position it starts playing from rather than continuing from the write-ahead frontier the abandoned utterance had reached.

A track takes its epoch at its first write, not when it opens. A successor opens the moment the interruption lands but doesn't write until STT, the LLM and TTS have run — 1.3s to 1.8s later in practice, varying with LLM latency, which would otherwise skew the cross-track deltas the shared timeline exists to preserve.

Only a track's first stamp reaches the wire as given: `moq-audio`'s encode producer takes it as that track's epoch and derives every later PTS from the running sample count.

## Ordering

Two races the swap has to avoid:

- `process_frame` calls `super()` first. The base class drains the audio queue and cancels the writer task, so the track is retired with no writes still racing it.
- `publish_audio` captures its producer up front and drops the chunk if the track was retired while it sat in the pacing sleep. That sleep can last seconds, and without the guard the chunk would land on the successor and anchor its epoch with audio that was just discarded. This also covers the mixer and uninterruptible paths, where the base class resets the queue instead of cancelling the task.

## Test plan

`TestMOQAudioTrackRestart` in `tests/test_moq_transport.py` covers the successor's name and rendition swap, repeated interruptions, the no-op when nothing is in flight, anchoring at the first write (both first track and successor), the no-op before the track opens, and the paced-chunk guard.

`uv run pytest tests/test_moq_transport.py` passes 61 tests with the `moq` extra installed. `ruff check` and `ruff format --check` clean.

Verified end-to-end against `examples/transports/transports-moq.py` in serve mode, driving interruptions from the playground's text input (`send-text` with `run_immediately` takes the same `broadcast_interruption()` path as VAD barge-in). Across three interruptions in one session, only the one that landed mid-utterance swapped the track, and the client followed it through the catalog:

```
subscribe close: id=2 broadcast=pipecat/response track=bot-audio
subscribe start: id=3 broadcast=pipecat/response track=bot-audio-1
subscribe ok:    id=3 broadcast=pipecat/response track=bot-audio-1
```

One client-side defect shows up at the swap boundary, once per swap:

```
InvalidStateError: Failed to execute 'decode' on 'AudioDecoder':
Cannot call 'decode' on a closed codec
```

A frame from the retiring track reaches the decoder after `Decoder` has closed it. It is caught rather than fatal — playback continues onto the successor — but it is a teardown-ordering bug in the player, separate from the ring-flush issue filed as moq-dev/moq#3064.
