### PR TITLE
Wait for the pipeline before driving a drain in the worker tests

### DIFF
--- a/tests/test_base_worker.py
+++ b/tests/test_base_worker.py
@@ -320,8 +320,18 @@ class TestDrainBeforeTransition(unittest.IsolatedAsyncioTestCase):
         runner = WorkerRunner(bus=self.bus, handle_sigint=False)
         await runner.add_workers(worker)
 
+        running = asyncio.Event()
+
+        @worker.event_handler("on_pipeline_started")
+        async def _on_pipeline_started(worker, frame):
+            running.set()
+
         async def drive():
-            await asyncio.sleep(0.05)
+            # Only a running pipeline is drained, so wait for the StartFrame to
+            # reach the end of it. Acting on a fixed delay instead races worker
+            # setup, and a host slow enough to lose that race sees the action
+            # arrive before there is a pipeline to drain.
+            await running.wait()
             await action()
             await worker.queue_frame(EndFrame())
 


### PR DESCRIPTION
## Summary

- `TestDrainBeforeTransition._run_until` waited a fixed 50 ms for a worker to come up before ending it or handing it over. It now waits for `on_pipeline_started` — the StartFrame reaching the end of the pipeline — so the tests act on a running pipeline regardless of how long setup takes.

`PipelineWorker._drain_pipeline` skips the drain when `_process_push_task is None`, which is correct: a pipeline that isn't running has nobody to bounce the flush probe back, so waiting would only spend the timeout. On a host still in worker setup after 50 ms, the end arrived before there was a pipeline to drain, the drain was correctly skipped, and `test_end_drains_a_running_pipeline` read that as a missing flush:

```
AssertionError: Lists differ: [] != [True]
```

Observed on [this run](https://github.com/pipecat-ai/pipecat/actions/runs/33627207633/job/100237660978), where asyncio reported `draining::setup` taking 0.365 s and the log shows the end landing before the pipeline started:

```
11:57:39.773  starting worker 'draining'
11:57:40.149  ending gracefully (reason=done)
11:57:40.151  received end
11:57:40.154  Waiting for StartFrame#60 to reach the end of the pipeline...
```

`on_pipeline_started` is a sufficient gate because a StartFrame cannot traverse the pipeline before `_process_push_task` exists, so the drain's own precondition is met by the time the tests act.

`test_end_skips_the_drain_when_nothing_is_running` drives the worker itself and is untouched.

## Testing

```sh
uv run pytest tests/test_base_worker.py
```

To see the race directly, give the pipeline a processor whose `setup()` sleeps 0.4 s: the fixed-delay version records `flushed == []` and the current one records `[True]`.