### PR TITLE
Add the changelog fragment for #5451

### DIFF
--- a/changelog/5451.fixed.md
+++ b/changelog/5451.fixed.md
@@ -1,0 +1,5 @@
+- Fixed the MoQ transport crashing when a fast peer's audio arrived before
+  the input transport started: the session task died with
+  `AttributeError: '_audio_in_queue'` and the bot stayed silent for the rest
+  of the call. Audio received before `StartFrame` has created the audio
+  queue is now dropped.


### PR DESCRIPTION
Follow-up to #5451 (moq: don't crash when peer audio arrives before the transport starts), which merged without its changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)