### PR TITLE
Deprecate the system prompt as an initial context message

### DIFF
--- a/changelog/5596.changed.md
+++ b/changelog/5596.changed.md
@@ -1,0 +1,1 @@
+- ⚠️ `Mem0MemoryService` now adds retrieved memories with the `"developer"` role instead of `"system"` when `add_as_system_message` is set. Memories are extra guidance for the model, not a system prompt. Services without a `"developer"` role receive them as `"user"` — the same treatment non-OpenAI services already gave the `"system"` message.

--- a/changelog/5596.deprecated.md
+++ b/changelog/5596.deprecated.md
@@ -1,0 +1,12 @@
+- Setting the system prompt as a `"system"` message at the start of `LLMContext` is deprecated and will stop working in 2.0.0. Set it on the LLM service instead:
+
+    ```python
+    # Before
+    context = LLMContext([{"role": "system", "content": "Be helpful."}])
+
+    # After
+    llm = OpenAILLMService(api_key=..., system_instruction="Be helpful.")
+    context = LLMContext()
+    ```
+
+    To change the prompt at runtime, push an `LLMUpdateSettingsFrame` carrying `LLMSettings(system_instruction=...)` instead of rewriting the first context message.

--- a/examples/transcription/transcription-google-llm.py
+++ b/examples/transcription/transcription-google-llm.py
@@ -181,7 +181,7 @@ class InputTranscriptionContextFilter(FrameProcessor):
             )
             new_message_content.append(last_part)
             msg = {"role": "developer", "content": new_message_content}
-            ctx = LLMContext([{"role": "system", "content": transcriber_system_message}, msg])
+            ctx = LLMContext([msg])
 
             await self.push_frame(LLMContextFrame(context=ctx))
         except Exception as e:

--- a/examples/update-settings/llm/llm-azure-realtime.py
+++ b/examples/update-settings/llm/llm-azure-realtime.py
@@ -10,7 +10,6 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import LLMContextMessage
 from pipecat.evals.transport import EvalTransportParams
 from pipecat.frames.frames import LLMRunFrame, LLMUpdateSettingsFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -59,16 +58,10 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = AzureRealtimeLLMService(
         api_key=os.environ["AZURE_REALTIME_API_KEY"],
         base_url=os.environ["AZURE_REALTIME_BASE_URL"],
+        system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
     )
 
-    messages: list[LLMContextMessage] = [
-        {
-            "role": "system",
-            "content": "You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
-        },
-    ]
-
-    context = LLMContext(messages)
+    context = LLMContext()
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
     )

--- a/examples/update-settings/llm/llm-grok-realtime.py
+++ b/examples/update-settings/llm/llm-grok-realtime.py
@@ -10,7 +10,6 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import LLMContextMessage
 from pipecat.evals.transport import EvalTransportParams
 from pipecat.frames.frames import LLMRunFrame, LLMUpdateSettingsFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -56,16 +55,12 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting bot")
 
-    llm = GrokRealtimeLLMService(api_key=os.environ["XAI_API_KEY"])
+    llm = GrokRealtimeLLMService(
+        api_key=os.environ["XAI_API_KEY"],
+        system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
+    )
 
-    messages: list[LLMContextMessage] = [
-        {
-            "role": "system",
-            "content": "You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
-        },
-    ]
-
-    context = LLMContext(messages)
+    context = LLMContext()
     # It appears that Grok Realtime can sometimes be slow to detect the start
     # of a user's turn; uncomment the below imports and user_params to
     # enable "supplemental" interruptions.

--- a/examples/update-settings/llm/llm-openai-realtime.py
+++ b/examples/update-settings/llm/llm-openai-realtime.py
@@ -10,7 +10,6 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import LLMContextMessage
 from pipecat.evals.transport import EvalTransportParams
 from pipecat.frames.frames import LLMRunFrame, LLMUpdateSettingsFrame
 from pipecat.pipeline.pipeline import Pipeline
@@ -56,16 +55,12 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info("Starting bot")
 
-    llm = OpenAIRealtimeLLMService(api_key=os.environ["OPENAI_API_KEY"])
+    llm = OpenAIRealtimeLLMService(
+        api_key=os.environ["OPENAI_API_KEY"],
+        system_instruction="You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
+    )
 
-    messages: list[LLMContextMessage] = [
-        {
-            "role": "system",
-            "content": "You are a helpful assistant in a voice conversation. Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken. Respond to what the user said in a creative, helpful, and brief way.",
-        },
-    ]
-
-    context = LLMContext(messages)
+    context = LLMContext()
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
     )

--- a/examples/update-settings/llm/llm-ultravox-realtime.py
+++ b/examples/update-settings/llm/llm-ultravox-realtime.py
@@ -11,7 +11,6 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 
-from pipecat.adapters.base_llm_adapter import LLMContextMessage
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.evals.transport import EvalTransportParams
 from pipecat.frames.frames import LLMRunFrame, LLMUpdateSettingsFrame
@@ -67,14 +66,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         one_shot_selected_tools=ToolsSchema(standard_tools=[]),
     )
 
-    messages: list[LLMContextMessage] = [
-        {
-            "role": "system",
-            "content": system_prompt,
-        },
-    ]
-
-    context = LLMContext(messages)
+    # The prompt is already set on the service via OneShotInputParams.
+    context = LLMContext()
     # Ultravox doesn't emit user-turn frames. To get them (for RTVI
     # speech events, turn observers, etc.) uncomment the local-VAD
     # imports + `user_params=` below. See realtime-ultravox.py for the

--- a/src/pipecat/adapters/base_llm_adapter.py
+++ b/src/pipecat/adapters/base_llm_adapter.py
@@ -71,6 +71,7 @@ class BaseLLMAdapter(ABC, Generic[TLLMInvocationParams]):
     def __init__(self):
         """Initialize the adapter."""
         self._warned_system_instruction = False
+        self._warned_context_system_message = False
         self._builtin_tools: dict[str, FunctionSchema] = {}
 
     @property
@@ -205,6 +206,33 @@ class BaseLLMAdapter(ABC, Generic[TLLMInvocationParams]):
         # Fallback to return the same tools in case they are not in a standard format
         return tools
 
+    def _warn_context_system_message(self):
+        """Warn once that the initial ``"system"`` context message is deprecated.
+
+        The system prompt belongs on the LLM service, where it composes with
+        the instructions the framework contributes — appended instructions,
+        turn-completion guidance, async-tool guidance. A prompt carried in the
+        context bypasses that composition, and providers that take the system
+        instruction as a separate parameter drop it entirely when the service
+        also has one.
+        """
+        if self._warned_context_system_message:
+            return
+        self._warned_context_system_message = True
+        # Raised under an `always` filter so it survives the default
+        # `ignore::DeprecationWarning` that hides call sites outside
+        # `__main__` — every caller here is inside an LLM service. The flag
+        # above supplies the deduplication that filter would provide.
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                'Passing the system prompt as an initial "system" message in `LLMContext` is'
+                " deprecated since 1.9.0 and will be removed in 2.0.0. Set `system_instruction`"
+                " on the LLM service instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
     def _extract_initial_system(
         self,
         messages: list,
@@ -243,6 +271,8 @@ class BaseLLMAdapter(ABC, Generic[TLLMInvocationParams]):
 
         if messages[0].get("role") != "system":
             return None
+
+        self._warn_context_system_message()
 
         # Would extracting empty the list? Convert to "user" instead.
         if len(messages) == 1:
@@ -296,9 +326,13 @@ class BaseLLMAdapter(ABC, Generic[TLLMInvocationParams]):
             if not self._warned_system_instruction:
                 self._warned_system_instruction = True
                 if discard_context_system:
+                    # This provider takes the system instruction as a separate
+                    # parameter, so only one of the two can be sent.
                     logger.warning(
-                        "Both system_instruction and an initial system message"
-                        " in context are set. Using system_instruction."
+                        "Both system_instruction and an initial system message in"
+                        " context are set. Using system_instruction; the context"
+                        " system message is not sent to the model. Move the prompt"
+                        " to system_instruction on the LLM service."
                     )
                 else:
                     logger.warning(

--- a/src/pipecat/adapters/services/aws_nova_sonic_adapter.py
+++ b/src/pipecat/adapters/services/aws_nova_sonic_adapter.py
@@ -146,6 +146,7 @@ class AWSNovaSonicLLMAdapter(BaseLLMAdapter[AWSNovaSonicLLMInvocationParams]):
         # If we have a "system" message as our first message,
         # pull that out into "instruction"
         if ucm and ucm[0].get("role") == "system":
+            self._warn_context_system_message()
             system = ucm.pop(0)
             content = system.get("content")
             if isinstance(content, str):

--- a/src/pipecat/adapters/services/grok_realtime_adapter.py
+++ b/src/pipecat/adapters/services/grok_realtime_adapter.py
@@ -128,6 +128,7 @@ class GrokRealtimeLLMAdapter(BaseLLMAdapter):
 
         # Extract system message as session instructions
         if messages and messages[0].get("role") == "system":
+            self._warn_context_system_message()
             system = messages.pop(0)
             content = system.get("content")
             if isinstance(content, str):

--- a/src/pipecat/adapters/services/inworld_realtime_adapter.py
+++ b/src/pipecat/adapters/services/inworld_realtime_adapter.py
@@ -128,6 +128,7 @@ class InworldRealtimeLLMAdapter(BaseLLMAdapter):
 
         # Extract system message as session instructions
         if messages and messages[0].get("role") == "system":
+            self._warn_context_system_message()
             system = messages.pop(0)
             content = system.get("content")
             if isinstance(content, str):

--- a/src/pipecat/adapters/services/open_ai_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_adapter.py
@@ -166,16 +166,18 @@ class OpenAILLMAdapter(BaseLLMAdapter[OpenAILLMInvocationParams]):
             self.get_messages(context), convert_developer_to_user=convert_developer_to_user
         )
 
+        # Detect initial system message for warning purposes (don't extract).
+        # ChatCompletionMessageParam.content is `str | Iterable[...]`; we
+        # only forward it for warning purposes, so coerce non-strings to
+        # None — the resolver handles None.
+        initial_content: str | None = None
+        if messages and messages[0].get("role") == "system":
+            self._warn_context_system_message()
+            raw_content = messages[0].get("content", "")
+            if isinstance(raw_content, str):
+                initial_content = raw_content
+
         if system_instruction:
-            # Detect initial system message for warning purposes (don't extract).
-            # ChatCompletionMessageParam.content is `str | Iterable[...]`; we
-            # only forward it for warning purposes, so coerce non-strings to
-            # None — the resolver handles None.
-            initial_content: str | None = None
-            if messages and messages[0].get("role") == "system":
-                raw_content = messages[0].get("content", "")
-                if isinstance(raw_content, str):
-                    initial_content = raw_content
             self._resolve_system_instruction(
                 initial_content,
                 system_instruction,

--- a/src/pipecat/adapters/services/open_ai_realtime_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_realtime_adapter.py
@@ -119,6 +119,7 @@ class OpenAIRealtimeLLMAdapter(BaseLLMAdapter):
         # If we have a "system" message as our first message,
         # pull that out into session "instructions"
         if messages and messages[0].get("role") == "system":
+            self._warn_context_system_message()
             system = messages.pop(0)
             content = system.get("content")
             if isinstance(content, str):

--- a/src/pipecat/adapters/services/open_ai_responses_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_responses_adapter.py
@@ -64,18 +64,20 @@ class OpenAIResponsesLLMAdapter(BaseLLMAdapter[OpenAIResponsesLLMInvocationParam
         """
         messages = self.get_messages(context)
 
-        # Check for conflict: system_instruction + initial system message
-        if system_instruction and messages:
+        if messages:
             first_msg = messages[0] if not isinstance(messages[0], LLMSpecificMessage) else None
             if first_msg and first_msg.get("role") == "system":
+                self._warn_context_system_message()
+                # Check for conflict: system_instruction + initial system message.
                 # `content` is `str | Iterable[...]`; we only forward it for
                 # warning purposes. Coerce non-strings to None.
                 first_content = first_msg.get("content", "")
-                self._resolve_system_instruction(
-                    first_content if isinstance(first_content, str) else None,
-                    system_instruction,
-                    discard_context_system=False,
-                )
+                if system_instruction:
+                    self._resolve_system_instruction(
+                        first_content if isinstance(first_content, str) else None,
+                        system_instruction,
+                        discard_context_system=False,
+                    )
 
         input_items = self._convert_messages_to_input(messages)
 

--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -950,7 +950,7 @@ class GeminiLiveLLMService(LLMService[GeminiLiveLLMAdapter]):
                     )
                     self._context.add_message(
                         {
-                            "role": "system",
+                            "role": "developer",
                             "content": assert_given(self._system_instruction_from_init),
                         }
                     )

--- a/src/pipecat/services/mem0/memory.py
+++ b/src/pipecat/services/mem0/memory.py
@@ -58,7 +58,9 @@ class Mem0MemoryService(FrameProcessor):
                     removed in 2.0.0.
 
             system_prompt: Prefix text for memory context messages.
-            add_as_system_message: Whether to add memories as system messages.
+            add_as_system_message: Whether to add memories as instruction
+                messages ("developer" role) rather than user messages.
+                Providers without a "developer" role receive them as "user".
             position: Position to insert memory messages in context.
         """
 
@@ -279,9 +281,9 @@ class Mem0MemoryService(FrameProcessor):
         for i, memory in enumerate(memories, 1):
             memory_text += f"{i}. {memory.get('memory', '')}\n\n"
 
-        # Add memories as a system message or user message based on configuration
+        # Add memories as a developer message or user message based on configuration
         memory_message: LLMStandardMessage = (
-            {"role": "system", "content": memory_text}
+            {"role": "developer", "content": memory_text}
             if self.add_as_system_message
             else {"role": "user", "content": memory_text}
         )

--- a/src/pipecat/utils/context/llm_context_summarization.py
+++ b/src/pipecat/utils/context/llm_context_summarization.py
@@ -131,8 +131,11 @@ class LLMAutoContextSummarizationConfig:
         max_context_tokens: Maximum allowed context size in tokens. When this
             limit is reached, summarization is triggered to compress the context.
             The tokens are calculated using the industry-standard approximation
-            of 1 token ≈ 4 characters. Set to ``None`` to disable token-based
-            triggering.
+            of 1 token ≈ 4 characters. This measures the context messages only:
+            the LLM service's ``system_instruction`` is sent on every inference
+            but is not part of the context, and summarization cannot compress
+            it. Size this limit against the model's window minus the
+            instruction. Set to ``None`` to disable token-based triggering.
         max_unsummarized_messages: Maximum number of new messages that can
             accumulate since the last summary before triggering a new
             summarization. This ensures regular compression even if token

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -70,7 +70,10 @@ For BaseLLMAdapter helpers:
 2. _resolve_system_instruction: conflict resolution between context and settings
 """
 
+import subprocess
+import sys
 import unittest
+import warnings
 from unittest.mock import patch
 
 from google.genai.types import Content, FunctionCall, FunctionResponse, Part
@@ -3062,6 +3065,7 @@ class TestBaseLLMAdapterHelpers(unittest.TestCase):
                 "from context", "from settings", discard_context_system=True
             )
             mock_logger.warning.assert_called_once()
+            self.assertIn("is not sent to the model", mock_logger.warning.call_args[0][0])
 
         self.assertEqual(result, "from settings")
 
@@ -3200,6 +3204,101 @@ class TestTrailingUserMessageInjection(unittest.TestCase):
         for model, expected in cases.items():
             service = self._bedrock(model=model)
             self.assertEqual(service._should_inject_trailing_user_message(), expected, model)
+
+
+class TestContextSystemMessageDeprecation(unittest.TestCase):
+    """Every adapter warns when the system prompt is carried in the context."""
+
+    def _context(self):
+        return LLMContext(
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+
+    def _invoke(self, adapter, system_instruction):
+        if isinstance(adapter, OpenAILLMAdapter):
+            return adapter.get_llm_invocation_params(
+                self._context(),
+                system_instruction=system_instruction,
+                convert_developer_to_user=False,
+            )
+        if isinstance(adapter, AnthropicLLMAdapter):
+            return adapter.get_llm_invocation_params(
+                self._context(),
+                system_instruction=system_instruction,
+                enable_prompt_caching=False,
+            )
+        return adapter.get_llm_invocation_params(
+            self._context(), system_instruction=system_instruction
+        )
+
+    def test_every_adapter_warns_with_or_without_system_instruction(self):
+        adapters = [
+            OpenAILLMAdapter,
+            OpenAIResponsesLLMAdapter,
+            AnthropicLLMAdapter,
+            GeminiLLMAdapter,
+            GeminiLiveLLMAdapter,
+            AWSBedrockLLMAdapter,
+            AWSNovaSonicLLMAdapter,
+            OpenAIRealtimeLLMAdapter,
+            GrokRealtimeLLMAdapter,
+        ]
+        for cls in adapters:
+            for system_instruction in (None, "Be concise."):
+                with self.subTest(adapter=cls.__name__, system_instruction=system_instruction):
+                    with warnings.catch_warnings(record=True) as caught:
+                        warnings.simplefilter("always")
+                        self._invoke(cls(), system_instruction)
+                    messages = [
+                        str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+                    ]
+                    self.assertTrue(messages, "expected a DeprecationWarning")
+                    self.assertIn("system_instruction", messages[0])
+
+    def test_warns_once_per_adapter(self):
+        adapter = OpenAILLMAdapter()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._invoke(adapter, None)
+            self._invoke(adapter, None)
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(deprecations), 1)
+
+    def test_warns_through_an_ignore_filter(self):
+        """The warning reaches a bot whose interpreter ignores the category.
+
+        Every caller is inside an LLM service, so the default
+        ``ignore::DeprecationWarning`` would hide it. Run in a subprocess to get
+        an interpreter whose filters ignore the category.
+        """
+        script = (
+            "from pipecat.adapters.services.open_ai_adapter import OpenAILLMAdapter\n"
+            "from pipecat.processors.aggregators.llm_context import LLMContext\n"
+            "ctx = LLMContext(messages=["
+            "{'role': 'system', 'content': 'Be helpful.'},"
+            "{'role': 'user', 'content': 'hi'}])\n"
+            "OpenAILLMAdapter().get_llm_invocation_params("
+            "ctx, system_instruction=None, convert_developer_to_user=False)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-W", "ignore::DeprecationWarning", "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("is deprecated since 1.9.0", result.stderr)
+
+    def test_no_warning_without_a_context_system_message(self):
+        context = LLMContext(messages=[{"role": "user", "content": "Hello"}])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OpenAILLMAdapter().get_llm_invocation_params(
+                context, system_instruction="Be concise.", convert_developer_to_user=False
+            )
+        self.assertFalse([w for w in caught if issubclass(w.category, DeprecationWarning)])
 
 
 if __name__ == "__main__":

--- a/tests/test_mem0.py
+++ b/tests/test_mem0.py
@@ -60,7 +60,7 @@ class TestMem0EnhanceContext(unittest.IsolatedAsyncioTestCase):
 
         injected = [m for m in ctx.get_messages() if "I recall" in str(m.get("content", ""))]
         self.assertEqual(len(injected), 1)
-        self.assertEqual(injected[0]["role"], "system")
+        self.assertEqual(injected[0]["role"], "developer")
         self.assertIn("User likes coffee", injected[0]["content"])
         self.assertIn("User is in Lisbon", injected[0]["content"])
 


### PR DESCRIPTION
## Summary

Deprecates setting the system prompt as a `"system"` message at the start of `LLMContext`. Set it on the LLM service as `system_instruction` instead — at construction, or at runtime with `LLMUpdateSettingsFrame`. Nothing is removed here; the old shape keeps working and logs a `DeprecationWarning` once per run.

Two reasons a developer needs to know about:

- Anthropic, Google, AWS Bedrock and the realtime services send the system prompt as a separate API field rather than as a message, so they can only send one. Set both and the context one is silently dropped.
- Pipecat composes its own turn-completion and async-tool instructions onto the service's `system_instruction`. A prompt in the context doesn't take part, so those instructions and the user's prompt can end up competing rather than combining.

Every LLM adapter now warns once when it finds a system message at the head of the context, whether or not the service also carries an instruction. In-tree callers move off the deprecated shape: `Mem0MemoryService`, the Gemini Live response-trigger seed, and the five remaining examples.

## Breaking Changes

- ⚠️ `Mem0MemoryService` adds retrieved memories with the `"developer"` role instead of `"system"` when `add_as_system_message` is set. Services without a `"developer"` role receive them as `"user"` — the same treatment non-OpenAI services already gave the `"system"` message. OpenAI-family services see `"developer"` where they previously saw `"system"`.

## Notes for reviewers

`LLMContextSummarizer`'s `max_context_tokens` counts context messages only, and does not include the service's `system_instruction`. That is now documented on the parameter, along with the advice to size the limit against the model's window minus the instruction. It stays a context measurement deliberately: summarization compresses context messages and can never reclaim the instruction's tokens, so counting them would let a large prompt hold the threshold permanently over the limit.

## Testing

- `uv run pytest` — full suite green.
- `tests/test_get_llm_invocation_params.py::TestContextSystemMessageDeprecation` covers the warning across 9 adapters × {instruction set, unset}, the once-per-adapter guard, and the no-warning case.
