### PR TITLE
Log provider request ID on STT connection

### DIFF
--- a/changelog/5475.other.md
+++ b/changelog/5475.other.md
@@ -1,0 +1,1 @@
+- `CartesiaSTTService`, `DeepgramFluxSTTService`, and `DeepgramFluxSageMakerSTTService` now log the provider's request ID when the connection is established, so a session can be traced in provider-side diagnostics.

--- a/src/pipecat/services/cartesia/stt.py
+++ b/src/pipecat/services/cartesia/stt.py
@@ -424,6 +424,10 @@ class CartesiaSTTService(WebsocketSTTService):
             }
 
             self._websocket = await self._websocket_connect(ws_url, additional_headers=headers)
+            request_id = None
+            if self._websocket and self._websocket.response:
+                request_id = self._websocket.response.headers.get("X-Request-ID")
+            logger.info(f"{self}: Connected to Cartesia STT ({request_id=})")
             await self._call_event_handler("on_connected")
         except Exception as e:
             self._websocket = None

--- a/src/pipecat/services/deepgram/flux/stt_base.py
+++ b/src/pipecat/services/deepgram/flux/stt_base.py
@@ -586,7 +586,7 @@ class DeepgramFluxSTTBase(STTService):
 
         match flux_message_type:
             case FluxMessageType.RECEIVE_CONNECTED:
-                await self._handle_connection_established()
+                await self._handle_connection_established(data)
             case FluxMessageType.RECEIVE_FATAL_ERROR:
                 await self._handle_fatal_error(data)
             case FluxMessageType.TURN_INFO:
@@ -602,13 +602,14 @@ class DeepgramFluxSTTBase(STTService):
                 await self._on_configure_acked()
                 await self.push_error(error_msg=error_msg)
 
-    async def _handle_connection_established(self):
+    async def _handle_connection_established(self, data: dict[str, Any]):
         """Handle successful connection establishment to Deepgram Flux.
 
         This event is fired when the connection to Deepgram Flux is successfully
         established and ready to receive audio data for transcription processing.
         """
-        logger.info("Connected to Flux - ready to stream audio")
+        request_id = data.get("request_id")
+        logger.info(f"{self}: Connected to Flux - ready to stream audio ({request_id=})")
         # Notify connection is established
         self._connection_established_event.set()
 


### PR DESCRIPTION
## Summary

Logs the provider-side request ID when an STT websocket connects, so a session can be traced in provider diagnostics from the bot's own logs.

- `CartesiaSTTService` reads it from the `X-Request-ID` response header on the websocket handshake.
- `DeepgramFluxSTTBase` reads it from the `request_id` field of the `Connected` message, which is now passed through to `_handle_connection_established()`.

## Test plan

- `uv run ruff check` / `uv run ruff format --check` pass.
- Connecting each service logs the ID alongside the existing connection message.