### PR TITLE
Align AssemblyAI Sync STT with the API config surface (language_codes, timestamps)

### DIFF
--- a/changelog/5603.added.md
+++ b/changelog/5603.added.md
@@ -1,0 +1,7 @@
+- Added `language_codes` and `timestamps` settings to `AssemblyAISyncSTTService`,
+  aligning it with the Sync API's config surface.
+  - `language_codes` (e.g. `[Language.EN, Language.ES]`) declares audio languages
+    for multilingual or code-switching audio; bound in preference to the single
+    `language` when both are set.
+  - `timestamps` requests per-word `start`/`end` timings on the transcription
+    result. Unset by default, so the API default (`False`) applies.

--- a/changelog/5603.added.md
+++ b/changelog/5603.added.md
@@ -1,7 +1,1 @@
-- Added `language_codes` and `timestamps` settings to `AssemblyAISyncSTTService`,
-  aligning it with the Sync API's config surface.
-  - `language_codes` (e.g. `[Language.EN, Language.ES]`) declares audio languages
-    for multilingual or code-switching audio; bound in preference to the single
-    `language` when both are set.
-  - `timestamps` requests per-word `start`/`end` timings on the transcription
-    result. Unset by default, so the API default (`False`) applies.
+- Added `language_codes` and `timestamps` settings to `AssemblyAISyncSTTService`, aligning it with the Sync API's config surface. `language_codes` (e.g. `[Language.EN, Language.ES]`) declares the audio's languages for multilingual or code-switching audio, and is bound in preference to the single `language` when both are set; regional variants resolve to their base code and duplicates are dropped, preserving declaration order. `timestamps` requests per-word `start`/`end` timings on the transcription result, and is unset by default so the API default of `False` applies.

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -1280,9 +1280,9 @@ class AssemblyAISyncSTTSettings(STTSettings):
     """Settings for :class:`AssemblyAISyncSTTService`.
 
     Parameters:
-        prompt: Custom transcription instruction prepended to the model's system
-            prompt. When set, ``language`` is ignored — state the language in the
-            prompt instead.
+        prompt: A natural-language description of what the audio is about: the
+            domain, the scenario, or details of the conversation. Prepended to the
+            model's system prompt to guide transcription.
         keyterms_prompt: Key terms or phrases to bias the decoder toward.
         conversation_context: Prior turns from the same conversation, oldest
             first, giving the model the surrounding dialogue for better continuity
@@ -1290,6 +1290,15 @@ class AssemblyAISyncSTTSettings(STTSettings):
             string is treated as one turn. Setting this explicitly turns off the
             service's automatic context buffer and sends exactly this value; leave
             it unset to let the service manage context (see ``max_context_turns``).
+        language_codes: Declared audio languages for multilingual or
+            code-switching audio (e.g. ``[Language.EN, Language.ES]``). A
+            single-element list pins one language. Bound in preference to the
+            single ``language`` setting when both are set. Defaults to unset (the
+            single ``language`` is used).
+        timestamps: Whether to compute per-word ``start``/``end`` timestamps,
+            returned on the ``words`` of the transcription result, at a small
+            added latency. Left unset by default, so the API default of ``False``
+            (no timestamps) applies.
     """
 
     prompt: str | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -1297,6 +1306,8 @@ class AssemblyAISyncSTTSettings(STTSettings):
     conversation_context: str | list[str] | None | NotGiven = field(
         default_factory=lambda: NOT_GIVEN
     )
+    language_codes: list[Language] | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
+    timestamps: bool | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
 
 
 class AssemblyAISyncSTTService(SegmentedSTTService):
@@ -1384,6 +1395,8 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
             prompt=None,
             keyterms_prompt=None,
             conversation_context=None,
+            language_codes=None,
+            timestamps=None,
         )
         if settings is not None:
             default_settings.apply_update(settings)
@@ -1440,10 +1453,13 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         """Assemble the optional ``config`` part from the current settings."""
         config: dict[str, Any] = {}
 
+        # ``language_codes`` (multilingual / code-switching) wins over the single
+        # ``language`` when both are set; either way the wire field is a list.
+        language_codes = self._settings.language_codes
         language = self._settings.language
-        if is_given(language) and language is not None:
-            # ``language_codes`` accepts a string or a list; a single
-            # language goes as a one-element list.
+        if is_given(language_codes) and language_codes:
+            config["language_codes"] = self._resolve_language_codes(language_codes)
+        elif is_given(language) and language is not None:
             config["language_codes"] = [language]
 
         prompt = self._settings.prompt
@@ -1454,12 +1470,29 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         if is_given(keyterms_prompt) and keyterms_prompt:
             config["keyterms_prompt"] = list(keyterms_prompt)
 
+        timestamps = self._settings.timestamps
+        if is_given(timestamps) and timestamps is not None:
+            config["timestamps"] = timestamps
+
         if self._context_is_manual():
             config["conversation_context"] = self._settings.conversation_context
         elif self._context_turns:
             config["conversation_context"] = list(self._context_turns)
 
         return config
+
+    @staticmethod
+    def _resolve_language_codes(language_codes: list[Language | str]) -> list[str]:
+        """Resolve declared languages to AssemblyAI codes, deduped in order.
+
+        Accepts ``Language`` enums (regional variants resolve to their base code)
+        or raw strings, dropping duplicates while preserving declaration order.
+        """
+        resolved = [
+            language_to_assemblyai_language(lang) if isinstance(lang, Language) else lang
+            for lang in language_codes
+        ]
+        return list(dict.fromkeys(resolved))
 
     def _context_is_manual(self) -> bool:
         """Whether conversation_context was supplied explicitly in settings."""

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -1482,11 +1482,11 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         return config
 
     @staticmethod
-    def _resolve_language_codes(language_codes: list[Language | str]) -> list[str]:
+    def _resolve_language_codes(language_codes: list[Language]) -> list[str]:
         """Resolve declared languages to AssemblyAI codes, deduped in order.
 
-        Accepts ``Language`` enums (regional variants resolve to their base code)
-        or raw strings, dropping duplicates while preserving declaration order.
+        Regional variants resolve to their base code, and duplicates are dropped
+        while preserving declaration order.
         """
         resolved = [
             language_to_assemblyai_language(lang) if isinstance(lang, Language) else lang

--- a/src/pipecat/services/assemblyai/stt.py
+++ b/src/pipecat/services/assemblyai/stt.py
@@ -75,7 +75,8 @@ U3_PRO_MODEL_PREFIXES = ("u3-rt-pro", "universal-3-5-pro", "universal-3-6-pro")
 # parameter and only takes effect on a new connection.
 HOT_UPDATABLE_SETTINGS = frozenset({"agent_context", "language_codes"})
 
-# Longest declared-language list AssemblyAI accepts.
+# Longest declared-language list the streaming API accepts. The Sync API sets no
+# such limit, so it prepares its codes without a cap.
 MAX_LANGUAGE_CODES = 10
 
 
@@ -156,7 +157,9 @@ def language_to_assemblyai_language(language: Language) -> str:
     return resolve_language(language, LANGUAGE_MAP, use_base_code=True)
 
 
-def _prepare_language_codes(language_codes: list[Language]) -> list[str]:
+def _prepare_language_codes(
+    language_codes: list[Language], *, max_codes: int | None = MAX_LANGUAGE_CODES
+) -> list[str]:
     """Resolve declared languages to the AssemblyAI codes sent on the wire.
 
     Duplicates are collapsed — regional variants of one language share a base
@@ -164,19 +167,21 @@ def _prepare_language_codes(language_codes: list[Language]) -> list[str]:
 
     Args:
         language_codes: Declared languages.
+        max_codes: Most distinct codes the endpoint accepts, or None for an
+            endpoint that sets no limit.
 
     Returns:
         AssemblyAI language codes, deduplicated in declaration order.
 
     Raises:
-        ValueError: If more than ``MAX_LANGUAGE_CODES`` distinct languages remain
-            after resolution.
+        ValueError: If more than ``max_codes`` distinct languages remain after
+            resolution.
     """
     prepared = [language_to_assemblyai_language(lang) for lang in language_codes]
     deduped = list(dict.fromkeys(prepared))
-    if len(deduped) > MAX_LANGUAGE_CODES:
+    if max_codes is not None and len(deduped) > max_codes:
         raise ValueError(
-            f"language_codes accepts at most {MAX_LANGUAGE_CODES} languages, got {len(deduped)}."
+            f"language_codes accepts at most {max_codes} languages, got {len(deduped)}."
         )
     return deduped
 
@@ -1292,9 +1297,10 @@ class AssemblyAISyncSTTSettings(STTSettings):
             it unset to let the service manage context (see ``max_context_turns``).
         language_codes: Declared audio languages for multilingual or
             code-switching audio (e.g. ``[Language.EN, Language.ES]``). A
-            single-element list pins one language. Bound in preference to the
-            single ``language`` setting when both are set. Defaults to unset (the
-            single ``language`` is used).
+            single-element list pins one language. Regional variants resolve to
+            their base code and duplicates are dropped, preserving declaration
+            order. Bound in preference to the single ``language`` setting when
+            both are set. Defaults to unset (the single ``language`` is used).
         timestamps: Whether to compute per-word ``start``/``end`` timestamps,
             returned on the ``words`` of the transcription result, at a small
             added latency. Left unset by default, so the API default of ``False``
@@ -1458,7 +1464,8 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
         language_codes = self._settings.language_codes
         language = self._settings.language
         if is_given(language_codes) and language_codes:
-            config["language_codes"] = self._resolve_language_codes(language_codes)
+            # The Sync API caps no declared-language list, so none is imposed here.
+            config["language_codes"] = _prepare_language_codes(language_codes, max_codes=None)
         elif is_given(language) and language is not None:
             config["language_codes"] = [language]
 
@@ -1480,19 +1487,6 @@ class AssemblyAISyncSTTService(SegmentedSTTService):
             config["conversation_context"] = list(self._context_turns)
 
         return config
-
-    @staticmethod
-    def _resolve_language_codes(language_codes: list[Language]) -> list[str]:
-        """Resolve declared languages to AssemblyAI codes, deduped in order.
-
-        Regional variants resolve to their base code, and duplicates are dropped
-        while preserving declaration order.
-        """
-        resolved = [
-            language_to_assemblyai_language(lang) if isinstance(lang, Language) else lang
-            for lang in language_codes
-        ]
-        return list(dict.fromkeys(resolved))
 
     def _context_is_manual(self) -> bool:
         """Whether conversation_context was supplied explicitly in settings."""

--- a/tests/test_assemblyai_sync_stt.py
+++ b/tests/test_assemblyai_sync_stt.py
@@ -152,6 +152,138 @@ async def test_config_carries_prompt_and_keyterms(aiohttp_client):
 
 
 @pytest.mark.asyncio
+async def test_config_carries_declared_language_codes(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                language_codes=[Language.EN, Language.ES],
+            ),
+        )
+
+        await service._transcribe(WAV)
+
+    assert _config(captured)["language_codes"] == ["en", "es"]
+
+
+@pytest.mark.asyncio
+async def test_language_codes_resolve_to_base_codes_deduped_in_order(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                language_codes=[Language.ES_MX, Language.EN_US, Language.ES],
+            ),
+        )
+
+        await service._transcribe(WAV)
+
+    assert _config(captured)["language_codes"] == ["es", "en"]
+
+
+@pytest.mark.asyncio
+async def test_language_codes_are_not_capped(aiohttp_client):
+    """The Sync API sets no limit, unlike the streaming API's ten."""
+    captured = {}
+    declared = [
+        Language.EN,
+        Language.ES,
+        Language.FR,
+        Language.DE,
+        Language.IT,
+        Language.PT,
+        Language.NL,
+        Language.SV,
+        Language.DA,
+        Language.FI,
+        Language.HI,
+        Language.JA,
+    ]
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(language_codes=declared),
+        )
+
+        await service._transcribe(WAV)
+
+    assert len(_config(captured)["language_codes"]) == len(declared)
+
+
+@pytest.mark.asyncio
+async def test_language_codes_win_over_the_single_language(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                language=Language.FR,
+                language_codes=[Language.EN, Language.ES],
+            ),
+        )
+
+        await service._transcribe(WAV)
+
+    assert _config(captured)["language_codes"] == ["en", "es"]
+
+
+@pytest.mark.asyncio
+async def test_the_single_language_is_used_when_no_codes_are_declared(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(
+                language=Language.FR,
+                language_codes=[],
+            ),
+        )
+
+        await service._transcribe(WAV)
+
+    assert _config(captured)["language_codes"] == ["fr"]
+
+
+@pytest.mark.asyncio
+async def test_config_carries_timestamps_when_requested(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(
+            aiohttp_client,
+            _transcribe_app(captured),
+            session,
+            settings=AssemblyAISyncSTTService.Settings(timestamps=True),
+        )
+
+        await service._transcribe(WAV)
+
+    assert _config(captured)["timestamps"] is True
+
+
+@pytest.mark.asyncio
+async def test_timestamps_are_omitted_by_default(aiohttp_client):
+    captured = {}
+    async with aiohttp.ClientSession() as session:
+        service = await _service(aiohttp_client, _transcribe_app(captured), session)
+
+        await service._transcribe(WAV)
+
+    assert "timestamps" not in _config(captured)
+
+
+@pytest.mark.asyncio
 async def test_config_part_is_omitted_when_nothing_applies(aiohttp_client):
     captured = {}
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

This aligns `AssemblyAISyncSTTService` with the AssemblyAI Sync API's `config` surface. The service currently exposes a subset of that surface; two supported config fields were missing, so some API behavior wasn't reachable from Pipecat:

| Sync API `config` field | Before | After |
|---|---|---|
| `language_codes` (array — multilingual / code-switching) | only single `language` (always sent as a one-element list) | **added** as `language_codes` |
| `timestamps` (per-word `start`/`end`) | not exposed | **added** as `timestamps` |

(`sample_rate`/`channels` remain intentionally unexposed — they apply only to raw PCM, and the segmented service always sends a WAV container that carries them in its header.)

### What changed

Two new fields on `AssemblyAISyncSTTService.Settings`:

- **`language_codes: list[Language]`** — declared audio languages for multilingual or code-switching audio, e.g. `[Language.EN, Language.ES]`. A single-element list pins one language. Regional variants resolve to their base code and duplicates are dropped in order. When both `language_codes` and the single `language` are set, `language_codes` is bound (matching how the API treats them as aliases for one parameter). The single `language` remains the convenience path and default (`Language.EN`).
- **`timestamps: bool`** — request per-word `start`/`end` timings, returned on the `words` of the transcription result. Left unset by default, so the API's own default (`False`, no timestamps) applies.

No new constructor parameters or dependencies; both are set via `settings`.

### Usage

```python
stt = AssemblyAISyncSTTService(
    api_key="...",
    aiohttp_session=session,
    settings=AssemblyAISyncSTTService.Settings(
        language_codes=[Language.EN, Language.ES],  # multilingual / code-switching
        timestamps=True,                            # per-word timings on the result
    ),
)
```

### Testing

Existing sync tests pass (27). New unit coverage for the language-code list (resolution, dedupe/order, single-vs-list precedence) and for `timestamps` (emitted when set, omitted by default). Verified end-to-end against the live Sync API: a multilingual `["en", "es"]` request and a `timestamps=True` request that returns word timings.
