### PR TITLE
ci(docs): stop the docs automation from missing public API changes

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -52,31 +52,43 @@ Run:
 git diff main..HEAD --name-only
 ```
 
-Filter to files that could affect documentation:
+Every `.py` file under `src/pipecat/` is in scope. The package ships public API
+well beyond the per-provider service files — frames, workers, the bus, the eval
+harness, the CLI, the runner, and the service base classes are all documented
+somewhere on the site.
 
-- `src/pipecat/services/**/*.py` (service implementations)
-- `src/pipecat/transports/**/*.py` (transport implementations)
-- `src/pipecat/serializers/**/*.py` (serializer implementations)
-- `src/pipecat/processors/**/*.py` (processor implementations)
-- `src/pipecat/audio/**/*.py` (audio utilities)
-- `src/pipecat/turns/**/*.py` (turn management)
-- `src/pipecat/observers/**/*.py` (observers)
-- `src/pipecat/pipeline/**/*.py` (pipeline core)
-- `src/pipecat/flows/**/*.py` (Pipecat Flows)
+Exclude only:
 
-Ignore `__init__.py`, `__pycache__`, test files, and files that only contain type re-exports.
+- `src/pipecat/tests/**` (test helpers)
+- `__pycache__/`, `*.pyc`, `py.typed`
+- `__init__.py` files that only re-export names defined elsewhere
+
+Changes outside `src/pipecat/` — examples, CI config, the docs directory — don't
+trigger doc updates on their own.
+
+Then apply the mapping file's Skip list (Step 4), which names the small set of
+genuinely internal files. Don't invent further reasons to drop a file here: being
+a base class, a shared module, or "core architecture" is not one. Public
+constructor parameters and observable behavior get documented wherever they live,
+and a file whose page isn't obvious should reach Step 8 as a reported gap rather
+than disappear.
 
 ### Step 4: Map source files to doc pages
 
 For each changed source file, resolve the doc page to edit. Read the mapping file at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` and apply this resolution order. **Confirm every candidate path exists in `DOCS_PATH` before using it.**
 
 1. **Skip list** — if the file matches the skip list, stop. It triggers no doc update.
-2. **Pattern match** — apply the pattern table to get a candidate path, then confirm the `.mdx` file exists (glob/`ls` it under `DOCS_PATH`). If it exists, use it.
+2. **Base classes** — if the file is in the base-classes table, use every page it lists. A change here affects the services that inherit it, so check each page rather than stopping at the first.
 3. **Non-standard locations** — if the file is in the non-standard table, use that entry as the candidate path and confirm it exists.
-4. **Search** — if no candidate from steps 2–3 exists on disk, grep `DOCS_PATH` for the file's main class name (see the mapping file's Search section).
-5. **Unmapped** — if nothing resolves, treat the file as unmapped and report it in Step 8.
+4. **Pattern match** — apply the pattern table to get a candidate path, then confirm the `.mdx` file exists (glob/`ls` it under `DOCS_PATH`). If it exists, use it.
+5. **Search** — if no candidate from steps 2–4 exists on disk, grep `DOCS_PATH` for the file's main class name (see the mapping file's Search section).
+6. **Unmapped** — if nothing resolves, treat the file as unmapped and report it in Step 8.
 
 Never edit a path you haven't confirmed exists. If a candidate path doesn't resolve, fall through to the search step.
+
+Reaching step 6 is a finding, not a dead end: an unmapped file means public API
+with no home on the docs site, which is exactly what Step 8 exists to surface.
+Never resolve a file by dropping it.
 
 ### Step 5: Analyze each source-doc pair
 

--- a/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
+++ b/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
@@ -30,29 +30,88 @@ These source paths don't follow the standard `services/{provider}/{type}.py` →
 | `flows/adapters.py`                         | `api-reference/pipecat-flows/overview.mdx`                                                       |
 | `flows/exceptions.py`                       | `api-reference/pipecat-flows/exceptions.mdx`                                                     |
 
+## Base classes
+
+A base class is not internal. Its constructor parameters, event handlers, and
+behavior are public API that every service inheriting from it exposes, documented
+in guides and concept pages rather than on a per-provider reference page.
+
+| Source path                      | Doc page                                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `services/tts_service.py`        | `pipecat/learn/text-to-speech.mdx`                                                                            |
+| `services/stt_service.py`        | `pipecat/learn/speech-to-text.mdx`                                                                            |
+| `services/llm_service.py`        | `pipecat/learn/llm.mdx` and `pipecat/learn/function-calling.mdx`                                              |
+| `services/websocket_service.py`  | `api-reference/server/events/service-events.mdx`                                                              |
+| `services/ai_service.py`         | `api-reference/server/events/service-events.mdx`                                                              |
+| `serializers/base_serializer.py` | `api-reference/server/services/serializers/introduction.mdx`                                                  |
+| `transports/base_input.py`       | `api-reference/server/services/transport/transport-params.mdx`                                                |
+| `transports/base_output.py`      | `api-reference/server/services/transport/transport-params.mdx`                                                |
+| `pipeline/pipeline.py`           | `pipecat/learn/pipeline.mdx`                                                                                  |
+| `processors/frame_processor.py`  | `pipecat/fundamentals/custom-frame-processor.mdx` and `api-reference/server/events/frame-processor-events.mdx` |
+
+Several of these carry documented parameters with no reference page of their own.
+Where a change fits none of the pages above, report it as a missing-page gap in
+SKILL.md Step 8 rather than skipping it.
+
+### What to document from a base class
+
+Most of a base class is framework machinery. A name without a leading underscore
+doesn't make it public — `process_frame`, `push_frame`, and `tts_process_generator`
+are all machinery. Apply this test instead:
+
+**Can someone change or observe this without subclassing?**
+
+| Kind                                                                | Verdict                                     |
+| ------------------------------------------------------------------- | ------------------------------------------- |
+| Constructor parameter that changes behavior                         | Document                                    |
+| Event handler                                                       | Document                                    |
+| Method called on a live instance (`set_model`, `set_voice`)         | Document                                    |
+| Only meaningful when implementing `run_tts` / `run_stt` / `setup()` | Skip — it's the subclass contract           |
+| Anything else                                                       | Skip                                        |
+
+The subclass contract is a real audience, but it lives in the pipecat repo
+alongside `COMMUNITY_INTEGRATIONS.md`, not on the docs site. A base-class change
+that touches only that contract is a legitimate no-op — say so, naming the
+methods, rather than editing a guide.
+
+Worked example: of `TTSService`'s 19 constructor parameters, `push_text_frames`,
+`push_stop_frames`, `push_start_frame`, and `reuse_context_id_within_turn` exist
+so `run_tts` implementations don't have to do that work themselves. They fail the
+test. `max_consecutive_zero_audio_contexts` passes it — it decides whether a
+silent provider gets written off mid-call.
+
+A deprecated parameter gets a deprecation notice and nothing more. Don't explain
+a mechanism that no longer runs: `pause_watchdog_timeout_s` is documented in
+source as "Unused", so its doc entry says it does nothing and is removed in
+2.0.0.
+
+### Inherited parameters belong to the guide, not the provider page
+
+A provider page documents what that provider **adds or overrides**. Parameters
+inherited from a base class are documented once, in the guide's "Base Class
+Configuration" section, and left out of the per-provider pages.
+
+Copying them onto provider pages doesn't scale: `text_aggregation_mode` reached
+15 of 53 TTS pages that way, which means 15 copies to keep current and 38 pages
+where the parameter appears not to exist. When a base-class parameter changes,
+edit the guide — don't fan the change out.
+
 ## Skip list
 
-These files should never trigger doc updates.
+These files never trigger doc updates. Keep this list short — it is for files
+with no observable public surface, not for files that are merely hard to place.
 
-| Pattern                              | Reason                               |
-| ------------------------------------ | ------------------------------------ |
-| `services/ai_service.py`             | Internal base class                  |
-| `services/stt_service.py`            | Internal base class                  |
-| `services/tts_service.py`            | Internal base class                  |
-| `services/llm_service.py`            | Internal base class                  |
-| `services/websocket_service.py`      | Internal base class                  |
-| `services/image_service.py`          | Internal base class                  |
-| `services/vision_service.py`         | Internal base class                  |
-| `services/settings.py`               | Internal                             |
-| `services/aws/agent_core.py`         | Internal                             |
-| `services/aws/sagemaker/**`          | No doc page                          |
-| `transports/base_input.py`           | Internal base class                  |
-| `transports/base_output.py`          | Internal base class                  |
-| `transports/websocket/client.py`     | No doc page                          |
-| `serializers/base_serializer.py`     | Internal base class                  |
-| `serializers/protobuf.py`            | Internal                             |
-| `processors/audio/vad_processor.py`  | No doc page                          |
-| `pipeline/pipeline.py`               | Core architecture, not a service doc |
+| Pattern                             | Reason                                    |
+| ----------------------------------- | ----------------------------------------- |
+| `services/image_service.py`         | Abstract interface only, no public params |
+| `services/vision_service.py`        | Abstract interface only, no public params |
+| `services/settings.py`              | Internal plumbing                         |
+| `services/aws/agent_core.py`        | Internal                                  |
+| `services/aws/sagemaker/**`         | No doc page                               |
+| `transports/websocket/client.py`    | No doc page                               |
+| `serializers/protobuf.py`           | Internal wire format                      |
+| `processors/audio/vad_processor.py` | No doc page                               |
+| `tests/**`                          | Test helpers                              |
 
 ## Pattern matching
 
@@ -74,6 +133,22 @@ For files not in the tables above, apply these patterns. Convert underscores to 
 | `audio/mixers/**`                 | `api-reference/server/utilities/audio/` (match by class name)     |
 | `processors/audio/**`             | `api-reference/server/utilities/audio/` (match by class name)     |
 | `processors/filters/**`           | `api-reference/server/utilities/filters/` (match by class name)   |
+| `workers/**`                      | `api-reference/server/workers/` (match by class name)             |
+| `bus/**`                          | `api-reference/server/bus/` (match by class name)                 |
+| `turns/**`                        | `api-reference/server/utilities/turn-management/`                 |
+| `frames/frames.py`                | `api-reference/server/frames/` (match by frame class name)        |
+| `evals/**`                        | `pipecat/evals/` and `api-reference/cli/eval.mdx`                 |
+| `cli/**`                          | `api-reference/cli/` (match by command name)                      |
+| `runner/**`                       | `api-reference/server/utilities/runner/guide.mdx`                 |
+| `metrics/**`                      | `pipecat/fundamentals/metrics.mdx`                                |
+| `adapters/**`                     | the LLM page for that provider under `api-reference/server/services/llm/` |
+| `utils/**`                        | match by class or function name across `api-reference/` and `pipecat/`    |
+
+A frame class is documented on the page matching its base class:
+`SystemFrame` subclasses on `frames/system-frames.mdx`, `ControlFrame` subclasses
+on `frames/control-frames.mdx`, and so on. When a frame changes base class, move
+its entry to the page for its new base and fix any prose that explains its
+ordering or interruption behavior.
 
 A pattern result is only valid if the file exists in `DOCS_PATH`. If it doesn't exist, fall through to the Search section before treating the file as unmapped.
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -4,16 +4,12 @@ on:
   pull_request_target:
     types: [closed]
     branches: [main]
+    # Everything shipped in the package is in scope, named as exclusions so a new
+    # directory is covered the day it appears rather than when someone remembers
+    # to list it.
     paths:
-      - "src/pipecat/services/**"
-      - "src/pipecat/transports/**"
-      - "src/pipecat/serializers/**"
-      - "src/pipecat/processors/**"
-      - "src/pipecat/audio/**"
-      - "src/pipecat/turns/**"
-      - "src/pipecat/observers/**"
-      - "src/pipecat/pipeline/**"
-      - "src/pipecat/flows/**"
+      - "src/pipecat/**"
+      - "!src/pipecat/tests/**"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,7 +26,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read
+      # write so a run that fails can say so on the PR that triggered it;
+      # issues: write covers the label, which goes through the issues API
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Generate app token
@@ -176,10 +175,29 @@ jobs:
             If `gh pr create` fails because a PR from that branch already exists,
             push the updated commits and use `gh pr edit` to update the body instead.
 
+            ### Recording the outcome
+            Every run must leave a one-line verdict at
+            `$RUNNER_TEMP/docs-update-outcome.txt`, written before you finish:
+
+            - `PR: <url>` — a docs PR was created or updated
+            - `NOOP: <reason>` — no docs change was needed, naming the specific
+              reason (e.g. "only internal wiring in pipeline/task_manager.py changed;
+              no public API affected")
+
+            A bare "no changes needed" is not a reason. This file is how a reader
+            later tells a deliberate no-op from a run that quietly fell short, so
+            write it even when the answer seems obvious.
+
             ### No-op
             If after analyzing the diff you determine no documentation changes are needed
             (e.g., only skip-listed files changed, or changes don't affect public API docs),
-            exit cleanly without creating a branch or PR. Output "No documentation changes needed."
+            write the `NOOP:` line described above and exit cleanly without creating a
+            branch or PR.
+
+            A file being a base class or a shared module is NOT by itself a reason to
+            skip it. Public constructor parameters, event handlers, and behavior belong
+            in the docs wherever they live — see the mapping file's Skip list for the
+            short set of genuinely internal files.
 
             ### Formatting and llms.txt
             Skip SKILL.md Step 9. A later workflow step runs Prettier over the pages
@@ -193,7 +211,7 @@ jobs:
             - Use `GH_TOKEN=$DOCS_TOKEN` for all `gh` commands targeting pipecat-ai/docs
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --max-turns 30
+            --max-turns 90
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash"
 
       # Pinned from the docs repo's own .nvmrc rather than left to whatever the
@@ -264,3 +282,66 @@ jobs:
           fi
           gh pr edit "$PR_URL" --add-assignee "$ASSIGNEE"
           echo "Assigned $PR_URL to $ASSIGNEE"
+
+      # The run summary states the outcome either way, so a run that documented
+      # nothing is distinguishable from one that produced a docs PR.
+      - name: Record outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+          DOCS_PR=$(gh pr list --repo pipecat-ai/docs \
+            --head "docs/pr-$PR_NUMBER" --state all \
+            --json url --jq '.[0].url' 2>/dev/null || true)
+
+          {
+            echo "## Docs automation for pipecat PR #$PR_NUMBER"
+            echo
+            if [ -n "$DOCS_PR" ]; then
+              echo "Docs PR: $DOCS_PR"
+            elif [ -f "$RUNNER_TEMP/docs-update-outcome.txt" ]; then
+              echo "No docs PR. Reported outcome:"
+              echo
+              echo '```'
+              cat "$RUNNER_TEMP/docs-update-outcome.txt"
+              echo '```'
+            else
+              echo "No docs PR and no recorded outcome — the run did not reach the"
+              echo "point of stating one. Treat this PR as undocumented."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Nothing outside the Actions tab surfaces a failed run, so it is reported
+      # on the PR that triggered it.
+      - name: Report failure on the source PR
+        if: failure() && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create docs-automation-failed \
+            --repo pipecat-ai/pipecat \
+            --color B60205 \
+            --description "The update-docs workflow failed for this PR" \
+            2>/dev/null || true
+
+          gh pr edit "$PR_NUMBER" --repo pipecat-ai/pipecat \
+            --add-label docs-automation-failed 2>/dev/null || true
+
+          gh pr comment "$PR_NUMBER" --repo pipecat-ai/pipecat --body "$(cat <<BODY
+          **Docs automation failed for this PR — its documentation is missing.**
+
+          The \`update-docs\` workflow did not produce a docs PR: [run log]($RUN_URL)
+
+          Re-run it once the cause is addressed:
+
+          \`\`\`
+          gh workflow run update-docs.yml -f pr_number=$PR_NUMBER --repo pipecat-ai/pipecat
+          \`\`\`
+
+          If this PR genuinely needs no documentation, remove the
+          \`docs-automation-failed\` label.
+          BODY
+          )"


### PR DESCRIPTION
## Summary

The `update-docs` workflow silently skipped a large share of merged PRs — 25 runs failed without anyone noticing. Four fixes:

- **Raised the turn cap from 30 to 90.** Every one of the 25 failures hit it, either as `error_max_turns` or as "reported a successful result after 38 turns, exceeding the configured maximum of 30" — the latter discarding work that had already finished. The cap is size-correlated, so it dropped exactly the cross-cutting PRs that most need docs (BaseUIWorker, the error-category model, the `StartFrame` → `FrameProcessorSetup` migration).
- **Replaced the directory allowlist with an exclusion list over all of `src/pipecat/`.** The allowlist covered 9 of 25 directories, omitting `frames`, `workers`, `bus`, `evals`, `cli`, `runner`, `utils` and `adapters`. It also existed twice — in the workflow `paths:` and again in `SKILL.md` Step 3 — so a PR touching both a listed and an unlisted directory started a run and then had the unlisted half filtered back out. The mapping file gains patterns for the newly covered directories, plus a rule for placing a frame class by its base class.
- **Service base classes now map to the guides that document them.** They were skipped as "internal base class", though `tts_service.py` and `llm_service.py` carry public constructor parameters — `max_consecutive_zero_audio_contexts` and `cancellable_by_llm` among them, all currently undocumented. The skip list keeps only files with no public surface.
- **Bounded what gets documented from a base class.** Widening the mapping needs a limit, or the automation copies all 19 of `TTSService`'s constructor parameters into a guide. The mapping file carries the test that sorts them — can someone change or observe this without subclassing? — with `TTSService` worked through as the example. Inherited parameters are documented once in the guide rather than on each provider page; `text_aggregation_mode` reached 15 of 53 TTS pages by copying, leaving 15 places to keep current and 38 where the parameter looks like it doesn't exist.
- **Failures and no-ops are now reported.** A failed run comments on the source PR with the run log and re-run command and labels it `docs-automation-failed`; every run records in the job summary whether it produced a docs PR or the specific reason it didn't, so a deliberate no-op is distinguishable from a run that fell short.

Requires `pull-requests: write` and `issues: write` (the label goes through the issues API).

## Testing

Trigger a run against a merged PR that touches a previously uncovered directory:

```
gh workflow run update-docs.yml -f pr_number=<PR> --repo pipecat-ai/pipecat
```

Check the job summary for the `PR:` or `NOOP:` verdict.
