### PR TITLE
feat(cartesia): default to sonic-3.6

### DIFF
--- a/changelog/5472.changed.md
+++ b/changelog/5472.changed.md
@@ -1,0 +1,1 @@
+- `CartesiaTTSService` and `CartesiaHttpTTSService` now default to `sonic-3.6`, Cartesia's current Sonic model. Pass `model="sonic-3.5"` to stay on the previous default.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -59,7 +59,7 @@ class GenerationConfig(BaseModel):
     """Configuration for Cartesia generation parameters.
 
     Cartesia interprets these parameters as guidance to ensure natural speech.
-    Test against your content for best results. Applicable to sonic-3 and sonic-3.5 models.
+    Test against your content for best results. Applicable to sonic-3 series models.
 
     Parameters:
         volume: Volume multiplier for generated speech. Valid range: [0.5, 2.0]. Default is 1.0.
@@ -326,7 +326,7 @@ class CartesiaTTSService(WebsocketTTSService):
 
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="sonic-3.5",
+            model="sonic-3.6",
             voice=None,
             language=Language.EN,
             generation_config=None,
@@ -867,7 +867,7 @@ class CartesiaHttpTTSService(TTSService):
         """
         # 1. Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="sonic-3.5",
+            model="sonic-3.6",
             voice=None,
             language=Language.EN,
             generation_config=None,


### PR DESCRIPTION
## Summary

- `CartesiaTTSService` and `CartesiaHttpTTSService` default to `sonic-3.6`, Cartesia's current Sonic model.
- The `GenerationConfig` docstring now describes its parameters as applying to the sonic-3 series rather than naming individual versions.

## Breaking Changes

- Bots that relied on the default model now run on `sonic-3.6`. Pass `model="sonic-3.5"` to pin the previous default.