### PR TITLE
fix(inworld): ignore generation timing from closed contexts

### DIFF
--- a/changelog/5521.fixed.md
+++ b/changelog/5521.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `InworldTTSService` word timestamps landing seconds in the future after an interruption, which left the transcript and the assistant context update lagging behind the audio. An interrupted context keeps sending timestamps and a final flush after the next turn has started, and those were advancing an offset shared by the whole connection.

--- a/src/pipecat/services/inworld/tts.py
+++ b/src/pipecat/services/inworld/tts.py
@@ -1076,7 +1076,16 @@ class InworldTTSService(WebsocketTTSService):
 
             # timestampInfo is inside audioChunk
             timestamp_info = audio_chunk.get("timestampInfo")
-            if timestamp_info:
+
+            # Closing a context flushes it first, so an interrupted context keeps
+            # sending timestamps and a final flush after its replacement has
+            # started. Only the live context may advance the shared offset, which
+            # is unambiguous while one context is live at a time.
+            context_is_live = not ctx_id or self.audio_context_available(ctx_id)
+            if not context_is_live and (timestamp_info or "flushCompleted" in result):
+                logger.trace(f"{self}: Ignoring generation timing for closed context {ctx_id}")
+
+            if timestamp_info and context_is_live:
                 word_times = self._calculate_word_times(timestamp_info)
                 if word_times:
                     if ctx_id:
@@ -1084,7 +1093,7 @@ class InworldTTSService(WebsocketTTSService):
                     await self.add_word_timestamps(word_times, ctx_id, pre_merge_tokens=True)
 
             # Handle flush completion, which indicates the end of a generation
-            if "flushCompleted" in result:
+            if "flushCompleted" in result and context_is_live:
                 logger.trace(
                     f"{self}: Generation completed - updating cumulative_time: "
                     f"{self._cumulative_time} -> {self._generation_end_time}"

--- a/tests/test_inworld_tts_timing.py
+++ b/tests/test_inworld_tts_timing.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for InworldTTSService generation-timing scoping."""
+
+import json
+
+import pytest
+
+from pipecat.services.inworld.tts import InworldTTSService
+
+LIVE_CTX = "ctx-live"
+CLOSED_CTX = "ctx-closed"
+
+
+def _alignment_msg(context_id: str | None, words, starts, ends) -> str:
+    """A timestamp-only audioChunk, as the ASYNC strategy delivers alignment."""
+    result = {
+        "audioChunk": {
+            "timestampInfo": {
+                "wordAlignment": {
+                    "words": words,
+                    "wordStartTimeSeconds": starts,
+                    "wordEndTimeSeconds": ends,
+                }
+            }
+        }
+    }
+    if context_id is not None:
+        result["contextId"] = context_id
+    return json.dumps({"result": result})
+
+
+def _flush_msg(context_id: str | None) -> str:
+    result = {"flushCompleted": {}}
+    if context_id is not None:
+        result["contextId"] = context_id
+    return json.dumps({"result": result})
+
+
+def _make_service() -> InworldTTSService:
+    return InworldTTSService(api_key="test-key")
+
+
+async def _drive(service: InworldTTSService, messages):
+    """Run _receive_messages over a scripted stream, capturing word timestamps.
+
+    Only ``LIVE_CTX`` has an audio context, and the capture replaces
+    ``add_word_timestamps``, which would itself drop words for a dead context.
+    """
+    captured = []
+
+    async def fake_add_word_timestamps(word_times, context_id=None, **kwargs):
+        captured.extend(word_times)
+
+    async def fake_ws():
+        for message in messages:
+            yield message
+
+    service.add_word_timestamps = fake_add_word_timestamps
+    service.audio_context_available = lambda context_id: context_id == LIVE_CTX
+    service._get_websocket = fake_ws
+
+    await service._receive_messages()
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_closed_context_timing_does_not_shift_live_context():
+    """A closed context's trailing alignment and flush leave the live context alone."""
+    service = _make_service()
+
+    messages = [
+        _alignment_msg(CLOSED_CTX, ["stale"], [0.1], [10.75]),
+        _flush_msg(CLOSED_CTX),
+        _alignment_msg(LIVE_CTX, ["hello"], [0.25], [0.9]),
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [("hello", pytest.approx(0.25))]
+
+
+@pytest.mark.asyncio
+async def test_closed_context_flush_does_not_advance_live_generation():
+    """A closed context's flush cannot promote the live context's partial end time."""
+    service = _make_service()
+
+    # The flush lands between two alignments of one live generation, when
+    # _generation_end_time holds that generation's end so far.
+    messages = [
+        _alignment_msg(LIVE_CTX, ["one", "two"], [0.0, 0.5], [0.4, 0.7]),
+        _flush_msg(CLOSED_CTX),
+        _alignment_msg(LIVE_CTX, ["three"], [0.8], [1.2]),
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [
+        ("one", pytest.approx(0.0)),
+        ("two", pytest.approx(0.5)),
+        ("three", pytest.approx(0.8)),
+    ]
+    assert service._cumulative_time == 0.0
+
+
+@pytest.mark.asyncio
+async def test_generations_within_one_context_accumulate():
+    """Raw times restart each generation, so a context's own flush advances its offset."""
+    service = _make_service()
+
+    messages = [
+        _alignment_msg(LIVE_CTX, ["one", "two"], [0.0, 0.5], [0.4, 0.9]),
+        _flush_msg(LIVE_CTX),
+        _alignment_msg(LIVE_CTX, ["three"], [0.1], [0.6]),
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [
+        ("one", pytest.approx(0.0)),
+        ("two", pytest.approx(0.5)),
+        ("three", pytest.approx(1.0)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_messages_without_a_context_id_still_advance_timing():
+    """A response carrying no contextId cannot be attributed, so timing still applies."""
+    service = _make_service()
+
+    messages = [
+        _alignment_msg(None, ["one"], [0.0], [0.9]),
+        _flush_msg(None),
+        _alignment_msg(None, ["two"], [0.1], [0.6]),
+    ]
+    captured = await _drive(service, messages)
+
+    assert captured == [("one", pytest.approx(0.0)), ("two", pytest.approx(1.0))]


### PR DESCRIPTION
Fixes #5325

## Problem

`InworldTTSService` keeps generation timing in two scalars shared by the whole websocket, `_cumulative_time` and `_generation_end_time`, while one connection carries several contexts. Closing a context implicitly flushes it, so an interrupted context keeps sending word timestamps and a final `flushCompleted` after the next turn has opened its own. The receive loop reads `contextId` off every response but never passes it to the timing code, so those stale events advance the shared offset and the next turn's words get stamped seconds into the future.

The audio still plays on time, so what you see is the transcript and the assistant context update lagging long after the bot has stopped speaking, with no error anywhere.

## Changes

Both places that touch the offset now check that the message's context is still live: the `timestampInfo` branch and the `flushCompleted` branch in `_receive_messages`. `audio_context_available` is the predicate `TTSService.add_word_timestamps` already uses to drop stale words. A response with no `contextId` is still treated as live.

This holds while one context is live at a time. If contexts ever overlap on one connection, timing will need to be per context.
