### PR TITLE
fix(pipeline): count provider turn frames as pipeline activity

### DIFF
--- a/changelog/5502.fixed.md
+++ b/changelog/5502.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the pipeline idle timeout cancelling a live session while the user is still talking, on pipelines that get their turns from a provider instead of local VAD. `idle_timeout_frames` now counts `UserStartedSpeakingFrame`, `TranscriptionFrame` and `InterimTranscriptionFrame` as user activity, alongside `BotSpeakingFrame` and the VAD-driven `UserSpeakingFrame`.

--- a/src/pipecat/pipeline/worker.py
+++ b/src/pipecat/pipeline/worker.py
@@ -53,6 +53,7 @@ from pipecat.frames.frames import (
     ErrorFrame,
     Frame,
     HeartbeatFrame,
+    InterimTranscriptionFrame,
     InterruptionFrame,
     InterruptionWorkerFrame,
     MetricsFrame,
@@ -60,8 +61,10 @@ from pipecat.frames.frames import (
     StartFrame,
     StopFrame,
     StopWorkerFrame,
+    TranscriptionFrame,
     TTSSpeakFrame,
     UserSpeakingFrame,
+    UserStartedSpeakingFrame,
 )
 from pipecat.metrics.metrics import ProcessingMetricsData, TTFBMetricsData
 from pipecat.observers.base_observer import BaseObserver, FramePushed
@@ -295,7 +298,13 @@ class PipelineWorker(BaseWorker):
         handle_flush_frame: bool | None = None,
         enable_rtvi: bool = True,
         exclude_frames: tuple[type[Frame], ...] | None = None,
-        idle_timeout_frames: tuple[type[Frame], ...] = (BotSpeakingFrame, UserSpeakingFrame),
+        idle_timeout_frames: tuple[type[Frame], ...] = (
+            BotSpeakingFrame,
+            InterimTranscriptionFrame,
+            TranscriptionFrame,
+            UserSpeakingFrame,
+            UserStartedSpeakingFrame,
+        ),
         idle_timeout_secs: float | None = IDLE_TIMEOUT_SECS,
         name: str | None = None,
         observers: list[BaseObserver] | None = None,
@@ -368,7 +377,9 @@ class PipelineWorker(BaseWorker):
                 that should not cross the bus (lifecycle frames are
                 always excluded).
             idle_timeout_frames: A tuple with the frames that should trigger an idle
-                timeout if not received within `idle_timeout_seconds`.
+                timeout if not received within `idle_timeout_secs`. The default
+                pairs the VAD-only `UserSpeakingFrame` with the turn and
+                transcription frames a provider-driven pipeline reports instead.
             idle_timeout_secs: Timeout (in seconds) to consider pipeline idle or
                 None. If a pipeline is idle the pipeline worker will be cancelled
                 automatically.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,12 +19,15 @@ from pipecat.frames.frames import (
     Frame,
     HeartbeatFrame,
     InputAudioRawFrame,
+    InterimTranscriptionFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     StartFrame,
     StopFrame,
     TextFrame,
     TTSStoppedFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
 )
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.pipeline.parallel_pipeline import ParallelPipeline
@@ -740,6 +743,62 @@ class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
 
         # Wait for the pending tasks to complete.
         await asyncio.gather(*pending)
+
+    async def test_idle_task_external_user_activity(self):
+        idle_timeout_secs = 0.4
+        activity_period_secs = 0.1
+
+        # A pipeline whose turns are detected by a provider instead of local VAD
+        # pushes no UserSpeakingFrame, so the default idle timeout frames have to
+        # pick up the turn and transcription frames it does push.
+        identity = IdentityFilter()
+        pipeline = Pipeline([identity])
+        worker = PipelineWorker(
+            pipeline,
+            idle_timeout_secs=idle_timeout_secs,
+            cancel_on_idle_timeout=False,
+        )
+
+        started = asyncio.Event()
+        idle_timeouts = 0
+        idle_timeouts_during_turn = 0
+
+        @worker.event_handler("on_pipeline_started")
+        async def on_pipeline_started(worker: PipelineWorker, frame: StartFrame):
+            started.set()
+
+        @worker.event_handler("on_idle_timeout")
+        async def on_idle_timeout(worker: PipelineWorker):
+            nonlocal idle_timeouts
+            idle_timeouts += 1
+
+        async def external_user_turn():
+            """Sending a single user turn that outlasts the idle timeout."""
+            nonlocal idle_timeouts_during_turn
+
+            # The idle monitor only watches frames the running pipeline pushes,
+            # so nothing sent before this point counts as activity.
+            await asyncio.wait_for(started.wait(), timeout=5)
+
+            await worker.queue_frame(UserStartedSpeakingFrame())
+            for _ in range(6):
+                await asyncio.sleep(activity_period_secs)
+                await worker.queue_frame(
+                    InterimTranscriptionFrame(text="Hello Pipecat!", user_id="cat", timestamp="")
+                )
+            await worker.queue_frame(UserStoppedSpeakingFrame())
+            idle_timeouts_during_turn = idle_timeouts
+
+            # The timeout still fires once the user goes quiet.
+            await asyncio.sleep(idle_timeout_secs * 2)
+            await worker.queue_frame(EndFrame())
+
+        await asyncio.gather(
+            worker.run(WorkerParams(task_manager=TaskManager())), external_user_turn()
+        )
+
+        assert idle_timeouts_during_turn == 0
+        assert idle_timeouts > 0
 
     async def test_idle_task_swallowed_frames(self):
         idle_timeout_secs = 0.2


### PR DESCRIPTION
Fixes #5479.

## Problem

The pipeline idle timeout cancels a live session while the user is still talking, on pipelines that get their turns from a provider instead of local VAD. The reporter saw a call drop almost exactly 300s after the last bot speech, with user turn and transcription frames still flowing the whole time.

## Root cause

`idle_timeout_frames` defaults to `(BotSpeakingFrame, UserSpeakingFrame)`.

`UserSpeakingFrame` is pushed from two places only, `vad_processor.py:89` and `llm_response_universal.py:1273`, and both are gated on a `VADController`. A realtime service, or an STT service with its own turn detection, never pushes one. So on those pipelines the default is effectively just `BotSpeakingFrame`, and only the bot talking keeps the session alive.

That default comes from 09d6ec109, which collapsed a longer list when it introduced `UserSpeakingFrame`. It was correct then: VAD lived on `TransportParams` and every example wired it, so the new frame covered everything the old list did, and more cheaply. #3583 later moved `vad_analyzer` to `LLMUserAggregatorParams` where it defaults to `None`, and #4533 made no-local-VAD the recommended setup for realtime services. The default was not revisited.

## Changes

`idle_timeout_frames` now also counts `UserStartedSpeakingFrame`, `TranscriptionFrame` and `InterimTranscriptionFrame`. `UserSpeakingFrame` stays, so VAD pipelines behave exactly as before. `LLMFullResponseEndFrame` from the old list is not restored, since it is bot side and `BotSpeakingFrame` already covers that.

`UserStoppedSpeakingFrame` is left out on purpose. It marks the user stopping, and since `ExternalUserTurnStopStrategy` waits for the transcript before emitting it, it lands with the final `TranscriptionFrame` and resets nothing new. Without transcripts it only pushes the deadline out by the length of the turn that ended, which slows abandoned session detection rather than helping here.


Added `test_idle_task_external_user_activity`, covering both halves: a provider driven turn longer than the timeout does not trip it, and the timeout still fires once the user goes quiet.