### PR TITLE
Report eval progress through BaseObject events

### DIFF
--- a/changelog/5520.added.md
+++ b/changelog/5520.added.md
@@ -1,0 +1,5 @@
+- Added `on_progress` and `on_update` event handlers to the eval framework. `EvalSession` and `EvalSuite` are now `BaseObject`s, so eval progress is observed the same way as every other Pipecat event. `EvalSuite`'s `on_update` handlers run synchronously and should return promptly, since an `EvalRun` is mutated in place as it executes; `EvalSession`'s `on_progress` handlers run as tasks, and `EvalSession.run()` waits for them before it returns.
+
+      @session.event_handler("on_progress")
+      async def on_progress(session, progress):
+          print(progress.event_name, progress.status)

--- a/changelog/5520.deprecated.md
+++ b/changelog/5520.deprecated.md
@@ -1,0 +1,1 @@
+- Deprecated the `on_progress` parameter of `EvalSession()` and `EvalSession.from_scenario()`, and the `on_update` parameter of `EvalSuite.run()`. Use the event handlers of the same name instead. Passing a callback still works, keeps its existing signature, and emits a `DeprecationWarning`. They will be removed in 2.0.0.

--- a/scripts/deprecations/deprecations.json
+++ b/scripts/deprecations/deprecations.json
@@ -80,6 +80,39 @@
       "location": "pipecat/bus/bridge_processor.py"
     },
     {
+      "subject": "EvalSession.from_scenario.on_progress",
+      "module": "pipecat.evals.harness",
+      "kind": "parameter",
+      "deprecated_in": "1.9.0",
+      "removed_in": "2.0.0",
+      "relation": "use_existing",
+      "replacement": "on_progress",
+      "message": "Use the ``on_progress`` event handler instead. Will be removed in 2.0.0.",
+      "location": "pipecat/evals/harness.py"
+    },
+    {
+      "subject": "EvalSession.on_progress",
+      "module": "pipecat.evals.harness",
+      "kind": "parameter",
+      "deprecated_in": "1.9.0",
+      "removed_in": "2.0.0",
+      "relation": "use_existing",
+      "replacement": "on_progress",
+      "message": "Use the ``on_progress`` event handler instead. Will be removed in 2.0.0.",
+      "location": "pipecat/evals/harness.py"
+    },
+    {
+      "subject": "EvalSuite.run.on_update",
+      "module": "pipecat.evals.suite",
+      "kind": "parameter",
+      "deprecated_in": "1.9.0",
+      "removed_in": "2.0.0",
+      "relation": "use_existing",
+      "replacement": "on_update",
+      "message": "Use the ``on_update`` event handler instead. Will be removed in 2.0.0.",
+      "location": "pipecat/evals/suite.py"
+    },
+    {
       "subject": "FlowManager.task",
       "module": "pipecat.flows.manager",
       "kind": "parameter",

--- a/src/pipecat/cli/commands/eval.py
+++ b/src/pipecat/cli/commands/eval.py
@@ -18,7 +18,6 @@ import sys
 import time
 import traceback
 from datetime import datetime
-from functools import partial
 from pathlib import Path
 
 import typer
@@ -116,7 +115,7 @@ def _dim(s: str) -> str:
     return _color(s, "2")
 
 
-def _print_progress(p: EvalTurnProgress) -> None:
+def _print_progress(session: EvalSession, p: EvalTurnProgress) -> None:
     """Print a per-turn / per-expectation line (verbose mode)."""
     if p.status == "turn":
         label = f'"{p.event_name}"' if p.event_name else "(observe)"
@@ -195,7 +194,7 @@ async def _execute_scenario(
     debug: bool,
     stop_bot: bool,
     trigger_disconnect: bool,
-    on_progress,
+    verbose: bool,
 ) -> None:
     """Run one scenario against its ``bot_url``, updating ``run`` in place.
 
@@ -211,17 +210,19 @@ async def _execute_scenario(
         scenario = EvalScenario.load(run.scenario_path)
         record_path = _record_path(record_dir, run.scenario) if audio else None
         with capture_pipeline_logs(Path(logs_dir), run.scenario, name=run.scenario, enabled=debug):
-            run.result = await EvalSession.from_scenario(
+            session = EvalSession.from_scenario(
                 scenario,
                 url,
                 default_timeout_ms=default_timeout_ms,
-                on_progress=on_progress,
                 record_path=record_path,
                 cache_dir=cache_dir,
                 use_cache=use_cache,
                 stop_bot=stop_bot,
                 trigger_disconnect=trigger_disconnect,
-            ).run()
+            )
+            if verbose:
+                session.add_event_handler("on_progress", _print_progress)
+            run.result = await session.run()
         if run.result.debug_log:
             Path(logs_dir).mkdir(parents=True, exist_ok=True)
             (Path(logs_dir) / f"{run.scenario}.eval.log").write_text(
@@ -263,7 +264,7 @@ async def _run_scenarios_all(
     a piped stdout fall back to streamed result lines instead.
     """
 
-    async def go(run: EvalRun, on_progress) -> None:
+    async def go(run: EvalRun, verbose: bool) -> None:
         await _execute_scenario(
             run,
             audio=audio,
@@ -275,18 +276,18 @@ async def _run_scenarios_all(
             debug=debug,
             stop_bot=stop_bot,
             trigger_disconnect=trigger_disconnect,
-            on_progress=on_progress,
+            verbose=verbose,
         )
 
     if _console.is_terminal and not verbose:
         with Live(_EvalDashboard(runs, started), console=_console, refresh_per_second=12.5):
             for run in runs:
                 if run.status != "done":  # skip a build-time load error
-                    await go(run, None)
+                    await go(run, False)
     else:
         for run in runs:
             if run.status != "done":
-                await go(run, _print_progress if verbose else None)
+                await go(run, verbose)
             _print_eval_line(run)
 
 
@@ -829,11 +830,13 @@ async def _run_suite_all(
                 default_timeout_ms=default_timeout_ms,
             )
     else:
+        suite.add_event_handler(
+            "on_update", lambda _suite, run: _print_eval_line(run, show_attempt=repeat > 1)
+        )
         await suite.run(
             logs_dir,
             record_dir=record_dir,
             results_path=results_path,
-            on_update=partial(_print_eval_line, show_attempt=repeat > 1),
             debug=debug,
             use_cache=use_cache,
             default_timeout_ms=default_timeout_ms,

--- a/src/pipecat/evals/harness.py
+++ b/src/pipecat/evals/harness.py
@@ -79,6 +79,7 @@ import json
 import mimetypes
 import time
 import traceback
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -106,6 +107,7 @@ from pipecat.evals.serializer import (
 )
 from pipecat.evals.speech import EvalSpeech
 from pipecat.evals.transcribe import EvalTranscriber
+from pipecat.utils.base_object import BaseObject
 
 # Generous default so an expectation without an explicit ``within_ms`` waits
 # long enough for slow LLM/TTS responses (and function-call round-trips) rather
@@ -254,13 +256,25 @@ class EvalTurnProgress:
     detail: str = ""
 
 
-class EvalSession:
+class EvalSession(BaseObject):
     """Runs one :class:`EvalScenario` against a bot over a single WebSocket session.
 
     Connects as an RTVI client, drives each turn (sending ``send-text``,
     ``raw-audio``, or ``dtmf``), collects the RTVI events the bot emits, and asserts on them.
     Build one with :meth:`from_scenario` (which constructs the judge, speech, and
     transcriber the scenario needs), then await :meth:`run`.
+
+    Event handlers available:
+
+    - on_progress: Called with an :class:`EvalTurnProgress` as each turn and each
+      expectation resolves. Records are emitted in order, and :meth:`run` waits for
+      every handler before it returns.
+
+    Example::
+
+        @session.event_handler("on_progress")
+        async def on_progress(session, progress):
+            print(progress.event_name, progress.status)
     """
 
     def __init__(
@@ -295,6 +309,11 @@ class EvalSession:
                 deadline anchored at the send). Defaults to 60s.
             on_progress: Optional callback invoked with a :class:`EvalTurnProgress`
                 as each turn and expectation resolves (used for verbose output).
+
+                .. deprecated:: 1.9.0
+                    Use the ``on_progress`` event handler instead.
+                    Will be removed in 2.0.0.
+
             record_path: When set (and the scenario is audio mode), asks the eval
                 transport to record the conversation audio to this path (bot-side).
             stop_bot: When True, ask the bot to cancel its pipeline (and exit) on
@@ -314,11 +333,12 @@ class EvalSession:
                 for the ``response`` event, or ``None`` when unused. Started and
                 stopped by the session.
         """
+        super().__init__()
+
         self._scenario = scenario
         self._bot_url = bot_url
         self._connect_timeout_s = connect_timeout_s
         self._default_timeout_ms = default_timeout_ms
-        self._on_progress = on_progress
         self._record_path = record_path
         self._stop_bot = stop_bot
         # Either the run-wide CLI flag or the scenario's own field opts in.
@@ -370,6 +390,10 @@ class EvalSession:
         self._tts_audio: bytearray = bytearray()  # current spoken segment's audio
         self._tts_sample_rate: int = 0
 
+        self._register_event_handler("on_progress")
+        if on_progress is not None:
+            self._add_legacy_progress_callback(on_progress)
+
     @classmethod
     def from_scenario(
         cls,
@@ -406,6 +430,11 @@ class EvalSession:
             default_timeout_ms: Per-expectation latency budget for expectations
                 without their own ``within_ms``. Defaults to 60s.
             on_progress: Optional per-turn/expectation progress callback (verbose).
+
+                .. deprecated:: 1.9.0
+                    Use the ``on_progress`` event handler instead.
+                    Will be removed in 2.0.0.
+
             record_path: Optional path to record the conversation audio (audio mode).
             cache_dir: Optional directory for cached synthesized user audio
                 (default ``<user-cache-dir>/pipecat/tts``).
@@ -442,12 +471,11 @@ class EvalSession:
             with logger.contextualize(eval_pipeline="transcription"):
                 transcriber = EvalTranscriber.from_config(scenario.transcriber)
 
-        return cls(
+        session = cls(
             scenario,
             bot_url,
             connect_timeout_s=connect_timeout_s,
             default_timeout_ms=default_timeout_ms,
-            on_progress=on_progress,
             record_path=record_path,
             stop_bot=stop_bot,
             trigger_disconnect=trigger_disconnect,
@@ -455,6 +483,9 @@ class EvalSession:
             speech=speech,
             transcriber=transcriber,
         )
+        if on_progress is not None:
+            session._add_legacy_progress_callback(on_progress)
+        return session
 
     async def run(self) -> EvalResult:
         """Connect, drive the scenario, and return the result."""
@@ -628,6 +659,9 @@ class EvalSession:
             if self._stop_bot:
                 await self._send_cancel()
             await self._ws.close()
+            # Progress handlers run as tasks; wait them out so every record is
+            # delivered before the caller has the result in hand.
+            await self.cleanup()
 
         self._debug(f"done: {'PASS' if not failures else 'FAIL'} ({len(failures)} failure(s))")
         return EvalResult(
@@ -1005,10 +1039,25 @@ class EvalSession:
             return f"{event.get('name') or '?'}({sig})"
         return event.get("text") or event.get("transcript") or ""
 
-    def _progress(self, record: EvalTurnProgress) -> None:
-        """Emit a progress record to the on_progress callback, if one was given."""
-        if self._on_progress is not None:
-            self._on_progress(record)
+    def _add_legacy_progress_callback(
+        self, on_progress: Callable[[EvalTurnProgress], None]
+    ) -> None:
+        """Register a bare ``on_progress`` callback as an ``on_progress`` handler.
+
+        The callback takes only the record, so it is wrapped to drop the session
+        that event handlers receive as their first argument.
+        """
+        warnings.warn(
+            "`on_progress` is deprecated since 1.9.0 and will be removed in 2.0.0. "
+            "Use the `on_progress` event handler instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        self.add_event_handler("on_progress", lambda _session, record: on_progress(record))
+
+    async def _progress(self, record: EvalTurnProgress) -> None:
+        """Emit a progress record to the ``on_progress`` handlers."""
+        await self._call_event_handler("on_progress", record)
 
     async def _run_turn(self, turn: EvalTurn, turn_idx: int) -> list[EvalAssertionFailure]:
         """Drive one turn: optionally honor send_after, send user input, match expectations.
@@ -1039,7 +1088,7 @@ class EvalSession:
                     )
                 )
                 self._debug(f"FAIL: {event_name}: {failures[-1].reason}")
-                self._progress(
+                await self._progress(
                     EvalTurnProgress(turn_idx, -1, event_name, "timeout", failures[-1].reason)
                 )
                 return failures
@@ -1082,7 +1131,7 @@ class EvalSession:
             if self._judge is not None:
                 self._judge.add_user_message(f"(DTMF keypad input: {turn.dtmf})")
 
-        self._progress(EvalTurnProgress(turn_idx, -1, turn.user or turn.dtmf or "", "turn"))
+        await self._progress(EvalTurnProgress(turn_idx, -1, turn.user or turn.dtmf or "", "turn"))
 
         # All of a turn's expectations share one deadline anchored at the send, so a
         # stalled turn fails within a single ``within_ms`` budget instead of spending
@@ -1108,7 +1157,7 @@ class EvalSession:
                     )
                 )
                 self._debug(f"FAIL: {expectation.event}: {reason}")
-                self._progress(
+                await self._progress(
                     EvalTurnProgress(turn_idx, exp_idx, expectation.event, "timeout", reason)
                 )
                 break
@@ -1116,11 +1165,11 @@ class EvalSession:
             if failure:
                 failures.append(failure)
                 self._debug(f"FAIL: {expectation.event}: {failure.reason}")
-                self._progress(
+                await self._progress(
                     EvalTurnProgress(turn_idx, exp_idx, expectation.event, "failed", failure.reason)
                 )
             else:
-                self._progress(
+                await self._progress(
                     EvalTurnProgress(
                         turn_idx, exp_idx, expectation.event, "matched", self._last_match_text
                     )

--- a/src/pipecat/evals/suite.py
+++ b/src/pipecat/evals/suite.py
@@ -531,9 +531,10 @@ class EvalSuite(BaseObject):
             # takes only the run. It stays registered for this call alone, so the
             # parameter keeps its per-call scope: a suite can be run again without
             # the callback firing a second time, or firing at all.
-            def handler(_suite, run):
+            def forward_update(_suite: "EvalSuite", run: EvalRun) -> None:
                 on_update(run)
 
+            handler = forward_update
             self.add_event_handler("on_update", handler)
 
         sem = asyncio.Semaphore(self.manifest.concurrency)

--- a/src/pipecat/evals/suite.py
+++ b/src/pipecat/evals/suite.py
@@ -518,6 +518,7 @@ class EvalSuite(BaseObject):
         if results_path is not None:
             results_path.parent.mkdir(parents=True, exist_ok=True)
 
+        handler = None
         if on_update is not None:
             warnings.warn(
                 "`on_update` is deprecated since 1.9.0 and will be removed in 2.0.0. "
@@ -525,27 +526,37 @@ class EvalSuite(BaseObject):
                 DeprecationWarning,
                 stacklevel=2,
             )
+
             # Event handlers take the suite as their first argument; the callback
-            # takes only the run.
-            self.add_event_handler("on_update", lambda _suite, run: on_update(run))
+            # takes only the run. It stays registered for this call alone, so the
+            # parameter keeps its per-call scope: a suite can be run again without
+            # the callback firing a second time, or firing at all.
+            def handler(_suite, run):
+                on_update(run)
+
+            self.add_event_handler("on_update", handler)
 
         sem = asyncio.Semaphore(self.manifest.concurrency)
-        await asyncio.gather(
-            *(
-                self._run_one(
-                    run,
-                    self.manifest.base_port + i,
-                    logs_dir,
-                    record_dir,
-                    results_path,
-                    sem,
-                    debug,
-                    use_cache,
-                    default_timeout_ms,
+        try:
+            await asyncio.gather(
+                *(
+                    self._run_one(
+                        run,
+                        self.manifest.base_port + i,
+                        logs_dir,
+                        record_dir,
+                        results_path,
+                        sem,
+                        debug,
+                        use_cache,
+                        default_timeout_ms,
+                    )
+                    for i, run in enumerate(self.runs)
                 )
-                for i, run in enumerate(self.runs)
             )
-        )
+        finally:
+            if handler is not None:
+                self.remove_event_handler("on_update", handler)
 
     async def _run_one(
         self,

--- a/src/pipecat/evals/suite.py
+++ b/src/pipecat/evals/suite.py
@@ -57,6 +57,7 @@ import shlex
 import sys
 import time
 import traceback
+import warnings
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -65,6 +66,7 @@ import yaml
 from loguru import logger
 
 from pipecat.evals.harness import DEFAULT_EVENT_TIMEOUT_MS, EvalResult, EvalSession
+from pipecat.utils.base_object import BaseObject
 
 DEFAULT_BASE_PORT = 7900
 DEFAULT_CONCURRENCY = 4
@@ -393,7 +395,7 @@ class EvalManifest:
         )
 
 
-class EvalSuite:
+class EvalSuite(BaseObject):
     """Runs the (bot, scenario) runs of an :class:`EvalManifest`, spawning each bot.
 
     Spawns each bot with its eval transport on its own port, drives it with the
@@ -401,11 +403,23 @@ class EvalSuite:
     concurrently (up to the manifest's ``concurrency``). The runs are mutated in
     place as they execute so a live display can read their progress.
 
+    Event handlers available:
+
+    - on_update: Called with an :class:`EvalRun` whenever that run changes status.
+      Runs are mutated in place, so handlers run synchronously and must return
+      promptly; they see the run as the change left it rather than however it has
+      moved on since.
+
     Example::
 
         manifest = EvalManifest.load("manifest.yaml")
         suite = EvalSuite(manifest)
         suite.filter(pattern="voice")
+
+        @suite.event_handler("on_update")
+        async def on_update(suite, run):
+            print(run.scenario, run.status)
+
         await suite.run(Path("logs"))
     """
 
@@ -416,8 +430,15 @@ class EvalSuite:
             manifest: The parsed :class:`EvalManifest`; its runs become the suite's
                 working set (narrowed by :meth:`filter`, executed by :meth:`run`).
         """
+        super().__init__()
+
         self.manifest = manifest
         self.runs = list(manifest.runs)
+
+        # Synchronous: an EvalRun is mutated in place as it executes, so a handler
+        # deferred to a task would read whatever the run has since become. A run
+        # that fails before it spawns reaches "done" with no await in between.
+        self._register_event_handler("on_update", sync=True)
 
     def filter(self, *, pattern: str | None = None, scenario: str | None = None) -> list[EvalRun]:
         """Subset the suite's runs by bot-name substring and/or scenario name.
@@ -464,6 +485,11 @@ class EvalSuite:
                 ``None`` to write none. Each line is flushed as its run completes,
                 so an interrupted sweep keeps everything already finished.
             on_update: Called whenever a run changes status, for live display.
+
+                .. deprecated:: 1.9.0
+                    Use the ``on_update`` event handler instead.
+                    Will be removed in 2.0.0.
+
             debug: When True, save each run's combined ``<run>.debug.log``.
             use_cache: When False, ignore cached user audio and force fresh synthesis.
             default_timeout_ms: Per-expectation budget for expectations without
@@ -492,6 +518,17 @@ class EvalSuite:
         if results_path is not None:
             results_path.parent.mkdir(parents=True, exist_ok=True)
 
+        if on_update is not None:
+            warnings.warn(
+                "`on_update` is deprecated since 1.9.0 and will be removed in 2.0.0. "
+                "Use the `on_update` event handler instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # Event handlers take the suite as their first argument; the callback
+            # takes only the run.
+            self.add_event_handler("on_update", lambda _suite, run: on_update(run))
+
         sem = asyncio.Semaphore(self.manifest.concurrency)
         await asyncio.gather(
             *(
@@ -502,7 +539,6 @@ class EvalSuite:
                     record_dir,
                     results_path,
                     sem,
-                    on_update,
                     debug,
                     use_cache,
                     default_timeout_ms,
@@ -519,7 +555,6 @@ class EvalSuite:
         record_dir: Path | None,
         results_path: Path | None,
         sem: asyncio.Semaphore,
-        on_update: Callable[[EvalRun], None] | None,
         debug: bool,
         use_cache: bool,
         default_timeout_ms: int,
@@ -538,8 +573,7 @@ class EvalSuite:
 
             run.status = "running"
             run.started_at = time.monotonic()
-            if on_update:
-                on_update(run)
+            await self._call_event_handler("on_update", run)
 
             proc: asyncio.subprocess.Process | None = None
             logf = None
@@ -606,8 +640,7 @@ class EvalSuite:
                 if run.started_at is not None:
                     run.duration_ms = int((time.monotonic() - run.started_at) * 1000)
                 run.status = "done"
-                if on_update:
-                    on_update(run)
+                await self._call_event_handler("on_update", run)
                 if proc is not None:
                     await self._stop_bot(proc)
                 if logf is not None:

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -14,11 +14,15 @@ Two layers:
   RTVI WebSocket server that replies to ``client-ready``/``send-text`` with
   scripted RTVI server messages — exercising the handshake, send/receive, event
   matching, and context paths without a real bot pipeline.
+- :class:`TestProgressEvent` covers the ``on_progress`` event and the deprecated
+  callback that feeds it.
 """
 
+import asyncio
 import json
 import socket
 import unittest
+import warnings
 
 import websockets
 
@@ -1046,6 +1050,85 @@ class TestEvalsHarnessIntegration(unittest.IsolatedAsyncioTestCase):
             if m.get("type") == "client-message" and m["data"].get("t") == "eval-context"
         ]
         self.assertEqual(context_messages, [])
+
+
+class TestProgressEvent(unittest.IsolatedAsyncioTestCase):
+    """``on_progress`` handlers see every turn and expectation, in order."""
+
+    def _scenario(self) -> EvalScenario:
+        return EvalScenario(
+            name="progress",
+            turns=[
+                EvalTurn(
+                    user="hi",
+                    expect=[
+                        EvalExpectation(event="llm_started", within_ms=2000),
+                        EvalExpectation(event="llm_response", within_ms=2000),
+                    ],
+                )
+            ],
+        )
+
+    async def asyncSetUp(self):
+        self.server = _FakeRTVIServer(_free_port())
+        await self.server.start()
+        self.server.on_text(
+            "hi",
+            _rtvi("bot-llm-started"),
+            _rtvi("bot-llm-text", {"text": "hello"}),
+            _rtvi("bot-llm-stopped"),
+        )
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+
+    async def test_event_handler_receives_records(self):
+        session = EvalSession.from_scenario(self._scenario(), self.server.url)
+        seen = []
+
+        @session.event_handler("on_progress")
+        async def on_progress(source, progress):
+            seen.append((source, progress))
+
+        await session.run()
+
+        self.assertTrue(all(source is session for source, _ in seen))
+        self.assertEqual(
+            [(p.event_name, p.status) for _, p in seen],
+            [("hi", "turn"), ("llm_started", "matched"), ("llm_response", "matched")],
+        )
+
+    async def test_records_are_delivered_before_run_returns(self):
+        """Handlers dispatch as tasks, so run() waits them out before it returns."""
+        session = EvalSession.from_scenario(self._scenario(), self.server.url)
+        finished = []
+
+        @session.event_handler("on_progress")
+        async def on_progress(source, progress):
+            await asyncio.sleep(0.01)
+            finished.append(progress.event_name)
+
+        await session.run()
+
+        self.assertEqual(finished, ["hi", "llm_started", "llm_response"])
+
+    async def test_callback_is_deprecated_and_still_called(self):
+        seen = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            session = EvalSession.from_scenario(
+                self._scenario(), self.server.url, on_progress=seen.append
+            )
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
+
+        await session.run()
+
+        # The callback takes only the record, not the session an event handler gets.
+        self.assertEqual(
+            [(p.event_name, p.status) for p in seen],
+            [("hi", "turn"), ("llm_started", "matched"), ("llm_response", "matched")],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_evals_suite.py
+++ b/tests/test_evals_suite.py
@@ -178,6 +178,24 @@ class TestSuiteUpdateEvent(unittest.IsolatedAsyncioTestCase):
         # The callback takes only the run, not the suite an event handler gets.
         self.assertEqual(seen, ["running", "done"])
 
+    async def test_callback_stays_scoped_to_the_call_it_was_passed_to(self):
+        """The callback is a per-call parameter, so a reused suite doesn't accumulate it."""
+        seen = []
+        callback = lambda run: seen.append(run.status)  # noqa: E731
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            await self.suite.run(self.logs_dir, on_update=callback)
+            self.assertEqual(seen, ["running", "done"])
+
+            # Passing it again reports each change once more, not twice.
+            await self.suite.run(self.logs_dir, on_update=callback)
+            self.assertEqual(seen, ["running", "done"] * 2)
+
+        # Omitting it stops the reporting.
+        await self.suite.run(self.logs_dir)
+        self.assertEqual(seen, ["running", "done"] * 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evals_suite.py
+++ b/tests/test_evals_suite.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Tests for the eval suite's manifest parsing and per-run log capture."""
+"""Tests for the eval suite's manifest parsing, per-run log capture, and run updates."""
 
+import sys
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 
 from loguru import logger
@@ -16,6 +18,8 @@ from pipecat.evals.suite import (
     DEFAULT_CONCURRENCY,
     DEFAULT_SPAWN,
     EvalManifest,
+    EvalRun,
+    EvalSuite,
     capture_pipeline_logs,
 )
 
@@ -115,6 +119,64 @@ class TestCapturePipelineLogs(unittest.TestCase):
             content = (logs_dir / "run1.debug.log").read_text()
             self.assertIn("mine", content)
             self.assertNotIn("theirs", content)
+
+
+class TestSuiteUpdateEvent(unittest.IsolatedAsyncioTestCase):
+    """``on_update`` handlers see each run enter ``running`` and reach ``done``."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.logs_dir = Path(self._tmp.name)
+        # A bot path that doesn't exist: the run errors out before spawning
+        # anything, which is enough to drive both status changes.
+        run = EvalRun(
+            bot="missing.py",
+            scenario="none",
+            scenario_path=self.logs_dir / "none.yaml",
+            bot_path=self.logs_dir / "missing.py",
+        )
+        self.suite = EvalSuite(
+            EvalManifest(
+                runs=[run],
+                spawn=DEFAULT_SPAWN,
+                python=sys.executable,
+                concurrency=1,
+                repeat=1,
+                base_port=7900,
+                runs_dir=self.logs_dir,
+                record=False,
+                cache_dir=None,
+            )
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        # EvalSuite.run() drops every log sink to keep stdout clean for its caller;
+        # put loguru's default back so the rest of the session still logs.
+        logger.remove()
+        logger.add(sys.stderr)
+
+    async def test_event_handler_receives_runs(self):
+        seen = []
+
+        @self.suite.event_handler("on_update")
+        async def on_update(source, run):
+            seen.append((source, run.status))
+
+        await self.suite.run(self.logs_dir)
+
+        self.assertTrue(all(source is self.suite for source, _ in seen))
+        self.assertEqual([status for _, status in seen], ["running", "done"])
+
+    async def test_callback_is_deprecated_and_still_called(self):
+        seen = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await self.suite.run(self.logs_dir, on_update=lambda run: seen.append(run.status))
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
+        # The callback takes only the run, not the suite an event handler gets.
+        self.assertEqual(seen, ["running", "done"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`EvalSession` and `EvalSuite` are now `BaseObject`s, and their progress callbacks
are Pipecat events.

| | Before | Now |
| --- | --- | --- |
| `EvalSession` | `on_progress=cb` on the constructor / `from_scenario` | `on_progress` event, `EvalTurnProgress` payload |
| `EvalSuite` | `on_update=cb` on `run()` | `on_update` event, `EvalRun` payload |

```python
@session.event_handler("on_progress")
async def on_progress(session, progress):
    print(progress.event_name, progress.status)
```

The callback parameters still work, now deprecated in favor of the events
(removal in 2.0.0). Each is wrapped to drop the emitter that an event handler
receives as its first argument, so existing callbacks keep their signature.

## Dispatch

The two events differ, for a reason worth recording:

`on_update` is synchronous. An `EvalRun` is mutated in place as it executes, so a
handler deferred to a task reads whatever the run has since become. A run that
fails before it spawns reaches `done` with no await in between, and both handlers
then observe `done`, losing the `running` transition entirely.

`on_progress` dispatches as a task, matching the framework default. Its
`EvalTurnProgress` is built fresh per record and never mutated, so there is no
stale-read hazard, and a synchronous handler would serialize into the per-turn
`time.monotonic()` anchor that expectations measure their `within_ms` budget
against. `EvalSession.run()` awaits `cleanup()` during teardown so every record is
delivered before the caller holds the result.

## Testing

New coverage for both events and both deprecated callbacks, where there was none
before. Verified `pipecat eval run --verbose` and the non-TTY suite path render
identically to before.