### PR TITLE
Update the NVIDIA, Groq, and Moondream models

### DIFF
--- a/changelog/5458.changed.md
+++ b/changelog/5458.changed.md
@@ -1,0 +1,1 @@
+- `MoondreamService` now defaults `revision` to `2025-06-21` instead of `2025-01-09`, picking up the newer Moondream build. Pass `revision="2025-01-09"` to stay on the previous one.

--- a/examples/function-calling/function-calling-nvidia.py
+++ b/examples/function-calling/function-calling-nvidia.py
@@ -90,8 +90,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = NvidiaLLMService(
         api_key=os.environ["NVIDIA_API_KEY"],
         settings=NvidiaLLMService.Settings(
-            model="nvidia/llama-3.3-nemotron-super-49b-v1.5",
-            # Recommended when turning thinking off
+            model="nvidia/nemotron-3.5-lightning-30b-a3b",
             temperature=0.0,
             system_instruction="/no_think You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),

--- a/examples/voice/voice-groq.py
+++ b/examples/voice/voice-groq.py
@@ -62,7 +62,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = GroqLLMService(
         api_key=os.environ["GROQ_API_KEY"],
         settings=GroqLLMService.Settings(
-            model="llama-3.1-8b-instant",
+            model="openai/gpt-oss-120b",
             system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )

--- a/examples/voice/voice-nvidia-segmented.py
+++ b/examples/voice/voice-nvidia-segmented.py
@@ -62,9 +62,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = NvidiaLLMService(
         api_key=os.environ["NVIDIA_API_KEY"],
         settings=NvidiaLLMService.Settings(
-            model="nvidia/llama-3.3-nemotron-super-49b-v1.5",
-            # /no_think disables Nemotron's reasoning mode, which would
-            # otherwise delay spoken responses by many seconds.
+            model="nvidia/nemotron-3.5-lightning-30b-a3b",
             system_instruction="/no_think You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )

--- a/examples/voice/voice-nvidia.py
+++ b/examples/voice/voice-nvidia.py
@@ -62,9 +62,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = NvidiaLLMService(
         api_key=os.environ["NVIDIA_API_KEY"],
         settings=NvidiaLLMService.Settings(
-            model="nvidia/llama-3.3-nemotron-super-49b-v1.5",
-            # /no_think disables Nemotron's reasoning mode, which would
-            # otherwise delay spoken responses by many seconds.
+            model="nvidia/nemotron-3.5-lightning-30b-a3b",
             system_instruction="/no_think You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
         ),
     )

--- a/src/pipecat/services/moondream/vision.py
+++ b/src/pipecat/services/moondream/vision.py
@@ -87,7 +87,7 @@ class MoondreamService(VisionService):
         self,
         *,
         model: str | None = None,
-        revision="2025-01-09",
+        revision="2025-06-21",
         use_cpu=False,
         settings: Settings | None = None,
         **kwargs,


### PR DESCRIPTION
Moves three examples and one service default onto current models.

- The NVIDIA examples run on `nvidia/nemotron-3.5-lightning-30b-a3b`, replacing `nvidia/llama-3.3-nemotron-super-49b-v1.5`.
- The Groq example runs on `openai/gpt-oss-120b`, replacing `llama-3.1-8b-instant`.
- `MoondreamService` defaults to the `2025-06-21` model revision, replacing `2025-01-09`.

The NVIDIA examples also drop two comments the new model made false. They said `/no_think` disables Nemotron's reasoning, but 3.5 Lightning returns `reasoning_content` whether or not the prompt asks for it:

```
WITH    /no_think: reasoning="Here's a thinking process: 1. Identify User Question..." content="Berlin"
WITHOUT /no_think: reasoning="Here's a thinking process: 1. Analyze User Input..."     content="The capital of Germany is Berlin."
```

The prompts are unchanged; `NvidiaLLMService` keeps reasoning out of the spoken output either way.

## Verification

Release evals, run per bot:

| Bot | Scenario | Result |
| --- | --- | --- |
| `voice/voice-nvidia.py` | `capital_question` | pass, 53.8s |
| `voice/voice-nvidia-segmented.py` | `capital_question` | pass, 63.9s |
| `voice/voice-groq.py` | `capital_question` | pass, 27.4s |
| `function-calling/function-calling-nvidia.py` | `weather_function_call` | pass, 23.2s |

The NVIDIA runs are slow because the model reasons on every turn, which is the same measurement as above.

The Moondream evals (`vision/vision-moondream.py`, `function-calling/function-calling-moondream-video.py`) were not run: they need more GPU memory than this machine has. That revision bump is unverified here.