### PR TITLE
Provider watch: one-wave groups, biweekly cadence, digest authored from the whole date

### DIFF
--- a/.agents/skills/provider-research-digest
+++ b/.agents/skills/provider-research-digest
@@ -1,0 +1,1 @@
+../../.claude/skills/provider-research-digest

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,7 @@
         "./.claude/skills/pr-submit",
         "./.claude/skills/prose-review",
         "./.claude/skills/provider-research",
+        "./.claude/skills/provider-research-digest",
         "./.claude/skills/squash-commits",
         "./.claude/skills/update-docs"
       ]

--- a/.claude/skills/provider-research-digest/SKILL.md
+++ b/.claude/skills/provider-research-digest/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: provider-research-digest
+description: Render the digest for one provider-research date from every report on disk, topped with authored highlight bullets; publishing is scripts/provider-watch/publish.py's job, run outside this skill
+disable-model-invocation: true
+argument-hint: "[--date YYYY-MM-DD]"
+---
+
+Render `digests/<date>.md` in the reports checkout from every report carrying the date, topped with highlight bullets you author. The digest is a function of the reports on disk, not of any one research run — re-running this skill after further same-date research replaces the digest with a fresh view of the whole date. Everything stays local — this skill publishes nothing; pushing the digest and opening the digest issue are `scripts/provider-watch/publish.py --finalize`'s job, run afterwards by whoever invoked this.
+
+## Arguments
+
+```
+/provider-research-digest [--date YYYY-MM-DD]
+```
+
+- `--date YYYY-MM-DD` — the date to digest. Defaults to today.
+
+## Instructions
+
+### Step 1: Sync the reports checkout
+
+Record `RUN_DATE` as `--date` if given, else today's date (`YYYY-MM-DD`), and pick a scratch directory outside the repo (your session scratchpad if you have one, else `mktemp -d -t provider-research-digest`). The reports checkout is always `./_reports` in this repo (gitignored). If it is missing, `gh repo clone pipecat-ai/provider-watch-reports _reports`; if it exists and has a remote, `git -C _reports pull --ff-only` — the digest must see every report published for the date, not a stale checkout. Stop with a clear error if no `_reports/reports/*/*/<RUN_DATE>.md` exists.
+
+### Step 2: Render a draft
+
+```bash
+uv run python scripts/provider-watch/digest.py --reports _reports --date <RUN_DATE> --out <scratch>/digest-draft.md
+```
+
+Read the draft: it aggregates every unit's summary, PRs, changes to consider and errors for the date.
+
+### Step 3: Author the highlights
+
+Write up to 5 highlight bullets to `<scratch>/highlights.md` from the draft: what a maintainer should look at first — services broken out of the box, PRs and branches worth reviewing first, long-open gaps that finally moved, providers that errored. Judge from the whole date, not from whichever units were researched most recently, and skip bullets when nothing stands out. Match the draft's conventions (unit ids and code in backticks, report paths where a pointer helps).
+
+### Step 4: Render the final digest and hand off
+
+1. ```bash
+   uv run python scripts/provider-watch/digest.py --reports _reports --date <RUN_DATE> --highlights <scratch>/highlights.md --out _reports/digests/<RUN_DATE>.md
+   ```
+2. Print the digest path and end with the next step, which belongs to the invoker, not to you — print the command together with its explanation, and never run it:
+   - `uv run python scripts/provider-watch/publish.py --date <RUN_DATE> --finalize` — publishes everything on disk for the date, digest included: pushes branches, reports and the digest, and opens (or updates) the digest issue.
+
+## Guardrails
+
+- Never print, commit, or paste environment variable values, `Authorization` headers, or raw API keys.
+- This skill publishes nothing: never push, never open PRs or issues, never run `publish.py` — print its command instead.
+- The digest body comes from `digest.py`; author only the highlights, and do not hand-edit the rendered sections.

--- a/.claude/skills/provider-research/SKILL.md
+++ b/.claude/skills/provider-research/SKILL.md
@@ -78,17 +78,14 @@ Rules for the batch loop:
 - Each researcher returns exactly one JSON line: `{"service", "default_model", "prs", "gaps", "error", "summary", "report_path"}`. Append it to `<scratch>/run.jsonl`. If a researcher fails or returns nothing usable, write the report yourself from `REPORT_TEMPLATE.md` with `error` set to what happened (no secrets), and append a matching line; a researcher failure never aborts the run.
 - If `git status` in this checkout shows changes you did not make, stop and report it.
 
-### Step 4: Highlights
-
-Write up to 5 highlight bullets to `<scratch>/highlights.md` from `run.jsonl` — for a small `--only` slice, only the 1–3 that must surface, since slices' bullets may be concatenated into one digest: what a maintainer should look at first (branches to review, long-open gaps, providers that errored). Skip bullets when nothing stands out.
-
-### Step 5: Clean up and summarize
+### Step 4: Clean up and summarize
 
 1. `git worktree prune` in this checkout and remove `<scratch>/wt-*` directories. Branches stay; they are the run's output.
 2. Print a summary table — unit, default model, branch, changes to consider, error — plus the review command for each branch (`git show <branch>`).
 3. End with the next steps, which belong to the invoker, not to you — print each command together with its explanation below, and never run them:
    - `uv run python scripts/provider-watch/publish.py --date <RUN_DATE>` — publishes everything on disk for the date: pushes the branches, opens their draft PRs, pushes the reports. Idempotent, so it can run again after further same-date research and only picks up what is new.
-   - `uv run python scripts/provider-watch/publish.py --date <RUN_DATE> --finalize <scratch>/highlights.md` — the same publish pass, plus the digest: renders `digests/<RUN_DATE>.md` from every report carrying the date and opens (or updates) the digest issue.
+   - `/provider-research-digest --date <RUN_DATE>` — renders `_reports/digests/<RUN_DATE>.md` from every report carrying the date, topped with authored highlight bullets.
+   - `uv run python scripts/provider-watch/publish.py --date <RUN_DATE> --finalize` — the same publish pass, plus the digest: pushes it and opens (or updates) the digest issue.
 
 ## Guardrails
 

--- a/.github/workflows/provider-watch.yml
+++ b/.github/workflows/provider-watch.yml
@@ -7,7 +7,8 @@ name: Provider watch
 # pipecat-ai/provider-watch-reports — is scripts/provider-watch/publish.py's
 # job, run by dedicated steps: once after each group's research (with a fresh
 # GitHub App token, since installation tokens expire after one hour) and once
-# at the end for the digest.
+# at the end, after the /provider-research-digest skill renders the digest
+# with authored highlights from every report carrying the run's date.
 
 on:
   schedule:
@@ -270,16 +271,18 @@ jobs:
             _reports/reports
             _reports/digests
             .pw-scratch/run.jsonl
-            .pw-scratch/highlights.md
             .pw-scratch/summary.md
 
   digest:
     needs: [plan, research]
-    # Renders the digest even when some groups failed; whatever they pushed is
-    # in the reports repo and belongs in it.
+    # Digests even when some groups failed; whatever they pushed is in the
+    # reports repo and belongs in it.
     if: always() && needs.plan.result == 'success' && needs.plan.outputs.skip != 'true' && inputs.dry_run != true
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 40
+    # The digest skill authors highlights with the bot's Anthropic key, which
+    # lives in this environment.
+    environment: provider-watch
     permissions:
       contents: write
       issues: write
@@ -310,36 +313,50 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install PyYAML
-        # publish.py needs only PyYAML here; the full project install is the
-        # research jobs' concern.
-        run: uv venv && uv pip install pyyaml
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        # The extras excluded here need system libraries or Apple hardware; the
+        # same set is excluded by the Read the Docs build.
+        run: |
+          uv sync --group dev --all-extras \
+            --no-extra gstreamer \
+            --no-extra local \
+            --no-extra local-smart-turn \
+            --no-extra moondream \
+            --no-extra mlx-whisper
 
       - name: Configure git identity
         run: |
           git -C _reports config user.name "pipecat-provider-watch-bot[bot]"
           git -C _reports config user.email "321038859+pipecat-provider-watch-bot[bot]@users.noreply.github.com"
 
-      - name: Download group highlights
-        uses: actions/download-artifact@v4
+      - name: Author the digest
+        timeout-minutes: 20
+        uses: anthropics/claude-code-action@v1
         with:
-          pattern: provider-watch-${{ github.run_id }}-*
-          path: group-artifacts
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            Run the provider-research-digest skill unattended:
 
-      - name: Merge highlights
-        run: |
-          : > highlights.md
-          for f in group-artifacts/*/.pw-scratch/highlights.md; do
-            [ -f "$f" ] && { cat "$f"; echo; } >> highlights.md
-          done
-          cat highlights.md
+            /provider-research-digest --date ${{ needs.plan.outputs.run_date }}
 
-      - name: Render the digest and open the issue
+            Read `.claude/skills/provider-research-digest/SKILL.md` and follow
+            it exactly. `./_reports` is already checked out on `main` with
+            every report published for the date; write the digest there and
+            publish nothing — the next workflow step runs publish.py.
+          claude_args: |
+            --model claude-opus-5
+            --max-turns 40
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash"
+
+      - name: Publish the digest
+        # Pushes the digest and opens (or updates) the digest issue. Runs even
+        # when authoring failed: publish.py then renders a highlights-less
+        # digest, so the issue still goes out.
+        if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          .venv/bin/python scripts/provider-watch/publish.py \
-            --date "${{ needs.plan.outputs.run_date }}" \
-            --reports _reports \
-            --repo-root . \
-            --finalize highlights.md
+        run: uv run python scripts/provider-watch/publish.py --date "${{ needs.plan.outputs.run_date }}" --finalize

--- a/.github/workflows/provider-watch.yml
+++ b/.github/workflows/provider-watch.yml
@@ -21,7 +21,7 @@ on:
         required: false
         type: string
       limit:
-        description: "Research only the first N selected units"
+        description: "Research only the first N selected units; 0 researches nothing and just re-renders and re-publishes today's digest and issue"
         required: false
         type: string
       dry_run:
@@ -93,7 +93,9 @@ jobs:
 
   research:
     needs: plan
-    if: needs.plan.outputs.skip != 'true'
+    # An empty plan is a digest-only run; skipping here keeps the empty
+    # matrix expression from ever being evaluated.
+    if: needs.plan.outputs.skip != 'true' && needs.plan.outputs.groups != '[]'
     runs-on: ubuntu-latest
     # The publish step mints its own token, so research only has to leave it
     # room inside the job timeout; the step timeout does that.

--- a/.github/workflows/provider-watch.yml
+++ b/.github/workflows/provider-watch.yml
@@ -33,6 +33,14 @@ concurrency:
   group: provider-watch
   cancel-in-progress: false
 
+# Each research job runs its whole group as a single concurrent wave of
+# researchers, so this one knob is both the plan group size and the skill's
+# --concurrency. It trades sweep wall-clock (fewer, larger groups mean fewer
+# matrix waves) against the burst of concurrent researchers (max-parallel
+# jobs × this many) that the Anthropic rate limits see.
+env:
+  PW_GROUP_SIZE: "8"
+
 jobs:
   plan:
     runs-on: ubuntu-latest
@@ -58,9 +66,7 @@ jobs:
         run: |
           ONLY="${{ inputs.only }}"
           LIMIT="${{ inputs.limit }}"
-          # Sized so a group's research (two researcher batches) clears the
-          # research step timeout with room to spare.
-          ARGS=(--json --group-size 10)
+          ARGS=(--json --group-size "$PW_GROUP_SIZE")
           [ -n "$ONLY" ] && ARGS+=(--only "$ONLY")
           [ -n "$LIMIT" ] && ARGS+=(--limit "$LIMIT")
           GROUPS_JSON=$(python3 scripts/provider-watch/plan.py "${ARGS[@]}")
@@ -83,7 +89,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      # Half the groups at a time bounds the burst of concurrent researchers.
+      # Five jobs at a time bounds the researcher burst to 5 × PW_GROUP_SIZE.
       max-parallel: 5
       matrix:
         group: ${{ fromJSON(needs.plan.outputs.groups) }}
@@ -179,7 +185,7 @@ jobs:
           prompt: |
             Run the provider-research skill unattended:
 
-            /provider-research --only ${{ matrix.group.units }} --date ${{ needs.plan.outputs.run_date }}
+            /provider-research --only ${{ matrix.group.units }} --date ${{ needs.plan.outputs.run_date }} --concurrency ${{ env.PW_GROUP_SIZE }}
 
             Read `.claude/skills/provider-research/SKILL.md` and follow it
             exactly, including its "Unattended runs" section. This job

--- a/.github/workflows/provider-watch.yml
+++ b/.github/workflows/provider-watch.yml
@@ -1,6 +1,6 @@
 name: Provider watch
 
-# Weekly provider research. Research jobs run the /provider-research skill,
+# Provider research, every other week. Research jobs run the /provider-research skill,
 # which only researches: one matrix job per group of units, each writing
 # reports and local provider-watch/* branches. Publishing — pushing reports,
 # opening draft PRs here, filing the digest issue on
@@ -11,6 +11,7 @@ name: Provider watch
 
 on:
   schedule:
+    # Mondays; the plan job's cadence gate skips every other one.
     - cron: "17 6 * * 1"
   workflow_dispatch:
     inputs:
@@ -50,7 +51,22 @@ jobs:
       # One date for the whole sweep, so groups that publish after UTC
       # midnight still write and publish under the date the run started.
       run_date: ${{ steps.groups.outputs.run_date }}
+      skip: ${{ steps.cadence.outputs.skip }}
     steps:
+      - name: Decide whether this scheduled Monday runs
+        id: cadence
+        # The sweep runs every other week. Cron can only say "every Monday",
+        # so the off Mondays are skipped here by epoch-week parity (stable
+        # across year boundaries, unlike ISO week numbers; even weeks run).
+        # Manual dispatches always run.
+        run: |
+          SKIP=false
+          if [ "${{ github.event_name }}" = "schedule" ] && [ $(( $(date -u +%s) / 604800 % 2 )) -eq 1 ]; then
+            SKIP=true
+          fi
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+          echo "skip=$SKIP"
+
       - name: Checkout pipecat
         uses: actions/checkout@v4
 
@@ -76,6 +92,7 @@ jobs:
 
   research:
     needs: plan
+    if: needs.plan.outputs.skip != 'true'
     runs-on: ubuntu-latest
     # The publish step mints its own token, so research only has to leave it
     # room inside the job timeout; the step timeout does that.
@@ -260,7 +277,7 @@ jobs:
     needs: [plan, research]
     # Renders the digest even when some groups failed; whatever they pushed is
     # in the reports repo and belongs in it.
-    if: always() && needs.plan.result == 'success' && inputs.dry_run != true
+    if: always() && needs.plan.result == 'success' && needs.plan.outputs.skip != 'true' && inputs.dry_run != true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/scripts/provider-watch/publish.py
+++ b/scripts/provider-watch/publish.py
@@ -24,12 +24,14 @@ For each report whose ``prs`` list has an entry in ``state: branch``:
 2. rewrite the report — frontmatter entry to ``state: open`` with the URL,
    and the body's branch/review line to the URL.
 
-Then commit and push ``_reports``. With ``--finalize`` it also renders the
-digest and opens (or updates) the digest issue on the reports repo when there
-is anything to show. Run::
+Then commit and push ``_reports``. With ``--finalize`` it also publishes the
+digest — the ``digests/<date>.md`` that ``/provider-research-digest`` rendered,
+or a highlights-less render made here when none exists — and opens (or
+updates) the digest issue on the reports repo when there is anything to show.
+Run::
 
     uv run python scripts/provider-watch/publish.py --date 2026-08-20
-    uv run python scripts/provider-watch/publish.py --date 2026-08-20 --finalize h.md
+    uv run python scripts/provider-watch/publish.py --date 2026-08-20 --finalize
 """
 
 from __future__ import annotations
@@ -311,13 +313,17 @@ def push_reports(sh: Shell, reports_dir: Path, date: str) -> bool:
     return True
 
 
-def render_digest(reports_dir: Path, date: str, highlights: Path | None, reports_repo: str) -> Path:
+def ensure_digest(reports_dir: Path, date: str, reports_repo: str) -> Path:
+    """The digest to publish: the one ``/provider-research-digest`` rendered, untouched,
+    else a highlights-less render so ``--finalize`` still has a digest to publish."""
     out = reports_dir / "digests" / f"{date}.md"
+    if out.exists():
+        return out
     out.parent.mkdir(parents=True, exist_ok=True)
     text = digest.render(
         digest.load_reports(reports_dir, date),
         date=date,
-        highlights=highlights.read_text() if highlights else None,
+        highlights=None,
         repo_url=f"https://github.com/{reports_repo}",
     )
     out.write_text(text)
@@ -395,12 +401,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--reports-repo", default="pipecat-ai/provider-watch-reports")
     parser.add_argument(
         "--finalize",
-        nargs="?",
-        const="",
-        default=None,
-        metavar="HIGHLIGHTS",
-        help="also render the digest and open/update the issue, with an optional "
-        "highlights file inserted at the top",
+        action="store_true",
+        help="also publish the digest (digests/<date>.md, rendered by "
+        "/provider-research-digest; a highlights-less one is rendered here if "
+        "missing) and open/update the digest issue",
     )
     args = parser.parse_args(argv)
 
@@ -414,14 +418,11 @@ def main(argv: list[str] | None = None) -> int:
         reports_repo=args.reports_repo,
         date=args.date,
     )
-    if args.finalize is not None:
-        highlights = Path(args.finalize) if args.finalize else None
-        render_digest(args.reports, args.date, highlights, args.reports_repo)
+    if args.finalize:
+        digest_file = ensure_digest(args.reports, args.date, args.reports_repo)
     outcome.reports_pushed = push_reports(sh, args.reports, args.date)
-    if args.finalize is not None and worth_an_issue(reports):
-        outcome.issue_url = open_or_update_issue(
-            sh, args.reports_repo, args.date, args.reports / "digests" / f"{args.date}.md"
-        )
+    if args.finalize and worth_an_issue(reports):
+        outcome.issue_url = open_or_update_issue(sh, args.reports_repo, args.date, digest_file)
 
     print(json.dumps(outcome.__dict__, indent=2))
     return 0

--- a/tests/test_provider_watch_scripts.py
+++ b/tests/test_provider_watch_scripts.py
@@ -568,6 +568,21 @@ class TestPublish:
         after = len([c for c in sh.calls if c[:3] == ("gh", "pr", "create")])
         assert before == 3 and after == 3
 
+    def test_ensure_digest_keeps_the_rendered_digest(self, reports_dir):
+        tmp_path, publish = reports_dir
+        digest_file = tmp_path / "digests" / "2026-08-20.md"
+        digest_file.parent.mkdir(parents=True)
+        digest_file.write_text("# Provider watch — 2026-08-20\n\n- authored highlight\n")
+        assert publish.ensure_digest(tmp_path, "2026-08-20", "o/r") == digest_file
+        assert "authored highlight" in digest_file.read_text()
+
+    def test_ensure_digest_renders_plain_when_missing(self, reports_dir):
+        tmp_path, publish = reports_dir
+        out = publish.ensure_digest(tmp_path, "2026-08-20", "o/r")
+        text = out.read_text()
+        assert out == tmp_path / "digests" / "2026-08-20.md"
+        assert "3 units researched" in text and "fireworks/llm" in text
+
     def test_worth_an_issue(self, reports_dir, tmp_path):
         _, publish = reports_dir
         assert publish.worth_an_issue(publish.load_reports(tmp_path, "2026-08-20"))


### PR DESCRIPTION
## Summary

Three groups hit the 55-minute research step timeout in the first full sweep (#5516's validation): a 10-unit group ran as two researcher waves (the skill's default `--concurrency 6`), and a wave costs its slowest researcher — two first-run-heavy waves don't fit in the step timeout.

- **Every group now runs as a single concurrent wave**: the workflow passes the skill a `--concurrency` equal to the group size, so a job costs roughly one slowest-researcher (~25–30 minutes worst case on first-run service units) regardless of group size.
- **Group size and researcher concurrency are one knob**, `PW_GROUP_SIZE`, set once at the top of the workflow and threaded into the plan step and the research prompt.
- **It's set to 8.** With one-wave jobs, sweep wall-clock is a step function of matrix waves only, so 8 gives the same ~1¾ h sweep as 10 (14 jobs, 3 waves of `max-parallel: 5`) at a burst of 40 concurrent researchers instead of 50 — the first full sweep showed no throttling signs at 30. Going faster (~1¼ h) would need groups of 11+, pushing the burst past 55; not worth it for a cron job.
- **The sweep now runs every other week.** Cron can only say "every Monday", so the plan job gates scheduled runs on epoch-week parity (stable across year boundaries, unlike ISO week numbers): even weeks run, odd Mondays are skipped. Manual dispatches always run. Next scheduled sweep: 2026-09-14.
- **The digest is authored by a new skill, `/provider-research-digest`, from the whole date.** Highlights were the one digest input that didn't compose: each orchestrator wrote bullets for its own slice into runner scratch, so a run amending an existing date replaced the digest issue's headline with only the latest slice's picks. The skill renders the digest from every report on disk for the date and authors the highlights from that whole-date view — the same commands locally and in CI (`/provider-research` Step 4 prints them). `publish.py --finalize` drops its highlights argument and publishes the rendered digest, rendering a highlights-less one itself only when the skill didn't run; the digest job runs the skill (in the `provider-watch` environment, for the bot's Anthropic key) and its artifact-merging steps are gone. A dispatch with `limit=0` selects no units and skips research entirely, so the run just re-authors and re-publishes today's digest and issue — the recovery path when a digest needs redoing without new research.

## Testing

- `plan.py --group-size 8` against the live tree: 14 groups (13 × 8 + 1 × 2).
- Workflow YAML parse-checked; 8 concurrent foreground subagent launches in one message verified to run as one wave under `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`.
- Validation run [33521040525](https://github.com/pipecat-ai/pipecat/actions/runs/33521040525), dispatched from this branch over the 8 service units the previous full sweep's timed-out groups missed — exactly one 8-researcher wave (41 min research, verify passed 8/8), on the first-run-heavy load the sizing is for. Running under the same date, it amended the sweep's [digest issue](https://github.com/pipecat-ai/provider-watch-reports/issues/3) in place — and its highlights clobbered the full sweep's, the failure the digest skill removes.
- `test_provider_watch_scripts.py` (36 tests green), including the finalize contract: an existing rendered digest is published untouched; a missing one gets a highlights-less render.
- Digest-only validation run [33532340075](https://github.com/pipecat-ai/pipecat/actions/runs/33532340075), dispatched with `limit=0`: research skipped, the digest skill re-authors highlights from all 106 of the date's reports, and finalize re-syncs the [digest issue](https://github.com/pipecat-ai/provider-watch-reports/issues/3).

No changelog fragment: CI and developer tooling only.
