### PR TITLE
fix(moq): don't crash when peer audio arrives before the transport st…

### DIFF
--- a/src/pipecat/transports/moq/transport.py
+++ b/src/pipecat/transports/moq/transport.py
@@ -1235,6 +1235,12 @@ class MOQInputTransport(BaseInputTransport):
             audio: Raw mono 16-bit PCM audio bytes.
             sample_rate: Sample rate of ``audio``, in Hz.
         """
+        # The MoQ session comes up during setup(), so a fast peer's audio can
+        # arrive before StartFrame has created the audio queue
+        # (_create_audio_task). Drop it instead of crashing the session task
+        # with an AttributeError.
+        if self._audio_task is None:
+            return
         await self.push_audio_frame(
             InputAudioRawFrame(audio=audio, sample_rate=sample_rate, num_channels=1)
         )


### PR DESCRIPTION
…arts

Since the MoQ session comes up during setup() (810fa002a), a fast peer's audio can reach MOQInputTransport.push_received_audio() before StartFrame has run _create_audio_task(), and push_audio_frame() then dies with AttributeError: '_audio_in_queue' — which takes the whole session task down with it. Reproduced on roughly half the runs of the transport latency benchmark's moq-serve scenario, where the client connects the moment the runner answers /start.

Drop audio that arrives before the input transport starts; no changelog entry since this fixes unreleased behavior.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.