### PR TITLE
fix(gladia): send stop_recording before closing the websocket

### DIFF
--- a/changelog/5499.fixed.md
+++ b/changelog/5499.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `GladiaSTTService` dropping Gladia's `stop_recording` message on a graceful end. The websocket closed before the message was sent, so sessions ended by dropping the connection rather than closing cleanly, and the service's `on_disconnected` event fired twice.

--- a/src/pipecat/services/gladia/stt.py
+++ b/src/pipecat/services/gladia/stt.py
@@ -470,9 +470,12 @@ class GladiaSTTService(WebsocketSTTService):
         Args:
             frame: The end frame triggering service shutdown.
         """
-        await super().stop(frame)
+        # stop_recording ends the session server-side and has to reach the
+        # socket before teardown closes it. Trailing transcripts are not
+        # waited for: Gladia finalizes the session and its stored result
+        # either way.
         await self._send_stop_recording()
-        await self._disconnect()
+        await super().stop(frame)
 
     async def cancel(self, frame: CancelFrame):
         """Cancel the Gladia STT websocket connection.

--- a/tests/test_gladia_stt.py
+++ b/tests/test_gladia_stt.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from websockets.protocol import State
+
+from pipecat.frames.frames import CancelFrame, EndFrame
+from pipecat.services.gladia.stt import GladiaSTTService
+from pipecat.utils.asyncio.task_manager import TaskManager
+from tests.frame_processor_helpers import frame_processor_setup
+
+
+class _FakeWebsocket:
+    def __init__(self, *, state=State.OPEN):
+        self.state = state
+        self.sent = []
+        self.closed = False
+
+    async def send(self, payload):
+        self.sent.append(json.loads(payload))
+
+    async def close(self):
+        self.closed = True
+        self.state = State.CLOSED
+
+    def __aiter__(self):
+        return self._iter_messages()
+
+    async def _iter_messages(self):
+        if False:
+            yield None
+
+
+def _connected_service():
+    """Build a service holding an open fake socket, without touching the network."""
+    service = GladiaSTTService(api_key="test-key")
+    service._setup = frame_processor_setup(TaskManager())
+    websocket = _FakeWebsocket()
+    service._websocket = websocket
+    service._connection_active = True
+    return service, websocket
+
+
+def _message_types(websocket):
+    return [message["type"] for message in websocket.sent]
+
+
+@pytest.mark.asyncio
+async def test_stop_sends_stop_recording_while_the_socket_is_open():
+    service, websocket = _connected_service()
+
+    await service.stop(EndFrame())
+
+    assert _message_types(websocket) == ["stop_recording"]
+    assert websocket.closed
+
+
+@pytest.mark.asyncio
+async def test_stop_disconnects_once():
+    service, _ = _connected_service()
+    service._disconnect_websocket = AsyncMock(wraps=service._disconnect_websocket)
+
+    await service.stop(EndFrame())
+
+    service._disconnect_websocket.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_does_not_send_stop_recording():
+    service, websocket = _connected_service()
+
+    await service.cancel(CancelFrame())
+
+    assert _message_types(websocket) == []
+    assert websocket.closed


### PR DESCRIPTION
## Summary

- `GladiaSTTService` now sends Gladia's `stop_recording` before teardown closes the websocket, so the message reaches the socket while it is still open and the session ends cleanly instead of by a dropped connection.
- The graceful path disconnects once. `on_disconnected` no longer fires an extra time.
- Shutdown is not held up: trailing transcripts are not waited for.

`stop()` previously called `super().stop(frame)` first. That runs `WebsocketSTTService.stop()`, which disconnects and clears `self._websocket`, so `_send_stop_recording()` hit its open-socket guard and returned without sending, and the `_disconnect()` on the next line was a second teardown. The duplicate `on_disconnected` came from that event living in a `finally` outside the guard in `_disconnect_websocket()`.

## Draining the final transcript is deliberately not included

#5405 asks for a bounded wait so the trailing final arrives in-stream. This PR does not do that, for the reason #5347 was closed: the pipeline would be held open for a transcript that generates no further turn.

Probing the live API with a 5s clip torn down immediately, so the tail was still unprocessed at teardown:

| Teardown | In-stream final | `GET /v2/live/:id` | `full_transcript` |
| --- | --- | --- | --- |
| `stop_recording`, then read | +0.46s, server closes +1.2s | `done` at ~7s | complete |
| Abrupt close, no message | none | `done` at ~11s | complete, identical |

An abrupt close still finalizes the session, with the trailing audio fully transcribed. The tail reaches Gladia's stored result either way, so a wait buys only the in-stream copy of it.

## Testing

`uv run pytest tests/test_gladia_stt.py`

The tests drive `stop()` and `cancel()` against a fake socket rather than mocking `_disconnect` away, so they assert what reaches the wire. The first two fail without the fix; the third pins the intentional split where `cancel()` sends nothing.

## Fixes

- Fixes #5405