### PR TITLE
Have provider-watch researchers run the repo's own checks; name changelog fragments from the open PRs

### DIFF
--- a/.claude/skills/provider-research/RESEARCH_GUIDE.md
+++ b/.claude/skills/provider-research/RESEARCH_GUIDE.md
@@ -76,15 +76,14 @@ In the worktree, cycling steps 1–4 once per item:
 
 1. Make the item's change. Update the docstring `Defaults to "..."` text and any test fixtures that pin the old value. If you resumed an existing branch, check whether the change is already there before editing.
 2. Add the item's changelog fragment `changelog/+<short-slug>.changed.md` (or `.fixed.md`; never a guessed PR number — `publish.py` renames the fragment to the real number once the PR is opened). — one line, user-facing, per `CONTRIBUTING.md`: `- \`CartesiaTTSService\` now defaults to \`sonic-4\`, Cartesia's successor to \`sonic-3.5\`.`
-3. Check with the repo's own pre-commit hooks plus pyright, from inside the worktree using the main checkout's environment:
+3. Check with the repo's own pre-commit hooks, from inside the worktree using the main checkout's environment:
 
    ```bash
    UV_NO_SYNC=1 UV_PROJECT_ENVIRONMENT=<repo_root>/.venv <repo_root>/.venv/bin/python -m pre_commit run --files <the files you changed>
-   <repo_root>/.venv/bin/python -m pyright <the .py files you changed>
    <repo_root>/.venv/bin/python -m pytest tests/test_<provider>*.py -q
    ```
 
-   The hooks are the same checks a maintainer's commit runs, and they auto-fix — formatting, unused imports, regenerated registries — so re-run until everything passes and include what they changed in the commit. pyright is CI's type check, not a hook; a change that fails it fails the PR. The `UV_*` variables make the hooks' `uv run` entries reuse the main environment instead of syncing one into the worktree; pytest's `pythonpath = ["src"]` makes the worktree's sources win over the installed package.
+   The hooks are the same checks a maintainer's commit runs — pyright included — and some auto-fix (formatting, unused imports, regenerated registries), so re-run until everything passes and include what they changed in the commit. The `UV_*` variables make the hooks' `uv run` entries reuse the main environment instead of syncing one into the worktree; pytest's `pythonpath = ["src"]` makes the worktree's sources win over the installed package.
 4. Commit — one commit per independent item, its changelog fragment included. Each message documents its item: an imperative subject (e.g. `Default CartesiaTTSService to sonic-4`) and a body saying what the code does now and why, citing the provider's statement, per AGENTS.md "Writing for Future Readers". The branch becomes the PR: a single commit verbatim (subject = title, body = description); with several commits the PR title is the `prs` entry's `summary` and the body stitches the messages, one section per commit — so write the summary to cover the set. Put the probe evidence in the report, not the commits; the PR links to the report. No trailers.
 5. Stop. Do not push, do not run `gh pr create`. Record the branch in the report's `prs` as `{branch: <BRANCH>, state: branch, summary: <one line covering everything on the branch>}`, the gap with `action: pr`, and the branch line under "PRs" in the form the template shows.
 

--- a/.claude/skills/provider-research/RESEARCH_GUIDE.md
+++ b/.claude/skills/provider-research/RESEARCH_GUIDE.md
@@ -76,7 +76,15 @@ In the worktree, cycling steps 1–4 once per item:
 
 1. Make the item's change. Update the docstring `Defaults to "..."` text and any test fixtures that pin the old value. If you resumed an existing branch, check whether the change is already there before editing.
 2. Add the item's changelog fragment `changelog/+<short-slug>.changed.md` (or `.fixed.md`; never a guessed PR number — `publish.py` renames the fragment to the real number once the PR is opened). — one line, user-facing, per `CONTRIBUTING.md`: `- \`CartesiaTTSService\` now defaults to \`sonic-4\`, Cartesia's successor to \`sonic-3.5\`.`
-3. Lint and test with the main checkout's environment: `<repo_root>/.venv/bin/python -m ruff format . && <repo_root>/.venv/bin/python -m ruff check . && <repo_root>/.venv/bin/python -m pytest tests/test_<provider>*.py -q` (pytest's `pythonpath = ["src"]` makes the worktree's sources win over the installed package).
+3. Check with the repo's own pre-commit hooks plus pyright, from inside the worktree using the main checkout's environment:
+
+   ```bash
+   UV_NO_SYNC=1 UV_PROJECT_ENVIRONMENT=<repo_root>/.venv <repo_root>/.venv/bin/python -m pre_commit run --files <the files you changed>
+   <repo_root>/.venv/bin/python -m pyright <the .py files you changed>
+   <repo_root>/.venv/bin/python -m pytest tests/test_<provider>*.py -q
+   ```
+
+   The hooks are the same checks a maintainer's commit runs, and they auto-fix — formatting, unused imports, regenerated registries — so re-run until everything passes and include what they changed in the commit. pyright is CI's type check, not a hook; a change that fails it fails the PR. The `UV_*` variables make the hooks' `uv run` entries reuse the main environment instead of syncing one into the worktree; pytest's `pythonpath = ["src"]` makes the worktree's sources win over the installed package.
 4. Commit — one commit per independent item, its changelog fragment included. Each message documents its item: an imperative subject (e.g. `Default CartesiaTTSService to sonic-4`) and a body saying what the code does now and why, citing the provider's statement, per AGENTS.md "Writing for Future Readers". The branch becomes the PR: a single commit verbatim (subject = title, body = description); with several commits the PR title is the `prs` entry's `summary` and the body stitches the messages, one section per commit — so write the summary to cover the set. Put the probe evidence in the report, not the commits; the PR links to the report. No trailers.
 5. Stop. Do not push, do not run `gh pr create`. Record the branch in the report's `prs` as `{branch: <BRANCH>, state: branch, summary: <one line covering everything on the branch>}`, the gap with `action: pr`, and the branch line under "PRs" in the form the template shows.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,14 @@ repos:
         entry: uv run ruff format
         language: system
         types: [python]
+      # Type check the changed files with the same pinned pyright CI runs on
+      # the whole tree (format.yaml); file-scoped here so a commit costs
+      # seconds.
+      - id: pyright
+        name: pyright
+        entry: uv run pyright
+        language: system
+        types: [python]
       # Keep the CLI's service registry in sync with the source. The imports hook
       # regenerates _imports.py (AST-based, no service SDKs needed) when a service
       # module or the metadata changes; if the result differs, the commit aborts so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,6 @@ repos:
         entry: uv run ruff format
         language: system
         types: [python]
-      # Type check the changed files with the same pinned pyright CI runs on
-      # the whole tree (format.yaml); file-scoped here so a commit costs
-      # seconds.
       - id: pyright
         name: pyright
         entry: uv run pyright

--- a/scripts/provider-watch/publish.py
+++ b/scripts/provider-watch/publish.py
@@ -19,10 +19,13 @@ For each report whose ``prs`` list has an entry in ``state: branch``:
 
 1. push the branch and open a draft PR (title and body from the branch's
    commit messages — a single commit verbatim, several stitched with the
-   report's summary as the title — plus a link to the report), then rename
-   the branch's ``+slug`` changelog fragments to the PR's number;
+   report's summary as the title — plus a link to the report);
 2. rewrite the report — frontmatter entry to ``state: open`` with the URL,
    and the body's branch/review line to the URL.
+
+A sweep over the open provider-watch PRs then renames every ``+slug``
+changelog fragment to its PR's number — the PRs this pass opened and any
+that a killed run left misnamed alike.
 
 Then commit and push ``_reports``. With ``--finalize`` it also publishes the
 digest — the ``digests/<date>.md`` that ``/provider-research-digest`` rendered,
@@ -144,23 +147,22 @@ def _fragment_type(name: str) -> str:
     return next((part for part in name.split(".") if part in FRAGMENT_TYPES), "other")
 
 
-def _rename_changelog_fragments(
-    sh: Shell, repo_root: Path, branch: str, pr_url: str, ref: str | None = None
-) -> None:
-    """Give the branch's changelog fragments the PR's number.
+def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url: str) -> None:
+    """Give a PR's changelog fragments the PR's number.
 
     Researchers write towncrier's ``+slug`` orphan form because no PR exists
     when a branch is committed, and must not guess a number. Once the PR is
     open its number is known: one follow-up commit renames every fragment the
     branch adds that does not already carry it — orphans and wrong guesses
     alike — to ``<number>.<type>.md``, with ``.2``/``.3`` counters when a
-    branch adds several of one type. ``ref`` is the commit to rename at; it
-    defaults to the local branch, and healing an open PR passes its fetched
-    head instead.
+    branch adds several of one type. Works from the branch as pushed, in a
+    detached worktree, so it needs no local branch and cannot collide with a
+    leftover researcher worktree still holding one.
     """
     number = pr_url.rstrip("/").split("/")[-1]
     if not number.isdigit():
         return
+    sh.run("git", "fetch", "--quiet", "origin", branch, cwd=repo_root)
     added = sh.run(
         "git",
         "diff",
@@ -168,7 +170,7 @@ def _rename_changelog_fragments(
         "--diff-filter=A",
         # Three-dot: only what the branch itself adds, however far main has
         # moved since the branch was cut.
-        f"{_main_base(sh, repo_root)}...{ref or branch}",
+        f"{_main_base(sh, repo_root)}...FETCH_HEAD",
         "--",
         "changelog/",
         cwd=repo_root,
@@ -183,11 +185,8 @@ def _rename_changelog_fragments(
             counters[fragment_type] = counters.get(fragment_type, 0) + 1
     workdir = tempfile.mkdtemp(prefix="pw-fragments-")
     try:
-        # Detached: the branch may still be checked out in a researcher's
-        # leftover worktree (a killed run never cleans them up), which would
-        # make checking it out here fail.
         sh.run(
-            "git", "worktree", "add", "--quiet", "--detach", workdir, ref or branch, cwd=repo_root
+            "git", "worktree", "add", "--quiet", "--detach", workdir, "FETCH_HEAD", cwd=repo_root
         )
         for path in rename:
             fragment_type = _fragment_type(Path(path).name)
@@ -210,22 +209,18 @@ def _rename_changelog_fragments(
             cwd=Path(workdir),
         )
         sh.run("git", "push", "origin", f"HEAD:refs/heads/{branch}", cwd=Path(workdir))
-        # Move the local branch along too (best-effort: it may be checked out
-        # elsewhere), so a later publish pass diffs against the renamed state.
-        sh.run("git", "branch", "-f", branch, "HEAD", cwd=Path(workdir), check=False)
     finally:
         sh.run("git", "worktree", "remove", "--force", workdir, cwd=repo_root, check=False)
 
 
 def heal_fragment_names(sh: Shell, repo_root: Path, pipecat_repo: str) -> list[str]:
-    """Rename ``+slug`` fragments on any open provider-watch PR to its number.
+    """Rename the ``+slug`` fragments on every open provider-watch PR to its number.
 
-    The publish pass of a killed run can open a PR without managing to rename
-    its fragments, and the researcher that next meets the unit records the
-    open PR instead of recreating its branch — so misnamed fragments have to
-    be found on the PRs themselves. Every publish pass sweeps the open bot
-    PRs and renames from a fetched head; a correctly named PR costs one
-    lookup. Returns the failures, as skip messages.
+    This sweep is the only place fragments are named: freshly opened PRs still
+    carry their researchers' ``+slug`` fragments, and a killed run's publish
+    can leave PRs misnamed with no local branch surviving — so naming works
+    from the PRs themselves, whatever run opened them. A correctly named PR
+    costs one lookup. Returns the failures, as skip messages.
     """
     skipped: list[str] = []
     owner = pipecat_repo.split("/")[0]
@@ -259,16 +254,11 @@ def heal_fragment_names(sh: Shell, repo_root: Path, pipecat_repo: str) -> list[s
         if all(Path(p).name.startswith(f"{number}.") for p in fragments):
             continue
         try:
-            sh.run("git", "fetch", "--quiet", "origin", head, cwd=repo_root)
             _rename_changelog_fragments(
-                sh,
-                repo_root,
-                head,
-                f"https://github.com/{pipecat_repo}/pull/{number}",
-                ref="FETCH_HEAD",
+                sh, repo_root, head, f"https://github.com/{pipecat_repo}/pull/{number}"
             )
         except RuntimeError as exc:
-            skipped.append(f"{head}: fragments not healed: {exc}")
+            skipped.append(f"{head}: fragments not renamed: {exc}")
     return skipped
 
 
@@ -348,13 +338,6 @@ def publish_prs(
                     .splitlines()[-1]
                 )
                 outcome.opened.append(url)
-
-            # Adopted PRs get the rename pass too: a rename an earlier,
-            # interrupted publish could not complete heals on the next pass.
-            try:
-                _rename_changelog_fragments(sh, repo_root, branch, url)
-            except RuntimeError as exc:
-                outcome.skipped.append(f"{branch}: changelog fragments not renamed: {exc}")
 
             pr.update({"state": "open", "url": url, "opened": date})
             report.body = BRANCH_LINE.sub(

--- a/scripts/provider-watch/publish.py
+++ b/scripts/provider-watch/publish.py
@@ -144,7 +144,9 @@ def _fragment_type(name: str) -> str:
     return next((part for part in name.split(".") if part in FRAGMENT_TYPES), "other")
 
 
-def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url: str) -> None:
+def _rename_changelog_fragments(
+    sh: Shell, repo_root: Path, branch: str, pr_url: str, ref: str | None = None
+) -> None:
     """Give the branch's changelog fragments the PR's number.
 
     Researchers write towncrier's ``+slug`` orphan form because no PR exists
@@ -152,7 +154,9 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
     open its number is known: one follow-up commit renames every fragment the
     branch adds that does not already carry it — orphans and wrong guesses
     alike — to ``<number>.<type>.md``, with ``.2``/``.3`` counters when a
-    branch adds several of one type.
+    branch adds several of one type. ``ref`` is the commit to rename at; it
+    defaults to the local branch, and healing an open PR passes its fetched
+    head instead.
     """
     number = pr_url.rstrip("/").split("/")[-1]
     if not number.isdigit():
@@ -162,7 +166,9 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
         "diff",
         "--name-only",
         "--diff-filter=A",
-        f"{_main_base(sh, repo_root)}..{branch}",
+        # Three-dot: only what the branch itself adds, however far main has
+        # moved since the branch was cut.
+        f"{_main_base(sh, repo_root)}...{ref or branch}",
         "--",
         "changelog/",
         cwd=repo_root,
@@ -180,7 +186,9 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
         # Detached: the branch may still be checked out in a researcher's
         # leftover worktree (a killed run never cleans them up), which would
         # make checking it out here fail.
-        sh.run("git", "worktree", "add", "--quiet", "--detach", workdir, branch, cwd=repo_root)
+        sh.run(
+            "git", "worktree", "add", "--quiet", "--detach", workdir, ref or branch, cwd=repo_root
+        )
         for path in rename:
             fragment_type = _fragment_type(Path(path).name)
             counters[fragment_type] = counters.get(fragment_type, 0) + 1
@@ -207,6 +215,61 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
         sh.run("git", "branch", "-f", branch, "HEAD", cwd=Path(workdir), check=False)
     finally:
         sh.run("git", "worktree", "remove", "--force", workdir, cwd=repo_root, check=False)
+
+
+def heal_fragment_names(sh: Shell, repo_root: Path, pipecat_repo: str) -> list[str]:
+    """Rename ``+slug`` fragments on any open provider-watch PR to its number.
+
+    The publish pass of a killed run can open a PR without managing to rename
+    its fragments, and the researcher that next meets the unit records the
+    open PR instead of recreating its branch — so misnamed fragments have to
+    be found on the PRs themselves. Every publish pass sweeps the open bot
+    PRs and renames from a fetched head; a correctly named PR costs one
+    lookup. Returns the failures, as skip messages.
+    """
+    skipped: list[str] = []
+    owner = pipecat_repo.split("/")[0]
+    prs = json.loads(
+        sh.run(
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            pipecat_repo,
+            "--label",
+            PR_LABEL,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,headRepositoryOwner",
+        )
+        or "[]"
+    )
+    for pr in prs:
+        number = str(pr.get("number") or "")
+        head = pr.get("headRefName") or ""
+        head_owner = (pr.get("headRepositoryOwner") or {}).get("login", "")
+        # Only branches the bot owns; never push to a fork or a human's branch.
+        if not head.startswith("provider-watch/") or head_owner != owner:
+            continue
+        files = json.loads(
+            sh.run("gh", "pr", "view", number, "--repo", pipecat_repo, "--json", "files") or "{}"
+        ).get("files")
+        fragments = [f["path"] for f in files or [] if f["path"].startswith("changelog/")]
+        if all(Path(p).name.startswith(f"{number}.") for p in fragments):
+            continue
+        try:
+            sh.run("git", "fetch", "--quiet", "origin", head, cwd=repo_root)
+            _rename_changelog_fragments(
+                sh,
+                repo_root,
+                head,
+                f"https://github.com/{pipecat_repo}/pull/{number}",
+                ref="FETCH_HEAD",
+            )
+        except RuntimeError as exc:
+            skipped.append(f"{head}: fragments not healed: {exc}")
+    return skipped
 
 
 def _pr_title_body(sh: Shell, repo_root: Path, branch: str, summary: str) -> tuple[str, str]:
@@ -427,6 +490,7 @@ def main(argv: list[str] | None = None) -> int:
         reports_repo=args.reports_repo,
         date=args.date,
     )
+    outcome.skipped += heal_fragment_names(sh, args.repo_root, args.pipecat_repo)
     if args.finalize:
         digest_file = ensure_digest(args.reports, args.date, args.reports_repo)
     outcome.reports_pushed = push_reports(sh, args.reports, args.date)

--- a/scripts/provider-watch/publish.py
+++ b/scripts/provider-watch/publish.py
@@ -177,7 +177,10 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
             counters[fragment_type] = counters.get(fragment_type, 0) + 1
     workdir = tempfile.mkdtemp(prefix="pw-fragments-")
     try:
-        sh.run("git", "worktree", "add", "--quiet", workdir, branch, cwd=repo_root)
+        # Detached: the branch may still be checked out in a researcher's
+        # leftover worktree (a killed run never cleans them up), which would
+        # make checking it out here fail.
+        sh.run("git", "worktree", "add", "--quiet", "--detach", workdir, branch, cwd=repo_root)
         for path in rename:
             fragment_type = _fragment_type(Path(path).name)
             counters[fragment_type] = counters.get(fragment_type, 0) + 1
@@ -198,7 +201,10 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
             f"Name the changelog fragments after PR #{number}",
             cwd=Path(workdir),
         )
-        sh.run("git", "push", "origin", branch, cwd=Path(workdir))
+        sh.run("git", "push", "origin", f"HEAD:refs/heads/{branch}", cwd=Path(workdir))
+        # Move the local branch along too (best-effort: it may be checked out
+        # elsewhere), so a later publish pass diffs against the renamed state.
+        sh.run("git", "branch", "-f", branch, "HEAD", cwd=Path(workdir), check=False)
     finally:
         sh.run("git", "worktree", "remove", "--force", workdir, cwd=repo_root, check=False)
 
@@ -279,10 +285,13 @@ def publish_prs(
                     .splitlines()[-1]
                 )
                 outcome.opened.append(url)
-                try:
-                    _rename_changelog_fragments(sh, repo_root, branch, url)
-                except RuntimeError as exc:
-                    outcome.skipped.append(f"{branch}: changelog fragments not renamed: {exc}")
+
+            # Adopted PRs get the rename pass too: a rename an earlier,
+            # interrupted publish could not complete heals on the next pass.
+            try:
+                _rename_changelog_fragments(sh, repo_root, branch, url)
+            except RuntimeError as exc:
+                outcome.skipped.append(f"{branch}: changelog fragments not renamed: {exc}")
 
             pr.update({"state": "open", "url": url, "opened": date})
             report.body = BRANCH_LINE.sub(

--- a/scripts/provider-watch/publish.py
+++ b/scripts/provider-watch/publish.py
@@ -24,8 +24,8 @@ For each report whose ``prs`` list has an entry in ``state: branch``:
    and the body's branch/review line to the URL.
 
 A sweep over the open provider-watch PRs then renames every ``+slug``
-changelog fragment to its PR's number — the PRs this pass opened and any
-that a killed run left misnamed alike.
+changelog fragment to its PR's number — the PRs this pass opened, plus any
+left misnamed from a previous killed run.
 
 Then commit and push ``_reports``. With ``--finalize`` it also publishes the
 digest — the ``digests/<date>.md`` that ``/provider-research-digest`` rendered,
@@ -213,7 +213,7 @@ def _rename_changelog_fragments(sh: Shell, repo_root: Path, branch: str, pr_url:
         sh.run("git", "worktree", "remove", "--force", workdir, cwd=repo_root, check=False)
 
 
-def heal_fragment_names(sh: Shell, repo_root: Path, pipecat_repo: str) -> list[str]:
+def rename_open_pr_fragments(sh: Shell, repo_root: Path, pipecat_repo: str) -> list[str]:
     """Rename the ``+slug`` fragments on every open provider-watch PR to its number.
 
     This sweep is the only place fragments are named: freshly opened PRs still
@@ -473,7 +473,7 @@ def main(argv: list[str] | None = None) -> int:
         reports_repo=args.reports_repo,
         date=args.date,
     )
-    outcome.skipped += heal_fragment_names(sh, args.repo_root, args.pipecat_repo)
+    outcome.skipped += rename_open_pr_fragments(sh, args.repo_root, args.pipecat_repo)
     if args.finalize:
         digest_file = ensure_digest(args.reports, args.date, args.reports_repo)
     outcome.reports_pushed = push_reports(sh, args.reports, args.date)

--- a/tests/test_provider_watch_scripts.py
+++ b/tests/test_provider_watch_scripts.py
@@ -514,34 +514,24 @@ class TestPublish:
         import publish
 
         branch = "provider-watch/cartesia-tts-updates"
-        path = tmp_path / "reports/cartesia/tts/2026-08-20.md"
-        path.parent.mkdir(parents=True)
-        path.write_text(
-            f"---\nservice: cartesia/tts\nprs:\n  - branch: {branch}\n"
-            f"    state: branch\n    summary: s\n---\n\n# R\n\n## PRs\n"
-            f"- `{branch}` — review: `git show {branch}` — s\n"
-        )
+        frags = [
+            "changelog/+cartesia-normalization.added.md",
+            "changelog/+cartesia-locale.added.md",
+            "changelog/+cartesia-sonic.fixed.md",
+            "changelog/999.changed.md",
+        ]
         sh = self.FakeShell(
-            branches=[branch],
-            fragments={
-                branch: [
-                    "changelog/+cartesia-normalization.added.md",
-                    "changelog/+cartesia-locale.added.md",
-                    "changelog/+cartesia-sonic.fixed.md",
-                    "changelog/999.changed.md",
-                ]
-            },
+            label_prs=[
+                {
+                    "number": 101,
+                    "headRefName": branch,
+                    "headRepositoryOwner": {"login": "pipecat-ai"},
+                }
+            ],
+            fragments={"FETCH_HEAD": frags},
         )
-        reports = publish.load_reports(tmp_path, "2026-08-20")
-        outcome = publish.publish_prs(
-            reports,
-            sh=sh,
-            repo_root=tmp_path,
-            pipecat_repo="pipecat-ai/pipecat",
-            reports_repo="pipecat-ai/provider-watch-reports",
-            date="2026-08-20",
-        )
-        assert len(outcome.opened) == 1 and not outcome.skipped
+        sh.pr_files = {"101": frags}
+        assert publish.heal_fragment_names(sh, tmp_path, "pipecat-ai/pipecat") == []
         moves = [c for c in sh.calls if c[:2] == ("git", "mv")]
         assert moves == [
             ("git", "mv", "changelog/+cartesia-locale.added.md", "changelog/101.added.md"),
@@ -594,41 +584,6 @@ class TestPublish:
         ]
         # The correctly named PR and the community PR are left alone.
         assert len([c for c in sh.calls if c[:2] == ("git", "fetch")]) == 1
-
-    def test_adopted_pr_still_renames_fragments(self, tmp_path):
-        import publish
-
-        branch = "provider-watch/deepseek-thinking"
-        path = tmp_path / "reports/deepseek/llm/2026-08-20.md"
-        path.parent.mkdir(parents=True)
-        path.write_text(
-            f"---\nservice: deepseek/llm\nprs:\n  - branch: {branch}\n"
-            f"    state: branch\n    summary: s\n---\n\n# R\n\n## PRs\n"
-            f"- `{branch}` — review: `git show {branch}` — s\n"
-        )
-        sh = self.FakeShell(
-            open_prs={branch: "https://github.com/pipecat-ai/pipecat/pull/7"},
-            branches=[branch],
-            fragments={branch: ["changelog/+deepseek-thinking.added.md"]},
-        )
-        outcome = publish.publish_prs(
-            publish.load_reports(tmp_path, "2026-08-20"),
-            sh=sh,
-            repo_root=tmp_path,
-            pipecat_repo="p/p",
-            reports_repo="p/r",
-            date="2026-08-20",
-        )
-        assert outcome.adopted and not outcome.opened and not outcome.skipped
-        assert (
-            "git",
-            "mv",
-            "changelog/+deepseek-thinking.added.md",
-            "changelog/7.added.md",
-        ) in sh.calls
-        assert ("git", "push", "origin", f"HEAD:refs/heads/{branch}") in [
-            c[:4] for c in sh.calls if c[:2] == ("git", "push")
-        ]
 
     def test_second_pass_is_a_no_op(self, reports_dir):
         tmp_path, publish = reports_dir

--- a/tests/test_provider_watch_scripts.py
+++ b/tests/test_provider_watch_scripts.py
@@ -350,25 +350,33 @@ class TestPublish:
     """publish.py against a fake git/gh so nothing leaves the machine."""
 
     class FakeShell:
-        def __init__(self, open_prs=None, branches=None, commits=None, fragments=None):
+        def __init__(
+            self, open_prs=None, branches=None, commits=None, fragments=None, label_prs=None
+        ):
             self.calls = []
             self.open_prs = open_prs or {}
             self.branches = set(branches or [])
             self.commits = commits or {}  # branch -> [(subject, body), ...]
-            self.fragments = fragments or {}  # branch -> [changelog paths added]
+            self.fragments = fragments or {}  # branch/ref -> [changelog paths added]
+            self.label_prs = label_prs or []  # rows for `gh pr list --label`
+            self.pr_files = {}  # number -> [changed paths]
             self.pr_counter = 100
 
         def run(self, *args, cwd=None, check=True):
             self.calls.append(args)
+            if args[:3] == ("gh", "pr", "list") and "--label" in args:
+                return json.dumps(self.label_prs)
             if args[:3] == ("gh", "pr", "list"):
                 head = args[args.index("--head") + 1]
                 url = self.open_prs.get(head)
                 return json.dumps([{"url": url}] if url else [])
+            if args[:3] == ("gh", "pr", "view") and "files" in args:
+                return json.dumps({"files": [{"path": p} for p in self.pr_files.get(args[3], [])]})
             if args[:3] == ("gh", "pr", "create"):
                 self.pr_counter += 1
                 return f"https://github.com/pipecat-ai/pipecat/pull/{self.pr_counter}\n"
             if args[:2] == ("git", "diff") and "--name-only" in args:
-                branch = args[4].split("..")[-1]
+                branch = args[4].split("..")[-1].lstrip(".")
                 return "\n".join(self.fragments.get(branch, []))
             if args[:2] == ("git", "rev-list"):
                 branch = args[-1].split("..")[-1]
@@ -545,6 +553,47 @@ class TestPublish:
         assert ("git", "push", "origin", f"HEAD:refs/heads/{branch}") in [
             c[:4] for c in sh.calls if c[:2] == ("git", "push")
         ]
+
+    def test_heals_fragments_on_open_prs(self, tmp_path):
+        import publish
+
+        sh = self.FakeShell(
+            label_prs=[
+                {
+                    "number": 5528,
+                    "headRefName": "provider-watch/deepseek-thinking",
+                    "headRepositoryOwner": {"login": "pipecat-ai"},
+                },
+                {
+                    "number": 5529,
+                    "headRefName": "provider-watch/anthropic-output-config",
+                    "headRepositoryOwner": {"login": "pipecat-ai"},
+                },
+                {
+                    "number": 2849,
+                    "headRefName": "feature/aws-languages",
+                    "headRepositoryOwner": {"login": "someone"},
+                },
+            ],
+            fragments={"FETCH_HEAD": ["changelog/+deepseek-thinking.added.md"]},
+        )
+        sh.pr_files = {
+            "5528": ["changelog/+deepseek-thinking.added.md", "src/x.py"],
+            "5529": ["changelog/5529.added.md"],
+        }
+        skipped = publish.heal_fragment_names(sh, tmp_path, "pipecat-ai/pipecat")
+        assert skipped == []
+        assert (
+            "git",
+            "mv",
+            "changelog/+deepseek-thinking.added.md",
+            "changelog/5528.added.md",
+        ) in sh.calls
+        assert ("git", "push", "origin", "HEAD:refs/heads/provider-watch/deepseek-thinking") in [
+            c[:4] for c in sh.calls if c[:2] == ("git", "push")
+        ]
+        # The correctly named PR and the community PR are left alone.
+        assert len([c for c in sh.calls if c[:2] == ("git", "fetch")]) == 1
 
     def test_adopted_pr_still_renames_fragments(self, tmp_path):
         import publish

--- a/tests/test_provider_watch_scripts.py
+++ b/tests/test_provider_watch_scripts.py
@@ -542,7 +542,42 @@ class TestPublish:
             ("git", "mv", "changelog/999.changed.md", "changelog/101.changed.md"),
         ]
         assert any(c[:2] == ("git", "commit") and "#101" in c[-1] for c in sh.calls)
-        assert ("git", "push", "origin", branch) in [
+        assert ("git", "push", "origin", f"HEAD:refs/heads/{branch}") in [
+            c[:4] for c in sh.calls if c[:2] == ("git", "push")
+        ]
+
+    def test_adopted_pr_still_renames_fragments(self, tmp_path):
+        import publish
+
+        branch = "provider-watch/deepseek-thinking"
+        path = tmp_path / "reports/deepseek/llm/2026-08-20.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            f"---\nservice: deepseek/llm\nprs:\n  - branch: {branch}\n"
+            f"    state: branch\n    summary: s\n---\n\n# R\n\n## PRs\n"
+            f"- `{branch}` — review: `git show {branch}` — s\n"
+        )
+        sh = self.FakeShell(
+            open_prs={branch: "https://github.com/pipecat-ai/pipecat/pull/7"},
+            branches=[branch],
+            fragments={branch: ["changelog/+deepseek-thinking.added.md"]},
+        )
+        outcome = publish.publish_prs(
+            publish.load_reports(tmp_path, "2026-08-20"),
+            sh=sh,
+            repo_root=tmp_path,
+            pipecat_repo="p/p",
+            reports_repo="p/r",
+            date="2026-08-20",
+        )
+        assert outcome.adopted and not outcome.opened and not outcome.skipped
+        assert (
+            "git",
+            "mv",
+            "changelog/+deepseek-thinking.added.md",
+            "changelog/7.added.md",
+        ) in sh.calls
+        assert ("git", "push", "origin", f"HEAD:refs/heads/{branch}") in [
             c[:4] for c in sh.calls if c[:2] == ("git", "push")
         ]
 

--- a/tests/test_provider_watch_scripts.py
+++ b/tests/test_provider_watch_scripts.py
@@ -531,7 +531,7 @@ class TestPublish:
             fragments={"FETCH_HEAD": frags},
         )
         sh.pr_files = {"101": frags}
-        assert publish.heal_fragment_names(sh, tmp_path, "pipecat-ai/pipecat") == []
+        assert publish.rename_open_pr_fragments(sh, tmp_path, "pipecat-ai/pipecat") == []
         moves = [c for c in sh.calls if c[:2] == ("git", "mv")]
         assert moves == [
             ("git", "mv", "changelog/+cartesia-locale.added.md", "changelog/101.added.md"),
@@ -544,7 +544,7 @@ class TestPublish:
             c[:4] for c in sh.calls if c[:2] == ("git", "push")
         ]
 
-    def test_heals_fragments_on_open_prs(self, tmp_path):
+    def test_sweep_leaves_correct_and_non_bot_prs_alone(self, tmp_path):
         import publish
 
         sh = self.FakeShell(
@@ -571,7 +571,7 @@ class TestPublish:
             "5528": ["changelog/+deepseek-thinking.added.md", "src/x.py"],
             "5529": ["changelog/5529.added.md"],
         }
-        skipped = publish.heal_fragment_names(sh, tmp_path, "pipecat-ai/pipecat")
+        skipped = publish.rename_open_pr_fragments(sh, tmp_path, "pipecat-ai/pipecat")
         assert skipped == []
         assert (
             "git",


### PR DESCRIPTION
## Summary

Quality gaps in bot-authored PRs, found in the first full sweeps:

- **Changelog fragments kept their `+slug` names when a run was killed.** The rename that gives fragments their PR number checked the branch out into a worktree right after opening the PR — but a timed-out or cancelled run never cleans up its researchers' worktrees, so the branch was still checked out there and the rename failed (`fatal: '<branch>' is already used by worktree …`), buried in publish.py's output; and since the researcher that next meets the unit records the open PR instead of recreating its branch, the misnamed fragments never healed. Renaming is now a single sweep: every publish pass lists the open provider-watch PRs and, for any whose changelog files don't carry its number, fetches the head and renames in a detached worktree — the PRs the pass just opened and any a killed run left misnamed alike. A correctly named PR costs one lookup; fork and human branches are never touched; the rename diff uses the merge base, so a branch main has moved past never claims fragments it did not add. The six affected open PRs (#5527, #5528, #5554, #5555, #5556, #5568) were repaired by hand ahead of this.
- **Researchers ran plain `ruff format`/`ruff check`, not the repo's checks.** That misses what the pre-commit hooks add (unused-import stripping, registry regeneration) and never ran pyright, CI's type check — which is how a type error reached #5549. The research guide now has researchers run the actual pre-commit hooks from their worktree against the main checkout's environment (`UV_NO_SYNC=1 UV_PROJECT_ENVIRONMENT=…`, so nothing syncs an environment into the worktree).
- **pyright is now a pre-commit hook**, so researchers and maintainers alike type-check at commit time. File-scoped, a commit costs seconds (~1–2 s for a typical commit's files; the whole tree measures ~13 s locally), with CI's whole-tree run as the backstop — the same arrangement as the ruff hooks. This also retires the guide's separate pyright command: invoking the pip wrapper directly does not resolve the environment, so it both missed real errors and invented spurious ones; the hook's `uv run` form resolves correctly.

## Testing

- `tests/test_provider_watch_scripts.py` (37 green), including tests that the sweep renames a misnamed PR from its fetched head (with `.2`/`.3` counters) and leaves correctly named and non-bot PRs alone.
- The pyright hook runs and passes via `pre-commit run --files` at the repo root and from a researcher worktree with the pinned environment (~1 s for a file batch).
- Hooks-from-worktree flow verified locally: a planted unused import was auto-stripped by the F401 hook, pyright ran clean against the worktree file, and the main environment was left untouched.

No changelog fragment: CI and developer tooling only.
