### PR TITLE
fix(gemini-live): answer a tool call that outlived its session

### DIFF
--- a/changelog/5497.fixed.md
+++ b/changelog/5497.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GeminiLiveLLMService` going quiet for the rest of a turn when a reconnect landed part-way through a tool call. The result now reaches the new session, and input the service cannot send is logged.

--- a/src/pipecat/adapters/services/gemini_live_adapter.py
+++ b/src/pipecat/adapters/services/gemini_live_adapter.py
@@ -43,6 +43,19 @@ class GeminiLiveLLMAdapter(GeminiLLMAdapter):
         )
 
     @staticmethod
+    def to_tool_result_text(tool_name: str, result: Any) -> str:
+        """Render a tool result as the conversation text Gemini Live accepts.
+
+        Args:
+            tool_name: Name of the function that was called.
+            result: What the function returned.
+
+        Returns:
+            The result as a line of conversation.
+        """
+        return f"[Function {tool_name} returned {result}]"
+
+    @staticmethod
     def _convert_tool_calls_to_text(messages: list[LLMContextMessage]) -> list[LLMContextMessage]:
         """Convert tool calls and their results to text messages.
 
@@ -81,7 +94,10 @@ class GeminiLiveLLMAdapter(GeminiLLMAdapter):
                 # call isn't in the context.
                 name = tool_call_names.get(msg.get("tool_call_id", ""), "tool_call_result")
                 converted.append(
-                    {"role": "user", "content": f"[Function {name} returned {msg['content']}]"}
+                    {
+                        "role": "user",
+                        "content": GeminiLiveLLMAdapter.to_tool_result_text(name, msg["content"]),
+                    }
                 )
             else:
                 converted.append(message)

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -604,6 +604,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         self._audio_input_paused = start_audio_paused
         self._video_input_paused = start_video_paused
         self._ready_for_realtime_input = False
+        self._logged_media_drop = False
         self._context: LLMContext | None = None
         self._api_key = api_key
         self._http_options = update_google_client_http_options(http_options)
@@ -671,7 +672,11 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         # tool's final result back to the provider, since the async-tool
         # message in the context only carries the id.
         self._tool_call_id_to_name: dict[str, str] = {}
+        # Calls the current session issued. A call from an earlier session can
+        # no longer be answered with a tool response (see _tool_result).
+        self._tool_calls_this_session: set[str] = set()
         self._async_tool_warning_logged: bool = False
+        self._completed_tool_calls_lock = asyncio.Lock()
 
     def create_client(self):
         """Create the Gemini API client instance. Subclasses can override this."""
@@ -976,6 +981,20 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             await self._process_completed_function_calls(send_new_results=True)
 
     async def _process_completed_function_calls(self, send_new_results: bool):
+        """Deliver results for tool calls the context has completed.
+
+        A reconnect flushes pending results from the connection task while the
+        frame task may be handling a context update, so scans run one at a time:
+        a result is claimed once, by whichever gets there first.
+
+        Args:
+            send_new_results: Whether to send results the service hasn't seen,
+                rather than only recording them as delivered.
+        """
+        async with self._completed_tool_calls_lock:
+            await self._scan_completed_function_calls(send_new_results)
+
+    async def _scan_completed_function_calls(self, send_new_results: bool):
         assert self._context is not None
 
         # If the user registered a function with cancel_on_interruption=False,
@@ -1040,13 +1059,10 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                     tool_name = self._tool_call_id_to_name.get(
                         async_payload.tool_call_id, "tool_call_result"
                     )
-                    response_dict = GeminiLiveLLMAdapter.to_function_response_dict(
-                        async_payload.result
-                    )
-                    if send_new_results:
-                        await self._tool_result(
-                            async_payload.tool_call_id, tool_name, response_dict
-                        )
+                    if send_new_results and not await self._tool_result(
+                        async_payload.tool_call_id, tool_name, async_payload.result
+                    ):
+                        continue
                     self._completed_tool_calls.add(async_payload.tool_call_id)
                     continue
                 # Defensive: any async-tool message must not fall through
@@ -1060,11 +1076,10 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                 if tool_call_id and tool_call_id not in self._completed_tool_calls:
                     # Found a newly-completed function call - send the result to the service
                     tool_name = self._tool_call_id_to_name.get(tool_call_id, "tool_call_result")
-                    response_dict = GeminiLiveLLMAdapter.to_function_response_dict(
-                        message.get("content")
-                    )
-                    if send_new_results:
-                        await self._tool_result(tool_call_id, tool_name, response_dict)
+                    if send_new_results and not await self._tool_result(
+                        tool_call_id, tool_name, message.get("content")
+                    ):
+                        continue
                     self._completed_tool_calls.add(tool_call_id)
 
     async def _set_bot_is_responding(self, responding: bool):
@@ -1430,8 +1445,10 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             if self._session:
                 await self._session.close()
                 self._session = None
-            self._completed_tool_calls = set()
-            self._tool_call_id_to_name = {}
+            # `_completed_tool_calls` and `_tool_call_id_to_name` are not reset
+            # here: like `_context`, they describe the conversation, which a
+            # reconnect carries over. A delivered result stays delivered and a
+            # pending one stays pending, under the name the model called.
             self._async_tool_warning_logged = False
             self._ready_for_realtime_input = False
             self._disconnecting = False
@@ -1462,6 +1479,29 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                 frame.vad_params.start_secs + AUTOSIZED_USER_AUDIO_PREROLL_MARGIN_SECS
             )
 
+    def _no_send_reason(self) -> str:
+        """Name the connection state that is keeping input from the service.
+
+        Returns:
+            A short description of why nothing can be sent right now.
+        """
+        if self._disconnecting:
+            return "disconnecting"
+        if not self._session:
+            return "no session"
+        return "session not ready for input"
+
+    def _log_media_drop(self, what: str):
+        """Report discarded realtime media once per outage.
+
+        Args:
+            what: The media being discarded, e.g. ``"audio"``.
+        """
+        if self._logged_media_drop:
+            return
+        self._logged_media_drop = True
+        logger.warning(f"{self}: dropping user {what} — {self._no_send_reason()}")
+
     async def _send_user_audio(self, frame):
         """Stream user audio to Gemini Live.
 
@@ -1475,12 +1515,11 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         With server-side VAD enabled we stream continuously, since Gemini's VAD
         needs the uninterrupted stream to detect turns.
         """
-        if (
-            self._audio_input_paused
-            or self._disconnecting
-            or not self._session
-            or not self._ready_for_realtime_input
-        ):
+        if self._audio_input_paused:
+            return
+
+        if self._disconnecting or not self._session or not self._ready_for_realtime_input:
+            self._log_media_drop("audio")
             return
 
         # Send all audio in server-VAD mode, or in local-VAD mode if we're
@@ -1536,6 +1575,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             text: The text to send as user input.
         """
         if self._disconnecting or not self._session or not self._ready_for_realtime_input:
+            logger.warning(f"{self}: dropping user text — {self._no_send_reason()}")
             return
 
         try:
@@ -1545,12 +1585,11 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
 
     async def _send_user_video(self, frame):
         """Send user video frame to Gemini Live API."""
-        if (
-            self._video_input_paused
-            or self._disconnecting
-            or not self._session
-            or not self._ready_for_realtime_input
-        ):
+        if self._video_input_paused:
+            return
+
+        if self._disconnecting or not self._session or not self._ready_for_realtime_input:
+            self._log_media_drop("video")
             return
 
         now = time.time()
@@ -1570,7 +1609,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         except Exception as e:
             await self._handle_send_error(e)
 
-    async def _create_initial_response(self, for_reconnect: bool = False):
+    async def _create_initial_response(self, for_reconnect: bool = False) -> bool:
         """Seed conversation history and optionally trigger an initial model response.
 
         Behavior by case:
@@ -1623,13 +1662,16 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
 
         Args:
             for_reconnect: When True, we're re-seeding after a reconnect.
+
+        Returns:
+            True if the conversation history reached the service.
         """
         if self._disconnecting:
-            return
+            return False
 
         if not self._session:
             self._run_llm_when_session_ready = True
-            return
+            return False
 
         assert self._context is not None
 
@@ -1641,7 +1683,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         if not messages:
             # No messages to seed convo with, so we're ready for realtime input right away
             self._ready_for_realtime_input = True
-            return
+            return True
 
         # On reconnect, Gemini 2.5 needs us to force an inference so the user
         # doesn't momentarily experience a "forgotten" assistant (see
@@ -1673,6 +1715,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                 await self._session.send_realtime_input(text=" ")
         except Exception as e:
             await self._handle_send_error(e)
+            return False
 
         # Gemini 2.5-only workaround: when we've seeded without triggering
         # inference, flag that the next user_stopped_speaking should send
@@ -1681,6 +1724,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             self._needs_initial_turn_complete_message = True
 
         self._ready_for_realtime_input = True
+        return True
 
     async def _create_single_response(self, messages_list):
         """Create a single response from a list of messages.
@@ -1717,16 +1761,34 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             await self._handle_send_error(e)
 
     @traced_gemini_live(operation="llm_tool_result")
-    async def _tool_result(
-        self, tool_call_id: str, tool_name: str, tool_result_message: dict[str, Any]
-    ):
-        """Send tool result back to the API."""
+    async def _tool_result(self, tool_call_id: str, tool_name: str, result: Any) -> bool:
+        """Send tool result back to the API.
+
+        Args:
+            tool_call_id: ID of the call being answered.
+            tool_name: Name of the function that was called.
+            result: What the function returned.
+
+        Returns:
+            True if the call should be considered settled, False if there was no
+            session to send on, leaving it unanswered.
+        """
         if self._disconnecting or not self._session:
-            return
+            logger.warning(
+                f"{self}: dropping tool result for tool_call_id={tool_call_id} "
+                f"— {self._no_send_reason()}"
+            )
+            return False
+
+        if tool_call_id not in self._tool_calls_this_session:
+            return await self._send_tool_result_as_text(tool_call_id, tool_name, result)
 
         logger.debug(
-            f"Sending tool result to Gemini Live for tool_call_id={tool_call_id}, tool_result_message={tool_result_message}"
+            f"Sending tool result to Gemini Live for tool_call_id={tool_call_id}, result={result}"
         )
+
+        session = self._session
+        tool_result_message = GeminiLiveLLMAdapter.to_function_response_dict(result)
 
         # Pair the NON_BLOCKING declaration on async tools with a
         # scheduling hint on the response. WHEN_IDLE lets Gemini finish
@@ -1746,14 +1808,73 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
         response = FunctionResponse(name=tool_name, id=tool_call_id, response=response_payload)
 
         try:
-            await self._session.send_tool_response(function_responses=response)
+            await session.send_tool_response(function_responses=response)
         except Exception as e:
             await self._handle_send_error(e)
+            # A send that lost its session mid-flight is worth another attempt.
+            # One that failed while the session was up isn't: the error is
+            # already surfaced, and every later context update would repeat it.
+            return session is self._session and not self._disconnecting
+
+        return True
+
+    async def _send_tool_result_as_text(
+        self, tool_call_id: str, tool_name: str, result: Any
+    ) -> bool:
+        """Hand a result to a session that didn't issue the call.
+
+        A resumed session restores the conversation but not the tool call it was
+        waiting on: a tool response for that call is accepted and then ignored,
+        leaving the model blocked for the rest of the turn. Seeding the result as
+        conversation does reach it, in the same text form the adapter uses when
+        it re-seeds tool calls on a reconnect.
+
+        Args:
+            tool_call_id: ID of the call being answered.
+            tool_name: Name of the function that was called.
+            result: What the function returned.
+
+        Returns:
+            True if the call should be considered settled, False if there was no
+            session to send on, leaving it unanswered.
+        """
+        session = self._session
+        assert session is not None
+
+        logger.debug(
+            f"Sending tool result as conversation for tool_call_id={tool_call_id}, result={result}"
+        )
+
+        # A synchronous tool leaves the model waiting, so the result runs
+        # inference. An async tool's model is still talking; hold the turn open
+        # rather than cut it off, as WHEN_IDLE does on the tool-response path.
+        run_inference = not (
+            self._supports_non_blocking_tools and self._function_is_async(tool_name)
+        )
+        text = GeminiLiveLLMAdapter.to_tool_result_text(tool_name, result)
+
+        await self.start_ttfb_metrics()
+
+        try:
+            await session.send_client_content(
+                turns=[Content(role="user", parts=[Part(text=text)])],
+                turn_complete=run_inference,
+            )
+            # Gemini 3.x wants turn_complete=True, but also won't run inference
+            # without a realtime input.
+            if self._is_gemini_3 and run_inference:
+                await session.send_realtime_input(text=" ")
+        except Exception as e:
+            await self._handle_send_error(e)
+            return session is self._session and not self._disconnecting
+
+        return True
 
     @traced_gemini_live(operation="llm_setup")
     async def _handle_session_ready(self, session: AsyncSession):
         """Handle the session being ready."""
         self._session = session
+        self._tool_calls_this_session = set()
         if self._run_llm_when_session_ready:
             # Initial connection: context arrived before session was ready.
             self._run_llm_when_session_ready = False
@@ -1762,6 +1883,10 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             # Reconnect with session resumption: the server will restore
             # session state, so we can accept realtime input right away.
             self._ready_for_realtime_input = True
+            # A tool call issued before the reconnect is still unanswered, and
+            # the restored session won't take a tool response for it.
+            if self._context:
+                await self._process_completed_function_calls(send_new_results=True)
         elif self._context:
             # Reconnect without session resumption (e.g. error occurred
             # before server sent a resumption handle): re-seed conversation
@@ -1769,12 +1894,18 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
             # accepting input. We route through _create_initial_response so
             # that the seed/commit dance stays in one place. See that
             # method's docstring for the reconnect-specific behavior.
-            await self._create_initial_response(for_reconnect=True)
+            # A re-seed that landed carries every tool result the context
+            # holds, so the fresh session needs no tool response — and would
+            # reject one for a call it never issued.
+            if await self._create_initial_response(for_reconnect=True):
+                await self._process_completed_function_calls(send_new_results=False)
         else:
             # Initial connection: session is ready before context has
             # arrived. Nothing to do — _handle_context will call
             # _create_initial_response when the context arrives.
             pass
+
+        self._logged_media_drop = False
 
     async def _handle_msg_model_turn(self, msg: LiveServerMessage):
         """Handle the model turn message."""
@@ -1883,6 +2014,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
 
         for fc in function_calls_llm:
             self._tool_call_id_to_name[fc.tool_call_id] = fc.function_name
+            self._tool_calls_this_session.add(fc.tool_call_id)
 
         await self.run_function_calls(function_calls_llm)
 

--- a/tests/test_gemini_live_reconnect.py
+++ b/tests/test_gemini_live_reconnect.py
@@ -1,0 +1,400 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for tool-result delivery in GeminiLiveLLMService across a reconnect.
+
+A tool call the model is blocked on stays blocked until its result arrives, so a
+result that doesn't reach the service has to survive the outage and go out once a
+session can take it. Which shape that takes depends on how the session comes
+back: a resumed session still holds the pending call, while a re-seeded one
+receives the result as conversation history instead.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+from loguru import logger
+
+from pipecat.frames.frames import InputAudioRawFrame, InputImageRawFrame
+from pipecat.processors.aggregators import async_tool_messages
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
+
+
+class _FakeSession:
+    """Records what the service sends."""
+
+    def __init__(self):
+        self.tool_responses: list[Any] = []
+        self.client_content: list[dict[str, Any]] = []
+
+    async def send_tool_response(self, function_responses=None):
+        self.tool_responses.append(function_responses)
+
+    async def send_client_content(self, **kwargs):
+        self.client_content.append(kwargs)
+
+    async def send_realtime_input(self, **kwargs):
+        pass
+
+    async def close(self):
+        pass
+
+
+def _make_service() -> GeminiLiveLLMService:
+    """Construct a service mid-conversation, with one completed tool call.
+
+    ``__init__`` does no I/O. Metrics need a started pipeline, so they're stubbed
+    out to let the handlers and the disconnect path run in isolation.
+    """
+    service = GeminiLiveLLMService(api_key="test-key")
+    service._session = _FakeSession()
+    service._tool_call_id_to_name["call-1"] = "book_flight"
+    service._tool_calls_this_session.add("call-1")
+    service._context = LLMContext(
+        messages=[
+            {"role": "user", "content": "book me a flight"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "book_flight", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "booked, ref XY123"},
+        ]
+    )
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    service.start_ttfb_metrics = _noop  # type: ignore[method-assign]
+    service.stop_all_metrics = _noop  # type: ignore[method-assign]
+    return service
+
+
+def _seeded_text(session: "_FakeSession") -> str:
+    """The text of the last conversation turn the service seeded."""
+    return session.client_content[-1]["turns"][-1].parts[0].text
+
+
+def _audio_frame() -> InputAudioRawFrame:
+    return InputAudioRawFrame(audio=b"\x01\x02" * 160, sample_rate=16000, num_channels=1)
+
+
+def _video_frame() -> InputImageRawFrame:
+    return InputImageRawFrame(image=b"\x00" * (8 * 8 * 3), size=(8, 8), format="RGB")
+
+
+@pytest.fixture
+def log_messages():
+    """Collect the messages logged during a test."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m.record["message"]), level="DEBUG")
+    yield messages
+    logger.remove(sink_id)
+
+
+@pytest.mark.asyncio
+async def test_result_dropped_across_a_disconnect_is_retried_under_its_own_name():
+    """A result that missed its session is sent again, naming the function called."""
+    service = _make_service()
+    session = service._session
+
+    await service._disconnect()
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert service._completed_tool_calls == set(), (
+        "an unanswered call must not be recorded as answered"
+    )
+
+    service._session = session
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert [r.id for r in session.tool_responses] == ["call-1"]
+    assert session.tool_responses[0].name == "book_flight", (
+        "the model is blocked on book_flight, so the response has to name it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delivered_result_is_not_resent_after_a_disconnect():
+    """A result the service already sent isn't repeated when the session returns."""
+    service = _make_service()
+    session = service._session
+    service._session_resumption_handle = "handle-abc"
+
+    await service._process_completed_function_calls(send_new_results=True)
+    assert len(session.tool_responses) == 1
+
+    await service._disconnect()
+    await service._handle_session_ready(session)
+
+    assert len(session.tool_responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_resumed_session_receives_the_pending_result_as_conversation():
+    """A resumed session never issued the call, so the result arrives as text."""
+    service = _make_service()
+    session = service._session
+    service._session_resumption_handle = "handle-abc"
+
+    await service._disconnect()
+    await service._process_completed_function_calls(send_new_results=True)
+    assert session.tool_responses == []
+
+    await service._handle_session_ready(session)
+
+    assert session.tool_responses == [], "the restored session would ignore a tool response"
+    assert service._completed_tool_calls == {"call-1"}
+    assert _seeded_text(session) == "[Function book_flight returned booked, ref XY123]"
+
+
+@pytest.mark.asyncio
+async def test_reseeded_session_takes_the_result_as_history():
+    """A re-seeded session never issued the call, so it gets no tool response."""
+    service = _make_service()
+    session = service._session
+
+    await service._disconnect()
+    await service._process_completed_function_calls(send_new_results=True)
+
+    await service._handle_session_ready(session)
+
+    assert session.client_content, "the reconnect re-seeds the conversation"
+    assert session.tool_responses == []
+    assert service._completed_tool_calls == {"call-1"}, (
+        "the re-seed carries the result, so the call is answered"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_failure_on_a_live_session_is_not_retried():
+    """A send that fails with the session up is reported once, not on every update."""
+    service = _make_service()
+    errors: list[str | None] = []
+
+    async def _raise(**kwargs):
+        raise RuntimeError("send failed")
+
+    async def _record_error(error_msg=None, **kwargs):
+        errors.append(error_msg)
+
+    service._session.send_tool_response = _raise  # type: ignore[method-assign]
+    service.push_error = _record_error  # type: ignore[method-assign]
+
+    for _ in range(3):
+        await service._process_completed_function_calls(send_new_results=True)
+
+    assert len(errors) == 1
+
+
+@pytest.mark.asyncio
+async def test_results_already_in_the_context_are_recorded_without_sending(log_messages):
+    """The bootstrap pass adopts existing results rather than replaying them."""
+    service = _make_service()
+    session = service._session
+    service._session = None
+
+    await service._process_completed_function_calls(send_new_results=False)
+
+    assert service._completed_tool_calls == {"call-1"}
+    assert session.tool_responses == []
+    assert not [m for m in log_messages if "dropping" in m], (
+        "adopting a result is not a delivery attempt, so nothing is dropped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dropped_tool_result_names_the_call_and_the_reason(log_messages):
+    """A dropped result says which call it leaves unanswered, and why."""
+    service = _make_service()
+    service._session = None
+
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert any(
+        "dropping tool result for tool_call_id=call-1 — no session" in m for m in log_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_dropped_user_text_names_the_reason(log_messages):
+    """Text that can't be sent says which connection state stopped it."""
+    service = _make_service()
+    service._disconnecting = True
+
+    await service._send_user_text("are you there?")
+
+    assert any("dropping user text — disconnecting" in m for m in log_messages)
+
+
+@pytest.mark.asyncio
+async def test_dropped_media_is_reported_once_per_outage(log_messages):
+    """Media discarded while a session is away is reported once, not per frame."""
+    service = _make_service()
+    session = service._session
+    service._session = None
+
+    for _ in range(5):
+        await service._send_user_audio(_audio_frame())
+
+    assert len([m for m in log_messages if "dropping user audio" in m]) == 1
+
+    await service._handle_session_ready(session)
+    service._session = None
+    await service._send_user_video(_video_frame())
+
+    assert any("dropping user video" in m for m in log_messages)
+
+
+@pytest.mark.asyncio
+async def test_paused_media_is_not_reported_as_dropped(log_messages):
+    """Pausing input is a deliberate choice, so nothing is reported as dropped."""
+    service = _make_service()
+    service._session = None
+    service.set_audio_input_paused(True)
+    service.set_video_input_paused(True)
+
+    await service._send_user_audio(_audio_frame())
+    await service._send_user_video(_video_frame())
+
+    assert not [m for m in log_messages if "dropping" in m]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scans_send_the_result_once():
+    """The reconnect flush and a context update can't both claim the same call."""
+    service = _make_service()
+    session = service._session
+    service._session_resumption_handle = "handle-abc"
+    delivered = session.send_tool_response
+
+    async def _yield_mid_send(function_responses=None):
+        await asyncio.sleep(0)
+        await delivered(function_responses=function_responses)
+
+    session.send_tool_response = _yield_mid_send  # type: ignore[method-assign]
+
+    await service._disconnect()
+    await asyncio.gather(
+        service._handle_session_ready(session),
+        service._process_completed_function_calls(send_new_results=True),
+    )
+
+    assert len(session.tool_responses) + len(session.client_content) == 1
+
+
+@pytest.mark.asyncio
+async def test_result_stays_pending_when_the_reseed_fails():
+    """A re-seed that never landed can't be what delivered the result."""
+    service = _make_service()
+    session = service._session
+
+    async def _fail(**kwargs):
+        raise RuntimeError("re-seed failed")
+
+    async def _swallow(**kwargs):
+        pass
+
+    session.send_client_content = _fail  # type: ignore[method-assign]
+    service.push_error = _swallow  # type: ignore[method-assign]
+
+    await service._disconnect()
+    await service._process_completed_function_calls(send_new_results=True)
+    await service._handle_session_ready(session)
+
+    assert session.tool_responses == []
+    assert service._completed_tool_calls == set()
+
+
+@pytest.mark.asyncio
+async def test_async_tool_result_without_a_session_is_retried():
+    """An async tool's final result is held and resent like a synchronous one."""
+    service = _make_service()
+    session = service._session
+    service._tool_call_id_to_name["call-2"] = "slow_job"
+    service._tool_calls_this_session.add("call-2")
+    service._context.add_message(async_tool_messages.build_started_message("call-2"))
+    service._context.add_message(async_tool_messages.build_final_result_message("call-2", "done"))
+    service._completed_tool_calls.add("call-1")
+
+    service._session = None
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert "call-2" not in service._completed_tool_calls
+
+    service._session = session
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert [(r.id, r.name) for r in session.tool_responses] == [("call-2", "slow_job")]
+
+
+@pytest.mark.asyncio
+async def test_a_session_lost_mid_scan_keeps_only_the_rest_pending():
+    """Results already sent stay settled; the ones that missed the session don't."""
+    service = _make_service()
+    session = service._session
+    service._tool_call_id_to_name["call-2"] = "check_seat"
+    service._tool_calls_this_session.add("call-2")
+    service._context.add_message(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call-2",
+                    "type": "function",
+                    "function": {"name": "check_seat", "arguments": "{}"},
+                }
+            ],
+        }
+    )
+    service._context.add_message({"role": "tool", "tool_call_id": "call-2", "content": "12A"})
+    delivered = session.send_tool_response
+
+    async def _then_lose_the_session(function_responses=None):
+        await delivered(function_responses=function_responses)
+        service._session = None
+
+    session.send_tool_response = _then_lose_the_session  # type: ignore[method-assign]
+
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert [r.id for r in session.tool_responses] == ["call-1"]
+    assert service._completed_tool_calls == {"call-1"}
+
+
+@pytest.mark.asyncio
+async def test_call_issued_by_this_session_uses_the_tool_response_channel():
+    """The ordinary path is unchanged: a live call gets a formal tool response."""
+    service = _make_service()
+    session = service._session
+
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert [r.id for r in session.tool_responses] == ["call-1"]
+    assert session.client_content == []
+
+
+@pytest.mark.asyncio
+async def test_call_that_outlived_its_session_is_delivered_as_conversation():
+    """A call the session never issued can't be answered with a tool response."""
+    service = _make_service()
+    session = service._session
+    service._tool_calls_this_session.clear()  # as a new session leaves it
+
+    await service._process_completed_function_calls(send_new_results=True)
+
+    assert session.tool_responses == []
+    assert service._completed_tool_calls == {"call-1"}
+    assert _seeded_text(session) == "[Function book_flight returned booked, ref XY123]", (
+        "the result reads as the adapter renders it, not as Gemini's response wrapper"
+    )


### PR DESCRIPTION
Fixes #5465

A Gemini Live tool call that outlives the session that issued it never gets answered. If the connection drops part-way through a long tool call, the reconnected session won't act on a `FunctionResponse` for a call it didn't issue, so the model stays blocked and the bot goes quiet for the rest of the turn.

The service was also discarding input while reconnecting without logging anything, which is what the issue was filed about.

## Changes

- A tool result for a call the current session didn't issue is delivered as conversation instead of a tool response.
- A result that couldn't be sent stays pending instead of being recorded as delivered, and goes out once a session can take it.
- Tool bookkeeping is no longer cleared on disconnect, it describes the conversation, not the socket.
- The context scan is serialized: a reconnect can flush results from the connection task while the frame task is handling a context update.
- All four send guards log what they dropped and why. Media logs once per outage, and a deliberate pause isn't reported as a drop.

## Testing

`uv run pytest tests/test_gemini_live_reconnect.py`- 16 tests.

Verified against the live API on `gemini-2.5-flash-native-audio-preview-12-2025` & `gemini-3.1-flash-live-preview`. A tool call spanning a reconnect goes from no reply at all to answering normally; a call issued & answered within one session still uses the tool-response channel.

