### PR TITLE
fix(deepgram-flux): reconnect for connection-only settings and surface FatalError details

### DIFF
--- a/changelog/5477.fixed.1.md
+++ b/changelog/5477.fixed.1.md
@@ -1,0 +1,1 @@
+- Deepgram Flux STT now applies a `model` or `numerals` update by reconnecting, since Flux reads those only from the connection URL. The reconnect waits until the user stops speaking, and settings Flux accepts on a live connection (`keyterm`, `eot_threshold`, `eager_eot_threshold`, `eot_timeout_ms`, `language_hints`) are still sent without dropping it.

--- a/changelog/5477.fixed.2.md
+++ b/changelog/5477.fixed.2.md
@@ -1,0 +1,1 @@
+- A Deepgram Flux `FatalError` now reports the code and description Flux sends, instead of a generic `Unknown error`.

--- a/src/pipecat/services/deepgram/flux/stt_base.py
+++ b/src/pipecat/services/deepgram/flux/stt_base.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from loguru import logger
+from typing_extensions import override
 
 from pipecat.frames.frames import (
     CancelFrame,
@@ -160,6 +161,10 @@ class DeepgramFluxSTTBase(STTService):
         "eot_timeout_ms",
         "language_hints",
     }
+    # Fields Flux only accepts in the connection URL, so changing them reconnects.
+    _CONNECTION_FIELDS = {"model", "numerals"}
+    # Fields applied to results as they arrive, so no connection change is needed.
+    _LOCAL_FIELDS = {"min_confidence"}
     _MULTILINGUAL_MODEL = "flux-general-multi"
     # How long an in-flight Configure is trusted before a new update supersedes
     # it outright. Flux caps the number of un-acked Configure messages, so at
@@ -284,6 +289,15 @@ class DeepgramFluxSTTBase(STTService):
     # ------------------------------------------------------------------
     # Connection helpers
     # ------------------------------------------------------------------
+
+    @override
+    async def _do_reconnect(self):
+        """Tear down the transport connection and re-establish it.
+
+        Called by ``STTService._reconnect()`` inside the reconnecting guard.
+        """
+        await self._disconnect()
+        await self._connect()
 
     def _build_query_string(self) -> str:
         """Build query string from current settings and init-only connection config."""
@@ -523,8 +537,8 @@ class DeepgramFluxSTTBase(STTService):
 
         Configure-able fields (keyterm, eot_threshold, eager_eot_threshold,
         eot_timeout_ms, language_hints) are sent to Deepgram via a Configure
-        message. Other fields are stored but cannot be applied to the active
-        connection.
+        message. Fields Flux only reads from the connection URL trigger a
+        reconnect, which waits until the user stops speaking.
         """
         changed = await super()._update_settings(delta)
 
@@ -535,7 +549,12 @@ class DeepgramFluxSTTBase(STTService):
         if configure_fields and self._transport_is_active():
             await self._send_configure(configure_fields)
 
-        self._warn_unhandled_updated_settings(changed.keys() - self._CONFIGURE_FIELDS)
+        if changed.keys() & self._CONNECTION_FIELDS:
+            await self._request_reconnect()
+
+        self._warn_unhandled_updated_settings(
+            changed.keys() - self._CONFIGURE_FIELDS - self._CONNECTION_FIELDS - self._LOCAL_FIELDS
+        )
 
         return changed
 

--- a/src/pipecat/services/deepgram/flux/stt_base.py
+++ b/src/pipecat/services/deepgram/flux/stt_base.py
@@ -644,8 +644,9 @@ class DeepgramFluxSTTBase(STTService):
         Raises:
             Exception: Always raises to trigger error handling in the transport layer.
         """
-        error_msg = data.get("error", "Unknown error")
-        deepgram_error = f"Fatal error: {error_msg}"
+        error_code = data.get("code", "unknown")
+        description = data.get("description", "no description")
+        deepgram_error = f"{self}: Fatal error [{error_code}] {description}"
         logger.error(deepgram_error)
         # Error will be handled by the transport's receive loop error handler
         raise Exception(deepgram_error)

--- a/tests/test_deepgram_flux_stt.py
+++ b/tests/test_deepgram_flux_stt.py
@@ -242,5 +242,17 @@ async def test_update_settings_configures_without_reconnecting():
     assert service.reconnect_requests == 0
 
 
+@pytest.mark.asyncio
+async def test_fatal_error_reports_code_and_description():
+    """A FatalError raises with the code and description Flux sends."""
+    service = _make_fake_flux_service()
+
+    with pytest.raises(Exception) as excinfo:
+        await service._handle_fatal_error({"code": "INVALID_AUTH", "description": "Bad key"})
+
+    assert "INVALID_AUTH" in str(excinfo.value)
+    assert "Bad key" in str(excinfo.value)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deepgram_flux_stt.py
+++ b/tests/test_deepgram_flux_stt.py
@@ -40,6 +40,8 @@ def _make_fake_flux_service():
             self._active = True
             self.sent_messages = []
             self.errors = []
+            self.reconnect_requests = 0
+            self.connection_events = []
 
         async def _transport_send_audio(self, audio: bytes):
             pass
@@ -51,9 +53,15 @@ def _make_fake_flux_service():
             return self._active
 
         async def _connect(self):
-            pass
+            self.connection_events.append("connect")
 
         async def _disconnect(self):
+            self.connection_events.append("disconnect")
+
+        async def _request_reconnect(self):
+            self.reconnect_requests += 1
+
+        async def set_usable(self, usable: bool):
             pass
 
         async def run_stt(self, audio: bytes):
@@ -200,6 +208,38 @@ def test_reset_configure_state_with_nothing_in_flight_is_safe():
 
     assert not service._configure_in_flight
     assert service._configure_pending_fields is None
+
+
+@pytest.mark.asyncio
+async def test_do_reconnect_tears_down_before_re_establishing():
+    """A reconnect drops the current connection before opening a new one."""
+    service = _make_fake_flux_service()
+
+    await service._do_reconnect()
+
+    assert service.connection_events == ["disconnect", "connect"]
+
+
+@pytest.mark.asyncio
+async def test_update_settings_reconnects_for_connection_only_field():
+    """Fields Flux only reads from the connection URL are applied by reconnecting."""
+    service = _make_fake_flux_service()
+
+    await service._update_settings(DeepgramFluxSTTSettings(numerals=True))
+
+    assert service.reconnect_requests == 1
+    assert service.sent_messages == []
+
+
+@pytest.mark.asyncio
+async def test_update_settings_configures_without_reconnecting():
+    """Configure-able fields reach the live connection without dropping it."""
+    service = _make_fake_flux_service()
+
+    await service._update_settings(DeepgramFluxSTTSettings(eot_threshold=0.9))
+
+    assert service.sent_messages == [{"type": "Configure", "thresholds": {"eot_threshold": 0.9}}]
+    assert service.reconnect_requests == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two fixes to Deepgram Flux STT.

**Connection-only settings now take effect.** `DeepgramFluxSTTBase` extends `STTService` directly, whose `_do_reconnect()` is a no-op, so a reconnect request had no effect. It now tears down the transport and re-establishes it. A settings update that changes `model` or `numerals` — the fields Flux reads only from the connection URL — requests a reconnect, which fires once the user stops speaking. Configure-able fields (`keyterm`, `eot_threshold`, `eager_eot_threshold`, `eot_timeout_ms`, `language_hints`) still go over the live connection, and `min_confidence` applies to results as they arrive, so neither drops the connection.

**FatalError details reach the logs.** Flux sends `code` and `description` on a FatalError message, so the raised error carries both instead of a generic `Fatal error: Unknown error`.

## Tests

`tests/test_deepgram_flux_stt.py` covers the reconnect teardown order, reconnect-on-connection-field, Configure-without-reconnect, and the FatalError message.