### PR TITLE
Keep muted stop frames from stranding user speaking state

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -802,6 +802,12 @@ class LLMUserAggregator(LLMContextAggregator):
         await super().process_frame(frame, direction)
 
         if await self._maybe_mute_frame(frame):
+            # The frame is suppressed — no strategy sees it and it is not pushed
+            # downstream — but "the user stopped speaking" is a state transition
+            # rather than a turn decision. Discarding one latches the controller's
+            # `_user_speaking` True for the rest of the call, which permanently
+            # blocks turn finalization. See `process_muted_frame`.
+            await self._user_turn_controller.process_muted_frame(frame)
             return
 
         if isinstance(frame, StartFrame):
@@ -1498,6 +1504,11 @@ class LLMAssistantAggregator(LLMContextAggregator):
         # arriving in the same speaking window are bundled into a single deferred push.
         self._push_context_on_bot_stopped_speaking: bool = False
 
+        # Same idea for the user: a function call result that settles while the
+        # user is speaking must not be dropped, because nothing would ever
+        # re-evaluate it. Defer the push to `UserStoppedSpeakingFrame` instead.
+        self._push_context_on_user_stopped_speaking: bool = False
+
         self._assistant_turn_start_timestamp = ""
 
         self._thought_append_to_context = False
@@ -1553,6 +1564,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
         await super().reset()
         await self._reset_thought_aggregation()  # Just to be safe
         self._push_context_on_bot_stopped_speaking = False
+        self._push_context_on_user_stopped_speaking = False
 
     async def _reset_thought_aggregation(self):
         """Reset the thought aggregation state."""
@@ -1634,15 +1646,31 @@ class LLMAssistantAggregator(LLMContextAggregator):
         elif isinstance(frame, UserStoppedSpeakingFrame):
             self._user_speaking = False
             await self.push_frame(frame, direction)
+            if self._push_context_on_user_stopped_speaking:
+                if self._bot_speaking:
+                    # Hand the deferral over rather than dropping it.
+                    self._push_context_on_user_stopped_speaking = False
+                    self._push_context_on_bot_stopped_speaking = True
+                else:
+                    logger.debug(f"{self}: User stopped speaking — pushing deferred context frame!")
+                    await self.push_context_frame(FrameDirection.UPSTREAM)
         elif isinstance(frame, BotStartedSpeakingFrame):
             self._bot_speaking = True
             await self.push_frame(frame, direction)
         elif isinstance(frame, BotStoppedSpeakingFrame):
             self._bot_speaking = False
             await self.push_frame(frame, direction)
-            if self._push_context_on_bot_stopped_speaking and not self._user_speaking:
-                logger.debug(f"{self}: Bot stopped speaking — pushing deferred context frame!")
-                await self.push_context_frame(FrameDirection.UPSTREAM)
+            if self._push_context_on_bot_stopped_speaking:
+                if self._user_speaking:
+                    # The user started speaking while this push was deferred.
+                    # Hand the deferral over to the user-stopped path instead of
+                    # dropping it: the bot is not guaranteed to speak again, so
+                    # this flag would otherwise never be re-evaluated.
+                    self._push_context_on_bot_stopped_speaking = False
+                    self._push_context_on_user_stopped_speaking = True
+                else:
+                    logger.debug(f"{self}: Bot stopped speaking — pushing deferred context frame!")
+                    await self.push_context_frame(FrameDirection.UPSTREAM)
         elif isinstance(frame, LLMServiceMetadataFrame):
             # Auto-configure realtime mode on the assistant half too — the
             # broadcast reaches both halves. The assistant only needs the flag
@@ -1726,6 +1754,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
         """
         await super().push_context_frame(direction)
         self._push_context_on_bot_stopped_speaking = False
+        self._push_context_on_user_stopped_speaking = False
 
     async def _handle_llm_run(self, frame: LLMRunFrame):
         await self.push_context_frame(FrameDirection.UPSTREAM)
@@ -1869,7 +1898,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
                 else:
                     run_llm = True
 
-        if run_llm and not self._user_speaking:
+        if run_llm:
             await self._maybe_push_context_after_function_result()
 
         # Call the `on_context_updated` callback once the function call result
@@ -1900,6 +1929,21 @@ class LLMAssistantAggregator(LLMContextAggregator):
             logger.debug(
                 f"{self}: More FunctionCallResultFrames queued — deferring context frame push."
             )
+        elif self._user_speaking:
+            # Defer until the user stops speaking, rather than dropping the push.
+            # Whatever the LLM would say now is about to be superseded by what the
+            # user is still saying, so pushing immediately is wrong — but so is
+            # discarding it, because this is the only signal that re-invokes the
+            # LLM with the tool result in scope. If it is dropped and the user
+            # then falls silent, no inference is ever run and the bot never
+            # speaks again.
+            #
+            # Checked before `_bot_speaking` on purpose: when both are set, the
+            # bot-stopped path below would refuse the push anyway (it also
+            # requires the user to be quiet), and the bot is not guaranteed to
+            # speak again, so the user-stopped path is the one certain to fire.
+            logger.debug(f"{self}: User is speaking — deferring context frame push.")
+            self._push_context_on_user_stopped_speaking = True
         elif self._bot_speaking:
             # Defer the context frame push until the bot finishes speaking. If multiple
             # function call results arrive while the bot is speaking, they all accumulate

--- a/src/pipecat/turns/user_turn_controller.py
+++ b/src/pipecat/turns/user_turn_controller.py
@@ -295,6 +295,52 @@ class UserTurnController(BaseObject):
         # We have received a transcription, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
 
+    async def process_muted_frame(self, frame: Frame):
+        """Apply speaking-state transitions from a frame suppressed by a mute strategy.
+
+        Mute strategies stop a muted user from driving turn *decisions*, and that
+        is the behaviour we want to keep: no strategy runs here, so a muted user
+        can still never start, stop or interrupt a turn.
+
+        ``_user_speaking``, however, is not a decision. It is edge-triggered
+        derived state, rebuilt by accumulating speaking frames, and it is
+        consulted as a guard in three places that can each end a conversation:
+
+        - :meth:`_trigger_user_turn_stop` refuses to finalize a turn while it is
+          set,
+        - :meth:`_user_turn_stop_timeout_task_handler` — the watchdog meant to
+          catch exactly that case — is gated on it as well,
+        - the assistant aggregator uses its own copy to decide whether a
+          function-call result may re-invoke the LLM.
+
+        Dropping a *start* edge is harmless: the flag stays ``False``, which is
+        the permissive value. Dropping a *stop* edge is not, because nothing in
+        the system ever re-derives the flag from ground truth. It latches
+        ``True`` with no path back to ``False``, and every guard above fails
+        closed, forever.
+
+        That is reachable whenever a mute window opens while the user is still
+        speaking — a function-call mute is the common case, since the same mute
+        also suppresses ``InputAudioRawFrame`` and so starves the VAD into
+        emitting its stop frame *inside* the window that discards it.
+
+        Applying only the ``False`` transition keeps the mute's purpose intact
+        while removing the latch: the muted user still cannot influence any turn
+        decision, but the state the rest of the pipeline reads stays truthful.
+        """
+        if isinstance(
+            frame,
+            (
+                UserStoppedSpeakingFrame,
+                ProposedUserStoppedSpeakingFrame,
+                VADUserStoppedSpeakingFrame,
+            ),
+        ):
+            self._user_speaking = False
+            # Re-arm the stop watchdog. Without this the turn could be finalized
+            # by a timeout measured from before the user had actually stopped.
+            self._user_turn_stop_timeout_event.set()
+
     async def _on_push_frame(
         self,
         strategy: BaseUserTurnStartStrategy | BaseUserTurnStopStrategy,

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1060,6 +1060,50 @@ class TestLLMUserAggregator(unittest.IsolatedAsyncioTestCase):
 
 
 class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
+    async def test_function_result_while_user_speaks_is_deferred_not_dropped(self):
+        """A result settling mid-user-speech must be deferred, then pushed.
+
+        The context frame pushed after a function call settles is the only
+        signal that re-invokes the LLM with the tool result in scope. Pushing it
+        while the user is still speaking is wrong, but so is discarding it: if
+        the user then falls silent, no inference ever runs and the bot never
+        speaks again.
+        """
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+
+        # The user is speaking when the result arrives.
+        await aggregator.process_frame(UserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        await aggregator.process_frame(
+            FunctionCallInProgressFrame(
+                function_name="fn_1", tool_call_id="1", arguments={}, cancel_on_interruption=True
+            ),
+            FrameDirection.DOWNSTREAM,
+        )
+        await aggregator.process_frame(
+            FunctionCallResultFrame(
+                function_name="fn_1", tool_call_id="1", arguments={}, result={"ok": True}
+            ),
+            FrameDirection.DOWNSTREAM,
+        )
+
+        # Deferred rather than pushed or dropped.
+        self.assertTrue(aggregator._push_context_on_user_stopped_speaking)
+
+        pushed = []
+        original = aggregator.push_context_frame
+
+        async def record(direction=FrameDirection.DOWNSTREAM):
+            pushed.append(direction)
+            await original(direction)
+
+        aggregator.push_context_frame = record
+
+        await aggregator.process_frame(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+
+        self.assertEqual(pushed, [FrameDirection.UPSTREAM])
+        self.assertFalse(aggregator._push_context_on_user_stopped_speaking)
+
     async def test_empty(self):
         context = LLMContext()
 

--- a/tests/test_user_turn_controller.py
+++ b/tests/test_user_turn_controller.py
@@ -89,6 +89,88 @@ class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
 
         await controller.cleanup()
 
+    async def test_muted_stop_frame_does_not_strand_user_speaking(self):
+        """A stop frame suppressed by a mute strategy must still clear speaking state.
+
+        `_user_speaking` is edge-triggered derived state and nothing re-derives it
+        from ground truth, so a discarded stop edge latches it True and every
+        guard that reads it fails closed for the rest of the call — including
+        `_trigger_user_turn_stop` and its own timeout watchdog.
+
+        `process_muted_frame` applies the state transition without running any
+        strategy, so the muted user still cannot drive a turn decision.
+        """
+        controller = UserTurnController(
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=[ExternalUserTurnCompletionStopStrategy()],
+            ),
+            user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+        )
+        await controller.setup(frame_processor_setup(self.task_manager))
+        await controller.start()
+
+        stopped = False
+        started = False
+
+        @controller.event_handler("on_user_turn_started")
+        async def on_user_turn_started(controller, strategy, params):
+            nonlocal started
+            started = True
+
+        @controller.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(controller, strategy, params):
+            nonlocal stopped
+            stopped = True
+
+        await controller.process_frame(VADUserStartedSpeakingFrame())
+        self.assertTrue(started)
+
+        # The user stops, but a mute window is open so the frame never reaches
+        # `process_frame`. Without the state transition below the turn can never
+        # be finalized again.
+        started = False
+        await controller.process_muted_frame(VADUserStoppedSpeakingFrame())
+
+        # The muted frame must not have driven any turn decision.
+        self.assertFalse(started)
+        self.assertFalse(stopped)
+
+        # But the turn is now finalizable, which is the whole point.
+        await controller.process_frame(UserTurnInferenceCompletedFrame())
+        self.assertTrue(stopped)
+
+        await controller.cleanup()
+
+    async def test_muted_start_frame_does_not_set_user_speaking(self):
+        """Only the `False` transition is applied to muted frames.
+
+        Suppressing a start is the mute strategy working as intended, so a muted
+        start frame must not mark the user as speaking — that would reintroduce
+        the latch from the other direction.
+        """
+        controller = UserTurnController(
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=[ExternalUserTurnCompletionStopStrategy()],
+            ),
+            user_turn_stop_timeout=USER_TURN_STOP_TIMEOUT,
+        )
+        await controller.setup(frame_processor_setup(self.task_manager))
+        await controller.start()
+
+        started = False
+
+        @controller.event_handler("on_user_turn_started")
+        async def on_user_turn_started(controller, strategy, params):
+            nonlocal started
+            started = True
+
+        await controller.process_muted_frame(VADUserStartedSpeakingFrame())
+        self.assertFalse(started)
+
+        await controller.cleanup()
+
     async def test_default_user_turn_strategies(self):
         controller = UserTurnController(
             user_turn_strategies=UserTurnStrategies(


### PR DESCRIPTION
A mute window that opens while the user is still speaking permanently latches
`_user_speaking` to `True`, which silently ends the conversation: the bot stops
responding and no error, warning, or log is produced.

### The failure

`_user_speaking` is edge-triggered derived state — each consumer rebuilds it by
accumulating speaking frames, and nothing ever re-derives it from ground truth.

`LLMUserAggregator._maybe_mute_frame` (`llm_response_universal.py:1150`) drops
two different categories of frame in one tuple:

```python
InputAudioRawFrame,             # content
InterimTranscriptionFrame,      # content
TranscriptionFrame,             # content
VADUserStartedSpeakingFrame,    # state transition
VADUserStoppedSpeakingFrame,    # state transition
ProposedUserStartedSpeakingFrame,
ProposedUserStoppedSpeakingFrame,
UserStartedSpeakingFrame,
UserStoppedSpeakingFrame,
InterruptionFrame,

Suppressing content is the intent. Suppressing state transitions is not, and the
early return at llm_response_universal.py:804 happens before the frame reaches
_user_turn_controller.process_frame or _user_idle_controller.process_frame.

The asymmetry is what makes it fatal. Dropping a start edge is harmless: the
flag stays False, the permissive value. Dropping a stop edge has no path
back — the flag latches True for the remainder of the call.

Three guards then fail closed, and they cover for each other under normal
conditions:

- user_turn_controller.py:380 — _trigger_user_turn_stop refuses to finalize
  the turn while the flag is set.
- user_turn_controller.py:407 — the stop-timeout watchdog, which exists to
  catch a turn that never finalizes, is gated on the same flag.
- llm_response_universal.py:1872 — if run_llm and not self._user_speaking:
  drops the context frame that re-invokes the LLM after a function call settles.
  Unlike its _bot_speaking sibling it sets no deferral flag and logs nothing,
  so the push is discarded with no record and never re-evaluated.

A function-call mute reaches this readily: the same mute suppresses
InputAudioRawFrame, which starves the VAD into emitting its stop frame inside
the window that discards it. The result is a pipeline that is entirely healthy —
heartbeats flowing, no exceptions, every service connected — and simply never
speaks again.

Why not just remove the stop frames from the mute tuple

That was the first thing I tried, and it is wrong. VADUserStoppedSpeakingFrame
is consumed by TurnAnalyzerUserTurnStopStrategy and
SpeechTimeoutUserTurnStopStrategy, and process_frame runs every start and
stop strategy after its own dispatch. Letting these frames through would allow a
muted user to drive turn decisions — a behaviour change, not a bug fix.

The changes

UserTurnController.process_muted_frame applies only the False transition
for suppressed stop frames and runs no strategies. The muted user still cannot
start, stop, or interrupt a turn; the state the rest of the pipeline reads stays
truthful. Only False is applied, since suppressing a start is the mute working
for suppressed stop frames and runs no strategies. The muted user still cannot
start, stop, or interrupt a turn; the state the rest of the pipeline reads stays
truthful. Only False is applied, since suppressing a start is the mute working
as intended.

llm_response_universal.py:804 routes suppressed frames through that method
before returning.

llm_response_universal.py:1872 becomes if run_llm:, with _user_speaking
handled as a deferral branch in _maybe_push_context_after_function_result
alongside the existing _bot_speaking one. A result settling mid-speech is held
and pushed on UserStoppedSpeakingFrame instead of dropped.

The two deferral paths now hand over to each other rather than discarding the
push, which closes the same latch on the bot side: llm_response_universal.py:1643
previously required not self._user_speaking, so a deferred push could be
dropped if the user started speaking and the bot never spoke again.

Tests

Three new tests, each verified to fail with the source changes reverted:

- test_muted_stop_frame_does_not_strand_user_speaking — the latch itself.
- test_muted_start_frame_does_not_set_user_speaking — that the fix does not
  weaken the mute from the other direction.
- test_function_result_while_user_speaks_is_deferred_not_dropped — deferral
  rather than drop.
and pushed on UserStoppedSpeakingFrame instead of dropped.

The two deferral paths now hand over to each other rather than discarding the
push, which closes the same latch on the bot side: llm_response_universal.py:1643
previously required not self._user_speaking, so a deferred push could be
dropped if the user started speaking and the bot never spoke again.

Tests

Three new tests, each verified to fail with the source changes reverted:

- test_muted_stop_frame_does_not_strand_user_speaking — the latch itself.
- test_muted_start_frame_does_not_set_user_speaking — that the fix does not
  weaken the mute from the other direction.
- test_function_result_while_user_speaks_is_deferred_not_dropped — deferral
  rather than drop.

The existing test_user_mute_strategies, which asserts a muted user never opens
a turn, is the regression guard for the behaviour this must preserve, and passes
unchanged.

135 passed across test_user_turn_controller.py,
test_context_aggregators_universal.py, and test_user_mute_strategy.py.
ruff check and ruff format --check are clean.

I'll add the towncrier fragment as changelog/<PR number>.fixed.md once this has
a number — happy to push it straight away.

Unrelated observation

test_deferred_wrapper_skips_stopped in tests/test_user_turn_controller.py
failed once for me and then passed consistently on both main and this branch.
It looks like a pre-existing timing sensitivity around the 0.2s
user_turn_stop_timeout used in that file, unrelated to these changes. Mentioning
it in case it shows up in CI.