### PR TITLE
Forward cancellable_by_llm through LLMSwitcher

### DIFF
--- a/changelog/5474.added.md
+++ b/changelog/5474.added.md
@@ -1,0 +1,1 @@
+- Added a `cancellable_by_llm` argument to `LLMSwitcher.register_function()`, which forwards it to every LLM the switcher fronts. Tools registered through a switcher can now opt into LLM-side cancellation, matching what `LLMService.register_function()` accepts.

--- a/src/pipecat/pipeline/llm_switcher.py
+++ b/src/pipecat/pipeline/llm_switcher.py
@@ -112,6 +112,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
         *,
         cancel_on_interruption: bool | None = None,
         timeout_secs: float | None = None,
+        cancellable_by_llm: bool | None = None,
     ):
         """Register a function handler for LLM function calls, on all LLMs, active or not.
 
@@ -124,6 +125,10 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
                 interruption occurs. Defaults to ``None`` (fall back to the
                 ``@tool_options`` decorator value on the handler, then to True).
             timeout_secs: Optional timeout in seconds for the function call.
+            cancellable_by_llm: Whether the LLM may cancel this call while it runs,
+                through the ``cancel_<name>`` tool advertised alongside it. Pair it
+                with ``cancel_on_interruption=False``. Defaults to ``None`` (fall
+                back to the ``@tool_options`` decorator value, then to False).
         """
         for llm in self.llms:
             llm.register_function(
@@ -131,6 +136,7 @@ class LLMSwitcher(ServiceSwitcher[StrategyType]):
                 handler=handler,
                 cancel_on_interruption=cancel_on_interruption,
                 timeout_secs=timeout_secs,
+                cancellable_by_llm=cancellable_by_llm,
             )
 
     @deprecated(


### PR DESCRIPTION
## Summary

- `LLMSwitcher.register_function()` accepts `cancellable_by_llm` and forwards it to every LLM the switcher fronts, alongside `cancel_on_interruption` and `timeout_secs`
- Tools registered through a switcher can opt into LLM-side cancellation without calling `register_function()` on each service individually
- Option resolution (explicit argument > `@tool_options` decorator > default) stays in `LLMService`, so `None` continues to mean "not provided"

The deprecated `register_direct_function()` is unchanged; `LLMService.register_direct_function()` does not expose this option either.

## Testing

`uv run pytest tests/test_llm_switcher.py`