### PR TITLE
fix(gladia): apply runtime settings updates by starting a new session

### DIFF
--- a/changelog/5454.fixed.md
+++ b/changelog/5454.fixed.md
@@ -1,0 +1,5 @@
+- Fixed `GladiaSTTService` silently ignoring runtime settings updates. Gladia submits
+  its configuration at session init, so a settings change now starts a new session with
+  the updated configuration instead of only being stored. The reconnect is deferred
+  until the current user turn ends, so audio isn't dropped mid-utterance. `language`
+  remains unsupported, since Gladia selects languages through `language_config`.

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -438,9 +438,18 @@ class GladiaSTTService(WebsocketSTTService):
         await self._connect()
 
     async def _update_settings(self, delta: Settings) -> dict[str, Any]:
-        """Apply settings delta.
+        """Apply a settings delta by starting a new Gladia session with it.
 
-        Settings are stored but not applied to the active session.
+        Gladia takes its whole configuration at session-init time (``POST
+        /v2/live``) rather than over the websocket, so a settings change can only
+        take effect on a new session. Dropping the cached session makes
+        ``_connect()`` initialize a fresh one from the updated settings, and
+        ``_request_reconnect()`` holds that reconnect until the current user turn
+        ends, buffering audio across the transition.
+
+        ``language`` is the exception: Gladia selects languages through
+        ``language_config``, so it never reaches the session payload and is still
+        reported as unhandled.
 
         Args:
             delta: A settings delta.
@@ -453,14 +462,11 @@ class GladiaSTTService(WebsocketSTTService):
         if not changed:
             return changed
 
-        # TODO: someday we could reconnect here to apply updated settings.
-        # Code might look something like the below:
-        # self._session_url = None
-        # self._session_id = None
-        # await self._disconnect()
-        # await self._connect()
+        self._session_url = None
+        self._session_id = None
+        await self._request_reconnect()
 
-        self._warn_unhandled_updated_settings(changed)
+        self._warn_unhandled_updated_settings(changed.keys() & {"language"})
 
         return changed
 

--- a/tests/test_gladia_stt.py
+++ b/tests/test_gladia_stt.py
@@ -1,0 +1,134 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for GladiaSTTService runtime settings updates."""
+
+import asyncio
+import io
+from collections.abc import Awaitable, Callable
+
+from loguru import logger
+
+from pipecat.frames.frames import VADUserStartedSpeakingFrame
+from pipecat.services.gladia.stt import GladiaSTTService
+from pipecat.transcriptions.language import Language
+from pipecat.utils.asyncio.task_manager import TaskManager
+from tests.frame_processor_helpers import frame_processor_setup
+
+
+def _stub_session(service: GladiaSTTService) -> list[dict]:
+    """Stub out the network and record every session-init payload.
+
+    Gladia configures a session over HTTP (``POST /v2/live``) and then opens a
+    websocket to the URL that call returns, so the recorded payloads are exactly
+    the settings each live session runs with.
+    """
+    payloads = []
+
+    async def fake_setup_gladia(settings):
+        payloads.append(settings)
+        return {
+            "url": f"wss://example.invalid/session-{len(payloads)}",
+            "id": f"session-{len(payloads)}",
+        }
+
+    async def fake_connect_websocket():
+        pass
+
+    async def fake_disconnect_websocket():
+        pass
+
+    service._setup_gladia = fake_setup_gladia
+    service._connect_websocket = fake_connect_websocket
+    service._disconnect_websocket = fake_disconnect_websocket
+    return payloads
+
+
+def _run(service: GladiaSTTService, body: Callable[[], Awaitable[None]]) -> None:
+    """Set the service up, run ``body``, and always tear the service down."""
+
+    async def run():
+        await service.setup(frame_processor_setup(TaskManager()))
+        try:
+            await body()
+        finally:
+            await service.cleanup()
+
+    asyncio.run(run())
+
+
+def test_settings_update_starts_a_new_session_carrying_the_change():
+    # Gladia only reads configuration at session init, so an update that doesn't
+    # start a new session never reaches the transcriber.
+    service = GladiaSTTService(api_key="test-key")
+    payloads = _stub_session(service)
+
+    async def body():
+        await service._update_settings(GladiaSTTService.Settings(endpointing=0.75))
+
+    _run(service, body)
+
+    assert len(payloads) == 2, "a changed setting must open a new Gladia session"
+    assert "endpointing" not in payloads[0]
+    assert payloads[1]["endpointing"] == 0.75
+    assert service._session_id == "session-2"
+
+
+def test_settings_update_with_no_change_keeps_the_session():
+    # Re-sending the settings the session already runs with must not churn it.
+    service = GladiaSTTService(
+        api_key="test-key",
+        settings=GladiaSTTService.Settings(endpointing=0.75),
+    )
+    payloads = _stub_session(service)
+
+    async def body():
+        await service._update_settings(GladiaSTTService.Settings(endpointing=0.75))
+
+    _run(service, body)
+
+    assert len(payloads) == 1
+    assert service._session_id == "session-1"
+
+
+def test_settings_update_mid_turn_defers_until_the_user_stops_speaking():
+    # Reconnecting mid-utterance would drop the audio the caller is still speaking.
+    service = GladiaSTTService(api_key="test-key")
+    payloads = _stub_session(service)
+
+    async def body():
+        await service._handle_vad_user_started_speaking(VADUserStartedSpeakingFrame())
+
+        await service._update_settings(GladiaSTTService.Settings(endpointing=0.75))
+        assert len(payloads) == 1, "must not reconnect while the user is speaking"
+
+        await service._maybe_reconnect_on_user_stopped_speaking()
+
+    _run(service, body)
+
+    assert len(payloads) == 2
+    assert payloads[1]["endpointing"] == 0.75
+
+
+def test_language_update_is_still_reported_as_unhandled():
+    # Gladia picks languages through language_config, so a bare `language` never
+    # reaches the session payload and must keep warning rather than look applied.
+    service = GladiaSTTService(api_key="test-key")
+    payloads = _stub_session(service)
+
+    sink = io.StringIO()
+    handler_id = logger.add(sink, level="WARNING", format="{message}")
+
+    async def body():
+        await service._update_settings(GladiaSTTService.Settings(language=Language.ES))
+
+    try:
+        _run(service, body)
+    finally:
+        logger.remove(handler_id)
+
+    assert "language" in sink.getvalue()
+    assert all("language" not in payload for payload in payloads)


### PR DESCRIPTION
Fixes #4719.

## The problem

`GladiaSTTService._update_settings` applied the delta to `self._settings` and then logged `runtime update of [...] is not currently supported`, leaving the live session untouched. An `STTUpdateSettingsFrame` sent mid-call had no effect on transcription — the change looked accepted and silently did nothing.

Gladia takes its whole configuration at session init (`POST /v2/live`) rather than over the websocket, so applying a change means starting a new session. The existing code carried a `TODO` acknowledging exactly this.

## The fix

Clear the cached session URL/ID and call `_request_reconnect()` — the same path `DeepgramSTTService._update_settings` already uses. `_connect()` then initializes a fresh session from the updated settings, and `_request_reconnect()` holds the reconnect until the current user turn ends (buffering audio across the transition), so an update that arrives mid-utterance doesn't drop the caller's speech.

`language` is deliberately still reported as unhandled. Gladia selects languages through `language_config`, so a bare `language` never reaches the session payload — a new session would not apply it. Narrowing the warning to that one field keeps the honest signal for the setting that genuinely can't be applied, while the settings that now do apply stop warning.

## Tests

New `tests/test_gladia_stt.py` stubs the session-init call and records every payload Gladia would receive, covering:

- a changed setting opens a new session carrying the change
- an unchanged setting does not churn the session
- an update mid-turn is deferred until the user stops speaking
- `language` still warns and still never reaches the payload

Reverting only the `stt.py` change makes the two behavioural tests fail, with the old code logging `runtime update of [endpointing] is not currently supported`:

```
FAILED tests/test_gladia_stt.py::test_settings_update_starts_a_new_session_carrying_the_change
FAILED tests/test_gladia_stt.py::test_settings_update_mid_turn_defers_until_the_user_stops_speaking
2 failed, 2 passed
```

With the fix: 4 passed. The wider STT suite (`test_gladia_stt`, `test_assemblyai_stt`, `test_cartesia_stt`, `test_soniox_stt`, `test_segmented_stt`, `test_stt_usage_metrics`) is 139 passed / 2 skipped across three consecutive runs. `ruff check` and `ruff format --check` are clean on both files.

One note in the interest of full disclosure: `tests/test_segmented_stt.py::test_default_mode_wraps_segment_in_wav` failed once during batch runs and passed in every other run, including with this patch reverted — it looks flaky independently of this change, but flagging it in case it's known.

A changelog fragment follows in a second commit now that the PR number exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
