### PR TITLE
fix(smallwebrtc): fade queued audio on interruption

### DIFF
--- a/changelog/5506.fixed.md
+++ b/changelog/5506.fixed.md
@@ -1,0 +1,1 @@
+- SmallWebRTC interruptions now fade the remaining transport-owned audio write to silence without extending playback.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -27,6 +27,43 @@ from pipecat.audio.resamplers.soxr_stream_resampler import SOXRStreamAudioResamp
 SPEAKING_THRESHOLD = 20
 
 
+def _apply_half_hann_fade_out(pcm: bytes) -> bytes:
+    """Fade signed 16-bit PCM from its current level to exact silence.
+
+    A descending half-Hann envelope preserves the first sample, reaches zero
+    at the final sample, and has smooth endpoint slopes. This avoids adding an
+    end-to-silence value discontinuity when releasing audio that immediately
+    follows samples already committed to playout. A one-sample input becomes
+    silence because it cannot preserve its only sample and also end at zero.
+
+    Args:
+        pcm: Signed 16-bit PCM audio.
+
+    Returns:
+        PCM audio with the same byte length and a descending half-Hann envelope.
+
+    Raises:
+        ValueError: If the PCM data does not contain complete 16-bit samples.
+    """
+    if len(pcm) % 2:
+        raise ValueError("PCM data must contain complete 16-bit samples")
+    if not pcm:
+        return pcm
+
+    samples = np.frombuffer(pcm, dtype=np.int16)
+    if len(samples) == 1:
+        return bytes(2)
+
+    phase = np.linspace(0.0, np.pi, num=len(samples), dtype=np.float64)
+    gains = 0.5 * (1.0 + np.cos(phase))
+    faded = np.rint(samples.astype(np.float64) * gains).astype(np.int16)
+
+    # Pin both contract endpoints instead of relying on floating-point cosine.
+    faded[0] = samples[0]
+    faded[-1] = 0
+    return faded.tobytes()
+
+
 def create_file_resampler(**kwargs) -> BaseAudioResampler:
     """Create an audio resampler instance for batch processing of complete audio files.
 

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -261,6 +261,25 @@ class BaseOutputTransport(FrameProcessor):
         """
         return False
 
+    def _prepare_audio_interruption(self, destination: str | None) -> bool:
+        """Prepare transport-owned playout audio for an interruption.
+
+        The media sender owns audio that has not reached the transport yet and
+        clears it separately. Subclasses can override this hook when they also
+        own a transport-level playout buffer that needs interruption handling.
+        Implementations must not yield: the hook runs before interruption
+        bookkeeping so event-loop-owned state cannot interleave with it.
+        Overrides remain responsible for synchronization with external threads.
+
+        Args:
+            destination: The destination whose audio was interrupted.
+
+        Returns:
+            Whether to request immediate cancellation of the audio writer. The
+            normal interruption path still awaits and recreates it afterward.
+        """
+        return False
+
     async def write_dtmf(self, frame: OutputDTMFFrame | OutputDTMFUrgentFrame):
         """Write a DTMF tone using the transport's preferred method.
 
@@ -342,6 +361,13 @@ class BaseOutputTransport(FrameProcessor):
             frame: The frame to process.
             direction: The direction of frame flow in the pipeline.
         """
+        # Capture the current transport-owned queue boundary before interruption
+        # bookkeeping or frame forwarding yields to another task.
+        if isinstance(frame, InterruptionFrame):
+            sender = self._media_senders.get(frame.transport_destination)
+            if sender:
+                await sender._prepare_audio_interruption()
+
         await super().process_frame(frame, direction)
 
         if isinstance(frame, StartFrame):
@@ -468,6 +494,7 @@ class BaseOutputTransport(FrameProcessor):
             self._audio_task: asyncio.Task | None = None
             self._video_task: asyncio.Task | None = None
             self._clock_task: asyncio.Task | None = None
+            self._audio_interruption_prepared = False
 
             # If timestamps are equal, use this count to preserve the insertion order
             self._clock_queue_counter = itertools.count()
@@ -573,7 +600,10 @@ class BaseOutputTransport(FrameProcessor):
             await self._cancel_clock_task()
             await self._cancel_video_task()
 
-            if self._audio_queue.has_uninterruptible or self._mixer:
+            if self._audio_interruption_prepared:
+                self._audio_interruption_prepared = False
+                self._create_audio_task(preserve_uninterruptible=True)
+            elif self._audio_queue.has_uninterruptible or self._mixer:
                 # Keep the audio task running but drain all interruptible frames
                 # so the pending UninterruptibleFrames are still delivered. With
                 # a mixer, cancelling the task would also stop mixer-only output
@@ -591,6 +621,22 @@ class BaseOutputTransport(FrameProcessor):
 
             # Let's send a bot stopped speaking if we have to.
             await self._bot_stopped_speaking()
+
+        async def _prepare_audio_interruption(self) -> None:
+            """Prepare transport-owned audio before asynchronous interruption work."""
+            if self._audio_queue.has_uninterruptible or self._mixer:
+                return
+
+            try:
+                cancel_immediately = self._transport._prepare_audio_interruption(self._destination)
+            except Exception as e:
+                logger.warning(f"{self._transport} failed to release interrupted audio: {e}")
+                return
+
+            if cancel_immediately:
+                self._audio_queue.reset()
+                await self._cancel_audio_task()
+                self._audio_interruption_prepared = True
 
         async def handle_audio_frame(self, frame: OutputAudioRawFrame):
             """Handle incoming audio frames by buffering and chunking.
@@ -684,10 +730,22 @@ class BaseOutputTransport(FrameProcessor):
         # Audio handling
         #
 
-        def _create_audio_task(self):
-            """Create the audio processing task."""
+        def _create_audio_task(self, *, preserve_uninterruptible: bool = False):
+            """Create the audio processing task.
+
+            Args:
+                preserve_uninterruptible: Whether to move uninterruptible frames
+                    received during early interruption cleanup into the new queue.
+            """
             if not self._audio_task:
+                previous_queue = getattr(self, "_audio_queue", None)
                 self._audio_queue = FrameQueue()
+                if preserve_uninterruptible and previous_queue:
+                    previous_queue.reset()
+                    while not previous_queue.empty():
+                        frame = previous_queue.get_nowait()
+                        self._audio_queue.put_nowait(frame)
+                        previous_queue.task_done()
                 self._audio_task = self._transport.create_task(self._audio_task_handler())
 
         async def _cancel_audio_task(self):

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -127,10 +127,11 @@ class RawAudioTrack(AudioStreamTrack):
     def _release_interrupted_audio(self) -> None:
         """Release the oldest queued write and discard later stale writes.
 
-        Each call to :meth:`add_audio_bytes` ends with a future-bearing chunk.
-        Retaining through the first such chunk keeps only the audio already
-        closest to playout. Applying one envelope across that exact remainder
-        preserves its first sample, ends at silence, and adds no duration.
+        Each non-empty call to :meth:`add_audio_bytes` ends with a
+        future-bearing chunk. Retaining through the first such chunk keeps only
+        the audio already closest to playout. Applying one envelope across that
+        exact remainder preserves its first sample, ends at silence, and adds
+        no duration.
 
         A rapid second interruption can arrive after a new write was appended
         behind a previous release tail. Those later writes have not reached

--- a/src/pipecat/transports/smallwebrtc/transport.py
+++ b/src/pipecat/transports/smallwebrtc/transport.py
@@ -22,6 +22,7 @@ import numpy as np
 from loguru import logger
 from pydantic import BaseModel
 
+from pipecat.audio.utils import _apply_half_hann_fade_out
 from pipecat.frames.frames import (
     CancelFrame,
     ClientConnectedFrame,
@@ -122,6 +123,46 @@ class RawAudioTrack(AudioStreamTrack):
             self._chunk_queue.append((chunk, fut))
 
         return future
+
+    def _release_interrupted_audio(self) -> None:
+        """Release the oldest queued write and discard later stale writes.
+
+        Each call to :meth:`add_audio_bytes` ends with a future-bearing chunk.
+        Retaining through the first such chunk keeps only the audio already
+        closest to playout. Applying one envelope across that exact remainder
+        preserves its first sample, ends at silence, and adds no duration.
+
+        A rapid second interruption can arrive after a new write was appended
+        behind a previous release tail. Those later writes have not reached
+        playout yet, so they are discarded and their waiters are cancelled.
+        """
+        if not self._chunk_queue:
+            return
+
+        queued_chunks = list(self._chunk_queue)
+        boundary = next(
+            (index for index, (_, future) in enumerate(queued_chunks) if future is not None),
+            len(queued_chunks) - 1,
+        )
+        release_chunks = queued_chunks[: boundary + 1]
+        stale_chunks = queued_chunks[boundary + 1 :]
+
+        for _, future in stale_chunks:
+            if future and not future.done():
+                future.cancel()
+
+        audio = b"".join(chunk for chunk, _ in release_chunks)
+        faded = _apply_half_hann_fade_out(audio)
+
+        faded_chunks = []
+        byte_offset = 0
+        for chunk, future in release_chunks:
+            faded_chunk = faded[byte_offset : byte_offset + len(chunk)]
+            faded_chunks.append((faded_chunk, future))
+            byte_offset += len(chunk)
+
+        self._chunk_queue.clear()
+        self._chunk_queue.extend(faded_chunks)
 
     async def recv(self):
         """Return the next audio frame for WebRTC transmission.
@@ -456,6 +497,11 @@ class SmallWebRTCClient:
             await self._audio_output_track.add_audio_bytes(frame.audio)
             return True
         return False
+
+    def _release_interrupted_audio(self) -> None:
+        """Release audio still waiting in the WebRTC output track."""
+        if self._audio_output_track:
+            self._audio_output_track._release_interrupted_audio()
 
     async def write_video_frame(self, frame: OutputImageRawFrame) -> bool:
         """Write a video frame to the WebRTC connection.
@@ -914,6 +960,22 @@ class SmallWebRTCOutputTransport(BaseOutputTransport):
         """
         await super().cancel(frame)
         await self._teardown()
+
+    def _prepare_audio_interruption(self, destination: str | None) -> bool:
+        """Fade audio already queued for WebRTC playout.
+
+        Args:
+            destination: The interrupted destination. SmallWebRTC currently has
+                only one output audio track, so this value is unused.
+        """
+        # Named media senders share the same RawAudioTrack. Releasing that shared
+        # queue for one sender could cancel another sender's in-flight write, so
+        # retain the existing BaseOutput interruption behavior for that setup.
+        if self._params.audio_out_destinations or self._params.video_out_destinations:
+            return False
+
+        self._client._release_interrupted_audio()
+        return True
 
     async def send_message(
         self, frame: OutputTransportMessageFrame | OutputTransportMessageUrgentFrame

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -8,7 +8,44 @@ import io
 import unittest
 import wave
 
-from pipecat.audio.utils import pcm_to_wav
+import numpy as np
+
+from pipecat.audio.utils import _apply_half_hann_fade_out, pcm_to_wav
+
+
+class TestHalfHannFadeOut(unittest.TestCase):
+    def test_matches_descending_half_hann_and_pins_endpoints(self):
+        samples = np.array([32767, -32768, 12000, -7000, 2000], dtype=np.int16)
+
+        faded = np.frombuffer(_apply_half_hann_fade_out(samples.tobytes()), dtype=np.int16)
+
+        phase = np.linspace(0.0, np.pi, num=len(samples), dtype=np.float64)
+        gains = 0.5 * (1.0 + np.cos(phase))
+        expected = np.rint(samples.astype(np.float64) * gains).astype(np.int16)
+        expected[0] = samples[0]
+        expected[-1] = 0
+        np.testing.assert_array_equal(faded, expected)
+        self.assertEqual(faded[0], samples[0])
+        self.assertEqual(faded[-1], 0)
+
+    def test_constant_signal_descends_monotonically_without_changing_length(self):
+        samples = np.full(640, -32768, dtype=np.int16)
+
+        faded_bytes = _apply_half_hann_fade_out(samples.tobytes())
+        faded = np.frombuffer(faded_bytes, dtype=np.int16)
+
+        self.assertEqual(len(faded_bytes), len(samples.tobytes()))
+        self.assertTrue(np.all(np.diff(np.abs(faded.astype(np.int32))) <= 0))
+
+    def test_handles_empty_and_single_sample_inputs(self):
+        self.assertEqual(_apply_half_hann_fade_out(b""), b"")
+        self.assertEqual(
+            _apply_half_hann_fade_out(np.array([123], dtype=np.int16).tobytes()), b"\0\0"
+        )
+
+    def test_rejects_partial_sample(self):
+        with self.assertRaisesRegex(ValueError, "complete 16-bit samples"):
+            _apply_half_hann_fade_out(b"\x01")
 
 
 class TestPcmToWav(unittest.TestCase):

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -9,7 +9,7 @@
 import asyncio
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
 from pipecat.clocks.system_clock import SystemClock
@@ -74,6 +74,7 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
     async def test_interruption_with_mixer_keeps_audio_task_and_mixer_output(self):
         transport = await self._make_transport(mixer=_PassthroughMixer())
         try:
+            transport._prepare_audio_interruption = MagicMock()
             sender = transport._media_senders[None]
             task_before = sender._audio_task
             self.assertIsNotNone(task_before)
@@ -92,6 +93,7 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
             count_after_interruption = transport.write_audio_frame.call_count
             await asyncio.sleep(0.1)
             self.assertGreater(transport.write_audio_frame.call_count, count_after_interruption)
+            transport._prepare_audio_interruption.assert_not_called()
         finally:
             await transport.cancel(CancelFrame())
 
@@ -102,11 +104,107 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
             task_before = sender._audio_task
             self.assertIsNotNone(task_before)
 
+            def prepare_audio_interruption(destination):
+                self.assertIsNone(destination)
+                self.assertFalse(task_before.done())
+                return True
+
+            transport._prepare_audio_interruption = MagicMock(
+                side_effect=prepare_audio_interruption
+            )
+            start_interruption = transport._start_interruption
+
+            async def assert_writer_cancelled_before_framework_interruption():
+                self.assertTrue(task_before.done())
+                await start_interruption()
+
+            transport._start_interruption = AsyncMock(
+                side_effect=assert_writer_cancelled_before_framework_interruption
+            )
+
             await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
 
             self.assertIsNot(sender._audio_task, task_before)
             self.assertIsNotNone(sender._audio_task)
+            self.assertTrue(task_before.done())
+            transport._prepare_audio_interruption.assert_called_once_with(None)
+            transport._start_interruption.assert_awaited_once_with()
         finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_interruption_recreates_audio_task_when_transport_hook_fails(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            task_before = sender._audio_task
+            transport._prepare_audio_interruption = MagicMock(
+                side_effect=RuntimeError("release failed")
+            )
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertTrue(task_before.done())
+            self.assertIsNot(sender._audio_task, task_before)
+            self.assertIsNotNone(sender._audio_task)
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_early_interruption_preserves_late_uninterruptible_frame(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            queue_before = sender._audio_queue
+            transport._prepare_audio_interruption = MagicMock(return_value=True)
+            start_interruption = transport._start_interruption
+
+            async def enqueue_during_cleanup():
+                self.assertIs(sender._audio_queue, queue_before)
+                sender._audio_queue.put_nowait(EndFrame())
+                await start_interruption()
+
+            transport._start_interruption = AsyncMock(side_effect=enqueue_during_cleanup)
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertIsNot(sender._audio_queue, queue_before)
+            self.assertIsNotNone(sender._audio_task)
+            await asyncio.wait_for(sender._audio_task, timeout=1.0)
+            self.assertTrue(sender._audio_task.done())
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_interruption_with_uninterruptible_frame_skips_transport_hook(self):
+        transport = await self._make_transport(mixer=None)
+        release_write = asyncio.Event()
+        try:
+            sender = transport._media_senders[None]
+            transport._prepare_audio_interruption = MagicMock()
+            write_started = asyncio.Event()
+
+            async def slow_write(frame):
+                write_started.set()
+                await release_write.wait()
+                return True
+
+            transport.write_audio_frame = AsyncMock(side_effect=slow_write)
+            audio = OutputAudioRawFrame(
+                audio=b"\x01\x02" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(audio, FrameDirection.DOWNSTREAM)
+            await write_started.wait()
+
+            task_before = sender._audio_task
+            sender._audio_queue.put_nowait(EndFrame())
+            self.assertTrue(sender._audio_queue.has_uninterruptible)
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertIs(sender._audio_task, task_before)
+            transport._prepare_audio_interruption.assert_not_called()
+        finally:
+            release_write.set()
             await transport.cancel(CancelFrame())
 
     async def test_interruption_with_mixer_still_discards_queued_bot_audio(self):

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -132,6 +132,31 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
         finally:
             await transport.cancel(CancelFrame())
 
+    async def test_default_transport_hook_keeps_existing_interruption_order(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            task_before = sender._audio_task
+            self.assertIsNotNone(task_before)
+            start_interruption = transport._start_interruption
+
+            async def assert_writer_active_during_framework_interruption():
+                self.assertFalse(task_before.done())
+                await start_interruption()
+
+            transport._start_interruption = AsyncMock(
+                side_effect=assert_writer_active_during_framework_interruption
+            )
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertTrue(task_before.done())
+            self.assertIsNot(sender._audio_task, task_before)
+            self.assertIsNotNone(sender._audio_task)
+            transport._start_interruption.assert_awaited_once_with()
+        finally:
+            await transport.cancel(CancelFrame())
+
     async def test_interruption_recreates_audio_task_when_transport_hook_fails(self):
         transport = await self._make_transport(mixer=None)
         try:

--- a/tests/test_smallwebrtc_transport.py
+++ b/tests/test_smallwebrtc_transport.py
@@ -30,12 +30,22 @@ And the `MediaStreamError` handling in
    one (the same mechanism `_handle_client_connected` uses), the iterator
    must pick up frames from the new track. A plain `break` on
    `MediaStreamError` would terminate the iterator and regress this path.
+
+And interruption release in `RawAudioTrack`:
+
+1. **RawAudioTrack queue remainder** — only the oldest queued write is faded, with
+   no added samples and unchanged timing/future ownership.
+
+2. **Rapid interruptions** — newer writes behind an existing release tail
+   are discarded so stale audio cannot accumulate across task restarts.
 """
 
 import asyncio
 import fractions
 import json
 import unittest
+from collections import deque
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -50,14 +60,30 @@ pytest.importorskip("av")
 from aiortc.mediastreams import MediaStreamError  # noqa: E402
 from av import AudioFrame, VideoFrame  # noqa: E402
 
-from pipecat.frames.frames import OutputTransportMessageUrgentFrame  # noqa: E402
+from pipecat.audio.utils import _apply_half_hann_fade_out  # noqa: E402
+from pipecat.clocks.system_clock import SystemClock  # noqa: E402
+from pipecat.frames.frames import (  # noqa: E402
+    CancelFrame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    OutputTransportMessageUrgentFrame,
+    StartFrame,
+)
+from pipecat.processors.frame_processor import (  # noqa: E402
+    FrameDirection,
+    FrameProcessorSetup,
+)
+from pipecat.transports.base_transport import TransportParams  # noqa: E402
 from pipecat.transports.smallwebrtc.connection import SmallWebRTCConnection  # noqa: E402
 from pipecat.transports.smallwebrtc.transport import (  # noqa: E402
     CAM_VIDEO_SOURCE,
     SCREEN_VIDEO_SOURCE,
+    RawAudioTrack,
     SmallWebRTCCallbacks,
     SmallWebRTCClient,
+    SmallWebRTCOutputTransport,
 )
+from pipecat.utils.asyncio.task_manager import TaskManager  # noqa: E402
 
 
 class FakeDataChannel:
@@ -100,6 +126,252 @@ def _make_client():
 
 def _message(message_type):
     return OutputTransportMessageUrgentFrame(message={"type": message_type})
+
+
+def _queued_audio(track: RawAudioTrack) -> bytes:
+    return b"".join(chunk for chunk, _ in track._chunk_queue)
+
+
+def _audio_frame_samples(frame: AudioFrame) -> np.ndarray:
+    return frame.to_ndarray().reshape(-1)
+
+
+class TestRawAudioTrackInterruptionFade(unittest.IsolatedAsyncioTestCase):
+    async def test_single_chunk_keeps_shape_future_and_playout_timing(self):
+        track = RawAudioTrack(sample_rate=16_000)
+        samples = np.full(track._samples_per_10ms, 12_000, dtype=np.int16)
+        future = track.add_audio_bytes(samples.tobytes())
+        original_shape = [
+            (len(chunk), queued_future) for chunk, queued_future in track._chunk_queue
+        ]
+
+        track._release_interrupted_audio()
+
+        expected = _apply_half_hann_fade_out(samples.tobytes())
+        self.assertEqual(_queued_audio(track), expected)
+        self.assertEqual(
+            [(len(chunk), queued_future) for chunk, queued_future in track._chunk_queue],
+            original_shape,
+        )
+        self.assertFalse(future.done())
+
+        track._start = 0
+        frame = await track.recv()
+        self.assertEqual(frame.pts, 0)
+        np.testing.assert_array_equal(
+            _audio_frame_samples(frame), np.frombuffer(expected, np.int16)
+        )
+        self.assertTrue(future.result())
+
+        silence = await track.recv()
+        self.assertEqual(silence.pts, track._samples_per_10ms)
+        self.assertFalse(np.any(_audio_frame_samples(silence)))
+
+    async def test_fades_one_global_remainder_after_playout_boundary(self):
+        track = RawAudioTrack(sample_rate=16_000)
+        sample_count = track._samples_per_10ms * 4
+        positions = np.arange(sample_count)
+        samples = np.rint(
+            12_000 * np.sin(2 * np.pi * 440 * positions / track._sample_rate + 0.4)
+        ).astype(np.int16)
+        future = track.add_audio_bytes(samples.tobytes())
+
+        first_frame = await track.recv()
+        first_chunk = _audio_frame_samples(first_frame)
+        remaining = samples[track._samples_per_10ms :]
+        original_shape = [
+            (len(chunk), queued_future) for chunk, queued_future in track._chunk_queue
+        ]
+
+        track._release_interrupted_audio()
+
+        expected = np.frombuffer(_apply_half_hann_fade_out(remaining.tobytes()), dtype=np.int16)
+        faded = np.frombuffer(_queued_audio(track), dtype=np.int16)
+        np.testing.assert_array_equal(faded, expected)
+        self.assertEqual(
+            [(len(chunk), queued_future) for chunk, queued_future in track._chunk_queue],
+            original_shape,
+        )
+        self.assertIs(track._chunk_queue[-1][1], future)
+        self.assertEqual(int(faded[0]), int(remaining[0]))
+        self.assertEqual(int(faded[-1]), 0)
+        self.assertEqual(
+            int(faded[0]) - int(first_chunk[-1]),
+            int(samples[track._samples_per_10ms]) - int(samples[track._samples_per_10ms - 1]),
+        )
+
+        track._start = 0
+        emitted = []
+        for expected_pts in (160, 320):
+            frame = await track.recv()
+            self.assertEqual(frame.pts, expected_pts)
+            emitted.append(_audio_frame_samples(frame))
+            self.assertFalse(future.done())
+        final_frame = await track.recv()
+        self.assertEqual(final_frame.pts, 480)
+        emitted.append(_audio_frame_samples(final_frame))
+
+        self.assertTrue(future.done())
+        self.assertTrue(future.result())
+        np.testing.assert_array_equal(np.concatenate(emitted), expected)
+
+        silence = await track.recv()
+        self.assertEqual(silence.pts, 640)
+        silence_samples = _audio_frame_samples(silence)
+        self.assertEqual(int(emitted[-1][-1]), int(silence_samples[0]))
+        self.assertFalse(np.any(silence_samples))
+
+    async def test_rapid_interruption_discards_newer_writes(self):
+        track = RawAudioTrack(sample_rate=16_000)
+        oldest = np.full(track._samples_per_10ms * 2, 10_000, dtype=np.int16)
+        oldest_future = track.add_audio_bytes(oldest.tobytes())
+
+        track._release_interrupted_audio()
+        oldest_future.cancel()
+        first_release = _queued_audio(track)
+
+        newer = np.full(track._samples_per_10ms * 2, 20_000, dtype=np.int16)
+        newer_future = track.add_audio_bytes(newer.tobytes())
+        self.assertEqual(len(track._chunk_queue), 4)
+
+        track._release_interrupted_audio()
+
+        self.assertEqual(len(track._chunk_queue), 2)
+        self.assertEqual(_queued_audio(track), _apply_half_hann_fade_out(first_release))
+        self.assertTrue(oldest_future.cancelled())
+        self.assertTrue(newer_future.cancelled())
+
+        latest = np.full(track._samples_per_10ms * 4, 30_000, dtype=np.int16)
+        latest_future = track.add_audio_bytes(latest.tobytes())
+        track._release_interrupted_audio()
+        self.assertEqual(len(track._chunk_queue), 2)
+        self.assertTrue(latest_future.cancelled())
+
+    async def test_cancelled_write_future_can_be_faded_and_drained(self):
+        track = RawAudioTrack(sample_rate=16_000)
+        samples = np.full(track._samples_per_10ms * 4, -12_000, dtype=np.int16)
+        future = track.add_audio_bytes(samples.tobytes())
+        future.cancel()
+
+        track._release_interrupted_audio()
+        track._start = 0
+        for _ in range(4):
+            await track.recv()
+
+        self.assertTrue(future.cancelled())
+
+    async def test_empty_queue_is_unchanged(self):
+        track = RawAudioTrack(sample_rate=16_000)
+
+        track._release_interrupted_audio()
+
+        self.assertEqual(track._chunk_queue, deque())
+
+
+class TestSmallWebRTCAudioInterruption(unittest.IsolatedAsyncioTestCase):
+    async def test_full_interruption_lifecycle_fades_and_drains_cancelled_write(self):
+        track = RawAudioTrack(sample_rate=16_000)
+        write_started = asyncio.Event()
+        write_future = None
+
+        async def write_audio(frame):
+            nonlocal write_future
+            write_future = track.add_audio_bytes(frame.audio)
+            write_started.set()
+            await write_future
+            return True
+
+        client = MagicMock()
+        client.setup = AsyncMock()
+        client.connect = AsyncMock()
+        client.disconnect = AsyncMock()
+        client.write_audio_frame = AsyncMock(side_effect=write_audio)
+        client._release_interrupted_audio = MagicMock(side_effect=track._release_interrupted_audio)
+        transport = SmallWebRTCOutputTransport(
+            client=client,
+            params=TransportParams(audio_out_enabled=True, audio_out_sample_rate=16_000),
+        )
+        transport.push_frame = AsyncMock()
+        await transport.setup(
+            FrameProcessorSetup(
+                clock=SystemClock(),
+                task_manager=TaskManager(),
+                pipeline_worker=SimpleNamespace(app_resources=None),  # type: ignore[arg-type]
+                audio_out_sample_rate=16_000,
+            )
+        )
+
+        try:
+            await transport.process_frame(
+                StartFrame(audio_out_sample_rate=16_000), FrameDirection.DOWNSTREAM
+            )
+            sender = transport._media_senders[None]
+            samples = np.full(sender.audio_chunk_size // 2, 12_000, dtype=np.int16)
+            await transport.process_frame(
+                OutputAudioRawFrame(audio=samples.tobytes(), sample_rate=16_000, num_channels=1),
+                FrameDirection.DOWNSTREAM,
+            )
+            await write_started.wait()
+            expected = _apply_half_hann_fade_out(samples.tobytes())
+
+            await transport.process_frame(InterruptionFrame(), FrameDirection.DOWNSTREAM)
+
+            self.assertIsNotNone(write_future)
+            self.assertTrue(write_future.cancelled())
+            self.assertEqual(_queued_audio(track), expected)
+            client._release_interrupted_audio.assert_called_once_with()
+
+            track._start = 0
+            emitted = []
+            for _ in range(4):
+                emitted.append(_audio_frame_samples(await track.recv()))
+            np.testing.assert_array_equal(
+                np.concatenate(emitted), np.frombuffer(expected, dtype=np.int16)
+            )
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_client_delegates_fade_to_output_track(self):
+        client, connection = _make_client()
+        try:
+            client._audio_output_track = MagicMock()
+
+            client._release_interrupted_audio()
+
+            client._audio_output_track._release_interrupted_audio.assert_called_once_with()
+        finally:
+            await connection._pc.close()
+
+    async def test_client_without_output_track_is_unchanged(self):
+        client, connection = _make_client()
+        try:
+            client._release_interrupted_audio()
+            self.assertIsNone(client._audio_output_track)
+        finally:
+            await connection._pc.close()
+
+    async def test_output_transport_delegates_to_client(self):
+        client = MagicMock()
+        transport = SmallWebRTCOutputTransport(client=client, params=TransportParams())
+
+        cancel_immediately = transport._prepare_audio_interruption(None)
+
+        client._release_interrupted_audio.assert_called_once_with()
+        self.assertTrue(cancel_immediately)
+
+    async def test_output_transport_skips_shared_track_with_named_destinations(self):
+        for params in (
+            TransportParams(audio_out_destinations=["secondary"]),
+            TransportParams(video_out_destinations=["secondary"]),
+        ):
+            with self.subTest(params=params):
+                client = MagicMock()
+                transport = SmallWebRTCOutputTransport(client=client, params=params)
+
+                cancel_immediately = transport._prepare_audio_interruption(None)
+
+                client._release_interrupted_audio.assert_not_called()
+                self.assertFalse(cancel_immediately)
 
 
 class TestSendMessage(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Addresses #3985.

## Problem

When SmallWebRTC is interrupted, the oldest in-flight audio write may already
have moved from `BaseOutputTransport` into `RawAudioTrack`. Cancelling the
framework audio writer does not alter that transport-owned remainder, so it can
end at a non-zero sample and produce an abrupt cutoff.

The earlier approach in #4364 faded bytes still owned by
`BaseOutputTransport`, but did not modify the remainder already queued in
`RawAudioTrack`. This change acts at that playout boundary instead.

## Fix

- Prepare transport-owned audio before asynchronous interruption bookkeeping.
- Keep only the remainder of SmallWebRTC's oldest in-flight write and discard
  later stale writes.
- Apply a descending half-Hann envelope that preserves the first sample and
  ends exactly at zero, without changing audio length, chunk order, or PTS.
- Preserve retained future ownership and late uninterruptible frames while the
  framework audio writer is recreated.
- Keep the existing interruption path for mixers, uninterruptible frames, and
  named-destination configurations that share one `RawAudioTrack`.

This is intentionally scoped to SmallWebRTC and adds no public interruption
policy or configuration.

## Testing

- `uv run pytest -q tests/test_audio_utils.py tests/test_base_output_transport.py tests/test_smallwebrtc_transport.py` — 40 passed with the WebRTC extra installed
- `uv run ruff check` — passed
- `uv run ruff format --check` — passed
- Pyright on all changed source and test files — 0 errors
- CLI registry drift check — passed
- `git diff --check` — passed

## Manual A/B

I compared an unmodified checkout and the same upstream revision with only
this patch, using the same fixed Cartesia utterance and voice. I injected
`InterruptionFrame`s at fixed offsets after playback began.

At the 0.8-second cutoff, both versions stopped at the same perceived time.
The baseline produced a brief chirp or unnatural mid-word cutoff that I did
not hear with the patch. The patched output was also clearly smoother at 2.7
seconds; at 1.4 seconds, the difference was less distinct.

I also exercised real microphone barge-in through Silero VAD. Both variants
had the same shared VAD delay, while the patched cutoff was smoother after the
interruption fired. This change does not claim to alter microphone or VAD
latency.
