### PR TITLE
Render each documented field once, and generate the API toctree

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -50,6 +50,8 @@ extensions = [
     "sphinx.ext.intersphinx",
 ]
 
+exclude_patterns = ["api/_packages.rst"]
+
 suppress_warnings = [
     "autodoc.mocked_object",
     "toc.not_included",
@@ -202,6 +204,36 @@ def skip_documented_field(app, what, name, obj, skip, options):
     return skip
 
 
+# Packages left out of the landing page's toctree even though apidoc generates
+# pages for them. Anything excluded from generation drops out on its own; this
+# is for pages that exist but should not be advertised as entry points.
+TOCTREE_EXCLUDED_PACKAGES = {"tests"}
+
+# Titles that are not just the capitalized package name.
+TOCTREE_TITLES = {"cli": "CLI"}
+
+
+def write_package_toctree(output_dir: Path) -> None:
+    """Write the landing page's toctree from the pages apidoc just generated.
+
+    Args:
+        output_dir: Directory apidoc wrote its .rst files to.
+    """
+    lines = [".. toctree::", "   :maxdepth: 2", "   :caption: API Reference", "   :hidden:", ""]
+    for path in sorted(output_dir.glob("pipecat.*.rst")):
+        # One dot past "pipecat" is a top-level package; deeper pages are
+        # reached from that package's own page.
+        if path.stem.count(".") != 1:
+            continue
+        name = path.stem.split(".")[1]
+        if name in TOCTREE_EXCLUDED_PACKAGES:
+            continue
+        lines.append(
+            f"   {TOCTREE_TITLES.get(name, name.replace('_', ' ').title())} <api/{path.stem}>"
+        )
+    (output_dir / "_packages.rst").write_text("\n".join(lines) + "\n")
+
+
 def import_core_modules():
     """Import core pipecat modules for autodoc to discover."""
     core_modules = [
@@ -304,6 +336,8 @@ def setup(app):
         )
 
         logger.info("API documentation generated successfully!")
+
+        write_package_toctree(Path(output_dir))
 
         # Process generated RST files to update titles
         for rst_file in Path(output_dir).glob("**/*.rst"):  # Changed to recursive glob

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -1,6 +1,7 @@
 import builtins
 import logging
 import os
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +12,13 @@ from pathlib import Path
 # accept Union-wrapped dict types (i.e., Optional[Dict[str, Any]]).
 import pydantic._internal._generate_schema as _pydantic_gs
 from sphinx import addnodes
+
+try:
+    from sphinx.ext.autodoc._sentinels import INSTANCE_ATTR
+except ImportError:
+    # Private to Sphinx, and the public ``INSTANCEATTR`` alias is a different
+    # object that never matches. Without it the redundant field stubs stay.
+    INSTANCE_ATTR = None
 
 _ORIG_DICT_TYPES = _pydantic_gs.DICT_TYPES
 # Expand the accepted types to include Union (Optional[Dict[str, Any]])
@@ -150,6 +158,50 @@ def resolve_builtins_against_python(app, doctree):
             node.attributes.pop("refspecific", None)
 
 
+# Sphinx hands an annotation-only class attribute to the member filter with its
+# skip flag already False, so ``undoc-members: False`` does not suppress it: a
+# dataclass or model field renders once in the class signature, once in the
+# Parameters block napoleon builds from the class docstring, and a third time as
+# a bare ``name: type`` stub carrying no prose. Drop that stub where the
+# docstring already describes the field, and keep it where it is the only place
+# the field appears at all.
+_FIELD_SECTION = re.compile(
+    r"^([ \t]*)(?:Parameters|Attributes|Args):[ \t]*\n(.*?)(?=\n\1\S|\Z)", re.M | re.S
+)
+_FIELD_NAME = re.compile(r"^\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?:", re.M)
+_documented_field_cache: dict[type, set] = {}
+
+
+def documented_fields(cls):
+    """Field names the class or one of its bases describes in its docstring."""
+    if cls in _documented_field_cache:
+        return _documented_field_cache[cls]
+    names = set()
+    for klass in getattr(cls, "__mro__", (cls,)):
+        # __dict__ rather than __doc__ so an inherited docstring is not counted
+        # twice; the MRO walk already covers the base that owns it.
+        for _, block in _FIELD_SECTION.findall(klass.__dict__.get("__doc__") or ""):
+            names.update(_FIELD_NAME.findall(block))
+    _documented_field_cache[cls] = names
+    return names
+
+
+def skip_documented_field(app, what, name, obj, skip, options):
+    """Skip a field stub whose description already lives in the docstring."""
+    if INSTANCE_ATTR is None:
+        return skip
+    if skip or obj is not INSTANCE_ATTR:
+        return skip
+    module = sys.modules.get(app.env.temp_data.get("autodoc:module") or "")
+    path = (app.env.temp_data.get("autodoc:class") or "").split(".")
+    cls = getattr(module, path[0], None) if module and path[0] else None
+    for part in path[1:]:
+        cls = getattr(cls, part, None)
+    if cls is not None and name in documented_fields(cls):
+        return True
+    return skip
+
+
 def import_core_modules():
     """Import core pipecat modules for autodoc to discover."""
     core_modules = [
@@ -203,6 +255,13 @@ def setup(app):
     from sphinx.ext.apidoc import main
 
     app.connect("doctree-read", resolve_builtins_against_python)
+    if INSTANCE_ATTR is None:
+        logger.warning(
+            "sphinx.ext.autodoc._sentinels.INSTANCE_ATTR is gone; every documented "
+            "dataclass and model field will render a second time as a bare stub. "
+            "Find what replaced it and update skip_documented_field."
+        )
+    app.connect("autodoc-skip-member", skip_documented_field)
 
     docs_dir = Path(__file__).parent
     project_root = docs_dir.parent.parent

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,30 +13,4 @@ Quick Links
 * `GitHub Repository <https://github.com/pipecat-ai/pipecat>`_
 * `Join our Community <https://discord.gg/pipecat>`_
 
-.. toctree::
-   :maxdepth: 2
-   :caption: API Reference
-   :hidden:
-
-   Adapters <api/pipecat.adapters>
-   Audio <api/pipecat.audio>
-   Bus <api/pipecat.bus>
-   CLI <api/pipecat.cli>
-   Clocks <api/pipecat.clocks>
-   Evals <api/pipecat.evals>
-   Extensions <api/pipecat.extensions>
-   Flows <api/pipecat.flows>
-   Frames <api/pipecat.frames>
-   Metrics <api/pipecat.metrics>
-   Observers <api/pipecat.observers>
-   Pipeline <api/pipecat.pipeline>
-   Processors <api/pipecat.processors>
-   Registry <api/pipecat.registry>
-   Runner <api/pipecat.runner>
-   Serializers <api/pipecat.serializers>
-   Services <api/pipecat.services>
-   Transcriptions <api/pipecat.transcriptions>
-   Transports <api/pipecat.transports>
-   Turns <api/pipecat.turns>
-   Utils <api/pipecat.utils>
-   Workers <api/pipecat.workers>
+.. include:: api/_packages.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,9 +187,6 @@ dev = [
 docs = [
     "sphinx>=8.1.3",
     "sphinx-rtd-theme",
-    "sphinx-markdown-builder",
-    "sphinx-autodoc-typehints",
-    "toml",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -5537,11 +5537,7 @@ dev = [
 docs = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-markdown-builder" },
     { name = "sphinx-rtd-theme" },
-    { name = "toml" },
 ]
 
 [package.metadata]
@@ -5677,10 +5673,7 @@ dev = [
 ]
 docs = [
     { name = "sphinx", specifier = ">=8.1.3" },
-    { name = "sphinx-autodoc-typehints" },
-    { name = "sphinx-markdown-builder" },
     { name = "sphinx-rtd-theme" },
-    { name = "toml" },
 ]
 
 [[package]]
@@ -8273,53 +8266,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.12'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/6a/c0360b115c81d449b3b73bf74b64ca773464d5c7b1b77bda87c5e874853b/sphinx_autodoc_typehints-3.6.1-py3-none-any.whl", hash = "sha256:dd818ba31d4c97f219a8c0fcacef280424f84a3589cedcb73003ad99c7da41ca", size = 20869, upload-time = "2026-01-02T15:23:45.194Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5f/7f2a768683c24dac122d6d9714b923ed84d87ffde058a37d525996687295/sphinx_autodoc_typehints-3.13.2.tar.gz", hash = "sha256:ea20b9a217b86391b0ece262c4336e3c2f476fe1f76028635d550b4e74cd7498", size = 88492, upload-time = "2026-08-03T22:26:01.344Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/53/7ae6f44d2a9275562ff6fb7cf8be14c35e8ab057ebd4954f9f10558efb0d/sphinx_autodoc_typehints-3.13.2-py3-none-any.whl", hash = "sha256:b2a7b531369a128c7c52867962fe224d89a1d480a462a314621c710a7d6e3ecf", size = 44836, upload-time = "2026-08-03T22:26:00.029Z" },
-]
-
-[[package]]
-name = "sphinx-markdown-builder"
-version = "0.6.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tabulate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/13/102d7134743120db25e636ffb57a30818e95a416583dca83aadac9c5dd87/sphinx_markdown_builder-0.6.11.tar.gz", hash = "sha256:ba3bf33e0e42ff30ae686ac73957a95e6d045790dcfbaca012dd8ae01794e577", size = 24020, upload-time = "2026-08-16T06:51:38.158Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/71/06b415631c2e494c80546073b46013d1715dceb3abe30bd63b34b4e7d9ca/sphinx_markdown_builder-0.6.11-py3-none-any.whl", hash = "sha256:acfb94d6ee66c7a47da0ca0420578fa16f115812af25b8fd21755d5909aacf51", size = 18088, upload-time = "2026-08-16T06:51:36.81Z" },
-]
-
-[[package]]
 name = "sphinx-rtd-theme"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8507,15 +8453,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tabulate"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
-]
-
-[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -8649,15 +8586,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #5456 — review that one first. This PR's base is `mb/docs-autogen-fixes`, so the diff here is just the three commits below.

## Summary

- **A documented field renders once instead of three times.** Sphinx hands an annotation-only class attribute to the member filter with its skip flag already False, so `undoc-members: False` never suppressed it. Every dataclass and model field appeared in the class signature, in the `Parameters:` block napoleon builds from the docstring, and a third time as a bare `name: type` stub carrying no prose. The stub is now dropped where the docstring — the class's own or a base's — already describes the field, and kept where it is the only place the field appears. Of 2942 annotated fields under `src/pipecat`, 2586 are described in a docstring; the other 356 render exactly as before.
- **The landing page's toctree is generated** from the pages apidoc produced, rather than listing 22 packages by hand against a tree that is regenerated on every build. `TOCTREE_EXCLUDED_PACKAGES` hides a package that has a page but should not be an entry point; anything excluded from generation never reaches that stage. The generated output matches the list it replaces.
- **Three unused docs dependencies dropped** — `sphinx-markdown-builder`, `sphinx-autodoc-typehints`, `toml` were declared but referenced nowhere.

Warnings go from 36 to 31 on a clean build; the filter clears a few ambiguous cross-references as a side effect, since fewer registered attributes mean fewer fuzzy-match collisions.

## Risk worth a reviewer's attention

The filter matches on `sphinx.ext.autodoc._sentinels.INSTANCE_ATTR`, which is **private to Sphinx**. The public `INSTANCEATTR` alias is a different object in Sphinx 9.1 and never matches, so it is not an option. The import is guarded, so a release that moves the sentinel restores the stubs rather than failing the build — and logs a warning naming what to fix, since silently re-adding 2000 stubs is not something anyone would spot by eye.

## Testing

```bash
cd docs/api && uv run ./build-docs.sh
```

`api/pipecat.services.anthropic.llm.html` shows the shape this targets: `AnthropicThinkingConfig` now ends after its `Parameters:` block. `api/pipecat.processors.frameworks.rtvi.models.html` is the control — 159 of its fields are documented only by their stub, so that page is unchanged.

No changelog entry: this is documentation-only, which `CONTRIBUTING.md` excludes.