### PR TITLE
Raise the Context Hub floor to pipecat-ai-context-hub 0.7.0

### DIFF
--- a/changelog/5513.changed.md
+++ b/changelog/5513.changed.md
@@ -1,0 +1,3 @@
+- Raised the `pipecat-ai[cli]` Context Hub floor to `pipecat-ai-context-hub` 0.7.0, whose `refresh` indexes the framework at its newest release tag rather than tracking its default branch. Hub answers stop mixing in unreleased APIs stamped with the previous release's number, which `version_compatibility` reported as compatible to anyone running that release.
+
+    Pass `--framework-version head` to index the default branch — the right choice when developing Pipecat itself or building against unreleased code. A `--framework-version` tag that does not exist now fails the refresh instead of logging a warning and exiting 0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ cli = [
     "jinja2>=3.1.0,<4",
     "questionary>=2.0.0,<3",
     "ruff>=0.12.1,<1",
-    "pipecat-ai-context-hub>=0.6.0,<1",
+    "pipecat-ai-context-hub>=0.7.0,<1",
 ]
 
 [dependency-groups]

--- a/src/pipecat/cli/hub_status.py
+++ b/src/pipecat/cli/hub_status.py
@@ -242,8 +242,8 @@ def _version_mismatch_warning(metadata: dict[str, str], cwd: Path | None) -> str
     if indexed_mm is None or project_mm is None:
         return None
 
-    # An unpinned refresh tracks the default branch, so the recorded tag is a
-    # floor: the index already contains commits published after it. Allow a
+    # A refresh pinned to the framework's default branch leaves the recorded tag
+    # as a floor: the index already contains commits published after it. Allow a
     # minor of slack in that case, or every developer on a source checkout gets
     # warned about an index that is in fact newer than its own tag.
     slack = 0

--- a/tests/cli/test_hub_status.py
+++ b/tests/cli/test_hub_status.py
@@ -269,7 +269,7 @@ class TestVersionMismatch:
         self._fresh_index(tmp_path, "1.9.0")
         assert freshness_warning(_make_project(tmp_path, "1.6.0")) is None
 
-    def test_unpinned_index_gets_a_minor_of_slack(self, tmp_path):
+    def test_default_branch_index_gets_a_minor_of_slack(self, tmp_path):
         """Tracking the default branch means the recorded tag is a floor.
 
         An index 55 commits past v1.6.0 may already contain 1.7.0's code, so
@@ -279,7 +279,7 @@ class TestVersionMismatch:
         assert freshness_warning(_make_project(tmp_path, "1.7.0")) is None
         assert freshness_warning(_make_project(tmp_path, "1.8.0")) is not None
 
-    def test_pinned_index_gets_no_slack(self, tmp_path):
+    def test_release_tag_index_gets_no_slack(self, tmp_path):
         self._fresh_index(tmp_path, "1.6.0", commits_ahead=0)
         assert freshness_warning(_make_project(tmp_path, "1.7.0")) is not None
 

--- a/uv.lock
+++ b/uv.lock
@@ -5609,7 +5609,7 @@ requires-dist = [
     { name = "pipecat-ai", extras = ["mcp"], marker = "extra == 'keenable'" },
     { name = "pipecat-ai", extras = ["moonshine"], marker = "extra == 'evals'" },
     { name = "pipecat-ai", extras = ["webrtc"], marker = "extra == 'webrtc-video'" },
-    { name = "pipecat-ai-context-hub", marker = "extra == 'cli'", specifier = ">=0.6.0,<1" },
+    { name = "pipecat-ai-context-hub", marker = "extra == 'cli'", specifier = ">=0.7.0,<1" },
     { name = "pipecat-ai-prebuilt", marker = "extra == 'runner'", specifier = ">=1.0.6" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.3.0,<2" },
     { name = "pocket-tts", marker = "extra == 'pocket-tts'", specifier = ">=2.1.0,<3" },
@@ -5678,7 +5678,7 @@ docs = [
 
 [[package]]
 name = "pipecat-ai-context-hub"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chromadb" },
@@ -5698,9 +5698,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-typescript" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/44/720b27277de571db35e253b4ab527462f5e6fb1378ef8ab9901e6338ee1d/pipecat_ai_context_hub-0.6.0.tar.gz", hash = "sha256:0f70c51c8b8c3f1072ce24cf899b08c944732000c83bb035341efdbaf54d1240", size = 1426482, upload-time = "2026-08-28T06:14:53.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/0d/8361e8480a27ecd09ee3c06b0e5a174a4974c89d6abd3a6a7e180cf37c0e/pipecat_ai_context_hub-0.7.0.tar.gz", hash = "sha256:52ba8caa2b53c7f896dc28decc59d36ea701bc845ad41166d474ea76be0affe3", size = 1445121, upload-time = "2026-08-31T03:41:13.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/9a/4720420d4fba05a2f07c90263e8aca70a7e73f58adf73d52dc127816992b/pipecat_ai_context_hub-0.6.0-py3-none-any.whl", hash = "sha256:990b83f69904f61dfa8e7e6df7cd38da2beaa3a57cca43294419bde3f0f14525", size = 238316, upload-time = "2026-08-28T06:14:54.737Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ca/714ba365da33ac84fe6e1ec3206ce3104c13d21d149318051e261d3fea4d/pipecat_ai_context_hub-0.7.0-py3-none-any.whl", hash = "sha256:c60557fcd8b463b0a13efea4badcabbbec513c00195fd61a05167ff1e7df2bae", size = 243168, upload-time = "2026-08-31T03:41:14.458Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Raises the `pipecat-ai[cli]` Context Hub floor to `pipecat-ai-context-hub` 0.7.0.
- At 0.7.0, `refresh` indexes the framework repo at its newest release tag instead of tracking its default branch. Every other indexed source is already release-aligned, so the default-branch checkout was the one source contributing unreleased APIs — and since `indexed_framework_version` is a git-describe *floor*, those APIs were stamped with the previous release's number and reported to callers on that release as `compatible`.
- `--framework-version head` (or `main`) still indexes the default branch, which is what a source checkout of Pipecat itself wants.
- A `--framework-version` tag that does not resolve now aborts the refresh with exit 1 rather than logging a warning and exiting 0 with nothing newly indexed.
- Updates the wording in `hub_status.py` that described a default-branch index as the unpinned case; the slack it grants still keys off `indexed_framework_commits_ahead`, so behavior is unchanged.

## Testing

`uv run pytest tests/cli/test_hub_status.py`