### PR TITLE
Take both YAML suffixes when an eval scenario directory is expanded

### DIFF
--- a/changelog/5463.fixed.md
+++ b/changelog/5463.fixed.md
@@ -1,0 +1,1 @@
+- A directory passed to `pipecat eval run` now reads `.yml` files as well as its `.yaml` ones, matching the scenario names a manifest resolves. A directory holding neither is still an error rather than an empty run.

--- a/src/pipecat/cli/commands/eval.py
+++ b/src/pipecat/cli/commands/eval.py
@@ -285,7 +285,9 @@ async def _run_scenarios_all(
 
 @eval_app.command("run")
 def run(
-    scenarios: list[Path] = typer.Argument(..., help="One or more scenario YAML files."),
+    scenarios: list[Path] = typer.Argument(
+        ..., help="One or more scenario YAML files, or directories of them."
+    ),
     bot_url: str = typer.Option(
         "ws://localhost:7860",
         "--bot-url",

--- a/src/pipecat/cli/commands/eval.py
+++ b/src/pipecat/cli/commands/eval.py
@@ -32,6 +32,7 @@ from rich.text import Text
 from pipecat.evals.harness import EvalSession, EvalTurnProgress
 from pipecat.evals.scenario import EvalScenario, describe_config
 from pipecat.evals.suite import (
+    SCENARIO_SUFFIXES,
     EvalManifest,
     EvalRun,
     EvalSuite,
@@ -138,7 +139,11 @@ def _record_path(record_dir: str | None, scenario_name: str) -> str | None:
 
 
 def _expand_scenario_paths(paths: list[Path]) -> list[Path]:
-    """Expand directory arguments into sorted YAML scenario paths."""
+    """Expand directory arguments into sorted YAML scenario paths.
+
+    Both YAML suffixes are taken, matching the scenario names a manifest
+    resolves.
+    """
     expanded: list[Path] = []
     for path in paths:
         if not path.is_dir():
@@ -146,10 +151,12 @@ def _expand_scenario_paths(paths: list[Path]) -> list[Path]:
             continue
 
         scenario_paths = sorted(
-            scenario_path for scenario_path in path.glob("*.yaml") if scenario_path.is_file()
+            scenario_path
+            for scenario_path in path.iterdir()
+            if scenario_path.suffix in SCENARIO_SUFFIXES and scenario_path.is_file()
         )
         if not scenario_paths:
-            raise typer.BadParameter(f"No .yaml scenario files found in {path}")
+            raise typer.BadParameter(f"No .yaml or .yml scenario files found in {path}")
         expanded.extend(scenario_paths)
     return expanded
 

--- a/src/pipecat/evals/suite.py
+++ b/src/pipecat/evals/suite.py
@@ -76,6 +76,8 @@ BOT_CONNECT_TIMEOUT_S = 60.0
 BOT_STOP_TIMEOUT_S = 10.0
 # Default spawn template; {python}/{bot}/{port} are substituted per run.
 DEFAULT_SPAWN = "{python} {bot} -t eval --port {port}"
+# What a scenario file may be named, wherever one is looked for.
+SCENARIO_SUFFIXES = (".yaml", ".yml")
 
 # The harness runs three sub-pipelines in-process and tags each one's logs with an
 # ``eval_pipeline`` context value via logger.contextualize (see harness.py),
@@ -355,7 +357,7 @@ class EvalManifest:
                 scenario = str(scenario)
                 # A scenario may be a bare name (resolved under scenarios_dir) or a
                 # path/.yaml relative to the manifest.
-                if scenario.endswith((".yaml", ".yml")) or "/" in scenario:
+                if scenario.endswith(SCENARIO_SUFFIXES) or "/" in scenario:
                     scenario_path = (base / scenario).resolve()
                     name = Path(scenario).stem
                 else:

--- a/tests/cli/test_eval_display.py
+++ b/tests/cli/test_eval_display.py
@@ -56,12 +56,22 @@ class TestScenarioPathExpansion(unittest.TestCase):
             directory = Path(tmp)
             (directory / "zeta.yaml").write_text("name: zeta\n")
             (directory / "alpha.yaml").write_text("name: alpha\n")
-            (directory / "ignored.yml").write_text("name: ignored\n")
             (directory / "notes.txt").write_text("not a scenario\n")
 
             paths = _expand_scenario_paths([directory])
 
         self.assertEqual(paths, [directory / "alpha.yaml", directory / "zeta.yaml"])
+
+    def test_both_yaml_suffixes_are_taken(self):
+        """A manifest resolves either suffix, so a directory does too."""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "beta.yml").write_text("name: beta\n")
+            (directory / "alpha.yaml").write_text("name: alpha\n")
+
+            paths = _expand_scenario_paths([directory])
+
+        self.assertEqual(paths, [directory / "alpha.yaml", directory / "beta.yml"])
 
     def test_file_arguments_are_preserved(self):
         scenario = Path("scenario.yaml")
@@ -69,5 +79,5 @@ class TestScenarioPathExpansion(unittest.TestCase):
 
     def test_empty_directory_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaisesRegex(Exception, "No \.yaml scenario files found"):
+            with self.assertRaisesRegex(Exception, "No \.yaml or \.yml scenario files found"):
                 _expand_scenario_paths([Path(tmp)])


### PR DESCRIPTION
`pipecat eval run` takes scenario directories, added in #5414 and shipped in 1.8.0. Two things were left behind.

**`.yml` scenarios were skipped.** The expansion globbed `*.yaml`, while a manifest resolves scenario names ending in either `.yaml` or `.yml`. A directory mixing the two ran only half its scenarios, and a directory of `.yml` files failed with "No .yaml scenario files found" while visibly holding scenarios:

```
dir with a.yaml + b.yml   ->  runs only "a"
dir with only b.yml       ->  Invalid value: No .yaml scenario files found in <dir>
```

`SCENARIO_SUFFIXES` now names what a scenario file may be called, and both the manifest and the directory expansion resolve against it. The same directories now yield `a` and `b`, and `b` respectively.

The suffix that was excluded was excluded on purpose: #5414's test wrote an `ignored.yml` fixture and asserted it was dropped. That assertion is replaced by `test_both_yaml_suffixes_are_taken`, since the manifest has always accepted both.

**`--help` did not mention directories.** The `SCENARIOS...` argument still read "One or more scenario YAML files", which is the first place anyone looks for what the argument takes.

## Verification

`tests/cli/` and `tests/test_evals_suite.py`: 398 passed. The one failure, `test_init_agent_ready.py::test_stale_guide_nudges`, also fails on `main` and is unrelated.

Checked against the CLI directly:

```
$ pipecat eval run <dir with a.yaml + b.yml>   ->  Scenarios: a, b
$ pipecat eval run <dir with only b.yml>       ->  Scenarios: b
$ pipecat eval run --help                      ->  "One or more scenario YAML files, or directories of them."
```