### PR TITLE
Default Gradium STT to English

### DIFF
--- a/changelog/5444.changed.md
+++ b/changelog/5444.changed.md
@@ -1,0 +1,1 @@
+- `GradiumSTTService` now defaults `language` to `Language.EN` instead of leaving it unset. Grounding the model to a language improves transcription accuracy. Set `settings=GradiumSTTService.Settings(language="any")` to have Gradium detect the language instead.

--- a/examples/voice/voice-gradium.py
+++ b/examples/voice/voice-gradium.py
@@ -24,7 +24,6 @@ from pipecat.runner.utils import create_transport
 from pipecat.services.gradium.stt import GradiumSTTService
 from pipecat.services.gradium.tts import GradiumTTSService
 from pipecat.services.openai.llm import OpenAILLMService
-from pipecat.transcriptions.language import Language
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
@@ -57,12 +56,7 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting bot")
 
-    stt = GradiumSTTService(
-        api_key=os.environ["GRADIUM_API_KEY"],
-        settings=GradiumSTTService.Settings(
-            language=Language.EN,
-        ),
-    )
+    stt = GradiumSTTService(api_key=os.environ["GRADIUM_API_KEY"])
 
     tts = GradiumTTSService(
         api_key=os.environ["GRADIUM_API_KEY"],

--- a/src/pipecat/services/gradium/stt.py
+++ b/src/pipecat/services/gradium/stt.py
@@ -43,6 +43,11 @@ from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 # before finalizing the transcription.
 TRANSCRIPT_AGGREGATION_DELAY = 0.1
 
+# Gradium's language code asking it to detect the language rather than being
+# grounded to one. It is not a Language enum member because it names a mode
+# rather than a language, so it is passed through as a plain string.
+_GRADIUM_ANY_LANGUAGE = "any"
+
 
 def _input_format_from_encoding(encoding: str, sample_rate: int) -> str:
     """Build Gradium input_format from encoding type and sample rate.
@@ -72,11 +77,11 @@ def _input_format_from_encoding(encoding: str, sample_rate: int) -> str:
     return encoding
 
 
-def language_to_gradium_language(language: Language) -> str:
+def language_to_gradium_language(language: Language | str) -> str:
     """Convert a Language enum to Gradium's language code format.
 
     Args:
-        language: The Language enum value to convert.
+        language: The Language enum value to convert, or ``"any"``.
 
     Returns:
         The corresponding Gradium language code. If ``language`` is not in
@@ -84,6 +89,9 @@ def language_to_gradium_language(language: Language) -> str:
         ``en`` from ``en-US``) and logs a warning (via
         ``resolve_language(..., use_base_code=True)``).
     """
+    if language == _GRADIUM_ANY_LANGUAGE:
+        return _GRADIUM_ANY_LANGUAGE
+
     LANGUAGE_MAP = {
         Language.DE: "de",
         Language.EN: "en",
@@ -92,7 +100,9 @@ def language_to_gradium_language(language: Language) -> str:
         Language.PT: "pt",
     }
 
-    return resolve_language(language, LANGUAGE_MAP, use_base_code=True)
+    # A raw string that is not a Language falls through to the base-code
+    # branch of resolve_language, which handles it as-is.
+    return resolve_language(cast("Language", language), LANGUAGE_MAP, use_base_code=True)
 
 
 @dataclass
@@ -115,6 +125,10 @@ class GradiumSTTService(WebsocketSTTService):
     Provides real-time speech transcription using Gradium's WebSocket API.
     Supports both interim and final transcriptions with configurable parameters
     for audio processing and connection management.
+
+    Transcribes English by default. Set ``settings.language`` to one of the
+    other supported languages (German, Spanish, French, Portuguese), or to
+    ``"any"`` to have Gradium detect the language.
     """
 
     Settings = GradiumSTTSettings
@@ -134,7 +148,8 @@ class GradiumSTTService(WebsocketSTTService):
         Parameters:
             language: Expected language of the audio (e.g., "en", "es", "fr").
                 This helps ground the model to a specific language and improve
-                transcription quality.
+                transcription quality. Defaults to ``Language.EN``; ``"any"``
+                asks Gradium to detect the language.
             delay_in_frames: Delay in audio frames (80ms each) before text is
                 generated. Higher delays allow more context but increase latency.
                 Allowed values: 7, 8, 10, 12, 14, 16, 20, 24, 36, 48.
@@ -198,7 +213,7 @@ class GradiumSTTService(WebsocketSTTService):
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
             model="default",
-            language=None,
+            language=Language.EN,
             delay_in_frames=12,
         )
 
@@ -208,7 +223,8 @@ class GradiumSTTService(WebsocketSTTService):
         if params is not None:
             self._warn_init_param_moved_to_settings("params")
             if not settings:
-                default_settings.language = params.language
+                if params.language is not None:
+                    default_settings.language = params.language
                 if params.delay_in_frames is not None:
                     default_settings.delay_in_frames = params.delay_in_frames
 


### PR DESCRIPTION
Gradium is making a change, requiring a language to be set. English is the default for essentially all models that require a default, so making that true here.

## Summary

- `GradiumSTTService` now defaults `language` to `Language.EN` rather than leaving it unset, matching the other STT services in Pipecat. Gradium's docs note that grounding the model to a language improves transcription quality.
- Gradium's `any` code reaches the service unchanged, so `settings=GradiumSTTService.Settings(language="any")` asks for language detection. It is not a `Language` enum member because it names a mode rather than a language.
- The deprecated `params` path overrides the language only when one is given, so `params` carrying other settings keep the default.
- `examples/voice/voice-gradium.py` relies on the default instead of setting the language explicitly.

## Testing

`json_config` captured from the setup message, per setting:

| `settings.language` | sent |
| --- | --- |
| unset (default) | `en` |
| `"any"` | `any` |
| `Language.DE` | `de` |
| `Language.EN_US` | `en` (base-code fallback) |
| `None` | parameter omitted |