### PR TITLE
Add AssemblyAI Sync speech-to-text service

### DIFF
--- a/changelog/5488.added.md
+++ b/changelog/5488.added.md
@@ -1,10 +1,3 @@
-- Added `AssemblyAISyncSTTService`, a `SegmentedSTTService` backed by AssemblyAI's
-  Sync API. It transcribes each VAD-detected speech segment in a single
-  `multipart/form-data` request — no streaming session, upload step, or polling.
-  - Connection pre-warming (`enable_prewarming`, plus `warm()`) opens the
-    connection when the user starts speaking so the transcription request skips
-    the DNS/TCP/TLS handshake.
-  - Automatic conversation context carries recent user and agent turns as
-    `conversation_context` on each request, captured from the assistant-turn
-    frame with no extra pipeline wiring. Bounded by `max_context_turns`
-    (`0` disables); an explicit `conversation_context` is honored as-is.
+- Added `AssemblyAISyncSTTService`, a segmented speech-to-text service backed by AssemblyAI's Sync API: pipeline VAD segments the audio and each segment (up to 120 seconds) is transcribed in one HTTP request, with no streaming session to manage. It takes an `aiohttp_session`, `base_url` selects a data-residency endpoint, and `Settings` supports `model`, `language`, `prompt`, `keyterms_prompt`, and `conversation_context`.
+
+Recent user and agent turns are sent automatically as `conversation_context` on each request, bounded by `max_context_turns` (`0` disables) and `max_context_chars`; setting `conversation_context` yourself replaces that buffer. The connection is pre-warmed when the user starts speaking so the transcription request skips the handshake (`enable_prewarming`).

--- a/changelog/5488.added.md
+++ b/changelog/5488.added.md
@@ -1,0 +1,10 @@
+- Added `AssemblyAISyncSTTService`, a `SegmentedSTTService` backed by AssemblyAI's
+  Sync API. It transcribes each VAD-detected speech segment in a single
+  `multipart/form-data` request — no streaming session, upload step, or polling.
+  - Connection pre-warming (`enable_prewarming`, plus `warm()`) opens the
+    connection when the user starts speaking so the transcription request skips
+    the DNS/TCP/TLS handshake.
+  - Automatic conversation context carries recent user and agent turns as
+    `conversation_context` on each request, captured from the assistant-turn
+    frame with no extra pipeline wiring. Bounded by `max_context_turns`
+    (`0` disables); an explicit `conversation_context` is honored as-is.

--- a/examples/voice/voice-assemblyai-sync.py
+++ b/examples/voice/voice-assemblyai-sync.py
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+
+import os
+
+import aiohttp
+from dotenv import load_dotenv
+from loguru import logger
+
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker, ProcessorUnusablePolicy
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.assemblyai.stt import AssemblyAISyncSTTService
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transcriptions.language import Language
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "eval": lambda: EvalTransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info("Starting bot")
+
+    async with aiohttp.ClientSession() as session:
+        # The Sync API transcribes one VAD-detected speech segment per HTTP
+        # request. Recent user and agent turns ride along as conversation
+        # context, so each segment is transcribed against the dialogue so far.
+        stt = AssemblyAISyncSTTService(
+            api_key=os.environ["ASSEMBLYAI_API_KEY"],
+            aiohttp_session=session,
+            settings=AssemblyAISyncSTTService.Settings(
+                language=Language.EN,
+            ),
+        )
+
+        tts = CartesiaTTSService(
+            api_key=os.environ["CARTESIA_API_KEY"],
+            settings=CartesiaTTSService.Settings(
+                voice="86e30c1d-714b-4074-a1f2-1cb6b552fb49",
+            ),
+        )
+
+        llm = OpenAILLMService(
+            api_key=os.environ["OPENAI_API_KEY"],
+            settings=OpenAILLMService.Settings(
+                system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
+            ),
+        )
+
+        context = LLMContext()
+        user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+            context,
+            user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+        )
+
+        pipeline = Pipeline(
+            [
+                transport.input(),  # Transport user input
+                stt,  # STT
+                user_aggregator,  # User responses
+                llm,  # LLM
+                tts,  # TTS
+                transport.output(),  # Transport bot output
+                assistant_aggregator,  # Assistant spoken responses
+            ]
+        )
+
+        worker = PipelineWorker(
+            pipeline,
+            params=PipelineParams(
+                enable_metrics=True,
+                enable_usage_metrics=True,
+            ),
+            idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+            processor_unusable_policy=ProcessorUnusablePolicy.END,
+        )
+
+        runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+        await runner.add_workers(worker)
+
+        @transport.event_handler("on_client_connected")
+        async def on_client_connected(transport, client):
+            logger.info("Client connected")
+            # Kick off the conversation.
+            context.add_message(
+                {"role": "developer", "content": "Please introduce yourself to the user."}
+            )
+            await worker.queue_frames([LLMRunFrame()])
+
+        @transport.event_handler("on_client_disconnected")
+        async def on_client_disconnected(transport, client):
+            logger.info("Client disconnected")
+            await runner.cancel()
+
+        await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/scripts/release-evals/manifest.yaml
+++ b/scripts/release-evals/manifest.yaml
@@ -20,6 +20,8 @@ suite:
     scenarios: [capital_question]
   - bot: voice/voice-assemblyai.py
     scenarios: [capital_question]
+  - bot: voice/voice-assemblyai-sync.py
+    scenarios: [capital_question]
   - bot: voice/voice-assemblyai-turn-detection.py
     scenarios: [capital_question]
   - bot: voice/voice-asyncai.py

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -38,7 +38,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.services.settings import STTSettings
-from pipecat.services.stt_latency import ASSEMBLYAI_TTFS_P99
+from pipecat.services.stt_latency import ASSEMBLYAI_SYNC_TTFS_P99, ASSEMBLYAI_TTFS_P99
 from pipecat.services.stt_service import SegmentedSTTService, WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
@@ -1271,9 +1271,6 @@ ASSEMBLYAI_SYNC_BASE_URL = "https://sync.assemblyai.com"
 ASSEMBLYAI_SYNC_TRANSCRIBE_PATH = "/v1/transcribe"
 ASSEMBLYAI_SYNC_WARM_PATH = "/v1/warm"
 
-# Default model, sent in the ``X-AAI-Model`` header AssemblyAI routes on.
-ASSEMBLYAI_SYNC_DEFAULT_MODEL = "universal-3-5-pro"
-
 
 @dataclass
 class AssemblyAISyncSTTSettings(STTSettings):
@@ -1344,7 +1341,7 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         max_context_turns: int = 5,
         max_context_chars: int = 1500,
         settings: Settings | None = None,
-        ttfs_p99_latency: float | None = None,
+        ttfs_p99_latency: float | None = ASSEMBLYAI_SYNC_TTFS_P99,
         **kwargs,
     ):
         """Initialize the AssemblyAI Sync STT service.
@@ -1379,8 +1376,8 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
             **kwargs: Additional arguments passed to SegmentedSTTService.
         """
         default_settings = self.Settings(
-            model=ASSEMBLYAI_SYNC_DEFAULT_MODEL,
-            language=None,
+            model="universal-3-5-pro",
+            language=Language.EN,
             prompt=None,
             keyterms_prompt=None,
             conversation_context=None,

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -31,6 +31,7 @@ from pipecat.frames.frames import (
     InterimTranscriptionFrame,
     ProposedUserStartedSpeakingFrame,
     ProposedUserStoppedSpeakingFrame,
+    StartFrame,
     STTMetadataFrame,
     TranscriptionFrame,
     VADUserStartedSpeakingFrame,
@@ -1479,6 +1480,15 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         ):
             self._context_turns.pop(0)
 
+    async def start(self, frame: StartFrame):
+        """Start the service on an empty conversation context.
+
+        The buffer holds one conversation, so an instance reused for another
+        run starts it fresh.
+        """
+        await super().start(frame)
+        self._context_turns.clear()
+
     async def _process_assistant_turn(self, text: str) -> None:
         """Feed the agent's completed reply into the conversation context.
 
@@ -1524,7 +1534,7 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
             The decoded JSON transcription result.
 
         Raises:
-            Exception: If the API returns a non-200 status.
+            aiohttp.ClientResponseError: If the API returns a non-200 status.
         """
         url = f"{self._base_url}{ASSEMBLYAI_SYNC_TRANSCRIBE_PATH}"
 
@@ -1547,7 +1557,15 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
 
         async with self._session.post(url, data=data, headers=self._request_headers()) as response:
             if response.status != 200:
-                raise Exception(await self._error_detail(response))
+                # The status rides on the exception so the framework can
+                # classify the failure: a rejected key leaves the service
+                # unusable, a rate limit or a server error does not.
+                raise aiohttp.ClientResponseError(
+                    response.request_info,
+                    response.history,
+                    status=response.status,
+                    message=await self._error_detail(response),
+                )
             return await response.json()
 
     async def _error_detail(self, response: aiohttp.ClientResponse) -> str:
@@ -1555,19 +1573,23 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
 
         Errors arrive either as a problem-details body (``title``/``detail``)
         or as ``{"error_code", "message"}``; surface whichever fields are
-        present, falling back to the raw body.
+        present, falling back to the raw body. The status is carried by the
+        exception this message goes on, so it isn't repeated here.
         """
         try:
             body = await response.json(content_type=None)
         except Exception:
             body = None
         if isinstance(body, dict):
-            title = body.get("title")
-            detail = body.get("detail") or body.get("message")
-            parts = [p for p in (title, detail) if p]
+            fields = (
+                body.get("error_code"),
+                body.get("title"),
+                body.get("detail") or body.get("message"),
+            )
+            parts = [field for field in fields if field]
             if parts:
-                return f"status {response.status}: {' - '.join(parts)}"
-        return f"status {response.status}: {await response.text()}"
+                return " - ".join(parts)
+        return await response.text()
 
     @traced_stt
     async def _handle_transcription(
@@ -1610,7 +1632,7 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
                 self._append_context_turn(text)
         except Exception as e:
             logger.error(f"{self}: error transcribing audio: {e}")
-            yield ErrorFrame(error=f"Sync transcription error: {e}")
+            yield ErrorFrame(error=f"Sync transcription error: {e}", exception=e)
 
     async def cleanup(self):
         """Cancel any in-flight pre-warm task and clean up."""

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -1264,17 +1264,14 @@ class AssemblyAISTTService(WebsocketSTTService):
                 )
 
 
-# Default host for the Sync speech-to-text API. Each speech segment is POSTed
-# here as ``multipart/form-data`` and the transcript is returned in the same
-# response — no WebSocket session, upload step, or polling.
+# Default host for the Sync speech-to-text API.
 ASSEMBLYAI_SYNC_BASE_URL = "https://sync.assemblyai.com"
 
-# Canonical (versioned) Sync API paths appended to the base URL.
+# Sync API paths appended to the base URL.
 ASSEMBLYAI_SYNC_TRANSCRIBE_PATH = "/v1/transcribe"
 ASSEMBLYAI_SYNC_WARM_PATH = "/v1/warm"
 
-# Default model for the Sync API, sent in the ``X-AAI-Model`` header the service
-# routes on.
+# Default model, sent in the ``X-AAI-Model`` header AssemblyAI routes on.
 ASSEMBLYAI_SYNC_DEFAULT_MODEL = "universal-3-5-pro"
 
 
@@ -1405,8 +1402,7 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         self._warm_task: asyncio.Task | None = None
 
         # Rolling buffer of prior turns (user + agent) carried as
-        # conversation_context. Both sides share one chronological buffer under a
-        # single turn/char cap, since the model draws no distinction between them.
+        # conversation_context (see _append_context_turn).
         self._max_context_turns = max_context_turns
         self._max_context_chars = max_context_chars
         self._context_turns: list[str] = []
@@ -1443,8 +1439,8 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
 
         language = self._settings.language
         if is_given(language) and language is not None:
-            # The Sync API's ``language_codes`` field takes a list; a
-            # single language is a one-element list.
+            # ``language_codes`` accepts a string or a list; a single
+            # language goes as a one-element list.
             config["language_codes"] = [language]
 
         prompt = self._settings.prompt
@@ -1455,8 +1451,6 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         if is_given(keyterms_prompt) and keyterms_prompt:
             config["keyterms_prompt"] = list(keyterms_prompt)
 
-        # A conversation_context set explicitly in settings is honored as-is and
-        # disables the automatic buffer; otherwise send the rolling buffer.
         if self._context_is_manual():
             config["conversation_context"] = self._settings.conversation_context
         elif self._context_turns:
@@ -1491,10 +1485,9 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
     async def _process_assistant_turn(self, text: str) -> None:
         """Feed the agent's completed reply into the conversation context.
 
-        Called automatically by the base class when an assistant turn ends
-        (an ``LLMContextAssistantTurnFrame`` reaches the service), so a standard
-        voice-agent pipeline needs no extra wiring. The reply is appended to the
-        same chronological buffer as user turns.
+        Called automatically by the base class when an assistant turn ends (an
+        ``LLMContextAssistantTurnFrame`` reaches the service). The reply is
+        appended to the same chronological buffer as user turns.
         """
         self._append_context_turn(text)
 
@@ -1563,8 +1556,8 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
     async def _error_detail(self, response: aiohttp.ClientResponse) -> str:
         """Build a readable message from a non-200 response.
 
-        The Sync API returns an RFC 9457 problem-details body
-        (``{"status", "title", "detail"}``); surface the title and detail when
+        Errors arrive either as a problem-details body (``title``/``detail``)
+        or as ``{"error_code", "message"}``; surface whichever fields are
         present, falling back to the raw body.
         """
         try:
@@ -1614,9 +1607,9 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
                     language,
                     result=result,
                 )
-                # Record this user turn so it contexts the next request. The
-                # config for this request was already built without it, so an
-                # utterance never appears in its own context.
+                # Record this user turn for the next request's context. This
+                # request's config was already built, so an utterance never
+                # appears in its own context.
                 self._append_context_turn(text)
         except Exception as e:
             logger.error(f"{self}: error transcribing audio: {e}")

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -15,7 +15,7 @@ import io
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field, replace
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import urlencode
 
 import aiohttp
@@ -45,7 +45,7 @@ from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-from pipecat.utils.types import NOT_GIVEN, NotGiven, is_given
+from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given, is_given
 
 from .models import (
     AssemblyAIConnectionParams,
@@ -1425,11 +1425,14 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         """
         return language_to_assemblyai_language(language)
 
-    def _request_headers(self) -> dict:
-        return {
-            "Authorization": self._api_key,
-            "X-AAI-Model": self._settings.model,
-        }
+    def _model_header(self) -> dict[str, str]:
+        """The routing header both endpoints send."""
+        model = assert_given(self._settings.model)
+        assert model is not None
+        return {"X-AAI-Model": model}
+
+    def _request_headers(self) -> dict[str, str]:
+        return {"Authorization": self._api_key, **self._model_header()}
 
     def _build_config(self) -> dict:
         """Assemble the optional ``config`` part from the current settings."""
@@ -1511,9 +1514,7 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         try:
             # Route the warm with the same model as the transcription so the
             # opened connection lands on the right backend.
-            async with self._session.get(
-                url, headers={"X-AAI-Model": self._settings.model}
-            ) as response:
+            async with self._session.get(url, headers=self._model_header()) as response:
                 await response.read()
         except Exception as e:
             logger.debug(f"{self}: connection pre-warm failed (ignored): {e}")
@@ -1616,7 +1617,9 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
 
             text = (result.get("text") or "").strip()
             if text:
-                language = self._settings.language if is_given(self._settings.language) else None
+                # Technically `_settings.language` could be a raw string, but
+                # Language is a StrEnum so downstream handles either.
+                language = cast("Language | None", assert_given(self._settings.language))
                 await self._handle_transcription(text, True, language)
                 logger.debug(f"Transcription: [{text}]")
                 yield TranscriptionFrame(

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -11,12 +11,14 @@ WebSocket API for streaming audio transcription.
 """
 
 import asyncio
+import io
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 from urllib.parse import urlencode
 
+import aiohttp
 from loguru import logger
 from websockets.protocol import State
 
@@ -24,23 +26,25 @@ from pipecat import version as pipecat_version
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
+    ErrorFrame,
     Frame,
     InterimTranscriptionFrame,
     ProposedUserStartedSpeakingFrame,
     ProposedUserStoppedSpeakingFrame,
     STTMetadataFrame,
     TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.services.settings import STTSettings
 from pipecat.services.stt_latency import ASSEMBLYAI_TTFS_P99
-from pipecat.services.stt_service import WebsocketSTTService
+from pipecat.services.stt_service import SegmentedSTTService, WebsocketSTTService
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 from pipecat.utils.time import time_now_iso8601
 from pipecat.utils.tracing.service_decorators import traced_stt
-from pipecat.utils.types import NOT_GIVEN, NotGiven
+from pipecat.utils.types import NOT_GIVEN, NotGiven, is_given
 
 from .models import (
     AssemblyAIConnectionParams,
@@ -1258,3 +1262,369 @@ class AssemblyAISTTService(WebsocketSTTService):
                         message,
                     )
                 )
+
+
+# Default host for the Sync speech-to-text API. Each speech segment is POSTed
+# here as ``multipart/form-data`` and the transcript is returned in the same
+# response — no WebSocket session, upload step, or polling.
+ASSEMBLYAI_SYNC_BASE_URL = "https://sync.assemblyai.com"
+
+# Canonical (versioned) Sync API paths appended to the base URL.
+ASSEMBLYAI_SYNC_TRANSCRIBE_PATH = "/v1/transcribe"
+ASSEMBLYAI_SYNC_WARM_PATH = "/v1/warm"
+
+# Default model for the Sync API, sent in the ``X-AAI-Model`` header the service
+# routes on.
+ASSEMBLYAI_SYNC_DEFAULT_MODEL = "universal-3-5-pro"
+
+
+@dataclass
+class AssemblyAISyncSTTSettings(STTSettings):
+    """Settings for :class:`AssemblyAISyncSTTService`.
+
+    Parameters:
+        prompt: Custom transcription instruction prepended to the model's system
+            prompt. When set, ``language`` is ignored — state the language in the
+            prompt instead.
+        keyterms_prompt: Key terms or phrases to bias the decoder toward.
+        conversation_context: Prior turns from the same conversation, oldest
+            first, giving the model the surrounding dialogue for better continuity
+            and proper-noun consistency across a multi-turn conversation. A single
+            string is treated as one turn. Setting this explicitly turns off the
+            service's automatic context buffer and sends exactly this value; leave
+            it unset to let the service manage context (see ``max_context_turns``).
+    """
+
+    prompt: str | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    keyterms_prompt: list[str] | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    conversation_context: str | list[str] | None | NotGiven = field(
+        default_factory=lambda: NOT_GIVEN
+    )
+
+
+class AssemblyAISyncSTTService(SegmentedSTTService):
+    """AssemblyAI Sync speech-to-text service.
+
+    Transcribes a complete speech segment in a single request/response against
+    AssemblyAI's Sync API, rather than holding open a streaming WebSocket. It
+    inherits from :class:`SegmentedSTTService`, which uses VAD events to buffer
+    each utterance and calls :meth:`run_stt` once per segment with the audio as a
+    WAV container. Each segment is POSTed as ``multipart/form-data`` and the
+    transcript is returned directly — no upload step, no polling, no session to
+    manage.
+
+    Audio segments must be at most 120 seconds; the API rejects longer ones. This
+    suits dictation, scribe, and voice-agent turns where the client detects
+    speech locally and transcribes each turn on demand.
+
+    When pre-warming is enabled (the default), the service opens the connection
+    as soon as the user starts speaking, so the transcription request skips the
+    DNS, TCP, and TLS handshake once the utterance ends. Call :meth:`warm`
+    directly to warm the connection at any other time.
+
+    Because the Sync API is stateless, the service also carries recent
+    conversation context automatically: it keeps a rolling buffer of the most
+    recent turns — user transcripts and the agent's replies together, in the
+    order spoken — and sends them as ``conversation_context`` on each request, so
+    the model transcribes each turn with the surrounding dialogue. Agent replies
+    are captured from the pipeline's assistant-turn frame, so this needs no
+    wiring in a standard voice-agent pipeline. Set ``max_context_turns=0`` to
+    disable it, or set ``conversation_context`` explicitly in ``settings`` to
+    supply the context yourself (that value is honored as-is).
+    """
+
+    Settings = AssemblyAISyncSTTSettings
+    _settings: Settings
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        aiohttp_session: aiohttp.ClientSession,
+        base_url: str = ASSEMBLYAI_SYNC_BASE_URL,
+        sample_rate: int | None = None,
+        enable_prewarming: bool = True,
+        max_context_turns: int = 5,
+        max_context_chars: int = 1500,
+        settings: Settings | None = None,
+        ttfs_p99_latency: float | None = None,
+        **kwargs,
+    ):
+        """Initialize the AssemblyAI Sync STT service.
+
+        Args:
+            api_key: AssemblyAI API key for authentication.
+            aiohttp_session: aiohttp ClientSession for HTTP requests. Pre-warming
+                only helps when the warm and transcribe requests share this
+                session's connection pool, so keep one session for the service.
+            base_url: Base URL for the Sync API. Override for a data-residency
+                endpoint (e.g. ``https://sync.us.assemblyai.com`` or
+                ``https://sync.eu.assemblyai.com``).
+            sample_rate: Audio sample rate in Hz. If not provided, uses the
+                pipeline's rate.
+            enable_prewarming: Whether to open the connection when the user starts
+                speaking so the transcription request avoids the connection
+                handshake. Defaults to True.
+            max_context_turns: Number of prior conversation turns — user
+                transcripts and agent replies together, in one chronological
+                buffer — automatically carried as ``conversation_context`` on each
+                request, so the model transcribes each turn with the surrounding
+                dialogue. Set to 0 to disable automatic context. Ignored when
+                ``conversation_context`` is set explicitly in ``settings`` (that
+                value is honored as-is). Defaults to 5.
+            max_context_chars: Character budget for the same buffer; the oldest
+                turns are dropped first once either cap is exceeded. Defaults to
+                1500.
+            settings: Runtime-updatable settings.
+            ttfs_p99_latency: P99 latency from speech end to final transcript in
+                seconds. Broadcast at pipeline start for downstream turn timing;
+                set it to your measured value.
+            **kwargs: Additional arguments passed to SegmentedSTTService.
+        """
+        default_settings = self.Settings(
+            model=ASSEMBLYAI_SYNC_DEFAULT_MODEL,
+            language=None,
+            prompt=None,
+            keyterms_prompt=None,
+            conversation_context=None,
+        )
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        super().__init__(
+            sample_rate=sample_rate,
+            ttfs_p99_latency=ttfs_p99_latency,
+            settings=default_settings,
+            **kwargs,
+        )
+
+        self._api_key = api_key
+        self._session = aiohttp_session
+        self._base_url = base_url.rstrip("/")
+        self._enable_prewarming = enable_prewarming
+        self._warm_task: asyncio.Task | None = None
+
+        # Rolling buffer of prior turns (user + agent) carried as
+        # conversation_context. Both sides share one chronological buffer under a
+        # single turn/char cap, since the model draws no distinction between them.
+        self._max_context_turns = max_context_turns
+        self._max_context_chars = max_context_chars
+        self._context_turns: list[str] = []
+
+    def can_generate_metrics(self) -> bool:
+        """Whether this service generates processing metrics.
+
+        Returns:
+            True. The Sync API issues a discrete request per segment, so its
+            duration is measured and reported.
+        """
+        return True
+
+    def language_to_service_language(self, language: Language) -> str | None:
+        """Convert a Pipecat Language to an AssemblyAI language code.
+
+        Args:
+            language: The language to convert.
+
+        Returns:
+            The AssemblyAI language code (base ISO code).
+        """
+        return language_to_assemblyai_language(language)
+
+    def _request_headers(self) -> dict:
+        return {
+            "Authorization": self._api_key,
+            "X-AAI-Model": self._settings.model,
+        }
+
+    def _build_config(self) -> dict:
+        """Assemble the optional ``config`` part from the current settings."""
+        config: dict[str, Any] = {}
+
+        language = self._settings.language
+        if is_given(language) and language is not None:
+            # The Sync API's ``language_codes`` field takes a list; a
+            # single language is a one-element list.
+            config["language_codes"] = [language]
+
+        prompt = self._settings.prompt
+        if is_given(prompt) and prompt is not None:
+            config["prompt"] = prompt
+
+        keyterms_prompt = self._settings.keyterms_prompt
+        if is_given(keyterms_prompt) and keyterms_prompt:
+            config["keyterms_prompt"] = list(keyterms_prompt)
+
+        # A conversation_context set explicitly in settings is honored as-is and
+        # disables the automatic buffer; otherwise send the rolling buffer.
+        if self._context_is_manual():
+            config["conversation_context"] = self._settings.conversation_context
+        elif self._context_turns:
+            config["conversation_context"] = list(self._context_turns)
+
+        return config
+
+    def _context_is_manual(self) -> bool:
+        """Whether conversation_context was supplied explicitly in settings."""
+        ctx = self._settings.conversation_context
+        return is_given(ctx) and bool(ctx)
+
+    def _append_context_turn(self, text: str) -> None:
+        """Append a completed turn (user or agent) to the rolling context buffer.
+
+        Both sides share one chronological buffer under a single turn/char cap,
+        matching how the model consumes context (it draws no distinction between
+        user and agent text). The oldest turns are evicted first once a cap is
+        exceeded. No-op when automatic context is disabled or a manual
+        conversation_context is set.
+        """
+        text = (text or "").strip()
+        if not text or self._max_context_turns <= 0 or self._context_is_manual():
+            return
+        self._context_turns.append(text)
+        while len(self._context_turns) > 1 and (
+            len(self._context_turns) > self._max_context_turns
+            or sum(len(t) for t in self._context_turns) > self._max_context_chars
+        ):
+            self._context_turns.pop(0)
+
+    async def _process_assistant_turn(self, text: str) -> None:
+        """Feed the agent's completed reply into the conversation context.
+
+        Called automatically by the base class when an assistant turn ends
+        (an ``LLMContextAssistantTurnFrame`` reaches the service), so a standard
+        voice-agent pipeline needs no extra wiring. The reply is appended to the
+        same chronological buffer as user turns.
+        """
+        self._append_context_turn(text)
+
+    async def warm(self):
+        """Pre-warm the connection to the Sync API.
+
+        Establishes the connection (DNS, TCP, TLS) ahead of a transcription
+        request so the next :meth:`run_stt` starts uploading audio immediately.
+        Best-effort: failures are logged and swallowed, since a failed warm-up
+        only forfeits the latency saving. The warmed connection is reused only by
+        requests that share this service's aiohttp session and base URL.
+        """
+        url = f"{self._base_url}{ASSEMBLYAI_SYNC_WARM_PATH}"
+        try:
+            # Route the warm with the same model as the transcription so the
+            # opened connection lands on the right backend.
+            async with self._session.get(
+                url, headers={"X-AAI-Model": self._settings.model}
+            ) as response:
+                await response.read()
+        except Exception as e:
+            logger.debug(f"{self}: connection pre-warm failed (ignored): {e}")
+
+    async def _handle_user_started_speaking(self, frame: VADUserStartedSpeakingFrame):
+        await super()._handle_user_started_speaking(frame)
+        if self._enable_prewarming and (self._warm_task is None or self._warm_task.done()):
+            self._warm_task = self.create_task(self.warm())
+
+    async def _transcribe(self, audio: bytes) -> dict:
+        """POST an audio segment to the Sync API and return the parsed result.
+
+        Args:
+            audio: Raw audio bytes in WAV format (already converted by the base
+                class).
+
+        Returns:
+            The decoded JSON transcription result.
+
+        Raises:
+            Exception: If the API returns a non-200 status.
+        """
+        url = f"{self._base_url}{ASSEMBLYAI_SYNC_TRANSCRIBE_PATH}"
+
+        # The base class always hands run_stt a WAV container, so the audio part
+        # is always sent as audio/wav.
+        data = aiohttp.FormData()
+        data.add_field(
+            "audio",
+            io.BytesIO(audio),
+            filename="audio.wav",
+            content_type="audio/wav",
+        )
+        config = self._build_config()
+        if config:
+            data.add_field(
+                "config",
+                json.dumps(config),
+                content_type="application/json",
+            )
+
+        async with self._session.post(url, data=data, headers=self._request_headers()) as response:
+            if response.status != 200:
+                raise Exception(await self._error_detail(response))
+            return await response.json()
+
+    async def _error_detail(self, response: aiohttp.ClientResponse) -> str:
+        """Build a readable message from a non-200 response.
+
+        The Sync API returns an RFC 9457 problem-details body
+        (``{"status", "title", "detail"}``); surface the title and detail when
+        present, falling back to the raw body.
+        """
+        try:
+            body = await response.json(content_type=None)
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            title = body.get("title")
+            detail = body.get("detail") or body.get("message")
+            parts = [p for p in (title, detail) if p]
+            if parts:
+                return f"status {response.status}: {' - '.join(parts)}"
+        return f"status {response.status}: {await response.text()}"
+
+    @traced_stt
+    async def _handle_transcription(
+        self, transcript: str, is_final: bool, language: str | None = None
+    ):
+        """Handle a transcription result with tracing."""
+        await self.stop_processing_metrics()
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame | None, None]:
+        """Transcribe an audio segment using the AssemblyAI Sync API.
+
+        Args:
+            audio: Raw audio bytes in WAV format (already converted by the base
+                class).
+
+        Yields:
+            Frame: A TranscriptionFrame with the transcribed text, or an
+            ErrorFrame on failure. Only non-empty transcriptions are yielded.
+        """
+        try:
+            await self.start_processing_metrics()
+
+            result = await self._transcribe(audio)
+
+            text = (result.get("text") or "").strip()
+            if text:
+                language = self._settings.language if is_given(self._settings.language) else None
+                await self._handle_transcription(text, True, language)
+                logger.debug(f"Transcription: [{text}]")
+                yield TranscriptionFrame(
+                    text,
+                    self._user_id,
+                    time_now_iso8601(),
+                    language,
+                    result=result,
+                )
+                # Record this user turn so it contexts the next request. The
+                # config for this request was already built without it, so an
+                # utterance never appears in its own context.
+                self._append_context_turn(text)
+        except Exception as e:
+            logger.error(f"{self}: error transcribing audio: {e}")
+            yield ErrorFrame(error=f"Sync transcription error: {e}")
+
+    async def cleanup(self):
+        """Cancel any in-flight pre-warm task and clean up."""
+        if self._warm_task is not None and not self._warm_task.done():
+            await self.cancel_task(self._warm_task)
+        self._warm_task = None
+        await super().cleanup()

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -67,3 +67,6 @@ TOGETHER_TTFS_P99: float = 1.00
 # These services run locally and should be replaced with measured values
 NVIDIA_TTFS_P99: float = DEFAULT_TTFS_P99
 WHISPER_TTFS_P99: float = DEFAULT_TTFS_P99
+
+# TODO: Add measured values for AssemblyAI Sync
+ASSEMBLYAI_SYNC_TTFS_P99: float = 0.50

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -39,6 +39,7 @@ DEFAULT_TTFS_P99: float = 1.0
 
 # Measured P99 TTFS latency values (in seconds)
 ASSEMBLYAI_TTFS_P99: float = 0.42
+ASSEMBLYAI_SYNC_TTFS_P99: float = 0.65
 AWS_TRANSCRIBE_TTFS_P99: float = 1.90
 AZURE_TTFS_P99: float = 1.80
 CARTESIA_TTFS_P99: float = 0.81
@@ -67,6 +68,3 @@ TOGETHER_TTFS_P99: float = 1.00
 # These services run locally and should be replaced with measured values
 NVIDIA_TTFS_P99: float = DEFAULT_TTFS_P99
 WHISPER_TTFS_P99: float = DEFAULT_TTFS_P99
-
-# TODO: Add measured values for AssemblyAI Sync
-ASSEMBLYAI_SYNC_TTFS_P99: float = 0.50

--- a/tests/test_assemblyai_sync_stt.py
+++ b/tests/test_assemblyai_sync_stt.py
@@ -1,0 +1,416 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the AssemblyAI Sync STT service."""
+
+import json
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+)
+from pipecat.services.assemblyai.stt import AssemblyAISyncSTTService
+from pipecat.services.stt_latency import ASSEMBLYAI_SYNC_TTFS_P99
+from pipecat.transcriptions.language import Language
+
+WAV = b"RIFF....WAVEfmt "
+
+
+def _transcribe_app(captured: dict, *, status: int = 200, body: dict | None = None):
+    """An app serving /v1/transcribe, recording what each request carried."""
+
+    async def handler(request):
+        captured["headers"] = dict(request.headers)
+        captured["parts"] = {}
+        reader = await request.multipart()
+        async for part in reader:
+            if part.name == "audio":
+                captured["parts"]["audio"] = await part.read()
+                captured["audio_type"] = part.headers.get("Content-Type")
+                captured["audio_filename"] = part.filename
+            else:
+                captured["parts"][part.name] = await part.text()
+        return web.json_response(
+            body if body is not None else {"text": "Hello there", "words": []},
+            status=status,
+        )
+
+    app = web.Application()
+    app.router.add_post("/v1/transcribe", handler)
+    return app
+
+
+async def _service(aiohttp_client, app, session, **kwargs) -> AssemblyAISyncSTTService:
+    """Build a service pointed at a test server running ``app``."""
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/")).rstrip("/")
+    return AssemblyAISyncSTTService(
+        api_key="test-key",
+        aiohttp_session=session,
+        base_url=base_url,
+        **kwargs,
+    )
+
+
+def _config(captured: dict) -> dict:
+    return json.loads(captured["parts"]["config"])
+
+
+#
+# Settings
+#
+
+
+def test_defaults_use_the_sync_model_and_english():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+
+    assert service._settings.model == "universal-3-5-pro"
+    # The base class converts the Language enum to AssemblyAI's code at init.
+    assert service._settings.language == "en"
+
+
+def test_ttfs_latency_defaults_to_the_service_constant():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+
+    assert service._ttfs_p99_latency == ASSEMBLYAI_SYNC_TTFS_P99
+
+
+def test_language_converts_to_the_assemblyai_code():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+
+    assert service.language_to_service_language(Language.ES_US) == "es"
+
+
+#
+# Request construction
+#
+
+
+@pytest.mark.asyncio
+async def test_transcribe_posts_the_audio_and_config_parts(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, _transcribe_app(captured), session)
+
+        result = await service._transcribe(WAV)
+
+    assert result["text"] == "Hello there"
+    assert captured["headers"]["Authorization"] == "test-key"
+    assert captured["headers"]["X-AAI-Model"] == "universal-3-5-pro"
+    assert captured["parts"]["audio"] == WAV
+    assert captured["audio_type"] == "audio/wav"
+    assert captured["audio_filename"] == "audio.wav"
+    assert _config(captured) == {"language_codes": ["en"]}
+
+
+@pytest.mark.asyncio
+async def test_config_carries_prompt_and_keyterms(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                prompt="Transcribe this call.",
+                keyterms_prompt=["Pipecat", "AssemblyAI"],
+            ),
+        )
+
+        await service._transcribe(WAV)
+
+    config = _config(captured)
+    assert config["prompt"] == "Transcribe this call."
+    assert config["keyterms_prompt"] == ["Pipecat", "AssemblyAI"]
+
+
+@pytest.mark.asyncio
+async def test_config_part_is_omitted_when_nothing_applies(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(language=None),
+        )
+
+        await service._transcribe(WAV)
+
+    assert "config" not in captured["parts"]
+
+
+#
+# Transcription
+#
+
+
+@pytest.mark.asyncio
+async def test_run_stt_yields_a_transcription_frame(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, _transcribe_app(captured), session)
+
+        frames = [frame async for frame in service.run_stt(WAV)]
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], TranscriptionFrame)
+    assert frames[0].text == "Hello there"
+    assert frames[0].language == "en"
+    assert frames[0].result == {"text": "Hello there", "words": []}
+
+
+@pytest.mark.asyncio
+async def test_run_stt_yields_nothing_for_an_empty_transcript(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(captured, body={"text": "   ", "words": []})
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        frames = [frame async for frame in service.run_stt(WAV)]
+
+    assert frames == []
+
+
+@pytest.mark.asyncio
+async def test_run_stt_yields_an_error_frame_on_a_problem_details_body(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(
+        captured,
+        status=400,
+        body={"status": 400, "title": "Bad Request", "detail": "invalid config part"},
+    )
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        frames = [frame async for frame in service.run_stt(WAV)]
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], ErrorFrame)
+    assert "Bad Request - invalid config part" in frames[0].error
+
+
+@pytest.mark.asyncio
+async def test_run_stt_surfaces_the_message_of_an_error_code_body(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(
+        captured,
+        status=413,
+        body={"error_code": "audio_too_large", "message": "audio exceeds 120 seconds"},
+    )
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        frames = [frame async for frame in service.run_stt(WAV)]
+
+    assert isinstance(frames[0], ErrorFrame)
+    assert "audio exceeds 120 seconds" in frames[0].error
+
+
+#
+# Conversation context
+#
+
+
+@pytest.mark.asyncio
+async def test_a_turn_is_absent_from_its_own_request_and_present_in_the_next(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, _transcribe_app(captured), session)
+
+        [frame async for frame in service.run_stt(WAV)]
+        assert "conversation_context" not in _config(captured)
+
+        [frame async for frame in service.run_stt(WAV)]
+
+    assert _config(captured)["conversation_context"] == ["Hello there"]
+
+
+@pytest.mark.asyncio
+async def test_agent_replies_share_the_buffer_in_the_order_spoken(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, _transcribe_app(captured), session)
+
+        [frame async for frame in service.run_stt(WAV)]
+        await service._process_assistant_turn("How can I help?")
+        [frame async for frame in service.run_stt(WAV)]
+
+    assert _config(captured)["conversation_context"] == ["Hello there", "How can I help?"]
+
+
+def test_context_evicts_the_oldest_turn_past_the_turn_cap():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object(), max_context_turns=2)
+
+    for turn in ("one", "two", "three"):
+        service._append_context_turn(turn)
+
+    assert service._context_turns == ["two", "three"]
+
+
+def test_context_evicts_the_oldest_turn_past_the_char_cap():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object(), max_context_chars=10)
+
+    service._append_context_turn("aaaaa")
+    service._append_context_turn("bbbbb")
+    service._append_context_turn("ccccc")
+
+    # Eviction stops as soon as the buffer is back within budget.
+    assert service._context_turns == ["bbbbb", "ccccc"]
+
+
+def test_a_turn_longer_than_the_char_cap_is_kept_alone():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object(), max_context_chars=10)
+
+    service._append_context_turn("aaaaa")
+    service._append_context_turn("b" * 40)
+
+    assert service._context_turns == ["b" * 40]
+
+
+def test_blank_turns_are_not_buffered():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+
+    service._append_context_turn("   ")
+
+    assert service._context_turns == []
+
+
+@pytest.mark.asyncio
+async def test_zero_max_context_turns_disables_the_buffer(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client, _transcribe_app(captured), session, max_context_turns=0
+        )
+
+        [frame async for frame in service.run_stt(WAV)]
+        [frame async for frame in service.run_stt(WAV)]
+
+    assert service._context_turns == []
+    assert "conversation_context" not in _config(captured)
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_context_is_sent_as_is_and_stops_buffering(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                conversation_context=["Booking a flight to Lisbon."]
+            ),
+        )
+
+        [frame async for frame in service.run_stt(WAV)]
+        [frame async for frame in service.run_stt(WAV)]
+
+    assert _config(captured)["conversation_context"] == ["Booking a flight to Lisbon."]
+    assert service._context_turns == []
+
+
+#
+# Pre-warming
+#
+
+
+@pytest.mark.asyncio
+async def test_warm_gets_the_warm_path_with_the_model_and_no_auth(aiohttp_client):
+    captured = {}
+
+    async def handler(request):
+        captured["headers"] = dict(request.headers)
+        return web.json_response({"warm": "toasty"})
+
+    app = web.Application()
+    app.router.add_get("/v1/warm", handler)
+
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        await service.warm()
+
+    assert captured["headers"]["X-AAI-Model"] == "universal-3-5-pro"
+    assert "Authorization" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_warm_is_swallowed(aiohttp_client):
+    async def handler(request):
+        return web.Response(status=500)
+
+    app = web.Application()
+    app.router.add_get("/v1/warm", handler)
+
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        # A failed warm only forfeits the latency saving; it must not raise.
+        await service.warm()
+
+
+@pytest.mark.asyncio
+async def test_speech_start_schedules_a_warm():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+    scheduled = []
+
+    def create_task(coro, *args, **kwargs):
+        scheduled.append(coro)
+        coro.close()
+        return None
+
+    service.create_task = create_task
+
+    await service._handle_user_started_speaking(VADUserStartedSpeakingFrame())
+
+    assert len(scheduled) == 1
+
+
+@pytest.mark.asyncio
+async def test_speech_start_schedules_no_warm_when_pre_warming_is_off():
+    service = AssemblyAISyncSTTService(
+        api_key="k", aiohttp_session=object(), enable_prewarming=False
+    )
+    scheduled = []
+
+    def create_task(coro, *args, **kwargs):
+        scheduled.append(coro)
+        coro.close()
+        return None
+
+    service.create_task = create_task
+
+    await service._handle_user_started_speaking(VADUserStartedSpeakingFrame())
+
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_a_pending_warm():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+    cancelled = []
+
+    class PendingTask:
+        def done(self):
+            return False
+
+    async def cancel_task(task, *args, **kwargs):
+        cancelled.append(task)
+
+    service._warm_task = PendingTask()
+    service.cancel_task = cancel_task
+
+    await service.cleanup()
+
+    assert len(cancelled) == 1
+    assert service._warm_task is None

--- a/tests/test_assemblyai_sync_stt.py
+++ b/tests/test_assemblyai_sync_stt.py
@@ -14,12 +14,14 @@ from aiohttp import web
 
 from pipecat.frames.frames import (
     ErrorFrame,
+    StartFrame,
     TranscriptionFrame,
     VADUserStartedSpeakingFrame,
 )
 from pipecat.services.assemblyai.stt import AssemblyAISyncSTTService
 from pipecat.services.stt_latency import ASSEMBLYAI_SYNC_TTFS_P99
 from pipecat.transcriptions.language import Language
+from pipecat.utils.errors import ErrorCategory
 
 WAV = b"RIFF....WAVEfmt "
 
@@ -62,6 +64,23 @@ async def _service(aiohttp_client, app, session, **kwargs) -> AssemblyAISyncSTTS
 
 def _config(captured: dict) -> dict:
     return json.loads(captured["parts"]["config"])
+
+
+async def _run_and_report(service: AssemblyAISyncSTTService) -> ErrorFrame:
+    """Run a segment and return the reported error.
+
+    Errors are classified as the base class pushes them, not as ``run_stt``
+    yields them, so a test reading ``category`` or ``is_usable`` has to go
+    through ``process_generator`` the way the pipeline does.
+    """
+    pushed = []
+
+    async def capture(frame, direction=None):
+        pushed.append(frame)
+
+    service.push_frame = capture
+    await service.process_generator(service.run_stt(WAV))
+    return pushed[-1]
 
 
 #
@@ -199,7 +218,7 @@ async def test_run_stt_yields_an_error_frame_on_a_problem_details_body(aiohttp_c
 
 
 @pytest.mark.asyncio
-async def test_run_stt_surfaces_the_message_of_an_error_code_body(aiohttp_client):
+async def test_run_stt_names_the_error_code_and_message(aiohttp_client):
     captured = {}
     app = _transcribe_app(
         captured,
@@ -212,7 +231,48 @@ async def test_run_stt_surfaces_the_message_of_an_error_code_body(aiohttp_client
         frames = [frame async for frame in service.run_stt(WAV)]
 
     assert isinstance(frames[0], ErrorFrame)
+    assert "audio_too_large" in frames[0].error
     assert "audio exceeds 120 seconds" in frames[0].error
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_key_leaves_the_service_unusable(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(captured, status=401, body={"status": 401, "detail": "Invalid API key"})
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        error = await _run_and_report(service)
+
+    assert error.category is ErrorCategory.AUTHENTICATION
+    # A key stays rejected, so the base class stops handing the service work.
+    assert service.is_usable is False
+
+
+@pytest.mark.asyncio
+async def test_a_server_error_leaves_the_service_usable(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(captured, status=503, body={"error_code": "service_unavailable"})
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        error = await _run_and_report(service)
+
+    assert error.category is ErrorCategory.SERVER
+    assert service.is_usable is True
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_segment_leaves_the_service_usable(aiohttp_client):
+    captured = {}
+    app = _transcribe_app(captured, status=413, body={"error_code": "audio_too_large"})
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, app, session)
+
+        await _run_and_report(service)
+
+    # One segment too long says nothing about the next one.
+    assert service.is_usable is True
 
 
 #
@@ -414,3 +474,13 @@ async def test_cleanup_cancels_a_pending_warm():
 
     assert len(cancelled) == 1
     assert service._warm_task is None
+
+
+@pytest.mark.asyncio
+async def test_a_new_run_starts_on_an_empty_conversation_context():
+    service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
+    service._append_context_turn("Booking a flight to Lisbon.")
+
+    await service.start(StartFrame())
+
+    assert service._context_turns == []


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This adds `AssemblyAISyncSTTService`, a speech-to-text service backed by **AssemblyAI's Sync API**.

### What the Sync API is

The Sync API transcribes a short audio clip (up to 120 seconds) in a single request/response: you POST the audio as `multipart/form-data` and get the transcript back in the same response — no streaming WebSocket session, no separate upload step, and no polling. It sits between the async (pre-recorded) and streaming APIs, and fits dictation, scribe, and voice-agent turns where the client detects speech locally and transcribes each turn on demand.

### How it works in Pipecat

`AssemblyAISyncSTTService` subclasses `SegmentedSTTService`, so pipeline VAD buffers each utterance and the service POSTs that segment when the user stops speaking, emitting a `TranscriptionFrame`. It lives alongside the existing streaming `AssemblyAISTTService` in the same module.

Highlights:

- **Connection pre-warming** — opens the connection (DNS/TCP/TLS) as soon as the user starts speaking, so the transcription request skips the handshake on the critical path. On by default (`enable_prewarming`), and also exposed as `warm()`. Pre-warming reuses the connection only when the warm and transcribe requests share the service's `aiohttp` session.
- **Automatic conversation context** — because the API is stateless, the service keeps a rolling buffer of recent turns (user transcripts and agent replies, in the order spoken) and sends them as `conversation_context` on each request, so each turn is transcribed with the surrounding dialogue. Agent replies are captured from the pipeline's assistant-turn frame, so a standard voice-agent pipeline needs no extra wiring. Bounded by `max_context_turns` (default 5; `0` disables); an explicitly set `conversation_context` is honored as-is.
- **Settings** — `model`, `language`, `prompt`, `keyterms_prompt`, `conversation_context`. Data-residency endpoints are supported via `base_url`.

### Usage

```python
import aiohttp
from pipecat.services.assemblyai.stt import AssemblyAISyncSTTService

session = aiohttp.ClientSession()

stt = AssemblyAISyncSTTService(
    api_key="YOUR_ASSEMBLYAI_API_KEY",
    aiohttp_session=session,
)
```

No new dependencies (`aiohttp` is already a core dependency), and the existing streaming service is unchanged.

### Testing

Verified end-to-end against the live Sync API (English, Spanish, and a longer multi-turn recording), plus unit coverage for request construction, the `config` part, error handling, pre-warm, and the conversation-context buffer (ordering, turn/char caps, disable, and manual override).
