### PR TITLE
fix(turns): clear speaking state on muted stop frames

### DIFF
--- a/changelog/5453.fixed.md
+++ b/changelog/5453.fixed.md
@@ -1,0 +1,1 @@
+- Fixed muted user-stop frames leaving an active turn stuck in the speaking state and preventing watchdog recovery.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -802,6 +802,18 @@ class LLMUserAggregator(LLMContextAggregator):
         await super().process_frame(frame, direction)
 
         if await self._maybe_mute_frame(frame):
+            if isinstance(
+                frame,
+                (
+                    VADUserStoppedSpeakingFrame,
+                    ProposedUserStoppedSpeakingFrame,
+                    UserStoppedSpeakingFrame,
+                ),
+            ):
+                # Muting suppresses turn signals and strategy processing, but a
+                # stop must still clear raw speaking state. Otherwise a turn
+                # that began before muting can never reach its watchdog.
+                await self._user_turn_controller._update_user_speaking_state(frame)
             return
 
         if isinstance(frame, StartFrame):

--- a/src/pipecat/turns/user_turn_controller.py
+++ b/src/pipecat/turns/user_turn_controller.py
@@ -202,15 +202,9 @@ class UserTurnController(BaseObject):
             frame: The frame to be processed.
 
         """
-        if isinstance(frame, (UserStartedSpeakingFrame, ProposedUserStartedSpeakingFrame)):
-            await self._handle_user_started_speaking(frame)
-        elif isinstance(frame, (UserStoppedSpeakingFrame, ProposedUserStoppedSpeakingFrame)):
-            await self._handle_user_stopped_speaking(frame)
-        elif isinstance(frame, VADUserStartedSpeakingFrame):
-            await self._handle_vad_user_started_speaking(frame)
-        elif isinstance(frame, VADUserStoppedSpeakingFrame):
-            await self._handle_vad_user_stopped_speaking(frame)
-        elif isinstance(frame, (TranscriptionFrame, InterimTranscriptionFrame)):
+        await self._update_user_speaking_state(frame)
+
+        if isinstance(frame, (TranscriptionFrame, InterimTranscriptionFrame)):
             await self._handle_transcription(frame)
 
         for strategy in self._user_turn_strategies.start or []:
@@ -222,6 +216,21 @@ class UserTurnController(BaseObject):
             result = await strategy.process_frame(frame)
             if result == ProcessFrameResult.STOP:
                 break
+
+    async def _update_user_speaking_state(self, frame: Frame) -> None:
+        """Update raw user speaking state without invoking turn strategies.
+
+        Args:
+            frame: A user speaking lifecycle frame.
+        """
+        if isinstance(frame, (UserStartedSpeakingFrame, ProposedUserStartedSpeakingFrame)):
+            await self._handle_user_started_speaking(frame)
+        elif isinstance(frame, (UserStoppedSpeakingFrame, ProposedUserStoppedSpeakingFrame)):
+            await self._handle_user_stopped_speaking(frame)
+        elif isinstance(frame, VADUserStartedSpeakingFrame):
+            await self._handle_vad_user_started_speaking(frame)
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            await self._handle_vad_user_stopped_speaking(frame)
 
     async def _setup_strategies(self):
         if not self._setup:

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -726,6 +726,46 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
         # The user mute strategies should have muted the user.
         self.assertFalse(user_turn)
 
+    async def test_muted_vad_stop_allows_active_turn_to_time_out(self):
+        context = LLMContext()
+
+        user_aggregator = LLMUserAggregator(
+            context,
+            params=LLMUserAggregatorParams(
+                user_turn_strategies=UserTurnStrategies(
+                    start=[VADUserTurnStartStrategy()],
+                    stop=[ExternalUserTurnStopStrategy()],
+                ),
+                user_mute_strategies=[FirstSpeechUserMuteStrategy()],
+                user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+            ),
+        )
+
+        timed_out = False
+
+        @user_aggregator.event_handler("on_user_turn_stop_timeout")
+        async def on_user_turn_stop_timeout(aggregator):
+            nonlocal timed_out
+            timed_out = True
+
+        pipeline = Pipeline([user_aggregator])
+
+        frames_to_send = [
+            # The turn starts before the bot's first speech activates muting.
+            VADUserStartedSpeakingFrame(),
+            BotStartedSpeakingFrame(),
+            # This frame is suppressed while muted, but it must still clear the
+            # controller's raw speaking state so the watchdog can close the turn.
+            VADUserStoppedSpeakingFrame(),
+            SleepFrame(sleep=USER_TURN_STOP_TIMEOUT + 0.1),
+        ]
+        (down_frames, _) = await run_test(pipeline, frames_to_send=frames_to_send)
+
+        self.assertTrue(timed_out)
+        self.assertFalse(
+            any(isinstance(frame, VADUserStoppedSpeakingFrame) for frame in down_frames)
+        )
+
     async def test_pending_transcription_emitted_on_end_frame(self):
         """Pending user transcription should be emitted when EndFrame arrives."""
         context = LLMContext()


### PR DESCRIPTION
## Summary

- keep muted user-stop frames hidden from downstream processors and turn strategies
- still clear the raw user-speaking latch so an active turn can reach its watchdog
- add a regression for the start-before-mute, stop-during-mute ordering

This addresses the stranded-turn case described in #5005 (Q3).

## Verification

- uv run pytest tests/test_context_aggregators_universal.py tests/test_user_turn_controller.py tests/test_user_mute_strategy.py -q (133 passed)
- uv run ruff check
- uv run ruff format --check
- broad all-extras run: 4,777 tests passed with no failures; the remaining service-init parameterization blocked on an unrelated external TLS read and was interrupted