### PR TITLE
ci(docs): make update-docs a shared skill with per-repo profiles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,7 @@
         "./.claude/skills/pr-submit",
         "./.claude/skills/prose-review",
         "./.claude/skills/provider-watch",
+        "./.claude/skills/squash-commits",
         "./.claude/skills/update-docs"
       ]
     }

--- a/.claude/skills/update-docs/PROFILE_CONTRACT.md
+++ b/.claude/skills/update-docs/PROFILE_CONTRACT.md
@@ -1,0 +1,80 @@
+# update-docs — writing a profile for a repo
+
+`SKILL.md` in this directory is the canonical, repo-agnostic instruction set for
+the `update-docs` automation. It is published by the `pipecat-dev-skills`
+marketplace and shared by every repository whose changes feed `pipecat-ai/docs`.
+
+It lives in one place because it previously did not. Copies in two repos drifted
+to 390 and 117 lines, the smaller missing every rule added after it was copied.
+With four more repos to onboard, per-repo copies would mean six places to fix
+each future change.
+
+## What each repo provides
+
+The skill supplies the workflow. Each documented repo supplies a **profile** at
+`.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` — everything the skill looks
+up but cannot know.
+
+```
+consuming repo (e.g. pipecat-cloud)        pipecat
+├── .github/workflows/update-docs.yml      └── .claude/skills/update-docs/
+└── .claude/skills/update-docs/                ├── SKILL.md              ← shared
+    └── SOURCE_DOC_MAPPING.md                  ├── PROFILE_CONTRACT.md   ← this file
+        ↑ repo-specific                        └── SOURCE_DOC_MAPPING.md ← pipecat's own profile
+```
+
+Locally, installing the plugin makes `/update-docs` work in any repo that has a
+profile. In CI, a workflow that does not already have this repo checked out
+fetches just the skill:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    repository: pipecat-ai/pipecat
+    sparse-checkout: .claude/skills/update-docs
+    path: _skill
+    fetch-depth: 1
+```
+
+## Required sections
+
+`SKILL.md` reads these by name. A profile missing one leaves the corresponding
+step with nothing to apply, so write all of them.
+
+| Section | What it defines | Used by |
+| --- | --- | --- |
+| **Scope** | Source roots in scope, and what to exclude within them. State exclusions, not an allowlist, so new directories are covered on the day they appear. | Step 3 |
+| **Skip list** | The few genuinely internal files that trigger no doc update. Being a base class or "core architecture" does not qualify. | Step 4.1 |
+| **Base classes** | Files whose changes affect many pages, each mapped to *every* page to check. | Step 4.2 |
+| **Non-standard locations** | Files whose page can't be derived by pattern. | Step 4.3 |
+| **Patterns** | Source path → doc path rules covering the bulk of the repo. | Step 4.4 |
+| **Search** | What symbol to grep for when the tables come up empty. | Step 4.5 |
+| **Section vocabulary** | The sections this repo's pages use, and what each is built from. | Step 5 |
+| **Guide directories** | Doc directories holding prose that cites this repo's API. | Step 7 |
+| **New pages** | Page template, destination path, and *every* registration step — navigation plus any index or support-matrix page. | Step 8 |
+
+## Writing one
+
+Start from the profile of whichever repo is closest in shape, then work through
+the table above. Two things are worth doing before trusting it:
+
+1. **Resolve backwards.** For a sample of doc pages, ask which source file the
+   profile would map to them. A page no rule reaches is a page the automation
+   will never update.
+2. **Run it on a merged PR.** `workflow_dispatch` accepts a PR number, so a
+   known-good change from last month is a free test with a reviewable diff.
+
+The test for the Skip list is not "is this internal architecture" but **"can
+someone change or observe this without subclassing it?"** If yes, it has a page
+somewhere and belongs in a mapping table.
+
+## Changing the shared skill
+
+An edit to `SKILL.md` changes behavior for every consuming repo at once — that
+is the point, and the risk. Prefer changes that make a rule clearer over ones
+that add a rule, and when guidance is only needed by one repo, put it in that
+repo's profile instead.
+
+`SKILL.md` also encodes conventions owned by `pipecat-ai/docs` — the `llms.txt`
+regeneration ordering, the frontmatter length bands, `docs.json` structure. When
+those change there, this file has to follow.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -5,6 +5,16 @@ description: Update documentation pages to match source code changes on the curr
 
 Update documentation pages to reflect source code changes on the current branch. Analyzes the diff against main, maps changed source files to their corresponding doc pages, and makes targeted edits.
 
+This skill is repo-agnostic and shared. It is published by the
+`pipecat-dev-skills` marketplace and used by every repository whose changes feed
+`pipecat-ai/docs`, so it must stay free of anything specific to one of them.
+
+Everything repo-specific — what is in scope, how files map to pages, what a new
+page looks like, where it gets registered — comes from that repo's **profile**,
+`.claude/skills/update-docs/SOURCE_DOC_MAPPING.md`, which lives in the repo
+being documented. The skill never hardcodes a source path, a page template, or a
+navigation group. See `PROFILE_CONTRACT.md` for what a profile must provide.
+
 ## Arguments
 
 ```
@@ -20,15 +30,21 @@ Examples:
 
 ## Instructions
 
-### Step 1: Resolve docs path
+### Step 1: Resolve docs path and profile
 
 If `DOCS_PATH` was provided as an argument, use it. Otherwise, ask the user for the path to their docs repository.
 
-Verify the path exists and contains `api-reference/server/services/` subdirectory.
+Verify the path exists and contains `docs.json`.
+
+Read the profile at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` in the
+**source** repository. It defines this repo's scope, mapping tables, page
+template, and registration steps. If it is missing, stop and say so — without it
+there is no way to resolve a file to a page, and guessing produces edits to
+pages that don't exist.
 
 ### Step 2: Create docs branch
 
-Get the current pipecat branch name:
+Get the current source branch name:
 
 ```bash
 git rev-parse --abbrev-ref HEAD
@@ -40,7 +56,7 @@ In the docs repo, create a new branch off main with a matching name:
 cd DOCS_PATH && git checkout main && git pull && git checkout -b {branch-name}-docs
 ```
 
-For example, if the pipecat branch is `feat/new-service`, the docs branch becomes `feat/new-service-docs`.
+For example, if the source branch is `feat/new-service`, the docs branch becomes `feat/new-service-docs`.
 
 All doc edits in subsequent steps are made on this branch.
 
@@ -52,21 +68,19 @@ Run:
 git diff main..HEAD --name-only
 ```
 
-Every `.py` file under `src/pipecat/` is in scope. The package ships public API
-well beyond the per-provider service files — frames, workers, the bus, the eval
-harness, the CLI, the runner, and the service base classes are all documented
-somewhere on the site.
+Every source file under the roots the profile's **Scope** section names is in
+scope. Repos ship public API well beyond their most obvious entry points, so
+scope is defined as exclusions rather than an allowlist: a new directory is
+covered the day it appears rather than when someone remembers to list it.
 
-Exclude only:
+Exclude what the profile's Scope section excludes, plus build and cache
+artifacts (`__pycache__/`, `*.pyc`, `node_modules/`, `dist/`) and re-export-only
+index files that define nothing themselves.
 
-- `src/pipecat/tests/**` (test helpers)
-- `__pycache__/`, `*.pyc`, `py.typed`
-- `__init__.py` files that only re-export names defined elsewhere
-
-Changes outside `src/pipecat/` — examples, CI config, the docs directory — don't
+Changes outside those roots — examples, CI config, the docs directory — don't
 trigger doc updates on their own.
 
-Then apply the mapping file's Skip list (Step 4), which names the small set of
+Then apply the profile's Skip list (Step 4), which names the small set of
 genuinely internal files. Don't invent further reasons to drop a file here: being
 a base class, a shared module, or "core architecture" is not one. Public
 constructor parameters and observable behavior get documented wherever they live,
@@ -75,13 +89,15 @@ than disappear.
 
 ### Step 4: Map source files to doc pages
 
-For each changed source file, resolve the doc page to edit. Read the mapping file at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md` and apply this resolution order. **Confirm every candidate path exists in `DOCS_PATH` before using it.**
+For each changed source file, resolve the doc page to edit using the profile's
+tables, in this order. **Confirm every candidate path exists in `DOCS_PATH`
+before using it.**
 
 1. **Skip list** — if the file matches the skip list, stop. It triggers no doc update.
-2. **Base classes** — if the file is in the base-classes table, use every page it lists. A change here affects the services that inherit it, so check each page rather than stopping at the first.
+2. **Base classes** — if the file is in the base-classes table, use every page it lists. A change here affects everything that inherits it, so check each page rather than stopping at the first.
 3. **Non-standard locations** — if the file is in the non-standard table, use that entry as the candidate path and confirm it exists.
 4. **Pattern match** — apply the pattern table to get a candidate path, then confirm the `.mdx` file exists (glob/`ls` it under `DOCS_PATH`). If it exists, use it.
-5. **Search** — if no candidate from steps 2–4 exists on disk, grep `DOCS_PATH` for the file's main class name (see the mapping file's Search section).
+5. **Search** — if no candidate from steps 2–4 exists on disk, grep `DOCS_PATH` for the file's main class or exported symbol name (see the profile's Search section).
 6. **Unmapped** — if nothing resolves, treat the file as unmapped and report it in Step 8.
 
 Never edit a path you haven't confirmed exists. If a candidate path doesn't resolve, fall through to the search step.
@@ -98,13 +114,16 @@ For each mapped pair:
 2. **Read the diff** for that file: `git diff main..HEAD -- <source_file>`
 3. **Read the current doc page** in full
 
-Identify what changed by comparing source to docs:
+Identify what changed by comparing source to docs. The profile's **Section
+vocabulary** names the sections this repo's pages use and what each is built
+from; check each one that applies:
 
-- **Constructor parameters**: Compare `__init__` signature to the Configuration section's `<ParamField>` entries
-- **InputParams fields**: Compare `InputParams(BaseModel)` class fields to the InputParams table
-- **Event handlers**: Compare `_register_event_handler` calls and event handler definitions to Event Handlers section
-- **Class names / imports**: Check if Usage examples reference correct names
-- **Behavioral changes**: Check if Notes section needs updating
+- **Constructor / initializer parameters**: compare the signature to the Configuration section's `<ParamField>` entries
+- **Options or settings objects**: compare the declared fields to the page's table for them
+- **Event handlers**: compare registered events and handler signatures to the Event Handlers section
+- **Class names / imports**: check that Usage examples reference correct names
+- **Behavioral changes**: check whether the Notes section needs updating
+- **Command-line surface**, where the repo ships one: compare flags, arguments, defaults, and exit behavior to the command reference
 
 ### Step 6: Make targeted edits
 
@@ -119,6 +138,29 @@ For each doc page that needs updates, edit **only the sections that need changes
 - **Preserve CardGroup, links, and examples** unless they reference removed functionality
 - **Don't touch frontmatter** unless the class was renamed
 
+#### Proportionality
+
+Match the size of the doc change to the size of the source change. A changed
+default is a changed default: edit the value and, if it needs one, the clause
+beside it. A two-line source change should not produce a paragraph. When a diff
+suggests more prose than the change warrants, that prose is usually explaining
+the change rather than the API.
+
+Add a note only when the behavior would surprise **a reader who has never seen
+the previous behavior**. Judge it with the diff covered up: if the note only
+makes sense as an explanation of what changed, it belongs in the changelog, not
+here.
+
+A behavior change is not by itself a reason to add a note. The question is
+whether the _new_ behavior needs explaining on its own terms. A default that
+moved from `True` to `None` needs the default updated; it needs a note only if
+`None` is confusing to someone meeting it for the first time — and then the note
+explains `None`, not the move.
+
+Do not add a `<Note>`, `<Warning>`, or `<Tip>` for a change that fits in the
+sentence that is already there. Callouts are for behavior a reader would
+otherwise get wrong, not for drawing attention to what a PR happened to touch.
+
 #### Section-specific guidance
 
 **Configuration** (constructor params):
@@ -128,10 +170,10 @@ For each doc page that needs updates, edit **only the sections that need changes
 - Remove params that no longer exist in source
 - Update types/defaults that changed
 
-**InputParams** (runtime settings):
+**Options / settings objects** (runtime settings):
 
-- Use markdown table format: `| Parameter | Type | Default | Description |`
-- Match the field names and types from the `InputParams(BaseModel)` class
+- Use whichever form the page already uses — a markdown table or `<ParamField>` entries
+- Match the field names and types from the declaring class
 - Include the default values from the source
 
 **Usage** (code examples):
@@ -154,17 +196,32 @@ For each doc page that needs updates, edit **only the sections that need changes
 
 **Overview / Key Features / Prerequisites**:
 
-- Only update if the PR fundamentally changes what the service does (new capability, removed capability, renamed class)
+- Only update if the PR fundamentally changes what the thing does (new capability, removed capability, renamed class)
 - Most PRs will NOT need changes to these sections
+
+#### Deprecations
+
+When source marks something deprecated — a `DeprecationWarning`, a
+`@deprecated` decorator, a docstring note, or a removal version — the doc entry
+for it says so too. Mark the entry itself rather than adding a separate note
+elsewhere on the page: readers find the parameter, not the changelog.
+
+- Use the `deprecated` attribute on `<ParamField>` where the page uses ParamFields
+- State the replacement and the removal version when source names them
+- Never delete a deprecated item that still exists in source — a reader with it
+  in their code needs to find it and learn what to move to
 
 ### Step 7: Update guides
 
-Guides at `DOCS_PATH/pipecat/` and `DOCS_PATH/pipecat-flows/` reference specific class names, parameters, imports, and code patterns. After completing reference doc edits, check if any guides need updates too.
+Guides reference specific class names, parameters, imports, and code patterns.
+After completing reference doc edits, check whether any guides need updates too.
+The profile's **Guide directories** section lists the directories to search for
+this repo.
 
-For each changed source file, collect the class names, renamed parameters, and changed imports from the diff. Search the guides directory:
+For each changed source file, collect the class names, renamed parameters, and changed imports from the diff, then search those directories:
 
 ```bash
-grep -rl "ClassName\|old_param_name" DOCS_PATH/pipecat/ DOCS_PATH/pipecat-flows/
+grep -rl "ClassName\|old_param_name" DOCS_PATH/<guide dirs from profile>
 ```
 
 For each guide that references changed code:
@@ -172,134 +229,29 @@ For each guide that references changed code:
 1. Read the full guide
 2. Update class names, parameter names, import paths, and code examples that are now incorrect
 3. **Don't rewrite prose** — only fix the specific references that changed
-4. Leave guides alone if they reference the service generally but don't use any changed APIs
-
-Guide directories:
-
-- `pipecat/learn/` — conceptual tutorials (pipeline, LLM, STT, TTS, etc.)
-- `pipecat/fundamentals/` — practical how-tos (metrics, recording, transcripts, etc.)
-- `pipecat/features/` — feature-specific guides (Gemini Live, OpenAI audio, WhatsApp, etc.)
-- `pipecat/telephony/` — telephony integration guides (Twilio, Plivo, Telnyx, etc.)
-- `pipecat-flows/guides/` — Pipecat Flows guides (nodes-and-messages, functions, context-strategies, state-management, actions); check these when `src/pipecat/flows/**` changed
+4. Leave guides alone if they reference the subject generally but don't use any changed APIs
 
 ### Step 8: Identify doc gaps
 
 After processing all mapped pairs, check for two kinds of gaps:
 
-**Missing pages**: Source files that resolved to no doc page (pattern, non-standard table, and search all came up empty) and are not on the skip list. For each, tell the user:
+**Missing pages**: Source files that resolved to no doc page (pattern, non-standard table, and search all came up empty) and are not on the skip list. For each, report:
 
 - The source file path
-- The main class(es) it defines
+- The main class(es) or exported symbol(s) it defines
 - Whether a new doc page should be created
 
-**Missing sections**: Mapped doc pages that are missing standard sections compared to the source. For example, a transport page with no Configuration section, or a service page with no InputParams table when the source defines `InputParams(BaseModel)`. Flag these and offer to add the missing sections.
+**Missing sections**: Mapped doc pages missing a section the source implies —
+a page with no Configuration section for a type that takes constructor
+parameters, or no options table where the source declares a settings class.
+Flag these and offer to add them.
 
-If the user wants a new page, do all three of the following:
+If a new page is wanted, follow the profile's **New pages** section, which
+provides the page template, the destination path, and every registration step
+this repo requires (navigation, and any index or support-matrix page). Do all of
+them: a page that exists but isn't registered is invisible.
 
-#### 8a: Create the doc page
-
-Create the new `.mdx` file under `DOCS_PATH/api-reference/server/services/{category}/{provider}.mdx` using this template structure:
-
-````
----
-title: "Service Name"
-description: "Brief description"
----
-
-## Overview
-
-[Description from class docstring or source analysis]
-
-<CardGroup cols={2}>
-  [Cards for API reference and examples if available]
-</CardGroup>
-
-## Installation
-
-```bash
-uv add "pipecat-ai[package-name]"
-````
-
-## Prerequisites
-
-[Environment variables and account setup]
-
-## Configuration
-
-[ParamField entries for constructor params]
-
-## InputParams
-
-[Table of InputParams fields, if the service has them]
-
-## Usage
-
-### Basic Setup
-
-```python
-[Minimal working example]
-```
-
-## Notes
-
-[Important caveats]
-
-## Event Handlers
-
-[Event table and example code]
-
-````
-
-#### 8b: Add to docs.json
-
-Add the new page path to `DOCS_PATH/docs.json` in the correct navigation group. The path format is `api-reference/server/services/{category}/{provider}` (without the `.mdx` extension).
-
-Find the matching group in the navigation structure:
-- **STT** → `"group": "Speech-to-Text"` under Services
-- **TTS** → `"group": "Text-to-Speech"` under Services
-- **LLM** → `"group": "LLM"` under Services
-- **S2S** → `"group": "Speech-to-Speech"` under Services
-- **Transport** → `"group": "Transport"` under Services
-- **Serializer** → `"group": "Serializers"` under Services
-- **Image generation** → `"group": "Image Generation"` under Services
-- **Video** → `"group": "Video"` under Services
-- **Memory** → `"group": "Memory"` under Services
-- **Vision** → `"group": "Vision"` under Services
-- **Analytics** → `"group": "Analytics & Monitoring"` under Services
-
-Insert the new entry **alphabetically** within the group's `pages` array. For example, adding a new STT service "foo":
-```json
-{
-  "group": "Speech-to-Text",
-  "pages": [
-    "api-reference/server/services/stt/assemblyai",
-    "api-reference/server/services/stt/aws",
-    ...
-    "api-reference/server/services/stt/foo",
-    ...
-  ]
-}
-````
-
-#### 8c: Add to supported-services.mdx
-
-Add a new row to the correct category table in `DOCS_PATH/api-reference/server/services/supported-services.mdx`.
-
-Use this format:
-
-```
-| [DisplayName](/api-reference/server/services/{category}/{provider}) | `uv add "pipecat-ai[package]"` |
-```
-
-To determine the correct values:
-
-- **DisplayName**: Use the service's human-readable name (e.g., "ElevenLabs", "AWS Polly", "Google Gemini")
-- **package**: Look at the service's `pyproject.toml` extras or the import pattern in the source code. For example, if the service is in `src/pipecat/services/foo/`, the package is typically `foo`.
-- If no pip dependencies are required, use `No dependencies required` instead.
-
-Insert the new row **alphabetically** within the table. Match the column alignment of the existing rows.
-
-#### 8d: Frontmatter conventions
+#### Frontmatter conventions
 
 A new page's `title` and `description` become its `llms.txt` entry and its
 citation label in AI tools, and the docs repo's metadata lint enforces them:
@@ -343,27 +295,25 @@ After all edits are complete, print a summary:
 ## Documentation Updates
 
 ### Updated reference pages
-- `api-reference/server/services/stt/deepgram.mdx` — Updated Configuration (added `new_param`), InputParams (updated `language` default)
-- `api-reference/server/services/tts/elevenlabs.mdx` — Updated Event Handlers (added `on_connected`)
-- `api-reference/pipecat-flows/flow-manager.mdx` — Updated FlowManager constructor (added `new_param`)
+- `<page path>` — what changed, and in which section
 
 ### Updated guides
-- `pipecat/learn/speech-to-text.mdx` — Updated code example (renamed `old_param` → `new_param`)
-- `pipecat-flows/guides/state-management.mdx` — Updated FlowManager init example
+- `<guide path>` — what changed
 
-### New service pages
-- `api-reference/server/services/tts/newprovider.mdx` — Created page, added to docs.json (Text-to-Speech), added to supported-services.mdx
+### New pages
+- `<page path>` — created, plus every place it was registered
 
 ### Unmapped source files
-- `src/pipecat/services/newprovider/tts.py` — NewProviderTTSService (no doc page exists)
+- `<source path>` — ClassName (no doc page exists)
 
 ### Skipped files
-- `src/pipecat/services/ai_service.py` — internal base class
+- `<source path>` — why
 ```
 
 ## Guidelines
 
 - **Write for a future reader, not the diff** — docs describe the API as it currently stands. Never narrate the change itself: no "newly added," "this replaces," "recently changed," or references to prior behavior. A reader landing on the page should see no sign that a PR just edited it. Match the weight of the prose to the feature — a routine new parameter gets a one-line description, not a paragraph.
+- **Don't carry the changelog's reasoning into the docs** — the PR body and the changelog entry argue for a change to someone who knew the old behavior. The docs describe the current state to someone who doesn't. Those need different prose, so the changelog is a source of _facts_ here — the new default, the new name, what a parameter now does — and never a source of sentences. Copying its justification across is the most common way a small change turns into a paragraph, and it survives the rule above because a justification carries no "newly" or "previously" to strip out.
 - **Avoid LLM tells** — write plainly. Skip filler and AI-signalling phrases ("delve," "seamless," "leverage," "it is worth noting," "this underscores"), formulaic "not just X, but Y" contrasts, and overuse of em dashes or boldface. Never leave placeholder text (`[X]`, `{placeholder}`) or assistant meta ("I hope this helps") in a page — this skill runs unattended in CI, so nothing downstream will catch it.
 - **Keep code and prose in sync** — when a page names a parameter, class, or identifier, spell it in prose exactly as the source and the `<ParamField>`/table entry do. After editing a code example or renaming a param, re-read the surrounding prose for stale references.
 - **Backtick inline technical terms** — wrap parameter names, class names, filenames, env vars, and config keys in backticks when they appear in prose (Overview, Notes, descriptions). Structured elements like `<ParamField>` already format these inside tables.
@@ -372,19 +322,20 @@ After all edits are complete, print a summary:
 - **Preserve voice** — match the writing style of the existing doc page, don't impose a different tone.
 - **One PR at a time** — this skill operates on the current branch's diff against main. Don't look at other branches.
 - **Parallel analysis** — when multiple source files map to different doc pages, analyze and edit them in parallel for efficiency.
-- **Shared source files** — files like `services/google/llm.py` are shared bases. Check which services import from them and update all affected doc pages.
+- **Shared source files** — base classes and shared modules affect everything that imports them. Check which pages cover those consumers and update all of them.
 
 ## Checklist
 
 Before finishing, verify:
 
-- [ ] All changed source files were checked against the mapping table
+- [ ] The source repo's profile was read, and every changed file was checked against its tables
 - [ ] Each doc page edit matches the actual source code change (not guessed)
 - [ ] No content was removed unless the corresponding source was removed
 - [ ] New parameters have accurate types and defaults from source
+- [ ] Deprecated items are marked as deprecated rather than deleted or left unmarked
+- [ ] The edit is no larger than the change: no note or paragraph that only makes sense as an explanation of what changed
 - [ ] Formatting matches the existing page style
 - [ ] Guides referencing changed APIs were checked and updated
-- [ ] New service pages were added to `docs.json` in the correct group, alphabetically
-- [ ] New service pages were added to `supported-services.mdx` in the correct table, alphabetically
+- [ ] New pages were registered everywhere the profile requires
 - [ ] Edited pages were formatted, then `llms.txt` and `llms-full.txt` regenerated and committed
-- [ ] Unmapped files were reported to the user
+- [ ] Unmapped files were reported

--- a/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
+++ b/.claude/skills/update-docs/SOURCE_DOC_MAPPING.md
@@ -4,6 +4,23 @@ Maps pipecat source files to their documentation pages. Source paths are relativ
 
 Doc paths in this file are candidates. Confirm each exists in `DOCS_PATH` before editing it; if it doesn't exist, fall through to the Search section.
 
+## Scope
+
+Every `.py` file under `src/pipecat/` is in scope. The package ships public API
+well beyond the per-provider service files — frames, workers, the bus, the eval
+harness, the CLI, the runner, and the service base classes are all documented
+somewhere on the site.
+
+Exclude only:
+
+- `src/pipecat/tests/**` (test helpers)
+- `__pycache__/`, `*.pyc`, `py.typed`
+- `__init__.py` files that only re-export names defined elsewhere
+
+Changes outside `src/pipecat/` — examples, CI config, the docs directory — don't
+trigger doc updates on their own.
+
+
 ## Non-standard locations
 
 These source paths don't follow the standard `services/{provider}/{type}.py` → `api-reference/server/services/{type}/{provider}.mdx` pattern. Use the doc page below as the candidate path.
@@ -159,3 +176,122 @@ For files that match no pattern above, or whose candidate doesn't exist in `DOCS
 1. Extract the main class name(s) from the source file.
 2. Grep `DOCS_PATH` for that class name: `grep -rl "ClassName" DOCS_PATH/api-reference/ DOCS_PATH/pipecat/`.
 3. If a page is found, use it. If nothing is found, the file is **unmapped** — report it in SKILL.md Step 8.
+
+## Section vocabulary
+
+Service pages are built from these sections. Check each against the source when
+the corresponding construct changed:
+
+| Section | Built from | Form |
+| --- | --- | --- |
+| Configuration | the `__init__` signature | `<ParamField>` entries |
+| InputParams | the `InputParams(BaseModel)` class fields | markdown table: `\| Parameter \| Type \| Default \| Description \|` |
+| Event Handlers | `_register_event_handler` calls and handler definitions | event table plus example |
+| Usage | current class names and import paths | code block |
+| Notes | behavioral caveats | prose |
+
+**InputParams** is the one most often out of step: match the field names, types,
+and defaults to the `InputParams(BaseModel)` class rather than to the
+constructor, which usually takes the whole object.
+
+## Guide directories
+
+Prose that cites pipecat API lives in:
+
+- `pipecat/learn/` — conceptual tutorials (pipeline, LLM, STT, TTS, etc.)
+- `pipecat/fundamentals/` — practical how-tos (metrics, recording, transcripts, etc.)
+- `pipecat/features/` — feature-specific guides (Gemini Live, OpenAI audio, WhatsApp, etc.)
+- `pipecat/telephony/` — telephony integration guides (Twilio, Plivo, Telnyx, etc.)
+- `pipecat/flows/` — Pipecat Flows guides (nodes-and-messages, functions, context-strategies, state-management, actions); check these when `src/pipecat/flows/**` changed
+
+## New pages
+
+### Location and template
+
+Create the new `.mdx` file under
+`DOCS_PATH/api-reference/server/services/{category}/{provider}.mdx` using this
+structure:
+
+````
+---
+title: "Service Name"
+description: "Brief description"
+---
+
+## Overview
+
+[Description from class docstring or source analysis]
+
+<CardGroup cols={2}>
+  [Cards for API reference and examples if available]
+</CardGroup>
+
+## Installation
+
+```bash
+uv add "pipecat-ai[package-name]"
+```
+
+## Prerequisites
+
+[Environment variables and account setup]
+
+## Configuration
+
+[ParamField entries for constructor params]
+
+## InputParams
+
+[Table of InputParams fields, if the service has them]
+
+## Usage
+
+### Basic Setup
+
+```python
+[Minimal working example]
+```
+
+## Notes
+
+[Important caveats]
+
+## Event Handlers
+
+[Event table and example code]
+````
+
+### Registration — both are required
+
+A page that exists but isn't registered is invisible. Do both.
+
+**1. `docs.json` navigation.** Add the path without the `.mdx` extension, in the
+matching group under Services:
+
+| Category | Group |
+| --- | --- |
+| STT | `Speech-to-Text` |
+| TTS | `Text-to-Speech` |
+| LLM | `LLM` |
+| S2S | `Speech-to-Speech` |
+| Transport | `Transport` |
+| Serializer | `Serializers` |
+| Image generation | `Image Generation` |
+| Video | `Video` |
+| Memory | `Memory` |
+| Vision | `Vision` |
+| Analytics | `Analytics & Monitoring` |
+
+Insert **alphabetically** within the group's `pages` array.
+
+**2. `supported-services.mdx`.** Add a row to the matching category table in
+`DOCS_PATH/api-reference/server/services/supported-services.mdx`:
+
+```
+| [DisplayName](/api-reference/server/services/{category}/{provider}) | `uv add "pipecat-ai[package]"` |
+```
+
+- **DisplayName** — the human-readable name ("ElevenLabs", "AWS Polly", "Google Gemini")
+- **package** — from the service's `pyproject.toml` extras or its import pattern; a service in `src/pipecat/services/foo/` is typically `foo`. Use `No dependencies required` when it needs none.
+
+Insert **alphabetically**, matching the column alignment of existing rows.

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -109,15 +109,15 @@ jobs:
 
             ## Setup
 
-            1. Read the skill instructions at `.claude/skills/update-docs/SKILL.md`
-            2. Read the source-to-doc mapping at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md`
+            1. Read the shared skill instructions at `.claude/skills/update-docs/SKILL.md`
+            2. Read this repo's profile at `.claude/skills/update-docs/SOURCE_DOC_MAPPING.md`
             3. The docs repository is checked out at `./_docs/`
 
             ## Get the diff
 
             Run `gh pr diff ${{ steps.pr.outputs.number }}` to see what changed in the PR.
             Also run `gh pr diff ${{ steps.pr.outputs.number }} --name-only` to get the list of changed files.
-            Filter to source files matching the directories listed in SKILL.md Step 3.
+            Filter to source files matching the profile's Scope section (SKILL.md Step 3).
 
             If no relevant source files were changed, exit with "No documentation changes needed."
 


### PR DESCRIPTION
Makes `update-docs` repo-agnostic so `pipecat-cloud` and the client repos can use it, with each repo owning a profile for its own specifics.

**Reworked** from the first version, which had this backwards — it moved the skill into `pipecat-ai/docs` and left a stub here. That stub would have shipped through the marketplace, since `.claude-plugin/marketplace.json` sources skills from `./.claude/skills/*`. Anyone updating `pipecat-dev` would have got a skill whose whole content was "read a path in a repo you may not have checked out."

## Why this repo is the right home

It's already the org's shared skill distribution. `pipecat-dev-skills` publishes ten skills, and most aren't pipecat-specific:

| Skill | Scope |
|---|---|
| `cleanup`, `code-review`, `pr-description`, `pr-submit`, `squash-commits`, `prose-review` | generic — any repo |
| `changelog` | mostly generic |
| `docstring` | any Python repo, so `pipecat-cloud` too |
| `provider-watch` | pipecat-specific |
| `update-docs` | generic workflow + per-repo profile |

A `pipecat-cloud` developer wants `pr-submit` and `code-review` as much as anyone here. Nothing new needs creating, and this is the repo that actually gets maintained.

## The split

`SKILL.md` becomes repo-agnostic — verified: zero references to `src/pipecat`, `supported-services`, `api-reference/server`, `InputParams(`, or `uv add`. Of the old 390 lines, **26 were pipecat-specific**, and those move into the profile.

`SOURCE_DOC_MAPPING.md` is now pipecat's profile, gaining four sections the skill looks up but can't know:

- **Scope** — what's in scope, stated as exclusions so a new directory is covered the day it appears
- **Section vocabulary** — what each page section is built from, including that `InputParams` comes from the `InputParams(BaseModel)` class rather than the constructor, which takes the whole object. That's the one most often out of step.
- **Guide directories** — including `pipecat/flows/`, now that Flows ships in core
- **New pages** — the template plus *both* registration steps. A page in `docs.json` but missing from `supported-services.mdx` is half-registered.

`PROFILE_CONTRACT.md` is new: what a consuming repo must provide, so a profile can be written without reading the skill. The nine required sections, the two checks worth running before trusting one (resolve backwards from doc pages; replay a merged PR through `workflow_dispatch`), and the skip-list test — *"can someone change or observe this without subclassing it?"* — which is what stops public API being dropped as "internal architecture."

## How other repos consume it

With the plugin installed, `/update-docs` works in any repo that has a profile — Step 1 already tells the skill to read the local one. For CI in a repo that doesn't have this one checked out:

```yaml
- uses: actions/checkout@v4
  with:
    repository: pipecat-ai/pipecat
    sparse-checkout: .claude/skills/update-docs
    path: _skill
    fetch-depth: 1
```

That avoids depending on whether `claude-code-action` can install plugins, which I haven't verified.

pipecat's own workflow is unchanged in substance — it still reads the skill from this repo. Only the wording moved, to name the profile's Scope section.

## Also: `squash-commits` was never published

It's been in `.claude/skills/` but absent from the manifest, so invisible to anyone installing the plugin. Added.

Worth knowing separately: the copy installed on my machine is pinned to `6189e920` from May and predates `prose-review`, `provider-watch`, and `squash-commits` entirely. A `/plugin update` is wanted before judging current behavior.

## Supersedes #5470

Its proportionality rules are here, including the two specifics my first extraction lacked: the *judge it with the diff covered up* test, and the `True`→`None` example. #5470 can be closed rather than merged.

`pipecat-ai/docs#1181` should also be closed — it added those same rules to the docs-repo copy, which this design doesn't use. `docs#1180` gets reverted in a follow-up.

## Verification

Workflow parses as valid YAML (12 steps, "Checkout docs" still before "Update documentation"); manifest is valid JSON; profile satisfies all nine contract sections; generic skill is clean of pipecat specifics.

Not run end to end. `workflow_dispatch` against this branch with a known-good merged PR is the test, and it opens a real docs PR — happy to run it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)