### PR TITLE
Make WebsocketService reconnect backoff configurable

### DIFF
--- a/changelog/5586.added.md
+++ b/changelog/5586.added.md
@@ -1,0 +1,1 @@
+- `WebsocketService` now accepts `reconnect_backoff_min_wait` and `reconnect_backoff_max_wait` to configure the wait between reconnection attempts. Defaults (4s / 10s) preserve the previous hardcoded behavior.

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -102,6 +102,8 @@ class WebsocketService(ABC):
         *,
         reconnect_on_error: bool = True,
         ws_close_timeout: float = WS_CLOSE_TIMEOUT,
+        reconnect_backoff_min_wait: float = 4.0,
+        reconnect_backoff_max_wait: float = 10.0,
         **kwargs,
     ):
         """Initialize the websocket service.
@@ -113,11 +115,17 @@ class WebsocketService(ABC):
                 connection. Applied to connections opened through
                 :meth:`_websocket_connect`. Increase it for peers that need
                 longer to complete a graceful close.
+            reconnect_backoff_min_wait: Minimum time, in seconds, to wait between
+                reconnection attempts.
+            reconnect_backoff_max_wait: Maximum time, in seconds, to wait between
+                reconnection attempts.
             **kwargs: Additional arguments (unused, for compatibility).
         """
         self._websocket: websockets.WebSocketClientProtocol | None = None  # pyright: ignore[reportAttributeAccessIssue]
         self._reconnect_on_error = reconnect_on_error
         self._ws_close_timeout = ws_close_timeout
+        self._reconnect_backoff_min_wait = reconnect_backoff_min_wait
+        self._reconnect_backoff_max_wait = reconnect_backoff_max_wait
         self._reconnect_in_progress: bool = False
         self._disconnecting: bool = False
         # Rapid failure detection: when a server accepts the WebSocket handshake
@@ -227,7 +235,11 @@ class WebsocketService(ABC):
                 if not self._is_service_usable:
                     logger.error(f"{self} abandoning reconnection: the service is no longer usable")
                     return False
-                wait_time = exponential_backoff_time(attempt)
+                wait_time = exponential_backoff_time(
+                    attempt,
+                    min_wait=self._reconnect_backoff_min_wait,
+                    max_wait=self._reconnect_backoff_max_wait,
+                )
                 await asyncio.sleep(wait_time)
             msg = f"{self} failed to reconnect after {max_retries} attempts"
             if last_exception:

--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -100,32 +100,32 @@ class WebsocketService(ABC):
     def __init__(
         self,
         *,
-        reconnect_on_error: bool = True,
-        ws_close_timeout: float = WS_CLOSE_TIMEOUT,
         reconnect_backoff_min_wait: float = 4.0,
         reconnect_backoff_max_wait: float = 10.0,
+        reconnect_on_error: bool = True,
+        ws_close_timeout: float = WS_CLOSE_TIMEOUT,
         **kwargs,
     ):
         """Initialize the websocket service.
 
         Args:
+            reconnect_backoff_min_wait: Minimum time, in seconds, to wait between
+                reconnection attempts.
+            reconnect_backoff_max_wait: Maximum time, in seconds, to wait between
+                reconnection attempts.
             reconnect_on_error: Whether to automatically reconnect on connection errors.
             ws_close_timeout: Maximum time, in seconds, to wait for the peer to
                 acknowledge the websocket closing handshake before dropping the
                 connection. Applied to connections opened through
                 :meth:`_websocket_connect`. Increase it for peers that need
                 longer to complete a graceful close.
-            reconnect_backoff_min_wait: Minimum time, in seconds, to wait between
-                reconnection attempts.
-            reconnect_backoff_max_wait: Maximum time, in seconds, to wait between
-                reconnection attempts.
             **kwargs: Additional arguments (unused, for compatibility).
         """
         self._websocket: websockets.WebSocketClientProtocol | None = None  # pyright: ignore[reportAttributeAccessIssue]
-        self._reconnect_on_error = reconnect_on_error
-        self._ws_close_timeout = ws_close_timeout
         self._reconnect_backoff_min_wait = reconnect_backoff_min_wait
         self._reconnect_backoff_max_wait = reconnect_backoff_max_wait
+        self._reconnect_on_error = reconnect_on_error
+        self._ws_close_timeout = ws_close_timeout
         self._reconnect_in_progress: bool = False
         self._disconnecting: bool = False
         # Rapid failure detection: when a server accepts the WebSocket handshake


### PR DESCRIPTION
## Changes
- Add `reconnect_backoff_min_wait` / `reconnect_backoff_max_wait` parameters to `WebsocketService.__init__` and thread them into the `exponential_backoff_time()` call in `_try_reconnect`.
- Defaults (4s / 10s) preserve the current behavior exactly; previously the backoff bounds were hardcoded at the call site.

Motivation: for latency-sensitive sessions (e.g. a live voice call recovering an STT websocket after a transient drop), a fixed 4s floor between reconnect attempts adds seconds of dead air that a subclass currently can only avoid by forking `_try_reconnect` or monkeypatching the module. This exposes the existing knobs of `exponential_backoff_time` at service construction.