### PR TITLE
Raise the Context Hub floor to pipecat-ai-context-hub 0.6.0

### DIFF
--- a/changelog/5480.changed.md
+++ b/changelog/5480.changed.md
@@ -1,0 +1,1 @@
+- Raised the `pipecat-ai[cli]` Context Hub floor to `pipecat-ai-context-hub` 0.6.0, which registers its MCP server with Claude Code for every directory rather than only the one `install` ran in. A project scaffolded after the hub was set up now has the server without re-running `install`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,11 +159,7 @@ cli = [
     "jinja2>=3.1.0,<4",
     "questionary>=2.0.0,<3",
     "ruff>=0.12.1,<1",
-    # Mounts as `pipecat context-hub`, the live Pipecat context the guides written
-    # by `pipecat init` tell coding agents to query. The 0.5.3 floor is load-bearing:
-    # the refresh those guides prescribe passes `--framework-version latest`, so the
-    # index matches the release the project runs, and earlier versions reject it.
-    "pipecat-ai-context-hub>=0.5.3,<1",
+    "pipecat-ai-context-hub>=0.6.0,<1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -5609,7 +5609,7 @@ requires-dist = [
     { name = "pipecat-ai", extras = ["mcp"], marker = "extra == 'keenable'" },
     { name = "pipecat-ai", extras = ["moonshine"], marker = "extra == 'evals'" },
     { name = "pipecat-ai", extras = ["webrtc"], marker = "extra == 'webrtc-video'" },
-    { name = "pipecat-ai-context-hub", marker = "extra == 'cli'", specifier = ">=0.5.3,<1" },
+    { name = "pipecat-ai-context-hub", marker = "extra == 'cli'", specifier = ">=0.6.0,<1" },
     { name = "pipecat-ai-prebuilt", marker = "extra == 'runner'", specifier = ">=1.0.6" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.3.0,<2" },
     { name = "pocket-tts", marker = "extra == 'pocket-tts'", specifier = ">=2.1.0,<3" },
@@ -5678,7 +5678,7 @@ docs = [
 
 [[package]]
 name = "pipecat-ai-context-hub"
-version = "0.5.3"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chromadb" },
@@ -5698,9 +5698,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-typescript" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/1e/dcb3debea2096458a170d5329f97508d97b96573c838f49bf5cb5c2a49d0/pipecat_ai_context_hub-0.5.3.tar.gz", hash = "sha256:82955bf6bd50f1a6991f9bdecbf3d1643c46cade4dd3b0f2e38f39159399c61a", size = 1410651, upload-time = "2026-08-19T15:52:06.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/44/720b27277de571db35e253b4ab527462f5e6fb1378ef8ab9901e6338ee1d/pipecat_ai_context_hub-0.6.0.tar.gz", hash = "sha256:0f70c51c8b8c3f1072ce24cf899b08c944732000c83bb035341efdbaf54d1240", size = 1426482, upload-time = "2026-08-28T06:14:53.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/68/761df48bf3e6148ffc9ed2bd9119e2a6d815a392a6a5890c3d4d33ae6315/pipecat_ai_context_hub-0.5.3-py3-none-any.whl", hash = "sha256:26d2ac4807aeef94e63aa36b406ba7740c85e70ecd45db6479a17b13227cb156", size = 236424, upload-time = "2026-08-19T15:52:07.997Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9a/4720420d4fba05a2f07c90263e8aca70a7e73f58adf73d52dc127816992b/pipecat_ai_context_hub-0.6.0-py3-none-any.whl", hash = "sha256:990b83f69904f61dfa8e7e6df7cd38da2beaa3a57cca43294419bde3f0f14525", size = 238316, upload-time = "2026-08-28T06:14:54.737Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Raises the `cli` extra's Context Hub floor from `0.5.3` to `0.6.0`, and re-locks.
- From 0.6.0, `pipecat-context-hub install` registers the MCP server at Claude Code's **user** scope instead of Claude's default **local** scope. Local scope keys the entry on the directory `install` ran in, so a project scaffolded later had no server — silently, since an agent without the tools answers from training data rather than failing. Nothing about the hub is per-project: one index serves the machine, and the registered command is an absolute path to a global install.
- 0.6.0 also carries the isolation that machine-wide registration requires: `-P` on the registered command, so a directory on the launch path can no longer prepend itself to `sys.path` and shadow the installed package, and an allowlist restricting cwd `.env` loading to `PIPECAT_HUB_*` keys. Both matter only once the server launches from every directory a coding agent opens, which is what the scope change does — so the floor is what actually guarantees them.

Existing per-directory registrations keep working and are not migrated. To move one:

```
claude mcp remove pipecat-context-hub -s local
pipecat context-hub install --no-refresh
```

## Testing

```
uv lock --check
```

Verified end-to-end against the shipped 0.6.0: with every local-scope entry removed, `pipecat context-hub install --no-refresh` writes a single `user`-scope registration that resolves from any directory, with `-P` present in the recorded args.