### PR TITLE
feat(sarvam): add SarvamHttpSTTService for REST transcription

### DIFF
--- a/changelog/5501.added.md
+++ b/changelog/5501.added.md
@@ -1,0 +1,6 @@
+- Added `SarvamHttpSTTService`, a segmented HTTP sibling of the WebSocket
+  `SarvamSTTService` that transcribes each speech segment through Sarvam's
+  synchronous REST speech-to-text API (Saaras v3/v4) and yields the
+  transcription inline from `run_stt()`, for pipelines that prefer per-segment
+  requests over a long-lived socket and for callers that use `run_stt()`
+  directly. Handles Indian languages and Hindi/English code-mix.

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -6,11 +6,15 @@
 
 """Sarvam AI Speech-to-Text service implementations.
 
-Both services stream audio to Sarvam's WebSocket API for Indian language speech
-recognition. :class:`SarvamSTTService` covers the transcription endpoint, with
-Voice Activity Detection and a choice of audio formats.
-:class:`SarvamRealtimeSTTService` targets the realtime endpoint, which adds
+:class:`SarvamSTTService` and :class:`SarvamRealtimeSTTService` stream audio to
+Sarvam's WebSocket APIs for Indian language speech recognition. The former
+covers the transcription endpoint, with Voice Activity Detection and a choice
+of audio formats; the latter targets the realtime endpoint, which adds
 server-side endpointing and in-band configuration updates.
+
+:class:`SarvamHttpSTTService` instead sends each VAD-detected speech segment to
+Sarvam's synchronous REST API and yields the transcription inline, so it also
+suits callers that use ``run_stt()`` directly.
 """
 
 import asyncio
@@ -41,8 +45,12 @@ from pipecat.frames.frames import (
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
 from pipecat.services.sarvam._sdk import sdk_headers
 from pipecat.services.settings import STTSettings
-from pipecat.services.stt_latency import SARVAM_REALTIME_TTFS_P99, SARVAM_TTFS_P99
-from pipecat.services.stt_service import STTService, WebsocketSTTService
+from pipecat.services.stt_latency import (
+    SARVAM_HTTP_TTFS_P99,
+    SARVAM_REALTIME_TTFS_P99,
+    SARVAM_TTFS_P99,
+)
+from pipecat.services.stt_service import SegmentedSTTService, STTService, WebsocketSTTService
 from pipecat.services.websocket_service import ReportErrorCallback
 from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
@@ -89,6 +97,61 @@ def language_to_sarvam_language(language: Language) -> str:
     }
 
     return resolve_language(language, LANGUAGE_MAP, use_base_code=False)
+
+
+# Sarvam language codes mapped back to pipecat Language values, for the codes
+# Sarvam reports on transcription results. Shared by the WebSocket and HTTP
+# services so the table lives in one place.
+_SARVAM_CODE_TO_LANGUAGE = {
+    "bn-IN": Language.BN_IN,
+    "gu-IN": Language.GU_IN,
+    "hi-IN": Language.HI_IN,
+    "kn-IN": Language.KN_IN,
+    "ml-IN": Language.ML_IN,
+    "mr-IN": Language.MR_IN,
+    "ta-IN": Language.TA_IN,
+    "te-IN": Language.TE_IN,
+    "pa-IN": Language.PA_IN,
+    "od-IN": Language.OR_IN,
+    "en-US": Language.EN_US,
+    "en-IN": Language.EN_IN,
+    "as-IN": Language.AS_IN,
+    "ur-IN": Language.UR_IN,
+    "mai-IN": Language.MAI_IN,
+    "sd-IN": Language.SD_IN,
+    "kok-IN": Language.KOK_IN,
+}
+
+
+def _language_code_to_language(
+    language_code: str | None, warned: set[str], service: Any
+) -> Language | None:
+    """Map a Sarvam language code to a pipecat Language, or None if unresolved.
+
+    Returns None for Sarvam's own "unknown"/auto-detect placeholder and for
+    any code -- present or future -- the table doesn't have an entry for,
+    rather than guessing a specific language. A code the table doesn't carry
+    only logs a warning once per ``warned`` set, so a long-running session
+    doesn't spam it every turn.
+
+    Args:
+        language_code: The code Sarvam reported, or the configured one.
+        warned: The owning service's set of codes already warned about.
+        service: The owning service, named in the warning.
+    """
+    # "unknown" is Sarvam's own placeholder for "not detected/configured yet"
+    # (see MODEL_CONFIGS.default_language), not a data gap worth warning about.
+    if not language_code or language_code == "unknown":
+        return None
+    language = _SARVAM_CODE_TO_LANGUAGE.get(language_code)
+    if language is None and language_code not in warned:
+        warned.add(language_code)
+        logger.warning(
+            f"{service} received Sarvam language code {language_code!r}, which has no "
+            "Language mapping; leaving TranscriptionFrame.language unset for it "
+            "rather than guessing."
+        )
+    return language
 
 
 SarvamMode = Literal["transcribe", "translate", "verbatim", "translit", "codemix"]
@@ -735,38 +798,7 @@ class SarvamSTTService(STTService):
         maps to a language this table doesn't carry only logs a warning once,
         so a long-running session doesn't spam it every turn.
         """
-        mapping = {
-            "bn-IN": Language.BN_IN,
-            "gu-IN": Language.GU_IN,
-            "hi-IN": Language.HI_IN,
-            "kn-IN": Language.KN_IN,
-            "ml-IN": Language.ML_IN,
-            "mr-IN": Language.MR_IN,
-            "ta-IN": Language.TA_IN,
-            "te-IN": Language.TE_IN,
-            "pa-IN": Language.PA_IN,
-            "od-IN": Language.OR_IN,
-            "en-US": Language.EN_US,
-            "en-IN": Language.EN_IN,
-            "as-IN": Language.AS_IN,
-            "ur-IN": Language.UR_IN,
-            "mai-IN": Language.MAI_IN,
-            "sd-IN": Language.SD_IN,
-            "kok-IN": Language.KOK_IN,
-        }
-        # "unknown" is Sarvam's own placeholder for "not detected/configured yet"
-        # (see MODEL_CONFIGS.default_language), not a data gap worth warning about.
-        if not language_code or language_code == "unknown":
-            return None
-        language = mapping.get(language_code)
-        if language is None and language_code not in self._unmapped_language_codes_warned:
-            self._unmapped_language_codes_warned.add(language_code)
-            logger.warning(
-                f"{self} received Sarvam language code {language_code!r}, which has no "
-                "Language mapping; leaving TranscriptionFrame.language unset for it "
-                "rather than guessing."
-            )
-        return language
+        return _language_code_to_language(language_code, self._unmapped_language_codes_warned, self)
 
     def _is_keepalive_ready(self) -> bool:
         """Check if the Sarvam SDK websocket client is connected."""
@@ -1553,3 +1585,233 @@ def _as_language(value: Any) -> Language | None:
         return Language(value)
     except ValueError:
         return None
+
+
+# Sarvam's REST speech-to-text endpoint offers the same Saaras generations as
+# the WebSocket endpoint, but with its own capability matrix: the REST API
+# documents ``mode`` for saaras:v3 only.
+HTTP_MODEL_CONFIGS: dict[str, ModelConfig] = {
+    "saaras:v3": ModelConfig(
+        supports_mode=True,
+        supports_language=True,
+        default_language="unknown",
+        default_mode="transcribe",
+    ),
+    "saaras:v4": ModelConfig(
+        supports_mode=False,
+        supports_language=True,
+        default_language="unknown",
+        default_mode=None,
+    ),
+}
+
+
+@dataclass
+class SarvamHttpSTTSettings(STTSettings):
+    """Settings for SarvamHttpSTTService."""
+
+    pass
+
+
+class SarvamHttpSTTService(SegmentedSTTService):
+    """Sarvam speech-to-text service using the synchronous REST API.
+
+    The HTTP sibling of the WebSocket :class:`SarvamSTTService`: each
+    VAD-detected speech segment is sent to Sarvam's REST speech-to-text
+    endpoint and the transcription is yielded inline from ``run_stt()``, so
+    it suits pipelines that prefer per-segment HTTP requests over a long-lived
+    socket, and callers that use ``run_stt()`` directly.
+
+    Requires VAD to be enabled in the pipeline.
+    """
+
+    Settings = SarvamHttpSTTSettings
+    _settings: Settings
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        mode: SarvamMode | None = None,
+        sample_rate: int | None = None,
+        settings: Settings | None = None,
+        ttfs_p99_latency: float | None = SARVAM_HTTP_TTFS_P99,
+        **kwargs,
+    ):
+        """Initialize the Sarvam HTTP STT service.
+
+        Args:
+            api_key: Sarvam API key for authentication.
+            mode: Mode of operation. Options: transcribe, translate, verbatim,
+                translit, codemix. Only applicable to models that support it
+                (``saaras:v3`` on the REST API). Defaults to the model's
+                default mode.
+            sample_rate: Audio sample rate. If None, uses the pipeline's rate.
+                Sarvam's REST API performs best with 16 kHz audio.
+            settings: Runtime-updatable settings. Defaults to the
+                ``saaras:v4`` model with automatic language detection.
+            ttfs_p99_latency: P99 latency from speech end to final transcript in seconds.
+                Override for your deployment. See https://github.com/pipecat-ai/stt-benchmark
+            **kwargs: Additional arguments passed to SegmentedSTTService.
+        """
+        default_settings = self.Settings(
+            model="saaras:v4",
+            language=None,
+        )
+
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        resolved_model = assert_given(default_settings.model)
+        if resolved_model is None or resolved_model not in HTTP_MODEL_CONFIGS:
+            allowed = ", ".join(sorted(HTTP_MODEL_CONFIGS.keys()))
+            raise ValueError(f"Unsupported model '{resolved_model}'. Allowed values: {allowed}.")
+
+        self._config = HTTP_MODEL_CONFIGS[resolved_model]
+
+        if mode is not None and not self._config.supports_mode:
+            raise ValueError(f"Model '{resolved_model}' does not support mode parameter.")
+        if mode is None:
+            mode = self._config.default_mode
+
+        super().__init__(
+            sample_rate=sample_rate,
+            ttfs_p99_latency=ttfs_p99_latency,
+            settings=default_settings,
+            **kwargs,
+        )
+
+        self._mode = mode
+        # Warn only once per unrecognized language code, so a session stuck
+        # detecting one unmapped language doesn't spam a warning per turn.
+        self._unmapped_language_codes_warned: set[str] = set()
+
+        self._sdk_headers = sdk_headers()
+        self._sarvam_client = AsyncSarvamAI(api_subscription_key=api_key, headers=self._sdk_headers)
+
+    def can_generate_metrics(self) -> bool:
+        """Check if this service can generate processing metrics.
+
+        Returns:
+            True, as Sarvam HTTP service supports metrics generation.
+        """
+        return True
+
+    def language_to_service_language(self, language: Language) -> str:
+        """Convert pipecat Language enum to Sarvam's language code.
+
+        Args:
+            language: The Language enum value to convert.
+
+        Returns:
+            The Sarvam language code string.
+        """
+        return language_to_sarvam_language(language)
+
+    def _get_language_string(self) -> str | None:
+        """Resolve the current language setting to a Sarvam language code string."""
+        # The stored language is a Sarvam code rather than a Language, but the
+        # mapping keys compare equal either way.
+        language = cast(Language, assert_given(self._settings.language))
+        if language:
+            return language_to_sarvam_language(language)
+        return self._config.default_language
+
+    def _map_language_code_to_enum(self, language_code: str | None) -> Language | None:
+        """Map a Sarvam language code to a pipecat Language, or None if unresolved."""
+        return _language_code_to_language(language_code, self._unmapped_language_codes_warned, self)
+
+    async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
+        """Apply a settings delta; model and language take effect on the next request.
+
+        Args:
+            delta: A :class:`STTSettings` (or ``SarvamHttpSTTService.Settings``) delta.
+
+        Returns:
+            Dict mapping changed field names to their previous values.
+
+        Raises:
+            ValueError: If the delta names a model the REST API does not offer.
+        """
+        # Validate before applying so a rejected delta leaves the store intact.
+        if is_given(delta.model) and delta.model not in HTTP_MODEL_CONFIGS:
+            allowed = ", ".join(sorted(HTTP_MODEL_CONFIGS.keys()))
+            raise ValueError(f"Unsupported model '{delta.model}'. Allowed values: {allowed}.")
+
+        changed = await super()._update_settings(delta)
+
+        if "model" in changed:
+            # The delta was validated above, so the stored model is a known key.
+            self._config = HTTP_MODEL_CONFIGS[cast(str, self._settings.model)]
+            # The mode is model-scoped: keep it only if the new model supports
+            # it, otherwise fall back to the new model's default.
+            if self._mode is not None and not self._config.supports_mode:
+                logger.debug(
+                    f"{self} model '{self._settings.model}' does not support mode; "
+                    f"dropping mode '{self._mode}'"
+                )
+                self._mode = self._config.default_mode
+
+        return changed
+
+    @traced_stt
+    async def _handle_transcription(
+        self, transcript: str, is_final: bool, language: Language | None = None
+    ):
+        """Handle a transcription result with tracing."""
+        pass
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+        """Transcribe an audio segment using Sarvam's REST API.
+
+        Args:
+            audio: Audio segment in WAV format (already wrapped by the
+                SegmentedSTTService base class).
+
+        Yields:
+            Frame: TranscriptionFrame containing the transcribed text, or
+            ErrorFrame on failure. Empty transcriptions are not yielded.
+        """
+        try:
+            await self.start_processing_metrics()
+
+            request_kwargs: dict[str, Any] = {
+                "file": ("segment.wav", audio, "audio/wav"),
+                "model": self._settings.model,
+            }
+
+            language_string = self._get_language_string()
+            if language_string is not None:
+                request_kwargs["language_code"] = language_string
+
+            if self._config.supports_mode and self._mode is not None:
+                request_kwargs["mode"] = self._mode
+
+            response = await self._sarvam_client.speech_to_text.transcribe(**request_kwargs)
+
+            await self.stop_processing_metrics()
+
+            transcript = response.transcript.strip() if response.transcript else ""
+            if not transcript:
+                return
+
+            # Prefer the language Sarvam detected; fall back to the configured one.
+            # Either can resolve to None -- an unrecognized code, or Sarvam's own
+            # "unknown"/auto-detect placeholder -- in which case the frame is left
+            # without a language rather than guessing one.
+            language = self._map_language_code_to_enum(
+                response.language_code or self._get_language_string()
+            )
+
+            await self._handle_transcription(transcript, True, language)
+            logger.debug(f"Transcription: [{transcript}]")
+            yield TranscriptionFrame(
+                transcript,
+                self._user_id,
+                time_now_iso8601(),
+                language,
+                result=(response.dict() if hasattr(response, "dict") else str(response)),
+            )
+
+        except Exception as e:
+            yield ErrorFrame(error=f"Sarvam HTTP STT error: {e}", exception=e)

--- a/src/pipecat/services/stt_latency.py
+++ b/src/pipecat/services/stt_latency.py
@@ -58,6 +58,9 @@ MISTRAL_TTFS_P99: float = 1.89
 OPENAI_TTFS_P99: float = 2.01
 OPENAI_REALTIME_TTFS_P99: float = 1.66
 SARVAM_TTFS_P99: float = 1.17
+# Provisional until benchmarked against the REST endpoint; aligned with the
+# other segmented HTTP STT services (Fal, Groq, OpenAI).
+SARVAM_HTTP_TTFS_P99: float = 2.00
 # Provisional until benchmarked against the realtime endpoint.
 SARVAM_REALTIME_TTFS_P99: float = 1.00
 SMALLEST_TTFS_P99: float = 1.59

--- a/tests/test_sarvam_stt.py
+++ b/tests/test_sarvam_stt.py
@@ -33,7 +33,9 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.processors.frameworks.rtvi.processor import RTVIProcessor
 from pipecat.services.sarvam._sdk import sdk_headers
 from pipecat.services.sarvam.stt import (
+    HTTP_MODEL_CONFIGS,
     MODEL_CONFIGS,
+    SarvamHttpSTTService,
     SarvamRealtimeSTTService,
     SarvamRealtimeSTTSettings,
     SarvamSTTService,
@@ -1197,3 +1199,229 @@ def _capture_class(frames):
         frames.append(frame_cls)
 
     return inner
+
+
+# ---------------------------------------------------------------------------
+# SarvamHttpSTTService (REST)
+# ---------------------------------------------------------------------------
+
+
+def _http_service(**kwargs) -> SarvamHttpSTTService:
+    return SarvamHttpSTTService(api_key="test-key", **kwargs)
+
+
+def _mock_rest_client(service: SarvamHttpSTTService, response=None, error=None) -> AsyncMock:
+    """Replace the service's SDK client with a stub REST transcribe call."""
+    from types import SimpleNamespace
+
+    if error is not None:
+        transcribe = AsyncMock(side_effect=error)
+    else:
+        transcribe = AsyncMock(return_value=response)
+    service._sarvam_client = SimpleNamespace(speech_to_text=SimpleNamespace(transcribe=transcribe))
+    return transcribe
+
+
+def _rest_response(transcript: str, language_code: str | None = None):
+    from sarvamai.types.speech_to_text_response import SpeechToTextResponse
+
+    return SpeechToTextResponse(transcript=transcript, language_code=language_code)
+
+
+async def _run_stt(service: SarvamHttpSTTService, audio: bytes = b"RIFF-fake-wav"):
+    return [frame async for frame in service.run_stt(audio)]
+
+
+def test_http_supported_models():
+    """The REST endpoint offers the current Saaras generations only."""
+    assert set(HTTP_MODEL_CONFIGS) == {"saaras:v3", "saaras:v4"}
+
+
+def test_http_default_model():
+    """Constructing without a model picks up the latest one, like the WS sibling."""
+    service = _http_service()
+    assert service._settings.model == "saaras:v4"
+
+
+def test_http_unsupported_model_raises():
+    """A model the REST service doesn't offer reports the allowed ones."""
+    with pytest.raises(ValueError, match="saaras:v3, saaras:v4"):
+        _http_service(settings=SarvamHttpSTTService.Settings(model="saarika:v2.5"))
+
+
+def test_http_mode_requires_supporting_model():
+    """The REST API documents mode for saaras:v3 only."""
+    with pytest.raises(ValueError, match="does not support mode"):
+        _http_service(mode="codemix")  # default model is saaras:v4
+
+    service = _http_service(
+        mode="codemix", settings=SarvamHttpSTTService.Settings(model="saaras:v3")
+    )
+    assert service._mode == "codemix"
+
+
+def test_http_mode_defaults_per_model():
+    """Without an explicit mode, each model gets its REST default."""
+    v3 = _http_service(settings=SarvamHttpSTTService.Settings(model="saaras:v3"))
+    assert v3._mode == "transcribe"
+
+    v4 = _http_service()
+    assert v4._mode is None
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_yields_transcription_inline():
+    """run_stt() transcribes the buffer and yields the frame itself, unlike the
+    WebSocket services, whose run_stt() yields nothing."""
+    service = _http_service(settings=SarvamHttpSTTService.Settings(model="saaras:v3"))
+    transcribe = _mock_rest_client(service, _rest_response("मेरा ऑर्डर कहाँ है", language_code="hi-IN"))
+
+    frames = await _run_stt(service, b"RIFF-fake-wav")
+
+    assert len(frames) == 1
+    frame = frames[0]
+    assert isinstance(frame, TranscriptionFrame)
+    assert frame.text == "मेरा ऑर्डर कहाँ है"
+    assert frame.language == Language.HI_IN
+
+    kwargs = transcribe.await_args.kwargs
+    filename, audio, content_type = kwargs["file"]
+    assert filename.endswith(".wav")
+    assert audio == b"RIFF-fake-wav"
+    assert content_type == "audio/wav"
+    assert kwargs["model"] == "saaras:v3"
+    assert kwargs["mode"] == "transcribe"
+    # No language configured: auto-detect via Sarvam's "unknown".
+    assert kwargs["language_code"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_sends_configured_language_and_no_mode_for_v4():
+    service = _http_service(
+        settings=SarvamHttpSTTService.Settings(language=Language.EN_IN),
+    )
+    transcribe = _mock_rest_client(service, _rest_response("hello", language_code="en-IN"))
+
+    frames = await _run_stt(service)
+
+    kwargs = transcribe.await_args.kwargs
+    assert kwargs["model"] == "saaras:v4"
+    assert kwargs["language_code"] == "en-IN"
+    assert "mode" not in kwargs
+    assert frames[0].language == Language.EN_IN
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_prefers_detected_language():
+    """The language Sarvam detected wins over the configured one."""
+    service = _http_service(settings=SarvamHttpSTTService.Settings(language=Language.EN_IN))
+    _mock_rest_client(service, _rest_response("नमस्ते", language_code="hi-IN"))
+
+    frames = await _run_stt(service)
+
+    assert frames[0].language == Language.HI_IN
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_leaves_language_unset_when_undetected():
+    """With auto-detect configured and no code on the response, the frame
+    carries no language rather than a guessed one."""
+    service = _http_service()
+    _mock_rest_client(service, _rest_response("नमस्ते"))
+
+    frames = await _run_stt(service)
+
+    assert frames[0].language is None
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_unrecognized_language_code_warns_once():
+    """A code the shared table lacks leaves the language unset and is warned
+    about once per service, like the WebSocket sibling."""
+    service = _http_service()
+    _mock_rest_client(service, _rest_response("text", language_code="sa-IN"))
+
+    first = await _run_stt(service)
+    second = await _run_stt(service)
+
+    assert first[0].language is None
+    assert second[0].language is None
+    assert service._unmapped_language_codes_warned == {"sa-IN"}
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_skips_empty_transcript():
+    service = _http_service()
+    _mock_rest_client(service, _rest_response("   "))
+
+    frames = await _run_stt(service)
+
+    assert frames == []
+
+
+@pytest.mark.asyncio
+async def test_http_run_stt_yields_error_frame_on_failure():
+    service = _http_service()
+    _mock_rest_client(service, error=RuntimeError("boom"))
+
+    frames = await _run_stt(service)
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], ErrorFrame)
+    assert "boom" in frames[0].error
+
+
+@pytest.mark.asyncio
+async def test_http_update_settings_rejects_unsupported_model():
+    service = _http_service()
+    with pytest.raises(ValueError, match="saaras:v3, saaras:v4"):
+        await service._update_settings(STTSettings(model="saarika:v2.5"))
+    # The store is untouched by the rejected delta.
+    assert service._settings.model == "saaras:v4"
+
+
+@pytest.mark.asyncio
+async def test_http_update_settings_drops_mode_the_new_model_lacks():
+    service = _http_service(
+        mode="codemix", settings=SarvamHttpSTTService.Settings(model="saaras:v3")
+    )
+    await service._update_settings(STTSettings(model="saaras:v4"))
+    assert service._settings.model == "saaras:v4"
+    assert service._mode is None
+
+
+@pytest.mark.asyncio
+async def test_http_segment_pipeline_emits_finalized_transcription():
+    """Driven by VAD frames in a pipeline, a segment comes back as one
+    finalized TranscriptionFrame with usage metrics ahead of it."""
+    from pipecat.frames.frames import InputAudioRawFrame
+    from pipecat.pipeline.worker import PipelineParams
+    from pipecat.tests.utils import run_test
+
+    sample_rate = 16000
+    service = _http_service(sample_rate=sample_rate)
+    _mock_rest_client(service, _rest_response("chai aur samosa", language_code="hi-IN"))
+
+    pcm = b"\x01\x02" * sample_rate  # 1s of 16-bit mono audio
+    received_down, _ = await run_test(
+        service,
+        frames_to_send=[
+            VADUserStartedSpeakingFrame(),
+            InputAudioRawFrame(audio=pcm, sample_rate=sample_rate, num_channels=1),
+            VADUserStoppedSpeakingFrame(),
+        ],
+        pipeline_params=PipelineParams(enable_usage_metrics=True),
+    )
+
+    transcripts = [f for f in received_down if isinstance(f, TranscriptionFrame)]
+    assert len(transcripts) == 1
+    assert transcripts[0].text == "chai aur samosa"
+    assert transcripts[0].finalized is True
+
+    usage_indexes = [
+        i
+        for i, f in enumerate(received_down)
+        if isinstance(f, MetricsFrame) and any(isinstance(d, STTUsageMetricsData) for d in f.data)
+    ]
+    assert len(usage_indexes) == 1
+    assert usage_indexes[0] < received_down.index(transcripts[0])


### PR DESCRIPTION
Fixes #5489

### What

Adds `SarvamHttpSTTService`, a `SegmentedSTTService` sibling of the WebSocket
`SarvamSTTService`, in the same file. It sends each VAD-detected speech segment
to Sarvam's synchronous REST speech-to-text API and yields the
`TranscriptionFrame` inline from `run_stt()`. This is the same split Cartesia
has with `CartesiaTTSService` and `CartesiaHttpTTSService`.

Scope note: an earlier revision also wired the service into the evals harness
as a built-in transcriber. Per review, that part is gone; with 1.9.0 the
service plugs into evals through the `factory:` field like any other provider.
This PR is now only the service, its latency constant, tests and changelog.

### Why

As #5489 lays out: every bundled Sarvam STT service is WebSocket-based, so
`run_stt()` yields nothing and results only arrive on socket callbacks. Anything
that wants a transcription back inline (per-segment HTTP pipelines, or callers
that use `run_stt()` directly) had no Sarvam option. Saaras handles Indian
languages and Hindi/English code-mix well and Sarvam exposes it over plain
REST, so the gap was just the service class.

### Implementation notes

- Uses the `sarvamai` SDK the `sarvam` extra already pins (`AsyncSarvamAI`
  `speech_to_text.transcribe`). No new dependencies.
- Models: `saaras:v3` and `saaras:v4` (default `saaras:v4`, matching the
  WebSocket sibling). The REST endpoint also still accepts the sunset
  `saarika:*` generations, but the Sarvam services here dropped those, so the
  new service follows the same `MODEL_CONFIGS`-style validation with a
  REST-specific capability table: per Sarvam's REST docs, `mode`
  (transcribe/translate/verbatim/translit/codemix) is a `saaras:v3` parameter,
  so passing `mode` with `saaras:v4` raises at construction the same way
  unsupported parameters do on the WebSocket service.
- Language handling mirrors the WebSocket service: the configured language is
  sent as `language_code`, defaulting to `unknown` (auto-detect); the frame's
  language prefers what Sarvam detected on the response. The code-to-`Language`
  table is hoisted to module level and shared by both services instead of
  being duplicated, and the HTTP service keeps the WebSocket service's current
  resolution rules: an unrecognized or `unknown` code leaves the frame's
  language unset rather than guessing, with a once-per-code warning.
- Segments arrive as WAV from the `SegmentedSTTService` base
  (`wants_wav_segments`), which is what the REST upload endpoint wants, so no
  extra encoding step.
- Runtime settings: `language` applies on the next request; a `model` delta is
  validated against the REST table before it is applied, and a model change
  drops a mode the new model lacks.
- `SARVAM_HTTP_TTFS_P99` is provisional (2.00s, in line with the other
  segmented HTTP STT services) until benchmarked; happy to run the
  stt-benchmark against it if you want a measured value in this PR.

### Validation

Unit tests, plus live requests against `api.sarvam.ai` with a real key and a
real 22.05 kHz Hinglish TTS clip: `run_stt()` called on the WAV yields a
finalized `TranscriptionFrame` with the text
`आपका ऑर्डर नंबर 543131 शिप हो चुका है और 9 जुलाई तक डिलीवर हो जाएगा।` and
detected language `hi-IN`. The spoken order number comes through digit-exact,
which is the entity-accuracy property that motivated #5489.

### Test coverage

`tests/test_sarvam_stt.py` gains 15 tests for the new service (mocked SDK, no
network): model and mode validation, request construction (model,
`language_code`, mode, WAV file tuple), detected-language preference, the
unset-language and warn-once paths, empty transcript and error paths, runtime
settings deltas, and a full pipeline run via `run_test()` asserting a
finalized `TranscriptionFrame` with usage metrics ahead of it. The existing
WebSocket language-resolution tests pass unchanged against the shared table.
`ruff format`, `ruff check`, and `pyright` on the touched files are clean.
