### PR TITLE
Add universal-3-6-pro as a supported AssemblyAI STT model

### DIFF
--- a/changelog/5598.added.md
+++ b/changelog/5598.added.md
@@ -1,0 +1,6 @@
+- Added `universal-3-6-pro` as a supported `AssemblyAISTTService` model. It is
+  `universal-3-5-pro` upgraded — the same model with the same feature set — and
+  is recognized as part of the Universal-3 Pro family, so every `u3-rt-pro`
+  feature (built-in turn detection, prompting, continuous partials,
+  `interruption_delay`, context carryover, and voice focus) applies to it as
+  well. `universal-3-5-pro` remains supported and stays the default.

--- a/src/pipecat/services/assemblyai/models.py
+++ b/src/pipecat/services/assemblyai/models.py
@@ -141,8 +141,8 @@ class AssemblyAIConnectionParams(BaseModel):
         min_end_of_turn_silence_when_confident: DEPRECATED. Use min_turn_silence instead.
         max_turn_silence: Maximum silence duration before forcing end-of-turn.
         keyterms_prompt: List of key terms to guide transcription. Will be JSON serialized before sending.
-        prompt: Optional text prompt to guide the transcription. Only used when speech_model is "universal-3-5-pro".
-        speech_model: Select between English, multilingual, and Universal-3.5 Pro models. Defaults to "universal-3-5-pro".
+        prompt: Optional text prompt to guide the transcription. Only used with a Universal-3 Pro model ("universal-3-5-pro" or "universal-3-6-pro").
+        speech_model: Select between English, multilingual, and Universal-3 Pro ("universal-3-5-pro", "universal-3-6-pro") models. Defaults to "universal-3-5-pro".
         language_detection: Enable automatic language detection. Only applicable to
             universal-streaming-multilingual. When enabled, Turn messages include
             language_code and language_confidence fields. Defaults to None (not sent).
@@ -176,6 +176,7 @@ class AssemblyAIConnectionParams(BaseModel):
         "u3-rt-pro",
         "u3-rt-pro-beta-1",
         "universal-3-5-pro",
+        "universal-3-6-pro",
     ] = "universal-3-5-pro"
     language_detection: bool | None = None
     format_turns: bool = True

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -63,11 +63,12 @@ MAX_AGENT_CONTEXT_CHARS = 1500
 
 # Model-name prefixes shared by every Universal-3 Pro streaming variant. The
 # ``u3-rt-pro`` family (``u3-rt-pro``, ``u3-rt-pro-beta-1``, future
-# ``u3-rt-pro-*`` releases) and ``universal-3-5-pro`` (and any
-# ``universal-3-5-pro-*`` release) both expose the full U3 Pro feature set:
-# built-in turn detection, prompting, continuous partials, interruption_delay,
-# context carryover, and voice focus.
-U3_PRO_MODEL_PREFIXES = ("u3-rt-pro", "universal-3-5-pro")
+# ``u3-rt-pro-*`` releases) and the ``universal-3-5-pro`` / ``universal-3-6-pro``
+# releases (and any ``universal-3-5-pro-*`` / ``universal-3-6-pro-*`` release)
+# all expose the full U3 Pro feature set: built-in turn detection, prompting,
+# continuous partials, interruption_delay, context carryover, and voice focus.
+# universal-3-6-pro is universal-3-5-pro upgraded — same model, same features.
+U3_PRO_MODEL_PREFIXES = ("u3-rt-pro", "universal-3-5-pro", "universal-3-6-pro")
 
 # Settings AssemblyAI accepts in an ``UpdateConfiguration`` message, so changing
 # them applies to the live session. Every other setting is a connect-time query
@@ -82,8 +83,9 @@ def is_u3_pro_model(model: str | None | NotGiven) -> bool:
     """Return whether a model name is a Universal-3 Pro streaming variant.
 
     Matches the ``u3-rt-pro`` family (``u3-rt-pro``, ``u3-rt-pro-beta-1``, and
-    any ``u3-rt-pro-*`` variant) and ``universal-3-5-pro`` (and any
-    ``universal-3-5-pro-*`` variant) so U3 Pro-only features are gated on the
+    any ``u3-rt-pro-*`` variant) and the ``universal-3-5-pro`` /
+    ``universal-3-6-pro`` releases (and any ``universal-3-5-pro-*`` /
+    ``universal-3-6-pro-*`` variant) so U3 Pro-only features are gated on the
     whole family rather than a single exact string.
 
     Args:

--- a/tests/test_assemblyai_stt.py
+++ b/tests/test_assemblyai_stt.py
@@ -141,6 +141,7 @@ def test_interruption_delay_out_of_range_raises(value):
         ("u3-rt-pro", True),
         ("u3-rt-pro-beta-1", True),
         ("universal-3-5-pro", True),
+        ("universal-3-6-pro", True),
         ("universal-streaming-english", False),
         ("universal-streaming-multilingual", False),
         (None, False),
@@ -231,6 +232,54 @@ def test_update_agent_context_works_for_universal_3_5_pro():
     service = AssemblyAISTTService(
         api_key="test-key",
         settings=AssemblyAISTTService.Settings(model="universal-3-5-pro"),
+    )
+    sent = []
+
+    async def fake_send(**fields):
+        sent.append(fields)
+
+    service._send_update_configuration = fake_send
+    asyncio.run(service.update_agent_context("hello"))
+
+    assert sent == [{"agent_context": "hello"}]
+
+
+# --- universal-3-6-pro (U3 Pro family; universal-3-5-pro upgraded) ---
+
+
+def test_u3_pro_features_sent_for_universal_3_6_pro():
+    # universal-3-6-pro is universal-3-5-pro upgraded and supports every u3-rt-pro param.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(
+            model="universal-3-6-pro",
+            agent_context="May I take your order?",
+            previous_context_n_turns=5,
+            interruption_delay=300,
+        ),
+    )
+    q = _query(service)
+    assert q["speech_model"] == ["universal-3-6-pro"]
+    assert q["agent_context"] == ["May I take your order?"]
+    assert q["previous_context_n_turns"] == ["5"]
+    assert q["interruption_delay"] == ["300"]
+    assert q["continuous_partials"] == ["true"]
+
+
+def test_universal_3_6_pro_allows_assemblyai_turn_detection_mode():
+    # vad_force_turn_endpoint=False requires a U3 Pro family model; u3.6 qualifies.
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(model="universal-3-6-pro"),
+        vad_force_turn_endpoint=False,
+    )
+    assert is_u3_pro_model(service._settings.model)
+
+
+def test_update_agent_context_works_for_universal_3_6_pro():
+    service = AssemblyAISTTService(
+        api_key="test-key",
+        settings=AssemblyAISTTService.Settings(model="universal-3-6-pro"),
     )
     sent = []
 


### PR DESCRIPTION
## Summary

Adds `universal-3-6-pro` as a supported model for `AssemblyAISTTService`. It is `universal-3-5-pro` upgraded — the same model with the same U3 Pro feature set, differing only in the ASR deployment that serves the session on AssemblyAI's side.

Without this, `universal-3-6-pro` is not recognized by `is_u3_pro_model()`, so a session pinned to it would silently drop every U3 Pro-only setting (built-in turn detection, prompting, continuous partials, `interruption_delay`, context carryover, voice focus) client-side before they reach the server.

## Changes

- Add `universal-3-6-pro` to `U3_PRO_MODEL_PREFIXES` so `is_u3_pro_model()` gates the full U3 Pro feature set on it (mirrors how `universal-3-5-pro` was added).
- Add `universal-3-6-pro` to the deprecated `AssemblyAIConnectionParams.speech_model` `Literal` so both the new `Settings(model=...)` path and the legacy `connection_params` path accept it.
- Update docstrings that enumerate the Pro family.
- Tests: extend `is_u3_pro_model` parametrization and mirror the `universal-3-5-pro` feature-gating tests for `universal-3-6-pro`.

`universal-3-5-pro` remains supported and stays the default — nothing changes on the wire for existing users.

## Testing

- `pytest tests/test_assemblyai_stt.py` — 95 passed (4 new).
- `ruff format --check` / `ruff check` — clean.
- Live probe against the real streaming endpoint:
  ```
  python scripts/provider-watch/probe.py run --service AssemblyAISTTService --model universal-3-6-pro
  [ok ] AssemblyAISTTService model=universal-3-6-pro ttfb=635 ms
        text: 'The quick brown fox jumps over the lazy dog. Pipecat makes voice agents easy to build.'
  ```