### PR TITLE
fix(tts): don't hold upstream frames behind the speaking pause

### DIFF
--- a/changelog/5573.fixed.md
+++ b/changelog/5573.fixed.md
@@ -1,0 +1,8 @@
+- Fixed `TTSService` holding upstream frames behind the pause it takes while
+  speaking. The pause exists to keep synthesized audio from overlapping, so it
+  now applies only to the downstream text-to-audio flow. Previously it also held
+  the `LLMContextFrame` that the assistant context aggregator pushes upstream
+  after a function call result, which meant the next LLM inference could not
+  start until the current utterance had finished playing — a tool returning
+  early in a long utterance still had to wait out the whole utterance before the
+  bot could respond to it.

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -1262,6 +1262,21 @@ class FrameProcessor(BaseObject):
             await self.cancel_task(self.__process_frame_task)
             self.__process_frame_task = None
 
+    async def _process_frame_now(
+        self,
+        frame: Frame,
+        direction: FrameDirection,
+        callback: FrameCallback | None = None,
+    ):
+        """Process a frame immediately, bypassing the input and process queues.
+
+        Subclasses use this to let a frame skip the queues — and therefore any
+        active ``pause_processing_frames()`` gate — while still firing the
+        ``on_before_process_frame`` / ``on_after_process_frame`` events and the
+        frame callback.
+        """
+        await self.__process_frame(frame, direction, callback)
+
     async def __process_frame(
         self, frame: Frame, direction: FrameDirection, callback: FrameCallback | None
     ):

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -45,7 +45,11 @@ from pipecat.frames.frames import (
     TTSTextFrame,
     TTSUpdateSettingsFrame,
 )
-from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
+from pipecat.processors.frame_processor import (
+    FrameCallback,
+    FrameDirection,
+    FrameProcessorSetup,
+)
 from pipecat.services.ai_service import AIService
 from pipecat.services.settings import TTSSettings
 from pipecat.services.websocket_service import WebsocketService
@@ -909,6 +913,35 @@ class TTSService(AIService):
                 await self._serialization_queue.put(frame)
             else:
                 await self.push_frame(frame, direction)
+
+    async def queue_frame(
+        self,
+        frame: Frame,
+        direction: FrameDirection = FrameDirection.DOWNSTREAM,
+        callback: FrameCallback | None = None,
+    ):
+        """Queue a frame, letting upstream frames skip the speaking pause.
+
+        While this service is speaking, ``_maybe_pause_frame_processing()``
+        blocks the non-system frame queue until ``BotStoppedSpeakingFrame``.
+        That gate exists to keep audio from overlapping, so it only needs to
+        hold back the downstream text -> audio flow.
+
+        Upstream frames do not feed that flow, but they do have to traverse
+        this service: the assistant context aggregator sits after the output
+        transport, so the context frame it pushes upstream after a function
+        call result reaches the LLM through here. Queuing that frame defers the
+        whole next inference until the current utterance has played out.
+
+        System frames keep the normal path, since their ordering relative to
+        interruptions matters; everything else travelling upstream is processed
+        immediately.
+        """
+        if direction == FrameDirection.UPSTREAM and not isinstance(frame, SystemFrame):
+            await self._process_frame_now(frame, direction, callback)
+            return
+
+        await super().queue_frame(frame, direction, callback)
 
     async def push_frame(self, frame: Frame, direction: FrameDirection = FrameDirection.DOWNSTREAM):
         """Push a frame downstream with TTS-specific handling.

--- a/tests/test_tts_service_upstream_frames.py
+++ b/tests/test_tts_service_upstream_frames.py
@@ -1,0 +1,152 @@
+#
+# Copyright (c) 2024-2025 Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import time
+import unittest
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    DataFrame,
+    Frame,
+    LLMFullResponseEndFrame,
+    TextFrame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.settings import TTSSettings
+from pipecat.services.tts_service import TTSService
+from pipecat.tests.utils import SleepFrame, run_test
+
+
+@dataclass
+class ReturningFrame(DataFrame):
+    """Stands in for the context frame the assistant aggregator pushes upstream.
+
+    Deliberately not a TextFrame: the service would synthesize that rather than
+    pass it through, which is not what this test is about.
+    """
+
+    label: str = ""
+
+
+class StubTTSService(TTSService):
+    """A TTS service that emits one audio frame per utterance."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            pause_frame_processing=True,
+            sample_rate=16000,
+            settings=TTSSettings(model=None, voice=None, language=None),
+            **kwargs,
+        )
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        yield TTSStartedFrame()
+        yield TTSAudioRawFrame(audio=b"\x00" * 640, sample_rate=16000, num_channels=1)
+        yield TTSStoppedFrame()
+
+
+class ArrivalRecorder(FrameProcessor):
+    """Sits before the TTS and timestamps the returning frame's arrival."""
+
+    def __init__(self, marks: dict, **kwargs):
+        super().__init__(**kwargs)
+        self._marks = marks
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, ReturningFrame):
+            self._marks.setdefault("returned", time.monotonic())
+        await self.push_frame(frame, direction)
+
+
+class ToolResultSimulator(FrameProcessor):
+    """Sits after the TTS, standing in for the assistant context aggregator.
+
+    On `LLMFullResponseEndFrame` — the point at which the TTS has just taken its
+    speaking pause — it pushes a frame upstream, the way the aggregator pushes
+    the updated context upstream after a function call result. It also marks the
+    moment the bot's audio ends, so the test can tell whether the frame got
+    through before or after playback finished.
+    """
+
+    def __init__(self, marks: dict, **kwargs):
+        super().__init__(**kwargs)
+        self._marks = marks
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        await self.push_frame(frame, direction)
+
+        if isinstance(frame, LLMFullResponseEndFrame):
+            await self.push_frame(ReturningFrame(label="tool result"), FrameDirection.UPSTREAM)
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            self._marks.setdefault("bot_stopped", time.monotonic())
+
+
+class TestTTSServiceUpstreamFrames(unittest.IsolatedAsyncioTestCase):
+    async def test_upstream_frame_is_not_held_by_the_speaking_pause(self):
+        """A frame travelling upstream must not wait for playback to finish.
+
+        `TTSService` pauses its non-system frame queue while it is speaking, to
+        keep audio from overlapping, and resumes on `BotStoppedSpeakingFrame`.
+        The pause is direction-agnostic, so it also holds frames travelling
+        upstream — including the context frame the assistant aggregator pushes
+        upstream after a function call result, which is what asks the LLM to
+        produce the next response. Holding it defers the whole next inference
+        until the current utterance has played out.
+        """
+        marks = {}
+
+        pipeline = Pipeline(
+            [
+                ArrivalRecorder(marks),
+                StubTTSService(),
+                ToolResultSimulator(marks),
+            ]
+        )
+
+        frames_to_send = [
+            # The LLM's response: some text to speak...
+            TextFrame(text="Here are the available doctors."),
+            # ...which the transport starts playing.
+            BotStartedSpeakingFrame(),
+            # End of the LLM response. The TTS pauses here, because it is
+            # speaking, and will not resume until BotStoppedSpeakingFrame.
+            # ToolResultSimulator pushes ReturningFrame upstream at this point.
+            LLMFullResponseEndFrame(),
+            # Playback continues for a while.
+            SleepFrame(sleep=0.5),
+            # Playback ends; the pause lifts.
+            BotStoppedSpeakingFrame(),
+            SleepFrame(sleep=0.3),
+        ]
+
+        await run_test(pipeline, frames_to_send=frames_to_send)
+
+        self.assertIn("returned", marks, "the upstream frame never arrived at all")
+        self.assertIn("bot_stopped", marks, "the bot never stopped speaking")
+
+        held_for_ms = (marks["returned"] - marks["bot_stopped"]) * 1000
+        self.assertLess(
+            marks["returned"],
+            marks["bot_stopped"],
+            f"the upstream frame arrived {held_for_ms:.1f}ms AFTER playback ended: "
+            "it was held by the speaking pause instead of crossing the TTS "
+            "service while the bot was still speaking. On a real call the hold "
+            "lasts as long as the utterance, delaying the next LLM inference by "
+            "exactly that much.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #5572.

## Problem

`TTSService` pauses its non-system frame queue while it is speaking (`_maybe_pause_frame_processing()`), and resumes on `BotStoppedSpeakingFrame`. The gate exists to stop synthesized audio from overlapping, so it only needs to hold back the downstream text → audio flow.

The gate in `FrameProcessor.__process_frame_task_handler` is direction-agnostic, so it holds upstream frames too. In the standard pipeline the assistant context aggregator sits *after* the output transport, so the `LLMContextFrame` it pushes upstream after a function call result — the frame that asks the LLM to produce the next response — has to traverse the paused TTS to get there.

**The next inference cannot start until the current utterance has finished playing.** A tool that returns 1.3s into a 13s utterance yields a reply ~13s later, not ~1.3s later.

Seen in production (Cartesia, gpt-4.1-mini): a tool result received at 09:28:55.662 reached the LLM at 09:29:07.847 — **3ms after** `Bot stopped speaking`. Nothing takes exactly 3ms; that is a queue opening. Full timings and the second, worse occurrence are in #5572.

This is distinct from the deadlock class in #4418 / #5026, where the pause never lifts. Here it lifts normally; the cost is latency, on every service that sets `pause_frame_processing=True`.

## Fix

Upstream non-system frames bypass the queue in `TTSService.queue_frame()`, via a new `FrameProcessor._process_frame_now()` that still fires `on_before_process_frame` / `on_after_process_frame` and the frame callback — the same mechanism `queue_frame` already uses for its direct-mode path.

- **System frames** keep the normal path; their ordering relative to interruptions matters.
- **Downstream frames** are unchanged and still wait for `BotStoppedSpeakingFrame`, so the audio-overlap guarantee is untouched.

## Tests

`tests/test_tts_service_upstream_frames.py` builds a pipeline with a recorder before the TTS and a `ToolResultSimulator` after it (where the assistant aggregator sits). The simulator pushes a frame upstream at the moment the TTS takes its pause; the test asserts that frame reaches the recorder *before* playback ends.

- Fails on `main` — the frame arrives after the release.
- Passes with this change.

Full suite: 4685 passed. The two failures (`test_task_manager.py::test_cancel_before_run_closes_coroutine`, `test_vonage_video_connector.py::test_vonage_client_sdk_cb_to_loop_full_queue`) fail identically on clean `main` and are unrelated.
