### PR TITLE
fix(workers): buffer job events before dispatch

### DIFF
--- a/changelog/5515.fixed.md
+++ b/changelog/5515.fixed.md
@@ -1,0 +1,1 @@
+- Fixed job and job-group async iterators losing events or hanging when a worker responds before request publication returns.

--- a/src/pipecat/pipeline/job_context.py
+++ b/src/pipecat/pipeline/job_context.py
@@ -322,11 +322,12 @@ class JobGroupContext:
         return event
 
     async def __aenter__(self) -> JobGroupContext:
+        event_queue = asyncio.Queue()
         self._group = await self._worker.create_job_group_and_request_job(
             list(self._worker_names),
             params=self._params,
+            event_queue=event_queue,
         )
-        self._group.event_queue = asyncio.Queue()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
@@ -413,11 +414,12 @@ class JobContext:
         return JobEvent(type=event.type, data=event.data)
 
     async def __aenter__(self) -> JobContext:
+        event_queue = asyncio.Queue()
         self._group = await self._worker.create_job_group_and_request_job(
             [self._worker_name],
             params=JobGroupParams(**self._params.model_dump()),
+            event_queue=event_queue,
         )
-        self._group.event_queue = asyncio.Queue()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:

--- a/src/pipecat/workers/base_worker.py
+++ b/src/pipecat/workers/base_worker.py
@@ -1042,6 +1042,7 @@ class BaseWorker(BaseObject, BusSubscriber):
         worker_names: list[str],
         *,
         params: JobGroupParams | None = None,
+        event_queue: asyncio.Queue[JobGroupEvent | None] | None = None,
         name: str | None = None,
         payload: dict | None = None,
         timeout: float | None = None,
@@ -1057,6 +1058,9 @@ class BaseWorker(BaseObject, BusSubscriber):
         Args:
             worker_names: Names of the workers to send the job to.
             params: How to run the group. See :class:`JobGroupParams`.
+            event_queue: Optional queue for collecting intermediate job events.
+                The queue is attached before the first request is sent so fast
+                workers cannot publish events before the consumer is ready.
             name: Job name.
 
                 .. deprecated:: 1.8.0
@@ -1098,7 +1102,11 @@ class BaseWorker(BaseObject, BusSubscriber):
         except TimeoutError:
             raise JobGroupError("workers not ready within timeout")
 
-        group = self._create_job_group(worker_names, params=group_params)
+        group = self._create_job_group(
+            worker_names,
+            params=group_params,
+            event_queue=event_queue,
+        )
 
         for worker_name in worker_names:
             await self._send_job_request(
@@ -1520,6 +1528,7 @@ class BaseWorker(BaseObject, BusSubscriber):
         worker_names: list[str],
         *,
         params: JobGroupParams,
+        event_queue: asyncio.Queue[JobGroupEvent | None] | None = None,
     ) -> JobGroup:
         job_id = str(uuid.uuid4())
         group = JobGroup(
@@ -1528,6 +1537,7 @@ class BaseWorker(BaseObject, BusSubscriber):
             cancel_on_error=params.cancel_on_error,
             label=params.label,
             cancellable=params.cancellable,
+            event_queue=event_queue,
         )
         self._job_groups[job_id] = group
 

--- a/tests/test_job_group.py
+++ b/tests/test_job_group.py
@@ -34,6 +34,31 @@ class StubTask(BaseWorker):
     pass
 
 
+class CompletionSignalingTask(StubTask):
+    """Requester that signals when its job group has completed."""
+
+    def __init__(self, name, completed):
+        super().__init__(name)
+        self._completed = completed
+
+    async def on_job_completed(self, result):
+        await super().on_job_completed(result)
+        self._completed.set()
+
+
+class ResponseBeforePublishReturnsBus(AsyncQueueBus):
+    """Bus that lets a fast worker finish before request publication returns."""
+
+    def __init__(self, completed):
+        super().__init__()
+        self._completed = completed
+
+    async def publish(self, message):
+        await super().publish(message)
+        if isinstance(message, BusJobRequestMessage):
+            await asyncio.wait_for(self._completed.wait(), timeout=1.0)
+
+
 class JobWorkerTask(BaseWorker):
     """Worker that automatically responds to job requests via the bus."""
 
@@ -118,6 +143,16 @@ async def create_test_env():
     await bus.start()
     registry = WorkerRegistry(runner_name="test-runner")
     return bus, tm, registry
+
+
+async def create_response_before_publish_env():
+    completed = asyncio.Event()
+    bus = ResponseBeforePublishReturnsBus(completed)
+    tm = TaskManager()
+    await bus.setup(tm)
+    await bus.start()
+    registry = WorkerRegistry(runner_name="test-runner")
+    return bus, tm, registry, completed
 
 
 async def setup_task(bus, registry, task):
@@ -363,6 +398,29 @@ class TestJobGroupContext(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events[1].data, {"progress": 75})
         self.assertEqual(tg.responses, {"worker": {"result": "done"}})
 
+    async def test_job_group_buffers_events_before_request_publish_returns(self):
+        """job_group() buffers events when a fast remote worker completes during publish."""
+        await self.bus.stop()
+        self.bus, self.tm, self.registry, completed = await create_response_before_publish_env()
+
+        parent = CompletionSignalingTask("parent", completed)
+        await setup_task(self.bus, self.registry, parent)
+
+        worker = UpdatingWorkerTask("worker", updates=[{"progress": 50}], response={"done": True})
+        await setup_task(self.bus, self.registry, worker)
+
+        async def run_job_group():
+            events = []
+            async with parent.job_group("worker") as group:
+                async for event in group:
+                    events.append(event)
+            return events, group.responses
+
+        events, responses = await asyncio.wait_for(run_job_group(), timeout=1.0)
+
+        self.assertEqual([event.data for event in events], [{"progress": 50}])
+        self.assertEqual(responses, {"worker": {"done": True}})
+
     async def test_job_group_iterates_stream_events(self):
         """async for yields stream_start, stream_data, and stream_end events."""
         parent = StubTask("parent")
@@ -593,6 +651,29 @@ class TestJobContext(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events[0].type, JobEvent.UPDATE)
         self.assertIsInstance(events[0], JobEvent)
         self.assertEqual(t.response, {"done": True})
+
+    async def test_job_buffers_events_before_request_publish_returns(self):
+        """job() buffers events when a fast remote worker completes during publish."""
+        await self.bus.stop()
+        self.bus, self.tm, self.registry, completed = await create_response_before_publish_env()
+
+        parent = CompletionSignalingTask("parent", completed)
+        await setup_task(self.bus, self.registry, parent)
+
+        worker = UpdatingWorkerTask("worker", updates=[{"progress": 50}], response={"done": True})
+        await setup_task(self.bus, self.registry, worker)
+
+        async def run_job():
+            events = []
+            async with parent.job("worker") as job:
+                async for event in job:
+                    events.append(event)
+            return events, job.response
+
+        events, response = await asyncio.wait_for(run_job(), timeout=1.0)
+
+        self.assertEqual([event.data for event in events], [{"progress": 50}])
+        self.assertEqual(response, {"done": True})
 
     async def test_job_streams_data(self):
         """job() yields stream events from a streaming worker."""


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

Job and job-group contexts previously attached their event queue only after `create_job_group_and_request_job()` returned. A bus implementation may yield while publishing a request, allowing a fast worker to send updates and complete before the queue exists. In that ordering, intermediate events and the terminal sentinel are dropped, and the context's async iterator waits indefinitely on a newly attached empty queue.

This change creates the queue before dispatch and attaches it to the `JobGroup` before the first request is sent. Fire-and-forget jobs continue to omit the queue, so they do not accumulate unconsumed streaming events.

The regression tests use a deterministic bus that lets a worker response complete before request publication returns. They cover both `job()` and `job_group()` and fail by timing out on the previous ordering.

Validation:

- `pytest tests/test_job_group.py -q` — 35 passed
- worker/bus/registry/UI lifecycle selection — 216 passed
- Ruff check and format check — passed
- Pyright on changed files — 0 errors, 0 warnings
- `git diff --check` — passed