### PR TITLE
Fix NvidiaLLMService TTFB ordering for reasoning output

### DIFF
--- a/changelog/5589.fixed.md
+++ b/changelog/5589.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `NvidiaLLMService` emitting reasoning frames before TTFB metrics, so observers receive TTFB before reasoning output for structured reasoning fields and inline `<think>` blocks.

--- a/src/pipecat/services/nvidia/llm.py
+++ b/src/pipecat/services/nvidia/llm.py
@@ -160,6 +160,7 @@ class NvidiaLLMService(OpenAILLMService):
             return text
 
         self._think_tag_buffer += text
+
         if self._think_tag_state == _ThinkTagState.DETECTING:
             if len(self._think_tag_buffer) < len(_THINK_OPEN):
                 if _THINK_OPEN.startswith(self._think_tag_buffer):

--- a/src/pipecat/services/nvidia/llm.py
+++ b/src/pipecat/services/nvidia/llm.py
@@ -160,7 +160,6 @@ class NvidiaLLMService(OpenAILLMService):
             return text
 
         self._think_tag_buffer += text
-
         if self._think_tag_state == _ThinkTagState.DETECTING:
             if len(self._think_tag_buffer) < len(_THINK_OPEN):
                 if _THINK_OPEN.startswith(self._think_tag_buffer):
@@ -171,6 +170,7 @@ class NvidiaLLMService(OpenAILLMService):
                 return passthrough
 
             if self._think_tag_buffer.startswith(_THINK_OPEN):
+                await self.stop_ttfb_metrics()
                 self._think_tag_state = _ThinkTagState.IN_THOUGHT
                 await self.push_frame(LLMThoughtStartFrame())
                 self._think_tag_buffer = self._think_tag_buffer[len(_THINK_OPEN) :]
@@ -287,6 +287,7 @@ class NvidiaLLMService(OpenAILLMService):
                     )
                     if rc:
                         if not self._has_reasoning_field:
+                            await self.stop_ttfb_metrics()
                             self._has_reasoning_field = True
                             await self.push_frame(LLMThoughtStartFrame())
                         await self.push_frame(LLMThoughtTextFrame(text=rc))

--- a/tests/test_nvidia_llm.py
+++ b/tests/test_nvidia_llm.py
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2026, Daily
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
@@ -11,7 +12,12 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 
-from pipecat.frames.frames import LLMThoughtStartFrame, MetricsFrame
+from pipecat.frames.frames import (
+    LLMThoughtEndFrame,
+    LLMThoughtStartFrame,
+    LLMThoughtTextFrame,
+    MetricsFrame,
+)
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.services.nvidia.llm import NvidiaLLMService
@@ -80,24 +86,60 @@ async def test_reasoning_output_reports_ttfb_before_thought_frames(reasoning_con
     service.push_frame = capture
     service._push_llm_text = AsyncMock()
 
-    stream = _FakeStream(
-        [_reasoning_chunk(reasoning_content=reasoning_content, content=content)]
-    )
-    with patch.object(
-        OpenAILLMService,
-        "get_chat_completions",
-        AsyncMock(return_value=stream),
-    ), patch.object(
-        FrameProcessor,
-        "metrics_enabled",
-        new_callable=PropertyMock,
-        return_value=True,
+    stream = _FakeStream([_reasoning_chunk(reasoning_content=reasoning_content, content=content)])
+    with (
+        patch.object(
+            OpenAILLMService,
+            "get_chat_completions",
+            AsyncMock(return_value=stream),
+        ),
+        patch.object(
+            FrameProcessor,
+            "metrics_enabled",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
     ):
-        await service._process_context(
-            LLMContext(messages=[{"role": "user", "content": "Hi"}])
-        )
+        await service._process_context(LLMContext(messages=[{"role": "user", "content": "Hi"}]))
 
     ttfb_frames = [frame for frame in pushed if isinstance(frame, MetricsFrame)]
     assert len(ttfb_frames) == 1
     assert isinstance(pushed[0], MetricsFrame)
     assert isinstance(pushed[1], LLMThoughtStartFrame)
+
+
+@pytest.mark.asyncio
+async def test_non_reasoning_output_reports_ttfb_without_thought_frames():
+    """A normal response reports TTFB without emitting thought frames."""
+    service = _service()
+    pushed = []
+
+    async def capture(frame, *args, **kwargs):
+        pushed.append(frame)
+
+    service.push_frame = capture
+    service._push_llm_text = AsyncMock()
+
+    stream = _FakeStream([_reasoning_chunk(reasoning_content=None, content="Answer")])
+    with (
+        patch.object(
+            OpenAILLMService,
+            "get_chat_completions",
+            AsyncMock(return_value=stream),
+        ),
+        patch.object(
+            FrameProcessor,
+            "metrics_enabled",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        await service._process_context(LLMContext(messages=[{"role": "user", "content": "Hi"}]))
+
+    ttfb_frames = [frame for frame in pushed if isinstance(frame, MetricsFrame)]
+    assert len(ttfb_frames) == 1
+    assert not any(
+        isinstance(frame, (LLMThoughtStartFrame, LLMThoughtTextFrame, LLMThoughtEndFrame))
+        for frame in pushed
+    )
+    service._push_llm_text.assert_awaited_once_with("Answer")

--- a/tests/test_nvidia_llm.py
+++ b/tests/test_nvidia_llm.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for NVIDIA NIM LLM service behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, PropertyMock, patch
+
+import pytest
+
+from pipecat.frames.frames import LLMThoughtStartFrame, MetricsFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameProcessor
+from pipecat.services.nvidia.llm import NvidiaLLMService
+from pipecat.services.openai.llm import OpenAILLMService
+
+
+class _FakeStream:
+    """Minimal asynchronous completion stream for service tests."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def close(self):
+        pass
+
+
+def _reasoning_chunk(*, reasoning_content: str | None, content: str | None):
+    """Build an OpenAI-compatible chunk containing NVIDIA reasoning output."""
+    return SimpleNamespace(
+        usage=None,
+        model=None,
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    reasoning_content=reasoning_content,
+                    content=content,
+                    tool_calls=None,
+                )
+            )
+        ],
+    )
+
+
+def _service():
+    """Create an NVIDIA service with its API client disabled."""
+    with patch.object(NvidiaLLMService, "create_client"):
+        return NvidiaLLMService(
+            api_key="test-key",
+            settings=NvidiaLLMService.Settings(model="test-model"),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reasoning_content", "content"),
+    [
+        pytest.param("Let me think.", None, id="reasoning-content"),
+        pytest.param(None, "<think>Let me think.</think>Answer", id="think-tags"),
+    ],
+)
+async def test_reasoning_output_reports_ttfb_before_thought_frames(reasoning_content, content):
+    """Reasoning is observable only after its TTFB metric is reported."""
+    service = _service()
+    pushed = []
+
+    async def capture(frame, *args, **kwargs):
+        pushed.append(frame)
+
+    service.push_frame = capture
+    service._push_llm_text = AsyncMock()
+
+    stream = _FakeStream(
+        [_reasoning_chunk(reasoning_content=reasoning_content, content=content)]
+    )
+    with patch.object(
+        OpenAILLMService,
+        "get_chat_completions",
+        AsyncMock(return_value=stream),
+    ), patch.object(
+        FrameProcessor,
+        "metrics_enabled",
+        new_callable=PropertyMock,
+        return_value=True,
+    ):
+        await service._process_context(
+            LLMContext(messages=[{"role": "user", "content": "Hi"}])
+        )
+
+    ttfb_frames = [frame for frame in pushed if isinstance(frame, MetricsFrame)]
+    assert len(ttfb_frames) == 1
+    assert isinstance(pushed[0], MetricsFrame)
+    assert isinstance(pushed[1], LLMThoughtStartFrame)


### PR DESCRIPTION
## Summary

- Report NVIDIA LLM TTFB when the first reasoning output arrives, before emitting `LLMThoughtStartFrame`
- Support both structured `reasoning_content` / `reasoning` deltas and inline leading `<think>...</think>` content
- Preserve existing behavior for non-reasoning responses and emit exactly one TTFB metrics frame

`NvidiaLLMService` processes reasoning in a stream wrapper before yielding chunks to the inherited OpenAI processing loop. As a result, observers could receive reasoning frames before the inherited loop reported TTFB.

This change reports TTFB at the point where NVIDIA reasoning is first detected. The inherited TTFB stop remains safe because metric collection is idempotent. TTFAT continues to represent the time until the first user-visible answer token.

## Testing

- `uv run pytest tests/test_nvidia_llm.py -v` — 3 passed
- `uv run ruff check src/pipecat/services/nvidia/llm.py tests/test_nvidia_llm.py` — passed
- `uv run ruff format --check src/pipecat/services/nvidia/llm.py tests/test_nvidia_llm.py` — passed

The tests cover:

- Structured `reasoning_content`
- Inline `<think>...</think>` content
- Non-reasoning output
- Single TTFB metric emission
- TTFB emission before `LLMThoughtStartFrame`
