### PR TITLE
fix(cli): read the Context Hub index whatever contract it declares

### DIFF
--- a/changelog/+context-hub-index-detection.fixed.md
+++ b/changelog/+context-hub-index-detection.fixed.md
@@ -1,0 +1,3 @@
+Fixed `pipecat init` repeatedly offering to build a Context Hub index that
+already exists, and the stale-index warning going quiet, when the index was
+built by a newer Context Hub than the CLI knows about.

--- a/changelog/+context-hub-index-detection.fixed.md
+++ b/changelog/+context-hub-index-detection.fixed.md
@@ -1,3 +1,0 @@
-Fixed `pipecat init` repeatedly offering to build a Context Hub index that
-already exists, and the stale-index warning going quiet, when the index was
-built by a newer Context Hub than the CLI knows about.

--- a/changelog/5468.fixed.md
+++ b/changelog/5468.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `pipecat init` repeatedly offering to build a Context Hub index that already exists, and the stale-index warning never appearing, on any index refreshed by Context Hub v0.5.3 or later. A future hub release can no longer silence these checks.

--- a/src/pipecat/cli/commands/init.py
+++ b/src/pipecat/cli/commands/init.py
@@ -382,10 +382,9 @@ def _offer_context_hub_index() -> None:
     leaves the MCP server dead and the agent relying on it having read AGENTS.md, which
     is a weaker path than tools it can always see.
     """
-    from pipecat.cli.hub_status import read_hub_metadata
+    from pipecat.cli.hub_status import index_is_built
 
-    metadata = read_hub_metadata()
-    if metadata and metadata.get("last_refresh_at"):
+    if index_is_built():
         return
 
     build_now = False

--- a/src/pipecat/cli/hub_status.py
+++ b/src/pipecat/cli/hub_status.py
@@ -20,6 +20,13 @@ directly is sub-millisecond and needs nothing outside the standard library.
 
 Every function here answers "unknown" rather than raising. A freshness hint must
 never break the command a user actually asked for.
+
+The contract carries a ``metadata_contract_version``, and its docs tell consumers
+to go silent on a value they don't recognise. This module doesn't: every question
+it asks has the same harmless remedy — run ``refresh`` — and going quiet on every
+hub bump would cost more than an occasionally stale hint. Each value is validated
+on its own instead, so a key that is missing, renamed, or unparseable yields
+silence whatever the contract number says.
 """
 
 import os
@@ -27,11 +34,6 @@ import re
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-
-# Highest metadata contract version this reader understands. A higher value in
-# the index means a newer hub changed the table's shape or a key's meaning, so
-# we stay silent rather than guess.
-_SUPPORTED_CONTRACT_VERSION = 1
 
 # Matches the hub's own default and env var, so tuning the threshold moves both
 # surfaces together rather than leaving them to disagree.
@@ -51,6 +53,10 @@ _VERSION_RE = re.compile(r"^(\d+)\.(\d+)")
 # `pipecat_ai-<version>.dist-info` in a project's virtualenv.
 _DIST_INFO_RE = re.compile(r"^pipecat_ai-(.+?)\.dist-info$")
 
+# How far into the future a recorded refresh may sit before the timestamp is
+# treated as unusable rather than as a clock that runs slightly fast.
+_CLOCK_SKEW_TOLERANCE_DAYS = 1.0
+
 
 def _enabled() -> bool:
     """False when the user has switched the check off."""
@@ -68,7 +74,7 @@ def _data_dir() -> Path:
 
 
 def read_hub_metadata() -> dict[str, str] | None:
-    """Read the hub's index metadata, or None when it can't be read.
+    """Every key in the hub's metadata table, or None when it can't be read.
 
     Opens read-only with no lock wait. The database is WAL, so this neither
     blocks nor is blocked by a concurrent refresh or a running MCP server, and
@@ -87,13 +93,18 @@ def read_hub_metadata() -> dict[str, str] | None:
         # Unreadable, locked, mid-first-build, on a filesystem without WAL, or
         # written by a hub whose schema predates the table. All mean "unknown".
         return None
-    metadata = {str(key): str(value) for key, value in rows}
-    try:
-        if int(metadata.get("metadata_contract_version", 0)) > _SUPPORTED_CONTRACT_VERSION:
-            return None
-    except ValueError:
-        return None
-    return metadata
+    return {str(key): str(value) for key, value in rows}
+
+
+def index_is_built() -> bool:
+    """Whether a completed index refresh exists on this machine.
+
+    The signal ``pipecat init`` needs before offering to build one: an index
+    cannot exist unless someone ran ``refresh``, so having one means this has
+    already been dealt with, here or in another project.
+    """
+    metadata = read_hub_metadata()
+    return bool(metadata and metadata.get("last_refresh_at"))
 
 
 def _stale_after_days() -> float:
@@ -123,7 +134,13 @@ def _index_age_days(metadata: dict[str, str]) -> float | None:
         return None
     if refreshed.tzinfo is None:
         refreshed = refreshed.replace(tzinfo=UTC)
-    return (datetime.now(UTC) - refreshed).total_seconds() / 86400
+    age = (datetime.now(UTC) - refreshed).total_seconds() / 86400
+    if age < -_CLOCK_SKEW_TOLERANCE_DAYS:
+        # Far enough ahead to be a broken clock rather than skew. Believing it
+        # would call a stale index fresh for as long as the timestamp holds.
+        return None
+    # Mild skew: the refresh effectively just happened.
+    return max(age, 0.0)
 
 
 def _major_minor(version: str) -> tuple[int, int] | None:
@@ -188,7 +205,8 @@ def freshness_warning(cwd: Path | None = None) -> str | None:
     threshold = _stale_after_days()
     age = _index_age_days(metadata)
     if age is None:
-        # An index whose refresh never completed. Reporting an age would be a
+        # No usable refresh timestamp: either no refresh ever completed, or the
+        # one recorded isn't a time worth trusting. Reporting an age would be a
         # lie, and calling it stale would be the wrong instruction.
         return (
             "Pipecat Context Hub index looks unbuilt — run `pipecat context-hub refresh` "

--- a/tests/cli/test_hub_status.py
+++ b/tests/cli/test_hub_status.py
@@ -5,7 +5,10 @@ every CLI command, so a bad index, a locked database, or an odd project layout
 must never break the command the user actually asked for.
 
 Fixtures build a real SQLite database rather than mocking the reader, so the
-tests exercise the same contract an installed hub publishes.
+tests exercise the same contract an installed hub publishes. That includes
+indexes stamped with a contract version this reader has never heard of: the
+checks here are validated per value rather than gated on the contract number,
+and must keep working across a hub that bumps it.
 """
 
 import sqlite3
@@ -15,6 +18,7 @@ import pytest
 
 from pipecat.cli.hub_status import (
     freshness_warning,
+    index_is_built,
     project_pipecat_version,
     read_hub_metadata,
 )
@@ -85,14 +89,31 @@ class TestReadHubMetadata:
         sqlite3.connect(data_dir / "metadata.db").close()
         assert read_hub_metadata() is None
 
-    def test_newer_contract_version_is_ignored(self, tmp_path):
-        """A hub that changed the contract must not be second-guessed."""
-        _write_index(tmp_path, metadata_contract_version=99, last_refresh_at=_ago(1))
-        assert read_hub_metadata() is None
-
-    def test_current_contract_version_is_accepted(self, tmp_path):
-        _write_index(tmp_path, metadata_contract_version=1, last_refresh_at=_ago(1))
+    @pytest.mark.parametrize("version", [None, 1, 2, 99])
+    def test_any_contract_version_is_read(self, tmp_path, version):
+        """A hub bump must not silence a check whose keys still parse."""
+        extra = {} if version is None else {"metadata_contract_version": version}
+        _write_index(tmp_path, last_refresh_at=_ago(1), **extra)
         assert read_hub_metadata() is not None
+
+
+class TestIndexIsBuilt:
+    """`init` asks this before offering a multi-minute, ~900 MB rebuild."""
+
+    def test_no_index(self):
+        assert index_is_built() is False
+
+    def test_a_completed_refresh(self, tmp_path):
+        _write_index(tmp_path, metadata_contract_version=2, last_refresh_at=_ago(1))
+        assert index_is_built() is True
+
+    def test_an_index_from_a_newer_hub(self, tmp_path):
+        _write_index(tmp_path, metadata_contract_version=99, last_refresh_at=_ago(1))
+        assert index_is_built() is True
+
+    def test_metadata_without_a_completed_refresh(self, tmp_path):
+        _write_index(tmp_path, metadata_contract_version=2)
+        assert index_is_built() is False
 
 
 class TestStaleness:
@@ -122,9 +143,26 @@ class TestStaleness:
         monkeypatch.setenv("PIPECAT_HUB_STALE_AFTER_DAYS", "0")
         assert freshness_warning() is None
 
+    def test_a_stale_index_from_a_newer_hub_still_warns(self, tmp_path):
+        """A bumped contract must not mute staleness."""
+        _write_index(tmp_path, metadata_contract_version=99, last_refresh_at=_ago(30))
+        assert freshness_warning() is not None
+
+    def test_mild_clock_skew_reads_as_just_refreshed(self, tmp_path):
+        """A clock that runs a little fast must not produce a spurious warning."""
+        _write_index(tmp_path, last_refresh_at=_ago(-0.5))
+        assert freshness_warning() is None
+
+    def test_a_refresh_far_in_the_future_is_not_trusted(self, tmp_path):
+        """Believing it would call the index fresh for as long as the date holds."""
+        _write_index(tmp_path, last_refresh_at=_ago(-400))
+        warning = freshness_warning()
+        assert warning is not None
+        assert "unbuilt" in warning
+
     def test_index_without_a_completed_refresh(self, tmp_path):
         """Reporting an age would be a lie; 'stale' would be the wrong advice."""
-        _write_index(tmp_path, metadata_contract_version=1)
+        _write_index(tmp_path, metadata_contract_version=2)
         warning = freshness_warning()
         assert warning is not None
         assert "unbuilt" in warning

--- a/tests/cli/test_init_context_hub.py
+++ b/tests/cli/test_init_context_hub.py
@@ -13,8 +13,10 @@ must never reach this, and the index question must not return once an index exis
 """
 
 import io
+import sqlite3
 import subprocess
 
+import pytest
 from typer.testing import CliRunner
 
 from pipecat.cli.main import app
@@ -68,18 +70,47 @@ class TestCodingAgentPath:
 
 
 class TestIndexPrompt:
-    """The index build is the only expensive step, so it is the only question."""
+    """The index build is the only expensive step, so it is the only question.
 
-    def _index(self, monkeypatch, metadata):
-        monkeypatch.setattr(
-            "pipecat.cli.hub_status.read_hub_metadata", lambda: metadata, raising=False
+    These build a real index database rather than mocking the reader, so they exercise
+    the metadata contract an installed hub actually publishes.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _hub_data_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PIPECAT_HUB_DATA_DIR", str(tmp_path / "hub"))
+
+    def _index(self, tmp_path, **metadata):
+        data_dir = tmp_path / "hub"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(data_dir / "metadata.db")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS index_metadata "
+            "(key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL)"
         )
+        conn.executemany(
+            "INSERT OR REPLACE INTO index_metadata VALUES (?, ?, ?)",
+            [(k, str(v), "now") for k, v in metadata.items()],
+        )
+        conn.commit()
+        conn.close()
 
-    def test_no_question_once_an_index_exists(self, monkeypatch, capsys):
+    def test_no_question_once_an_index_exists(self, tmp_path, monkeypatch, capsys):
         """An index cannot exist unless someone ran refresh, so this is the 'been here' flag."""
         from pipecat.cli.commands.init import _offer_context_hub_index
 
-        self._index(monkeypatch, {"last_refresh_at": "2026-08-03T00:00:00+00:00"})
+        self._index(tmp_path, metadata_contract_version=2, last_refresh_at="2026-08-03T00:00:00Z")
+        monkeypatch.setattr("pipecat.cli.commands.init._is_interactive", lambda: True)
+        _offer_context_hub_index()
+        assert capsys.readouterr().out == ""
+
+    def test_an_index_from_a_newer_hub_still_counts(self, tmp_path, monkeypatch, capsys):
+        """A contract bump changes what the interpreted keys mean, never whether a
+        refresh completed — so an index from a newer hub is still an index.
+        """
+        from pipecat.cli.commands.init import _offer_context_hub_index
+
+        self._index(tmp_path, metadata_contract_version=99, last_refresh_at="2026-08-03T00:00:00Z")
         monkeypatch.setattr("pipecat.cli.commands.init._is_interactive", lambda: True)
         _offer_context_hub_index()
         assert capsys.readouterr().out == ""
@@ -87,16 +118,17 @@ class TestIndexPrompt:
     def test_non_interactive_prints_the_command_instead_of_asking(self, monkeypatch, capsys):
         from pipecat.cli.commands.init import _offer_context_hub_index
 
-        self._index(monkeypatch, None)
         monkeypatch.setattr("pipecat.cli.commands.init._is_interactive", lambda: False)
         _offer_context_hub_index()
         assert "pipecat context-hub refresh" in capsys.readouterr().out
 
-    def test_an_index_without_a_completed_refresh_still_prompts(self, monkeypatch, capsys):
+    def test_an_index_without_a_completed_refresh_still_prompts(
+        self, tmp_path, monkeypatch, capsys
+    ):
         """Metadata can exist before any refresh finished; that is not a built index."""
         from pipecat.cli.commands.init import _offer_context_hub_index
 
-        self._index(monkeypatch, {"metadata_contract_version": "1"})
+        self._index(tmp_path, metadata_contract_version=2)
         monkeypatch.setattr("pipecat.cli.commands.init._is_interactive", lambda: False)
         _offer_context_hub_index()
         assert "pipecat context-hub refresh" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Fixes `pipecat init` repeatedly offering to build a Context Hub index that already exists, and the stale-index warning never firing, on any index refreshed by Context Hub v0.5.3 or later.
- The hub stamps a `metadata_contract_version` into its index and bumps it whenever a documented key changes meaning. v0.5.3 moved it to `2`, and that is the floor `pipecat-ai[cli]` pins, so a current hub writes it on every refresh. The CLI's reader understood only `1` and, per the contract's own guidance, returned "unknown" above that — which `init` read as "no index exists" before offering a multi-minute, ~900 MB rebuild. `freshness_warning()` went through the same reader, so the stale-index notice had stopped appearing too.
- The checks now validate each value they read instead of gating on the contract number, so a future bump cannot mute them. A key that is missing, renamed, or unparseable already yields silence, leaving only a key that still parses under a new meaning — narrow cover for the price of muting every check on every bump. All three checks here resolve to the same harmless remedy, run `refresh`.
- `index_is_built()` gives `init` its one signal. `_index_age_days()` is bounded against a clock that runs fast: mild skew reads as a just-completed refresh, a date far ahead as no usable timestamp.
- The departure from the hub contract's "stay silent on an unknown version" guidance is recorded in the module docstring so it is not reinstated by accident. No changes are needed in `pipecat-context-hub`.

## Testing

```
uv run pytest tests/cli
```

Fixtures build real index databases rather than mocking the reader, covering contract versions 1, 2, 99 and absent, an index with no completed refresh, and both sides of the clock-skew bound.