### PR TITLE
fix(asyncai): apply model, voice and language changes by opening a new session

### DIFF
--- a/changelog/5464.fixed.md
+++ b/changelog/5464.fixed.md
@@ -1,4 +1,1 @@
-- Fixed `AsyncAITTSService` ignoring runtime `model`, `voice` and `language` updates. Those
-  three are sent only in the websocket init message and never repeated per utterance, so a
-  change to any of them now opens a new session instead of being stored and warned about.
-  `AsyncAIHttpTTSService` is unaffected, since it sends them on every request.
+- Fixed `AsyncAITTSService` ignoring runtime `model`, `voice` and `language` updates. Those three are sent only in the websocket init message and never repeated per utterance, so a change to any of them now opens a new session instead of being stored and warned about.

--- a/changelog/5464.fixed.md
+++ b/changelog/5464.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `AsyncAITTSService` ignoring runtime `model`, `voice` and `language` updates. Those
+  three are sent only in the websocket init message and never repeated per utterance, so a
+  change to any of them now opens a new session instead of being stored and warned about.
+  `AsyncAIHttpTTSService` is unaffected, since it sends them on every request.

--- a/src/pipecat/services/asyncai/tts.py
+++ b/src/pipecat/services/asyncai/tts.py
@@ -81,6 +81,10 @@ class AsyncAITTSService(WebsocketTTSService):
     """
 
     Settings = AsyncAITTSSettings
+
+    #: Settings baked into the websocket init message, and therefore only
+    #: changeable by starting a new session.
+    _SESSION_INIT_FIELDS = frozenset({"model", "voice", "language"})
     _settings: Settings
 
     @deprecated(
@@ -204,16 +208,29 @@ class AsyncAITTSService(WebsocketTTSService):
         self._keepalive_task = None
 
     async def _update_settings(self, delta: TTSSettings) -> dict[str, Any]:
-        """Apply a settings delta.
+        """Apply a settings delta, reconnecting when a session-init field changes.
 
-        Settings are stored but not applied to the active connection.
+        ``model``, ``voice`` and ``language`` are sent once in the init message at
+        connect time and are never repeated per utterance — ``_build_msg`` carries
+        only the transcript and context id — so a new websocket session is the only
+        way a change to any of them reaches Async.
+
+        Args:
+            delta: A settings delta.
+
+        Returns:
+            Dict mapping changed field names to their previous values.
         """
         changed = await super()._update_settings(delta)
 
         if not changed:
             return changed
 
-        self._warn_unhandled_updated_settings(changed)
+        if self._SESSION_INIT_FIELDS & changed.keys():
+            await self._disconnect()
+            await self._connect()
+
+        self._warn_unhandled_updated_settings(changed.keys() - self._SESSION_INIT_FIELDS)
 
         return changed
 

--- a/tests/test_asyncai_tts.py
+++ b/tests/test_asyncai_tts.py
@@ -1,0 +1,114 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for AsyncAITTSService runtime settings updates."""
+
+import asyncio
+import io
+import json
+
+import pytest
+from loguru import logger
+
+from pipecat.services.asyncai.tts import AsyncAITTSService
+from pipecat.utils.asyncio.task_manager import TaskManager
+from tests.frame_processor_helpers import frame_processor_setup
+
+
+def _service(**settings) -> AsyncAITTSService:
+    return AsyncAITTSService(
+        api_key="test-key",
+        settings=AsyncAITTSService.Settings(model="m1", voice="v1", language=None, **settings),
+    )
+
+
+def _stub_reconnect(service: AsyncAITTSService) -> list[str]:
+    """Record the reconnect sequence instead of touching the network."""
+    calls: list[str] = []
+
+    async def fake_disconnect():
+        calls.append("disconnect")
+
+    async def fake_connect():
+        calls.append("connect")
+
+    service._disconnect = fake_disconnect
+    service._connect = fake_connect
+    return calls
+
+
+@pytest.mark.parametrize("field,value", [("voice", "v2"), ("model", "m2"), ("language", "es")])
+def test_session_init_field_change_starts_a_new_session(field, value):
+    # model, voice and language are only ever sent in the init message, so the
+    # session has to be rebuilt for a change to them to reach Async at all.
+    service = _service()
+    calls = _stub_reconnect(service)
+
+    asyncio.run(service._update_settings(AsyncAITTSService.Settings(**{field: value})))
+
+    assert calls == ["disconnect", "connect"], f"{field} must rebuild the session"
+
+
+def test_unchanged_settings_keep_the_session():
+    service = _service()
+    calls = _stub_reconnect(service)
+
+    asyncio.run(service._update_settings(AsyncAITTSService.Settings(voice="v1")))
+
+    assert calls == []
+
+
+def test_new_session_carries_the_updated_voice():
+    # The reconnect is only worth anything if the fresh init message actually
+    # carries the new value, so drive the real _connect_websocket and read it.
+    service = _service()
+    sent: list[str] = []
+    opened: list[int] = []
+
+    class FakeWebsocket:
+        state = None
+
+        async def send(self, msg):
+            sent.append(msg)
+
+    async def fake_websocket_connect(_uri, **_kwargs):
+        return FakeWebsocket()
+
+    async def fake_call_event_handler(*_args, **_kwargs):
+        pass
+
+    service._websocket_connect = fake_websocket_connect
+    service._call_event_handler = fake_call_event_handler
+
+    async def run():
+        await service.setup(frame_processor_setup(TaskManager()))
+        await service._connect_websocket()
+        assert json.loads(sent[-1])["voice"]["id"] == "v1", "sanity: first session uses v1"
+        before = len(sent)
+        # the real _disconnect/_connect run here, which is what re-sends init
+        await service._update_settings(AsyncAITTSService.Settings(voice="v2"))
+        opened.append(len(sent) - before)
+
+    asyncio.run(run())
+
+    assert opened == [1], "the settings change itself must open exactly one new session"
+    assert json.loads(sent[-1])["voice"]["id"] == "v2", "the new session must carry the new voice"
+
+
+def test_a_field_that_is_not_in_the_init_message_still_warns():
+    # Anything outside model/voice/language genuinely cannot be applied to a
+    # live session, so it must keep warning rather than look handled.
+    service = _service()
+    _stub_reconnect(service)
+
+    sink = io.StringIO()
+    handler_id = logger.add(sink, level="WARNING", format="{message}")
+    try:
+        asyncio.run(service._update_settings(AsyncAITTSService.Settings(extra={"pace": 1.2})))
+    finally:
+        logger.remove(handler_id)
+
+    assert "pace" in sink.getvalue()

--- a/tests/test_asyncai_tts.py
+++ b/tests/test_asyncai_tts.py
@@ -9,105 +9,125 @@
 import asyncio
 import io
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from loguru import logger
+from websockets.protocol import State
 
 from pipecat.services.asyncai.tts import AsyncAITTSService
 from pipecat.utils.asyncio.task_manager import TaskManager
 from tests.frame_processor_helpers import frame_processor_setup
 
 
-def _service(**settings) -> AsyncAITTSService:
+def _service() -> AsyncAITTSService:
     return AsyncAITTSService(
         api_key="test-key",
-        settings=AsyncAITTSService.Settings(model="m1", voice="v1", language=None, **settings),
+        settings=AsyncAITTSService.Settings(model="m1", voice="v1", language=None),
     )
 
 
-def _stub_reconnect(service: AsyncAITTSService) -> list[str]:
-    """Record the reconnect sequence instead of touching the network."""
+def _stub_reconnect(monkeypatch, service: AsyncAITTSService) -> list[str]:
+    """Record the reconnect sequence in place of the real websocket calls."""
     calls: list[str] = []
-
-    async def fake_disconnect():
-        calls.append("disconnect")
-
-    async def fake_connect():
-        calls.append("connect")
-
-    service._disconnect = fake_disconnect
-    service._connect = fake_connect
+    monkeypatch.setattr(
+        service, "_disconnect", AsyncMock(side_effect=lambda: calls.append("disconnect"))
+    )
+    monkeypatch.setattr(service, "_connect", AsyncMock(side_effect=lambda: calls.append("connect")))
     return calls
 
 
+class FakeWebsocket:
+    """Websocket that records what the service sends and never yields a message.
+
+    The receive loop reconnects on its own whenever it sees the connection
+    drop, so the iterator parks until close instead of ending: a socket that
+    stops iterating would leave the base class opening sessions of its own,
+    on top of the ones under test.
+    """
+
+    state = State.OPEN
+
+    def __init__(self, sent: list[str]):
+        self._sent = sent
+        self._closed = asyncio.Event()
+
+    async def send(self, msg: str):
+        self._sent.append(msg)
+
+    async def ping(self):
+        pass
+
+    async def close(self):
+        self._closed.set()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await self._closed.wait()
+        raise StopAsyncIteration
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("field,value", [("voice", "v2"), ("model", "m2"), ("language", "es")])
-def test_session_init_field_change_starts_a_new_session(field, value):
+async def test_session_init_field_change_starts_a_new_session(monkeypatch, field, value):
     # model, voice and language are only ever sent in the init message, so the
     # session has to be rebuilt for a change to them to reach Async at all.
     service = _service()
-    calls = _stub_reconnect(service)
+    calls = _stub_reconnect(monkeypatch, service)
 
-    asyncio.run(service._update_settings(AsyncAITTSService.Settings(**{field: value})))
+    await service._update_settings(AsyncAITTSService.Settings(**{field: value}))
 
     assert calls == ["disconnect", "connect"], f"{field} must rebuild the session"
 
 
-def test_unchanged_settings_keep_the_session():
+@pytest.mark.asyncio
+async def test_unchanged_settings_keep_the_session(monkeypatch):
     service = _service()
-    calls = _stub_reconnect(service)
+    calls = _stub_reconnect(monkeypatch, service)
 
-    asyncio.run(service._update_settings(AsyncAITTSService.Settings(voice="v1")))
+    await service._update_settings(AsyncAITTSService.Settings(voice="v1"))
 
     assert calls == []
 
 
-def test_new_session_carries_the_updated_voice():
+@pytest.mark.asyncio
+async def test_new_session_carries_the_updated_voice(monkeypatch):
     # The reconnect is only worth anything if the fresh init message actually
     # carries the new value, so drive the real _connect_websocket and read it.
     service = _service()
     sent: list[str] = []
-    opened: list[int] = []
-
-    class FakeWebsocket:
-        state = None
-
-        async def send(self, msg):
-            sent.append(msg)
 
     async def fake_websocket_connect(_uri, **_kwargs):
-        return FakeWebsocket()
+        return FakeWebsocket(sent)
 
-    async def fake_call_event_handler(*_args, **_kwargs):
-        pass
+    monkeypatch.setattr(service, "_websocket_connect", fake_websocket_connect)
 
-    service._websocket_connect = fake_websocket_connect
-    service._call_event_handler = fake_call_event_handler
-
-    async def run():
-        await service.setup(frame_processor_setup(TaskManager()))
-        await service._connect_websocket()
-        assert json.loads(sent[-1])["voice"]["id"] == "v1", "sanity: first session uses v1"
+    await service.setup(frame_processor_setup(TaskManager()))
+    try:
+        assert json.loads(sent[-1])["voice"]["id"] == "v1"
         before = len(sent)
-        # the real _disconnect/_connect run here, which is what re-sends init
+
         await service._update_settings(AsyncAITTSService.Settings(voice="v2"))
-        opened.append(len(sent) - before)
 
-    asyncio.run(run())
+        assert len(sent) - before == 1, "the settings change must open exactly one new session"
+        assert json.loads(sent[-1])["voice"]["id"] == "v2"
+    finally:
+        await service.cleanup()
 
-    assert opened == [1], "the settings change itself must open exactly one new session"
-    assert json.loads(sent[-1])["voice"]["id"] == "v2", "the new session must carry the new voice"
 
-
-def test_a_field_that_is_not_in_the_init_message_still_warns():
+@pytest.mark.asyncio
+async def test_a_field_that_is_not_in_the_init_message_still_warns(monkeypatch):
     # Anything outside model/voice/language genuinely cannot be applied to a
     # live session, so it must keep warning rather than look handled.
     service = _service()
-    _stub_reconnect(service)
+    _stub_reconnect(monkeypatch, service)
 
     sink = io.StringIO()
     handler_id = logger.add(sink, level="WARNING", format="{message}")
     try:
-        asyncio.run(service._update_settings(AsyncAITTSService.Settings(extra={"pace": 1.2})))
+        await service._update_settings(AsyncAITTSService.Settings(extra={"pace": 1.2}))
     finally:
         logger.remove(handler_id)
 


### PR DESCRIPTION
Found by reading the service, not from a bug report — so there is no issue to close.

## The problem

`AsyncAITTSService` writes `model_id`, `voice` and `language` into the init message once, in `_connect_websocket`:

```python
init_msg = {
    "model_id": self._settings.model,
    "voice": {"mode": "id", "id": self._settings.voice},
    "output_format": {...},
    "language": self._settings.language,
}
await self._get_websocket().send(json.dumps(init_msg))
```

The per-utterance message carries none of them — `_build_msg` is only `{"transcript", "context_id", "force"}`. So on a live connection those three settings are frozen at whatever they were when the socket opened.

`_update_settings` stored the delta and then called `_warn_unhandled_updated_settings(changed)`. A runtime voice change was therefore accepted into `self._settings`, logged as unsupported, and the service carried on speaking in the old voice for the rest of the session.

## The fix

Reconnect when one of the three session-init fields changes, so `_connect_websocket` writes a fresh init message from the updated settings.

`GradiumTTSService` already does exactly this for its own voice change. asyncai needs it for all three fields because all three are in its init message, so they are named in one `_SESSION_INIT_FIELDS` set rather than special-casing `voice`.

`extra` is still reported as unhandled — asyncai never sends it anywhere, so it genuinely cannot be applied to a live session and should keep warning.

`AsyncAIHttpTTSService` is deliberately untouched: it builds `voice_config` per request, so its settings already take effect on the next synthesis.

## Tests

New `tests/test_asyncai_tts.py`, 6 tests. Reverting only the `tts.py` change fails 4 of them:

```
FAILED test_session_init_field_change_starts_a_new_session[voice-v2]
FAILED test_session_init_field_change_starts_a_new_session[model-m2]
FAILED test_session_init_field_change_starts_a_new_session[language-es]
FAILED test_new_session_carries_the_updated_voice
4 failed, 2 passed
```

The last of those is the one worth reading: it stubs the websocket, captures the init messages, and asserts the settings update itself opens **exactly one** new session and that its init message carries the new voice. An earlier version of that test asserted only "more than one session was opened" and passed without the patch — the service's own reconnect machinery was masking it — so it is now written to count sessions opened by the update specifically.

The two that pass either way are deliberate guardrails: one that an unchanged value opens no session, one that a non-init field still warns.

`ruff check` and `ruff format --check` are clean, and the surrounding TTS/STT tests are 25 passed / 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
