### PR TITLE
Prove concurrent processor setup with a barrier

### DIFF
--- a/tests/test_startup_timing_observer.py
+++ b/tests/test_startup_timing_observer.py
@@ -50,6 +50,38 @@ class SlowSetupProcessor(FrameProcessor):
         await self.push_frame(frame, direction)
 
 
+class ConcurrentSetupProcessor(FrameProcessor):
+    """A processor that records whether its setup overlapped with its peers'.
+
+    The barrier releases only once every processor sharing it is inside
+    ``setup()``, so setting up one at a time leaves each waiting for peers that
+    never arrive.
+    """
+
+    OVERLAP_TIMEOUT_SECS = 0.5
+
+    def __init__(self, barrier: asyncio.Barrier, timeout: float = OVERLAP_TIMEOUT_SECS, **kwargs):
+        super().__init__(**kwargs)
+        self._barrier = barrier
+        self._timeout = timeout
+        self.overlapped = False
+
+    async def setup(self, setup):
+        await super().setup(setup)
+        try:
+            await asyncio.wait_for(self._barrier.wait(), timeout=self._timeout)
+            self.overlapped = True
+        except (TimeoutError, asyncio.BrokenBarrierError):
+            # A setup that raises is reported as a processor error and the
+            # pipeline carries on, so a missed overlap has to reach the test
+            # as a value to be asserted on.
+            self.overlapped = False
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        await self.push_frame(frame, direction)
+
+
 class FastProcessor(FrameProcessor):
     """A processor with no start delay."""
 
@@ -129,13 +161,14 @@ class TestStartupTimingObserver(unittest.IsolatedAsyncioTestCase):
     async def test_total_is_the_span_rather_than_the_sum(self):
         """Processors are set up concurrently, so their cost does not add up.
 
-        Summing what each cost would report three concurrent 0.1s connections
-        as 0.3s, so a pipeline reads as slower the more it overlaps.
+        Summing what each cost would report three concurrent connections as
+        their total, so a pipeline reads as slower the more it overlaps. The
+        barrier holds all three inside setup() at once, establishing the
+        overlap the report depends on.
         """
         observer = StartupTimingObserver()
-        pipeline = Pipeline(
-            [SlowSetupProcessor(delay=0.1) for _ in range(3)],
-        )
+        barrier = asyncio.Barrier(3)
+        processors = [ConcurrentSetupProcessor(barrier) for _ in range(3)]
 
         reports = []
 
@@ -144,21 +177,29 @@ class TestStartupTimingObserver(unittest.IsolatedAsyncioTestCase):
             reports.append(report)
 
         await run_test(
-            pipeline,
+            Pipeline(processors),
             frames_to_send=[TextFrame(text="hello")],
             expected_down_frames=[TextFrame],
             observers=[observer],
+            # A setup that does not overlap spends a timeout per processor
+            # before reaching the assertion below, which the default start
+            # timeout would cut short and report as a failure to start.
+            start_timeout=5.0,
+        )
+
+        self.assertTrue(
+            all(p.overlapped for p in processors),
+            "the three processors were not all inside setup() at once",
         )
 
         report = reports[0]
-        summed = sum(t.duration_secs for t in report.processor_timings)
-
-        self.assertGreaterEqual(summed, 0.25, "each processor should be measured")
-        self.assertLess(
-            report.total_duration_secs,
-            summed,
-            "the three setups overlapped, so the span is shorter than the sum",
-        )
+        measured = [
+            t for t in report.processor_timings if "ConcurrentSetupProcessor" in t.processor_name
+        ]
+        self.assertEqual(len(measured), 3, "each processor should be measured")
+        # Each waited for all three, so each cost the whole overlap and the
+        # span covers one of them rather than all three added together.
+        self.assertGreaterEqual(report.total_duration_secs, max(t.duration_secs for t in measured))
 
     async def test_processor_types_filter(self):
         """Test that processor_types filter limits which processors appear."""


### PR DESCRIPTION
## Summary

- `test_total_is_the_span_rather_than_the_sum` holds all three processors inside `setup()` on an `asyncio.Barrier`, so the concurrency the report depends on is established rather than measured.
- The wall-clock comparison it replaces fails whenever this test is the first in a process to start a pipeline, which is a matter of suite ordering.

## Root cause

`PipelineWorker` warms Pipecat's deferred imports immediately after the observer starts its clock:

```python
await self._observer.setup(self.task_manager)
lazy_imports_task = self.create_task(asyncio.to_thread(warm_deferred_imports))
```

That loads NLTK, which reaches scipy behind it, and `_setup()` then waits on the task before the pipeline starts (`worker.py:1315`). The wait is there so the first sentence boundary of the opening turn never loads the tokenizer on the event loop, and it costs nothing once a pipeline's own setup outlasts the import. A pipeline that sets up faster than the import, as one built from local processors does, carries the remainder inside the span `StartupTimingObserver` reports. Instrumented, with three processors that each sleep 0.1s in `setup()`:

```
   t (ms)  event
      0.0  observer.setup() -> clock starts
      0.4  setup ENTER  p0 / p1 / p2
    101.9  setup EXIT   p0 / p1 / p2
    445.4  StartFrame reaches the processors

total_duration_secs = 0.4455   summed = 0.3046
```

The setups overlap exactly as intended. The span exceeds the sum because of ~340ms belonging to no processor. `_sent_tokenizer` is `@cache`d, so that cost is paid once per process, and the assertion holds only when an earlier test has already started a pipeline.

## Notes

- The barrier timeout is caught and asserted on: a `setup()` that raises is reported as a processor error and the pipeline carries on, which would hide the failure.
- `start_timeout=5.0` keeps `run_test`'s own one-second limit from firing first and reporting a generic timeout in place of the assertion.

## Testing

- `uv run pytest tests/test_startup_timing_observer.py` — 12 passed
- The test in isolation, the case that fails on `main` — passes
- Full suite — 4939 passed, 32 skipped
- Serializing `_setup_processors` makes it fail with `the three processors were not all inside setup() at once`
