### PR TITLE
Expose actual OpenAI response service tiers in usage metrics

### DIFF
--- a/changelog/5485.added.md
+++ b/changelog/5485.added.md
@@ -1,0 +1,1 @@
+- Added the actual OpenAI service tier to LLM usage metrics for Chat Completions and Responses API services.

--- a/src/pipecat/metrics/metrics.py
+++ b/src/pipecat/metrics/metrics.py
@@ -127,6 +127,7 @@ class LLMTokenUsage(BaseModel):
         input_audio_tokens: Number of prompt tokens that were audio, if applicable.
         output_audio_tokens: Number of completion tokens that were audio, if applicable.
         cache_read_input_audio_tokens: Number of cache-read tokens that were audio, if applicable.
+        service_tier: Actual service tier echoed by the LLM provider for this response, if applicable.
     """
 
     prompt_tokens: int
@@ -138,6 +139,7 @@ class LLMTokenUsage(BaseModel):
     input_audio_tokens: int | None = None
     output_audio_tokens: int | None = None
     cache_read_input_audio_tokens: int | None = None
+    service_tier: str | None = None
 
 
 class LLMUsageMetricsData(MetricsData):

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -487,12 +487,14 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                             if chunk.usage.completion_tokens_details
                             else None
                         )
+                        service_tier = getattr(chunk, "service_tier", None)
                         token_usage = LLMTokenUsage(
                             prompt_tokens=chunk.usage.prompt_tokens,
                             completion_tokens=chunk.usage.completion_tokens,
                             total_tokens=chunk.usage.total_tokens,
                             cache_read_input_tokens=cached_tokens,
                             reasoning_tokens=reasoning_tokens,
+                            service_tier=service_tier if isinstance(service_tier, str) else None,
                         )
 
                     if chunk.model and self.get_full_model_name() != chunk.model:

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -1149,12 +1149,14 @@ class OpenAIResponsesLLMService(
                 if usage:
                     input_details = usage.get("input_tokens_details") or {}
                     output_details = usage.get("output_tokens_details") or {}
+                    service_tier = response.get("service_tier")
                     tokens = LLMTokenUsage(
                         prompt_tokens=usage.get("input_tokens", 0),
                         completion_tokens=usage.get("output_tokens", 0),
                         total_tokens=usage.get("total_tokens", 0),
                         cache_read_input_tokens=input_details.get("cached_tokens", 0),
                         reasoning_tokens=output_details.get("reasoning_tokens", 0),
+                        service_tier=service_tier if isinstance(service_tier, str) else None,
                     )
                     await self.start_llm_usage_metrics(tokens)
 
@@ -1391,6 +1393,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                         # leak None into metrics.
                         input_details = usage.input_tokens_details
                         output_details = usage.output_tokens_details
+                        service_tier = getattr(response, "service_tier", None)
                         tokens = LLMTokenUsage(
                             prompt_tokens=usage.input_tokens or 0,
                             completion_tokens=usage.output_tokens or 0,
@@ -1401,6 +1404,7 @@ class OpenAIResponsesHttpLLMService(_BaseOpenAIResponsesLLMService):
                             reasoning_tokens=(output_details.reasoning_tokens or 0)
                             if output_details
                             else 0,
+                            service_tier=service_tier if isinstance(service_tier, str) else None,
                         )
                         await self.start_llm_usage_metrics(tokens)
 

--- a/tests/test_openai_llm_timeout.py
+++ b/tests/test_openai_llm_timeout.py
@@ -6,7 +6,7 @@
 
 """Unit tests for OpenAI LLM error handling."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import openai
@@ -187,6 +187,44 @@ async def test_openai_llm_stream_closed_on_cancellation():
 
         # Verify stream was closed despite the cancellation
         assert stream_closed, "Stream should be closed even when CancelledError occurs"
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_usage_metrics_report_response_service_tier():
+    """Chat Completions usage metrics use the tier echoed by OpenAI's response."""
+    with patch.object(OpenAILLMService, "create_client"):
+        service = OpenAILLMService(settings=OpenAILLMService.Settings(model="gpt-4"))
+
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    usage.total_tokens = 15
+    usage.prompt_tokens_details = None
+    usage.completion_tokens_details = None
+    chunk = MagicMock()
+    chunk.usage = usage
+    chunk.service_tier = "fast"
+    chunk.model = None
+    chunk.choices = []
+
+    class MockAsyncStream:
+        def __aiter__(self):
+            async def iterator():
+                yield chunk
+
+            return iterator()
+
+        async def close(self):
+            pass
+
+    service.get_chat_completions = AsyncMock(return_value=MockAsyncStream())
+    service.start_ttfb_metrics = AsyncMock()
+    service.start_llm_usage_metrics = AsyncMock()
+
+    await service._process_context(LLMContext(messages=[{"role": "user", "content": "Hello"}]))
+
+    tokens = service.start_llm_usage_metrics.call_args.args[0]
+    assert tokens.service_tier == "fast"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_responses_http.py
+++ b/tests/test_openai_responses_http.py
@@ -87,11 +87,12 @@ class _FakeAsyncStream:
         pass
 
 
-def _completed_event(usage):
+def _completed_event(usage, service_tier=None):
     """Build a ResponseCompletedEvent carrying the given usage object."""
     response = MagicMock()
     response.usage = usage
     response.model = "gpt-4.1"
+    response.service_tier = service_tier
     event = MagicMock(spec=ResponseCompletedEvent)
     event.response = response
     return event
@@ -153,7 +154,7 @@ class TestHttpTokenUsageMetrics:
             input_tokens_details=InputTokensDetails(cached_tokens=20, cache_write_tokens=0),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         )
-        await _run(service, _completed_event(usage))
+        await _run(service, _completed_event(usage, service_tier="fast"))
 
         tokens = service.start_llm_usage_metrics.call_args[0][0]
         assert tokens.prompt_tokens == 100
@@ -161,6 +162,7 @@ class TestHttpTokenUsageMetrics:
         assert tokens.total_tokens == 150
         assert tokens.cache_read_input_tokens == 20
         assert tokens.reasoning_tokens == 10
+        assert tokens.service_tier == "fast"
 
     @pytest.mark.asyncio
     async def test_token_usage_with_missing_details(self):

--- a/tests/test_openai_responses_websocket.py
+++ b/tests/test_openai_responses_websocket.py
@@ -378,6 +378,7 @@ class TestReceiveResponseEventsText:
                 "response": {
                     "id": "resp_1",
                     "model": "gpt-4.1",
+                    "service_tier": "fast",
                     "usage": {
                         "input_tokens": 100,
                         "output_tokens": 50,
@@ -399,6 +400,7 @@ class TestReceiveResponseEventsText:
         assert tokens.total_tokens == 150
         assert tokens.cache_read_input_tokens == 20
         assert tokens.reasoning_tokens == 10
+        assert tokens.service_tier == "fast"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Expose the actual service tier returned by OpenAI in LLM usage metrics.
- Populate it for Chat Completions and Responses API HTTP/WebSocket completions.

## Validation

- `uv run ruff format --check`
- `uv run ruff check`
- Changed-file `uv run pyright` (clean)
- Focused OpenAI tests (90 passed)
- Full suite: 4,913 passed; 8 existing failures in worker handoff and Gemini Live SDK compatibility tests.

Generated with [Codex](https://openai.com/codex/).
Co-authored-by: Codex <noreply@openai.com>
