### PR TITLE
fix(openai): scope Responses reasoning context

### DIFF
--- a/changelog/5467.fixed.md
+++ b/changelog/5467.fixed.md
@@ -1,0 +1,1 @@
+- Fixed OpenAI Responses failover sending encrypted reasoning to incompatible providers or models when services share an `LLMContext`; compatible service instances can opt into sharing with `reasoning_context_id`.

--- a/src/pipecat/adapters/services/open_ai_responses_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_responses_adapter.py
@@ -7,6 +7,7 @@
 """OpenAI Responses API adapter for Pipecat."""
 
 import copy
+import uuid
 from typing import Any, Required, TypedDict, cast
 
 from openai._types import NotGiven as OpenAINotGiven
@@ -42,10 +43,38 @@ class OpenAIResponsesLLMAdapter(BaseLLMAdapter[OpenAIResponsesLLMInvocationParam
     - Extracting and sanitizing messages from the LLM context for logging
     """
 
+    def __init__(self, *, llm_specific_message_id: str | None = None):
+        """Initialize the adapter.
+
+        Args:
+            llm_specific_message_id: Identifier used to select Responses-specific
+                messages from a shared context. Defaults to a unique identifier so
+                encrypted reasoning is only returned to this adapter instance.
+
+        Raises:
+            ValueError: If ``llm_specific_message_id`` is empty.
+        """
+        super().__init__()
+        self.id_for_llm_specific_messages = (
+            llm_specific_message_id
+            if llm_specific_message_id is not None
+            else f"openai_responses:{uuid.uuid4().hex}"
+        )
+
     @property
     def id_for_llm_specific_messages(self) -> str:
-        """Get the identifier used in LLMSpecificMessage instances."""
-        return "openai_responses"
+        """Get the identifier used in LLMSpecificMessage instances.
+
+        Returns:
+            Identifier for selecting this adapter's Responses-specific messages.
+        """
+        return self._llm_specific_message_id
+
+    @id_for_llm_specific_messages.setter
+    def id_for_llm_specific_messages(self, value: str) -> None:
+        if not value:
+            raise ValueError("llm_specific_message_id must not be empty")
+        self._llm_specific_message_id = value
 
     def get_llm_invocation_params(
         self,

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import time
+import uuid
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -226,6 +227,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
         project=None,
         default_headers: Mapping[str, str] | None = None,
         service_tier: str | None = None,
+        reasoning_context_id: str | None = None,
         settings: Settings | None = None,
         retry_timeout_secs: float | None = 5.0,
         retry_on_timeout: bool | None = False,
@@ -240,6 +242,10 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
             project: OpenAI project ID.
             default_headers: Additional HTTP headers to include in requests.
             service_tier: Service tier to use (e.g., "auto", "flex", "priority").
+            reasoning_context_id: Identifier for sharing encrypted reasoning between
+                compatible service instances. By default, reasoning is scoped to this
+                service instance and model. Use the same identifier only for services
+                whose backends can decrypt each other's reasoning payloads.
             settings: Runtime-updatable settings.
             retry_timeout_secs: How long an inference may go without producing
                 output before it is abandoned and re-issued, when
@@ -248,7 +254,14 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
                 attempt produces no output within ``retry_timeout_secs``. The
                 retry is unbounded.
             **kwargs: Additional arguments passed to the parent LLMService.
+
+        Raises:
+            ValueError: If ``reasoning_context_id`` is empty.
         """
+        if reasoning_context_id == "":
+            raise ValueError("reasoning_context_id must not be empty")
+        self._reasoning_context_id = reasoning_context_id or uuid.uuid4().hex
+
         default_settings = self.Settings(
             model="gpt-4.1",
             system_instruction=None,
@@ -273,6 +286,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
             settings=default_settings,
             **kwargs,
         )
+        self._sync_reasoning_context_id()
 
         # Resolve the API key from the environment if not provided. The
         # AsyncOpenAI HTTP client does this automatically, but the WebSocket
@@ -294,6 +308,27 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
 
         if self._settings.system_instruction:
             logger.debug(f"{self}: Using system instruction: {self._settings.system_instruction}")
+
+    def _sync_reasoning_context_id(self) -> None:
+        """Scope encrypted reasoning to this service context and model."""
+        model = assert_given(self._settings.model)
+        self.get_llm_adapter().id_for_llm_specific_messages = (
+            f"openai_responses:{self._reasoning_context_id}:{model}"
+        )
+
+    async def _update_settings(self, delta: OpenAIResponsesLLMSettings) -> dict[str, Any]:
+        """Apply settings and update the reasoning scope after a model change.
+
+        Args:
+            delta: Settings fields to update.
+
+        Returns:
+            Mapping of changed fields to their previous values.
+        """
+        changed = await super()._update_settings(delta)
+        if "model" in changed:
+            self._sync_reasoning_context_id()
+        return changed
 
     def _create_client(
         self,
@@ -603,6 +638,20 @@ class OpenAIResponsesLLMService(
         self._current_response_id: str | None = None  # ID of current non-cancelled response
         self._cancel_pending_response: bool = False
         self._needs_drain: bool = False
+
+    async def _update_settings(self, delta: OpenAIResponsesLLMSettings) -> dict[str, Any]:
+        """Apply settings and discard cached provider state after a model change.
+
+        Args:
+            delta: Settings fields to update.
+
+        Returns:
+            Mapping of changed fields to their previous values.
+        """
+        changed = await super()._update_settings(delta)
+        if "model" in changed:
+            self._clear_previous_response_state()
+        return changed
 
     # -- WebsocketLLMService interface ----------------------------------------
 

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -313,7 +313,7 @@ class _BaseOpenAIResponsesLLMService(LLMService[OpenAIResponsesLLMAdapter]):
         """Scope encrypted reasoning to this service context and model."""
         model = assert_given(self._settings.model)
         self.get_llm_adapter().id_for_llm_specific_messages = (
-            f"openai_responses:{self._reasoning_context_id}:{model}"
+            f"openai_responses:{model}:{self._reasoning_context_id}"
         )
 
     async def _update_settings(self, delta: OpenAIResponsesLLMSettings) -> dict[str, Any]:

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -64,6 +64,7 @@ For OpenAI Responses adapter:
 6. Tools schema flattening (nested function dict -> flat format)
 7. system_instruction sets instructions (or becomes developer message if input is empty)
 8. Developer messages pass through as developer role without triggering warnings
+9. Encrypted reasoning messages remain scoped to compatible adapter instances
 
 For BaseLLMAdapter helpers:
 1. _extract_initial_system: system extraction and conversion logic
@@ -2605,7 +2606,7 @@ class TestOpenAIResponsesGetLLMInvocationParams(unittest.TestCase):
         self.assertEqual(params["input"], [])
 
     def test_llm_specific_message_passthrough(self):
-        """LLMSpecificMessage with llm='openai_responses' passes through."""
+        """A message created by this Responses adapter passes through."""
         specific_msg = self.adapter.create_llm_specific_message(
             {"type": "function_call", "call_id": "x", "name": "foo", "arguments": "{}"}
         )
@@ -2667,8 +2668,41 @@ class TestOpenAIResponsesGetLLMInvocationParams(unittest.TestCase):
         self.assertNotIn("encrypted_content", params["input"][0])
 
     def test_id_for_llm_specific_messages(self):
-        """Adapter identifier is 'openai_responses'."""
-        self.assertEqual(self.adapter.id_for_llm_specific_messages, "openai_responses")
+        """Each adapter instance gets a separate message identifier."""
+        other_adapter = OpenAIResponsesLLMAdapter()
+
+        self.assertTrue(self.adapter.id_for_llm_specific_messages.startswith("openai_responses:"))
+        self.assertNotEqual(
+            self.adapter.id_for_llm_specific_messages,
+            other_adapter.id_for_llm_specific_messages,
+        )
+
+    def test_empty_llm_specific_message_id_is_rejected(self):
+        """An explicit message identifier must not be empty."""
+        with self.assertRaises(ValueError):
+            OpenAIResponsesLLMAdapter(llm_specific_message_id="")
+
+    def test_reasoning_message_does_not_cross_adapter_instances(self):
+        """Encrypted reasoning remains scoped to the adapter that created it."""
+        provider_a = OpenAIResponsesLLMAdapter()
+        provider_b = OpenAIResponsesLLMAdapter()
+        context = LLMContext(
+            messages=[
+                {"role": "user", "content": "hello"},
+                provider_a.create_llm_specific_message(
+                    {
+                        "type": "reasoning",
+                        "id": "rs_provider_a",
+                        "summary": [],
+                        "encrypted_content": "provider-a-ciphertext",
+                    }
+                ),
+            ]
+        )
+
+        provider_b_input = provider_b.get_llm_invocation_params(context)["input"]
+
+        self.assertEqual(provider_b_input, [{"role": "user", "content": "hello"}])
 
     def test_system_instruction_with_messages_sets_instructions(self):
         """When system_instruction is provided and input is non-empty, sets instructions."""

--- a/tests/test_openai_responses_http.py
+++ b/tests/test_openai_responses_http.py
@@ -43,7 +43,7 @@ from pipecat.frames.frames import (
     LLMThoughtStartFrame,
     LLMThoughtTextFrame,
 )
-from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
 from pipecat.services.openai.responses.llm import OpenAIResponsesHttpLLMService
 from pipecat.tests.utils import run_test
 
@@ -279,6 +279,98 @@ class TestHttpReasoningCapture:
             "summary": [{"type": "summary_text", "text": "Thinking..."}],
             "encrypted_content": "ENCRYPTED",
         }
+
+
+class TestReasoningContextScoping:
+    @staticmethod
+    def _service(
+        *, model: str = "gpt-5.4", reasoning_context_id: str | None = None
+    ) -> OpenAIResponsesHttpLLMService:
+        with patch.object(OpenAIResponsesHttpLLMService, "_create_client"):
+            return OpenAIResponsesHttpLLMService(
+                api_key="test-key",
+                reasoning_context_id=reasoning_context_id,
+                settings=OpenAIResponsesHttpLLMService.Settings(model=model),
+            )
+
+    @staticmethod
+    def _reasoning_message(
+        service: OpenAIResponsesHttpLLMService, item_id: str
+    ) -> LLMSpecificMessage:
+        adapter = service.get_llm_adapter()
+        return adapter.create_llm_specific_message(
+            {
+                "type": "reasoning",
+                "id": item_id,
+                "summary": [],
+                "encrypted_content": f"{item_id}-ciphertext",
+            }
+        )
+
+    @classmethod
+    def _context_with_reasoning(cls, service: OpenAIResponsesHttpLLMService) -> LLMContext:
+        return LLMContext(
+            messages=[
+                {"role": "user", "content": "hello"},
+                cls._reasoning_message(service, "rs_provider_a"),
+            ]
+        )
+
+    def test_default_scope_does_not_cross_service_instances(self):
+        provider_a = self._service()
+        provider_b = self._service()
+        context = self._context_with_reasoning(provider_a)
+        context.add_message(self._reasoning_message(provider_b, "rs_provider_b"))
+
+        provider_b_input = provider_b.get_llm_adapter().get_llm_invocation_params(context)["input"]
+        provider_a_input = provider_a.get_llm_adapter().get_llm_invocation_params(context)["input"]
+
+        assert [item.get("id") for item in provider_b_input if item.get("type") == "reasoning"] == [
+            "rs_provider_b"
+        ]
+        assert [item.get("id") for item in provider_a_input if item.get("type") == "reasoning"] == [
+            "rs_provider_a"
+        ]
+
+    def test_explicit_scope_shares_reasoning_between_compatible_services(self):
+        provider_a = self._service(reasoning_context_id="compatible-backend")
+        provider_b = self._service(reasoning_context_id="compatible-backend")
+        context = self._context_with_reasoning(provider_a)
+
+        provider_b_input = provider_b.get_llm_adapter().get_llm_invocation_params(context)["input"]
+
+        assert provider_b_input[-1]["encrypted_content"] == "rs_provider_a-ciphertext"
+
+    def test_explicit_scope_remains_model_specific(self):
+        provider_a = self._service(model="gpt-5.4", reasoning_context_id="compatible-backend")
+        provider_b = self._service(model="gpt-5.5", reasoning_context_id="compatible-backend")
+        context = self._context_with_reasoning(provider_a)
+
+        provider_b_input = provider_b.get_llm_adapter().get_llm_invocation_params(context)["input"]
+
+        assert provider_b_input == [{"role": "user", "content": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_model_switch_restores_that_models_reasoning_scope(self):
+        service = self._service(model="gpt-5.4")
+        original_id = service.get_llm_adapter().id_for_llm_specific_messages
+        context = self._context_with_reasoning(service)
+
+        await service._update_settings(service.Settings(model="gpt-5.5"))
+        updated_id = service.get_llm_adapter().id_for_llm_specific_messages
+        context.add_message(self._reasoning_message(service, "rs_model_b"))
+        model_b_input = service.get_llm_adapter().get_llm_invocation_params(context)["input"]
+        await service._update_settings(service.Settings(model="gpt-5.4"))
+        model_a_input = service.get_llm_adapter().get_llm_invocation_params(context)["input"]
+
+        assert updated_id != original_id
+        assert service.get_llm_adapter().id_for_llm_specific_messages == original_id
+        assert [item.get("id") for item in model_b_input if item.get("type") == "reasoning"] == [
+            "rs_model_b"
+        ]
+        assert [item.get("id") for item in model_a_input if item.get("type") == "reasoning"] == [
+            "rs_provider_a"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_openai_responses_http.py
+++ b/tests/test_openai_responses_http.py
@@ -363,6 +363,8 @@ class TestReasoningContextScoping:
         await service._update_settings(service.Settings(model="gpt-5.4"))
         model_a_input = service.get_llm_adapter().get_llm_invocation_params(context)["input"]
 
+        assert original_id.startswith("openai_responses:gpt-5.4:")
+        assert updated_id.startswith("openai_responses:gpt-5.5:")
         assert updated_id != original_id
         assert service.get_llm_adapter().id_for_llm_specific_messages == original_id
         assert [item.get("id") for item in model_b_input if item.get("type") == "reasoning"] == [

--- a/tests/test_openai_responses_logging.py
+++ b/tests/test_openai_responses_logging.py
@@ -65,7 +65,7 @@ def test_standard_messages_pass_through():
 def test_context_not_mutated_by_elision():
     adapter, context = _adapter_and_context()
     adapter.get_messages_for_logging(context)
-    stored = context.get_messages("openai_responses")[1]
+    stored = context.get_messages(adapter.id_for_llm_specific_messages)[1]
     assert stored.message["encrypted_content"] == REASONING_MESSAGE["encrypted_content"]
 
 

--- a/tests/test_openai_responses_websocket.py
+++ b/tests/test_openai_responses_websocket.py
@@ -281,6 +281,17 @@ class TestPreviousResponseOptimization:
         assert service._previous_input_hash is None
         assert service._previous_input_length is None
 
+    @pytest.mark.asyncio
+    async def test_model_update_clears_previous_response_state(self):
+        service = _make_service(settings=OpenAIResponsesLLMService.Settings(model="gpt-5.4"))
+        service._store_previous_response_state("resp_123", [{"role": "user", "content": "hi"}], [])
+
+        await service._update_settings(service.Settings(model="gpt-5.5"))
+
+        assert service._previous_response_id is None
+        assert service._previous_input_hash is None
+        assert service._previous_input_length is None
+
 
 # ---------------------------------------------------------------------------
 # _receive_response_events — text streaming


### PR DESCRIPTION
## Summary

- Prevent encrypted OpenAI Responses reasoning from crossing incompatible adapters, service instances, or models through a shared LLMContext.
- Add reasoning_context_id for explicitly sharing reasoning between compatible service instances while keeping model scopes separate.
- Clear WebSocket previous_response_id state when the configured model changes.

## Testing

- 279 related adapter, HTTP, WebSocket, logging, and run_inference tests passed.
- Full repository Ruff check and format check passed.

## Fixes

- Fixes #5466