### PR TITLE
fix(pipeline): reset idle timeout on provider-owned turn detection

### DIFF
--- a/changelog/5503.fixed.md
+++ b/changelog/5503.fixed.md
@@ -1,0 +1,6 @@
+- Fixed `PipelineWorker` idle timeout cancelling a live session while the user was
+  still speaking, on pipelines that get turn detection from a provider instead of
+  local VAD. `idle_timeout_frames` now defaults to counting
+  `UserStartedSpeakingFrame`, `UserStoppedSpeakingFrame`, `InterimTranscriptionFrame`
+  and `TranscriptionFrame` as user activity, alongside `BotSpeakingFrame` and the
+  VAD-driven `UserSpeakingFrame`.

--- a/src/pipecat/pipeline/worker.py
+++ b/src/pipecat/pipeline/worker.py
@@ -53,6 +53,7 @@ from pipecat.frames.frames import (
     ErrorFrame,
     Frame,
     HeartbeatFrame,
+    InterimTranscriptionFrame,
     InterruptionFrame,
     InterruptionWorkerFrame,
     MetricsFrame,
@@ -60,8 +61,11 @@ from pipecat.frames.frames import (
     StartFrame,
     StopFrame,
     StopWorkerFrame,
+    TranscriptionFrame,
     TTSSpeakFrame,
     UserSpeakingFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
 )
 from pipecat.metrics.metrics import ProcessingMetricsData, TTFBMetricsData
 from pipecat.observers.base_observer import BaseObserver, FramePushed
@@ -295,7 +299,14 @@ class PipelineWorker(BaseWorker):
         handle_flush_frame: bool | None = None,
         enable_rtvi: bool = True,
         exclude_frames: tuple[type[Frame], ...] | None = None,
-        idle_timeout_frames: tuple[type[Frame], ...] = (BotSpeakingFrame, UserSpeakingFrame),
+        idle_timeout_frames: tuple[type[Frame], ...] = (
+            BotSpeakingFrame,
+            UserSpeakingFrame,
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            InterimTranscriptionFrame,
+            TranscriptionFrame,
+        ),
         idle_timeout_secs: float | None = IDLE_TIMEOUT_SECS,
         name: str | None = None,
         observers: list[BaseObserver] | None = None,
@@ -368,7 +379,12 @@ class PipelineWorker(BaseWorker):
                 that should not cross the bus (lifecycle frames are
                 always excluded).
             idle_timeout_frames: A tuple with the frames that should trigger an idle
-                timeout if not received within `idle_timeout_seconds`.
+                timeout if not received within `idle_timeout_seconds`. Defaults to
+                local VAD activity (``BotSpeakingFrame``, ``UserSpeakingFrame``)
+                plus provider-owned turn detection (``UserStartedSpeakingFrame``,
+                ``UserStoppedSpeakingFrame``, ``InterimTranscriptionFrame``,
+                ``TranscriptionFrame``), so bots using a service's server-side VAD
+                and transcription (instead of local VAD) still reset the timer.
             idle_timeout_secs: Timeout (in seconds) to consider pipeline idle or
                 None. If a pipeline is idle the pipeline worker will be cancelled
                 automatically.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,12 +19,15 @@ from pipecat.frames.frames import (
     Frame,
     HeartbeatFrame,
     InputAudioRawFrame,
+    InterimTranscriptionFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     StartFrame,
     StopFrame,
     TextFrame,
+    TranscriptionFrame,
     TTSStoppedFrame,
+    UserStartedSpeakingFrame,
 )
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.pipeline.parallel_pipeline import ParallelPipeline
@@ -740,6 +743,58 @@ class TestPipelineWorker(unittest.IsolatedAsyncioTestCase):
 
         # Wait for the pending tasks to complete.
         await asyncio.gather(*pending)
+
+    async def test_idle_task_default_frames_external_turn_detection(self):
+        """The default ``idle_timeout_frames`` also resets on provider-owned turn detection.
+
+        A provider-owned turn detector (e.g. server-side VAD) emits
+        ``UserStartedSpeakingFrame`` and transcription frames instead of the
+        local-VAD-only ``UserSpeakingFrame``. The default tuple must treat those
+        as activity too, or the idle timeout fires mid-conversation. Regression
+        test for https://github.com/pipecat-ai/pipecat/issues/5479.
+        """
+        idle_timeout_secs = 0.2
+        send_interval_secs = 0.05
+
+        identity = IdentityFilter()
+        pipeline = Pipeline([identity])
+        worker = PipelineWorker(
+            pipeline,
+            idle_timeout_secs=idle_timeout_secs,
+            cancel_on_idle_timeout=False,
+        )
+
+        idle_timeout_count = 0
+
+        @worker.event_handler("on_idle_timeout")
+        async def on_idle_timeout(worker: PipelineWorker):
+            nonlocal idle_timeout_count
+            idle_timeout_count += 1
+
+        async def send_turn_activity():
+            """Sending external-turn-detection frames, never a UserSpeakingFrame.
+
+            This spans several idle-timeout windows. If the default tuple
+            doesn't treat these frame types as activity, the idle timeout
+            fires while this loop is still running.
+            """
+            for _ in range(6):
+                await worker.queue_frame(UserStartedSpeakingFrame())
+                await asyncio.sleep(send_interval_secs)
+                await worker.queue_frame(
+                    InterimTranscriptionFrame(text="Hel", user_id="user", timestamp="now")
+                )
+                await asyncio.sleep(send_interval_secs)
+                await worker.queue_frame(
+                    TranscriptionFrame(text="Hello Pipecat!", user_id="user", timestamp="now")
+                )
+                await asyncio.sleep(send_interval_secs)
+            await worker.queue_frame(EndFrame())
+
+        await asyncio.gather(
+            send_turn_activity(), worker.run(WorkerParams(task_manager=TaskManager()))
+        )
+        assert idle_timeout_count == 0
 
     async def test_idle_task_swallowed_frames(self):
         idle_timeout_secs = 0.2


### PR DESCRIPTION
## Heads up on overlap

#5502 was opened a few hours ago and fixes the same issue. This PR was prepared independently before that one appeared, and it differs in one substantive way: it also adds `UserStoppedSpeakingFrame` to the default. Happy to close this in favour of #5502 if a maintainer would rather just fold that one frame type into it.

## Root cause

`PipelineWorker` defaults `idle_timeout_frames` to `(BotSpeakingFrame, UserSpeakingFrame)`. `UserSpeakingFrame` is emitted only by local VAD (`vad_processor.py`). A pipeline whose turns come from the provider instead — Deepgram, Soniox, and the other server-side-VAD STT services — never pushes it; it pushes `UserStartedSpeakingFrame`/`UserStoppedSpeakingFrame` plus `InterimTranscriptionFrame`/`TranscriptionFrame`.

On those pipelines the idle timer never resets while the user is talking, so the worker (and by default the whole runner) is cancelled `idle_timeout_secs` after the last bot speech. Reported live in #5479 as a call cut at almost exactly 300s mid-conversation.

This is a regression of #2474, which fixed the same class of bug on `PipelineTask.idle_timeout_frames` — including `UserStoppedSpeakingFrame`. That default was not carried over when `PipelineTask` became `PipelineWorker`.

## Fix

Adds `UserStartedSpeakingFrame`, `UserStoppedSpeakingFrame`, `InterimTranscriptionFrame` and `TranscriptionFrame` to the default tuple, and documents in the docstring which frames come from local VAD and which from provider-owned turn detection.

## Testing

Added `test_idle_task_default_frames_external_turn_detection`, which drives a worker with only provider-style frames across several idle-timeout windows and asserts `on_idle_timeout` never fires.

- Against the pre-fix default (source reverted, test kept): `FAILED tests/test_pipeline.py::TestPipelineWorker::test_idle_task_default_frames_external_turn_detection - assert 3 == 0`
- With the fix: `1 passed, 36 deselected`
- `uv run pytest tests/test_pipeline.py` -> `37 passed`
- `tests/test_base_worker.py tests/test_bridge_processor.py tests/test_pipeline_worker_ui_bridge.py` -> `100 passed`
- `ruff check` and `ruff format --diff` clean on both touched files

Provider integration suites were not run; they need API keys.

Fixes #5479
