### PR TITLE
Fix SyncParallelPipeline system frame duplication

### DIFF
--- a/changelog/5500.fixed.md
+++ b/changelog/5500.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SyncParallelPipeline` emitting system frames twice and retaining copies in branch queues.

--- a/src/pipecat/pipeline/sync_parallel_pipeline.py
+++ b/src/pipecat/pipeline/sync_parallel_pipeline.py
@@ -20,6 +20,7 @@ import asyncio
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
+from weakref import WeakValueDictionary
 
 from loguru import logger
 
@@ -75,6 +76,12 @@ class SyncParallelPipelineSource(FrameProcessor):
         """
         super().__init__(enable_direct_mode=True)
         self._up_queue = upstream_queue
+        # A branch may swallow a frame, so tracking it must not keep it alive.
+        self._bypassed_system_frames: WeakValueDictionary[int, SystemFrame] = WeakValueDictionary()
+
+    def _register_bypassed_system_frame(self, frame: SystemFrame):
+        """Mark a fanned-out system frame so its branch copy is not retained."""
+        self._bypassed_system_frames[id(frame)] = frame
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames and route them based on direction.
@@ -87,6 +94,8 @@ class SyncParallelPipelineSource(FrameProcessor):
 
         match direction:
             case FrameDirection.UPSTREAM:
+                if self._bypassed_system_frames.get(id(frame)) is frame:
+                    return
                 await self._up_queue.put(frame)
             case FrameDirection.DOWNSTREAM:
                 await self.push_frame(frame, direction)
@@ -108,6 +117,12 @@ class SyncParallelPipelineSink(FrameProcessor):
         """
         super().__init__(enable_direct_mode=True)
         self._down_queue = downstream_queue
+        # A branch may swallow a frame, so tracking it must not keep it alive.
+        self._bypassed_system_frames: WeakValueDictionary[int, SystemFrame] = WeakValueDictionary()
+
+    def _register_bypassed_system_frame(self, frame: SystemFrame):
+        """Mark a fanned-out system frame so its branch copy is not retained."""
+        self._bypassed_system_frames[id(frame)] = frame
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames and route them based on direction.
@@ -122,6 +137,8 @@ class SyncParallelPipelineSink(FrameProcessor):
             case FrameDirection.UPSTREAM:
                 await self.push_frame(frame, direction)
             case FrameDirection.DOWNSTREAM:
+                if self._bypassed_system_frames.get(id(frame)) is frame:
+                    return
                 await self._down_queue.put(frame)
 
 
@@ -171,6 +188,8 @@ class SyncParallelPipeline(BasePipeline):
         self._sinks = []
         self._sources = []
         self._pipelines = []
+        self._upstream_bookends: list[SyncParallelPipelineSource] = []
+        self._downstream_bookends: list[SyncParallelPipelineSink] = []
 
         self._up_queue = asyncio.Queue()
         self._down_queue = asyncio.Queue()
@@ -190,6 +209,8 @@ class SyncParallelPipeline(BasePipeline):
             # the source and the sinks so we can use it later.
             self._sources.append({"processor": source, "queue": down_queue})
             self._sinks.append({"processor": sink, "queue": up_queue})
+            self._upstream_bookends.append(source)
+            self._downstream_bookends.append(sink)
 
             # Create pipeline
             pipeline = Pipeline(processors, source=source, sink=sink)
@@ -262,15 +283,18 @@ class SyncParallelPipeline(BasePipeline):
         """
         await super().process_frame(frame, direction)
 
-        # SystemFrames are simply passed through all internal pipelines without
-        # draining queued output. This avoids the race condition where a
-        # SystemFrame's wait_for_sync steals frames from a concurrent
-        # non-SystemFrame's wait_for_sync.
+        # SystemFrames pass through every internal pipeline, while the receiving
+        # bookends suppress only the original fanned-out copies. The parent then
+        # pushes the original once without draining other queued output.
         if isinstance(frame, SystemFrame):
             if direction == FrameDirection.UPSTREAM:
+                for source in self._upstream_bookends:
+                    source._register_bypassed_system_frame(frame)
                 for s in self._sinks:
                     await s["processor"].process_frame(frame, direction)
             elif direction == FrameDirection.DOWNSTREAM:
+                for sink in self._downstream_bookends:
+                    sink._register_bypassed_system_frame(frame)
                 for s in self._sources:
                     await s["processor"].process_frame(frame, direction)
             await self.push_frame(frame, direction)

--- a/tests/test_sync_parallel_pipeline.py
+++ b/tests/test_sync_parallel_pipeline.py
@@ -7,12 +7,18 @@
 import asyncio
 import unittest
 from dataclasses import dataclass
+from weakref import ref
 
-from pipecat.frames.frames import Frame, TextFrame
-from pipecat.pipeline.sync_parallel_pipeline import FrameOrder, SyncParallelPipeline
+from pipecat.frames.frames import Frame, InputAudioRawFrame, SystemFrame, TextFrame
+from pipecat.pipeline.sync_parallel_pipeline import (
+    FrameOrder,
+    SyncParallelPipeline,
+    SyncParallelPipelineSink,
+    SyncParallelPipelineSource,
+)
 from pipecat.processors.filters.identity_filter import IdentityFilter
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.tests.utils import run_test
+from pipecat.tests.utils import SleepFrame, run_test
 
 
 @dataclass
@@ -48,7 +54,100 @@ class EmitTaggedFrameProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
 
 
+class CaptureFramesProcessor(FrameProcessor):
+    """Records frames while preserving their direction and identity."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.seen_frame_ids: list[int] = []
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        self.seen_frame_ids.append(frame.id)
+        await self.push_frame(frame, direction)
+
+
+@dataclass
+class SampleSystemFrame(SystemFrame):
+    """System frame used to verify branch bookend behavior."""
+
+    pass
+
+
 class TestSyncParallelPipeline(unittest.IsolatedAsyncioTestCase):
+    async def test_system_frames_downstream_are_delivered_once(self):
+        """System frames should traverse every branch without being emitted twice."""
+        first_branch = CaptureFramesProcessor()
+        second_branch = CaptureFramesProcessor()
+        pipeline = SyncParallelPipeline([first_branch], [second_branch])
+
+        audio_frames = [
+            InputAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
+            for _ in range(3)
+        ]
+        text_frames = [TextFrame(text="one"), TextFrame(text="two")]
+        frames_to_send = audio_frames + text_frames
+
+        down_frames, _ = await run_test(pipeline, frames_to_send=frames_to_send, start_timeout=5.0)
+
+        assert [frame.id for frame in down_frames] == [frame.id for frame in frames_to_send]
+        for branch in (first_branch, second_branch):
+            for frame in audio_frames:
+                assert branch.seen_frame_ids.count(frame.id) == 1
+
+    async def test_bookends_do_not_retain_system_frames(self):
+        """Bookends should suppress fanned copies while preserving branch-generated frames."""
+        upstream_queue = asyncio.Queue()
+        downstream_queue = asyncio.Queue()
+        source = SyncParallelPipelineSource(upstream_queue)
+        sink = SyncParallelPipelineSink(downstream_queue)
+
+        fanned_upstream = SampleSystemFrame()
+        fanned_downstream = SampleSystemFrame()
+        source._register_bypassed_system_frame(fanned_upstream)
+        sink._register_bypassed_system_frame(fanned_downstream)
+
+        await source.process_frame(fanned_upstream, FrameDirection.UPSTREAM)
+        await sink.process_frame(fanned_downstream, FrameDirection.DOWNSTREAM)
+
+        assert upstream_queue.empty()
+        assert downstream_queue.empty()
+
+        generated_upstream = SampleSystemFrame()
+        generated_downstream = SampleSystemFrame()
+        await source.process_frame(generated_upstream, FrameDirection.UPSTREAM)
+        await sink.process_frame(generated_downstream, FrameDirection.DOWNSTREAM)
+
+        assert await upstream_queue.get() is generated_upstream
+        assert await downstream_queue.get() is generated_downstream
+
+        swallowed_frame = SampleSystemFrame()
+        swallowed_frame_ref = ref(swallowed_frame)
+        source._register_bypassed_system_frame(swallowed_frame)
+        del swallowed_frame
+
+        assert swallowed_frame_ref() is None
+
+    async def test_system_frames_upstream_are_delivered_once(self):
+        """Upstream system frames should traverse every branch without being emitted twice."""
+        first_branch = CaptureFramesProcessor()
+        second_branch = CaptureFramesProcessor()
+        pipeline = SyncParallelPipeline([first_branch], [second_branch])
+
+        system_frame = SampleSystemFrame()
+        data_frame = TextFrame(text="upstream")
+        _, up_frames = await run_test(
+            pipeline,
+            # Keep the harness's downstream EndFrame from racing the upstream sync.
+            frames_to_send=[system_frame, data_frame, SleepFrame(sleep=0.1)],
+            frames_to_send_direction=FrameDirection.UPSTREAM,
+            start_timeout=5.0,
+        )
+
+        assert [frame.id for frame in up_frames] == [system_frame.id, data_frame.id]
+        for branch in (first_branch, second_branch):
+            assert branch.seen_frame_ids.count(system_frame.id) == 1
+
     async def test_dedup_multiple_frames(self):
         """Identical frames from multiple paths should be deduplicated."""
         pipeline = SyncParallelPipeline([IdentityFilter()], [IdentityFilter()])


### PR DESCRIPTION
## Summary

- prevent fanned-out SystemFrame copies from remaining in branch queues
- preserve system frames generated inside a branch
- cover downstream audio, upstream flow, and queue retention

Closes #5492.

## Testing

- relevant pipeline suite: 58 passed
- Ruff check and format check
- Pyright on the changed source and tests