### PR TITLE
Send Cerebras the chat completion params its API supports

### DIFF
--- a/changelog/5448.changed.md
+++ b/changelog/5448.changed.md
@@ -1,0 +1,3 @@
+- `CerebrasLLMService` now sends "developer"-role messages unchanged instead of
+  converting them to "user" messages. Cerebras maps the role to its developer
+  instruction layer, which sits above user instructions in the prompt hierarchy.

--- a/changelog/5448.fixed.md
+++ b/changelog/5448.fixed.md
@@ -1,0 +1,3 @@
+- Fixed `CerebrasLLMService` dropping `max_tokens`, `frequency_penalty`,
+  `presence_penalty` and `service_tier` from chat completion requests. All four
+  are supported by the Cerebras API and are now sent.

--- a/src/pipecat/services/cerebras/llm.py
+++ b/src/pipecat/services/cerebras/llm.py
@@ -28,10 +28,6 @@ class CerebrasLLMService(OpenAILLMService):
     maintaining full compatibility with OpenAI's interface and functionality.
     """
 
-    # Cerebras doesn't support the "developer" message role.
-    # This value is used by BaseOpenAILLMService when calling the adapter.
-    supports_developer_role = False
-
     Settings = CerebrasLLMSettings
     _settings: Settings
 

--- a/src/pipecat/services/cerebras/llm.py
+++ b/src/pipecat/services/cerebras/llm.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
 
@@ -89,33 +88,3 @@ class CerebrasLLMService(OpenAILLMService):
         """
         logger.debug(f"Creating Cerebras client with api {base_url}")
         return super().create_client(api_key, base_url, **kwargs)
-
-    def build_chat_completion_params(self, params_from_context: OpenAILLMInvocationParams) -> dict:
-        """Build parameters for Cerebras chat completion request.
-
-        Cerebras supports a subset of OpenAI parameters, focusing on core
-        completion settings without advanced features like frequency/presence penalties.
-
-        Args:
-            params_from_context: Parameters, derived from the LLM context, to
-                use for the chat completion. Contains messages, tools, and tool
-                choice.
-
-        Returns:
-            Dictionary of parameters for the chat completion request.
-        """
-        params = {
-            "model": self._settings.model,
-            "stream": True,
-            "seed": self._settings.seed,
-            "temperature": self._settings.temperature,
-            "top_p": self._settings.top_p,
-            "max_completion_tokens": self._settings.max_completion_tokens,
-        }
-
-        # Messages, tools, tool_choice
-        params.update(params_from_context)
-
-        params.update(self._settings.extra)
-
-        return params

--- a/tests/test_cerebras_llm.py
+++ b/tests/test_cerebras_llm.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 from openai import NOT_GIVEN as OPENAI_NOT_GIVEN
 
+from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.cerebras.llm import CerebrasLLMService
 
 
@@ -74,3 +75,20 @@ def test_extra_passes_provider_specific_params(service_factory):
     params = service.build_chat_completion_params({})
 
     assert params["reasoning_effort"] == "low"
+
+
+def test_developer_messages_are_sent_as_is(service_factory):
+    """Cerebras maps the "developer" role to its developer instruction layer."""
+    service = service_factory(model="gpt-oss-120b")
+    context = LLMContext(
+        messages=[
+            {"role": "developer", "content": "Be terse."},
+            {"role": "user", "content": "Hello"},
+        ]
+    )
+
+    params = service.get_llm_adapter().get_llm_invocation_params(
+        context, convert_developer_to_user=not service.supports_developer_role
+    )
+
+    assert params["messages"][0]["role"] == "developer"

--- a/tests/test_cerebras_llm.py
+++ b/tests/test_cerebras_llm.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Unit tests for Cerebras LLM service."""
+
+from unittest.mock import patch
+
+import pytest
+from openai import NOT_GIVEN as OPENAI_NOT_GIVEN
+
+from pipecat.services.cerebras.llm import CerebrasLLMService
+
+
+@pytest.fixture
+def service_factory():
+    """Build a CerebrasLLMService without opening a client connection."""
+
+    def _build(**settings_kwargs):
+        with patch.object(CerebrasLLMService, "create_client"):
+            return CerebrasLLMService(
+                api_key="test-key",
+                settings=CerebrasLLMService.Settings(**settings_kwargs),
+            )
+
+    return _build
+
+
+def test_max_tokens_reaches_the_request(service_factory):
+    """Cerebras accepts and honors ``max_tokens``, so it must not be dropped."""
+    service = service_factory(model="gpt-oss-120b", max_tokens=200)
+
+    params = service.build_chat_completion_params({})
+
+    assert params["max_tokens"] == 200
+
+
+def test_max_completion_tokens_reaches_the_request(service_factory):
+    """``max_completion_tokens`` is the documented spelling and must survive too."""
+    service = service_factory(model="gpt-oss-120b", max_completion_tokens=200)
+
+    params = service.build_chat_completion_params({})
+
+    assert params["max_completion_tokens"] == 200
+
+
+def test_penalties_reach_the_request(service_factory):
+    """Cerebras supports frequency and presence penalties."""
+    service = service_factory(model="gpt-oss-120b", frequency_penalty=0.5, presence_penalty=-0.5)
+
+    params = service.build_chat_completion_params({})
+
+    assert params["frequency_penalty"] == 0.5
+    assert params["presence_penalty"] == -0.5
+
+
+def test_unset_params_are_omitted(service_factory):
+    """Unset fields carry the OpenAI sentinel so the SDK keeps them off the wire."""
+    service = service_factory(model="gpt-oss-120b")
+
+    params = service.build_chat_completion_params({})
+
+    assert params["max_tokens"] is OPENAI_NOT_GIVEN
+    assert params["max_completion_tokens"] is OPENAI_NOT_GIVEN
+    assert params["frequency_penalty"] is OPENAI_NOT_GIVEN
+
+
+def test_extra_passes_provider_specific_params(service_factory):
+    """``extra`` carries Cerebras-only params such as ``reasoning_effort``."""
+    service = service_factory(model="gpt-oss-120b", extra={"reasoning_effort": "low"})
+
+    params = service.build_chat_completion_params({})
+
+    assert params["reasoning_effort"] == "low"


### PR DESCRIPTION
Fixes #5448.

`CerebrasLLMService.build_chat_completion_params` built its request dict from
scratch and emitted only `model`, `stream`, `seed`, `temperature`, `top_p` and
`max_completion_tokens`. It was written against a narrower Cerebras API than the
one that exists today, so several supported params were silently dropped —
including `max_tokens`, which meant a service configured with
`Settings(max_tokens=200)` sent requests with no token cap at all.

Every param the `OpenAILLMService` builder emits is accepted by Cerebras, so the
override is removed rather than patched. Unset fields carry the OpenAI SDK's
`NOT_GIVEN` sentinel and stay off the wire.

| Param | Before | After |
|---|---|---|
| `max_tokens` | dropped | sent |
| `frequency_penalty` / `presence_penalty` | dropped | sent |
| `service_tier` | dropped, so the `service_tier=` init arg did nothing | sent |
| `stream_options` | omitted | sent (accepted; usage already arrived either way) |

A second commit drops `supports_developer_role = False`. Cerebras
[documents](https://inference-docs.cerebras.ai/resources/openai) the `developer`
role as mapping to a developer-level instruction layer above user instructions;
converting those messages to `user` placed them *below* system messages instead.

### On `max_tokens`

`max_tokens` is absent from the published
[OpenAPI schema](https://inference-docs.cerebras.ai/api-reference/chat-completions),
but absence there doesn't mean unsupported — the API rejects genuinely unknown
fields, so an accepted param is a supported one. Verified against the live API:

```
totally_bogus_param   -> HTTP 400  "property 'totally_bogus_param' is unsupported"
max_tokens=12         -> HTTP 200  finish_reason=length, completion_tokens=12   (gpt-oss-120b)
max_tokens=12         -> HTTP 200  finish_reason=length, completion_tokens=12   (gemma-4-31b)
no cap                -> HTTP 200  finish_reason=stop,   completion_tokens=119
```

This is why the fix passes `max_tokens` through rather than aliasing it onto
`max_completion_tokens` or rejecting it at `Settings` construction, both of which
the issue offered as alternatives.

### Testing

- New `tests/test_cerebras_llm.py`. Three of its six cases fail without the first
  commit (`KeyError: 'max_tokens'`).
- `pipecat eval suite ... -p cerebras -s weather_function_call` passes, so tool
  calling still works end to end with the wider param set.
- Live check through the service: `max_tokens=16` now truncates the reply;
  before this change the same setting returned the full uncapped completion.
- Full suite: 4795 passed. The 4 `krisp_viva` failures and the `moq` collection
  error also occur on `main` and are unrelated.

Also checked while I was in here, no change needed: the default model
`gpt-oss-120b` is still current and nothing we reference is on the
[deprecation list](https://inference-docs.cerebras.ai/support/deprecation), and
Cerebras returns `usage` on the final stream chunk unprompted, so token metrics
were already working.