### PR TITLE
feat(openai): add a strict option for function calling

### DIFF
--- a/changelog/5606.added.md
+++ b/changelog/5606.added.md
@@ -1,0 +1,4 @@
+- Added a `strict` option to `FunctionSchema`, read by the OpenAI Chat Completions
+  and Responses adapters. The adapters supply the `additionalProperties: false`
+  that strict mode requires. Defaults to `None`, leaving tools that don't ask for
+  it unchanged.

--- a/src/pipecat/adapters/schemas/function_schema.py
+++ b/src/pipecat/adapters/schemas/function_schema.py
@@ -36,6 +36,7 @@ class FunctionSchema:
         properties: dict[str, Any],
         required: list[str],
         handler: "FunctionCallHandler | None" = None,
+        strict: bool | None = None,
     ) -> None:
         """Initialize the function schema.
 
@@ -50,12 +51,21 @@ class FunctionSchema:
                 ``register_function`` call unnecessary. Decorate the handler with
                 ``@tool_options`` to override its default call options
                 (``cancel_on_interruption``, ``timeout_secs``).
+            strict: Whether the provider should enforce this schema when generating
+                the call. Honored only by the OpenAI Chat Completions and Responses
+                adapters, which also require every property to be listed in
+                ``required``. Keep a parameter optional by adding ``"null"`` to its
+                type rather than leaving it out. The adapters supply the
+                ``additionalProperties: false`` that strict mode needs, except on an
+                object that declares its own. Defaults to None, leaving the choice to
+                the provider.
         """
         self._name = name
         self._description = description
         self._properties = properties
         self._required = required
         self._handler = handler
+        self._strict = strict
 
     def to_default_dict(self) -> dict[str, Any]:
         """Converts the function schema to a dictionary.
@@ -118,3 +128,13 @@ class FunctionSchema:
             separately, through ``register_function``.
         """
         return self._handler
+
+    @property
+    def strict(self) -> bool | None:
+        """Get whether the provider should enforce this schema.
+
+        Returns:
+            Whether strict enforcement was requested, or ``None`` to leave the
+            choice to the provider.
+        """
+        return self._strict

--- a/src/pipecat/adapters/services/open_ai_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_adapter.py
@@ -77,6 +77,50 @@ def openai_from_llm_context_tools(
     return tools
 
 
+def openai_strict_parameters(parameters: Any) -> Any:
+    """Add the constraints strict mode requires to a tool's parameters.
+
+    Strict mode needs ``additionalProperties: false`` on each object in a tool's
+    parameters. The root object is built by :class:`FunctionSchema` rather than
+    written by the tool's author, so the adapters supply it. An object that
+    declares ``additionalProperties`` itself keeps what it declares: replacing it
+    would change what the tool accepts, and OpenAI reports a schema strict mode
+    can't take. Keys under ``properties`` name the tool's parameters rather than
+    schema keywords, so a parameter called ``additionalProperties`` is left alone.
+
+    Args:
+        parameters: The tool's parameters, as a JSON schema.
+
+    Returns:
+        A copy carrying the added constraints. The original is left untouched,
+        since a ``FunctionSchema``'s properties are shared with its author.
+    """
+    if not isinstance(parameters, dict):
+        return parameters
+
+    result: dict[str, Any] = {}
+    for key, value in parameters.items():
+        if key == "properties" and isinstance(value, dict):
+            result[key] = {name: openai_strict_parameters(prop) for name, prop in value.items()}
+        elif isinstance(value, dict):
+            result[key] = openai_strict_parameters(value)
+        elif isinstance(value, list):
+            result[key] = [openai_strict_parameters(item) for item in value]
+        else:
+            result[key] = value
+
+    # A nullable object spells its type as a list, which is how strict mode keeps
+    # a parameter optional.
+    declared_type = result.get("type")
+    is_object = declared_type == "object" or (
+        isinstance(declared_type, list) and "object" in declared_type
+    )
+    if is_object and "additionalProperties" not in result:
+        result["additionalProperties"] = False
+
+    return result
+
+
 def openai_from_llm_standard_message(
     message: LLMStandardMessage,
 ) -> ChatCompletionMessageParam:
@@ -198,6 +242,9 @@ class OpenAILLMAdapter(BaseLLMAdapter[OpenAILLMInvocationParams]):
     def to_provider_tools_format(self, tools_schema: ToolsSchema) -> list[ChatCompletionToolParam]:
         """Convert function schemas to OpenAI's function-calling format.
 
+        A schema asking for ``strict`` carries it through, along with the
+        ``additionalProperties: false`` strict mode requires.
+
         Args:
             tools_schema: The Pipecat tools schema to convert.
 
@@ -206,13 +253,19 @@ class OpenAILLMAdapter(BaseLLMAdapter[OpenAILLMInvocationParams]):
             with ChatCompletion API.
         """
         functions_schema = tools_schema.standard_tools
-        # `function=...` expects a `FunctionDefinition` TypedDict; the dict
-        # produced by `to_default_dict()` is structurally compatible. Cast at
-        # the boundary.
-        formatted_standard_tools: list[ChatCompletionToolParam] = [
-            ChatCompletionToolParam(type="function", function=cast(Any, func.to_default_dict()))
-            for func in functions_schema
-        ]
+        formatted_standard_tools: list[ChatCompletionToolParam] = []
+        for func in functions_schema:
+            definition = func.to_default_dict()
+            if func.strict is not None:
+                definition["strict"] = func.strict
+                if func.strict:
+                    definition["parameters"] = openai_strict_parameters(definition["parameters"])
+            # `function=...` expects a `FunctionDefinition` TypedDict; the dict
+            # produced by `to_default_dict()` is structurally compatible. Cast at
+            # the boundary.
+            formatted_standard_tools.append(
+                ChatCompletionToolParam(type="function", function=cast(Any, definition))
+            )
         custom_openai_tools: list[ChatCompletionToolParam] = []
         if tools_schema.custom_tools:
             custom_openai_tools = cast(

--- a/src/pipecat/adapters/services/open_ai_responses_adapter.py
+++ b/src/pipecat/adapters/services/open_ai_responses_adapter.py
@@ -14,7 +14,10 @@ from openai.types.responses import FunctionToolParam, ResponseInputItemParam, To
 
 from pipecat.adapters.base_llm_adapter import BaseLLMAdapter
 from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
-from pipecat.adapters.services.open_ai_adapter import openai_from_llm_context_tools
+from pipecat.adapters.services.open_ai_adapter import (
+    openai_from_llm_context_tools,
+    openai_strict_parameters,
+)
 from pipecat.processors.aggregators.llm_context import (
     LLMContext,
     LLMContextMessage,
@@ -118,6 +121,12 @@ class OpenAIResponsesLLMAdapter(BaseLLMAdapter[OpenAIResponsesLLMInvocationParam
     def to_provider_tools_format(self, tools_schema: ToolsSchema) -> list[ToolParam]:
         """Convert function schemas to Responses API function tool format.
 
+        A schema asking for ``strict`` gets the ``additionalProperties: false``
+        that strict mode requires on each of its objects. Strict mode also
+        requires every property to be listed in ``required``, which is left to
+        the schema's author since adding it would make optional parameters
+        mandatory.
+
         Args:
             tools_schema: The Pipecat tools schema to convert.
 
@@ -128,11 +137,12 @@ class OpenAIResponsesLLMAdapter(BaseLLMAdapter[OpenAIResponsesLLMInvocationParam
         result = []
         for func in functions_schema:
             d = func.to_default_dict()
+            parameters = d.get("parameters", {})
             tool: FunctionToolParam = {
                 "type": "function",
                 "name": d["name"],
-                "parameters": d.get("parameters", {}),
-                "strict": d.get("strict", None),
+                "parameters": openai_strict_parameters(parameters) if func.strict else parameters,
+                "strict": func.strict,
             }
             if "description" in d:
                 tool["description"] = d["description"]

--- a/tests/test_function_calling_adapters.py
+++ b/tests/test_function_calling_adapters.py
@@ -427,6 +427,186 @@ class TestFunctionAdapters(unittest.TestCase):
         ]
         assert OpenAIResponsesLLMAdapter().to_provider_tools_format(self.tools_def) == expected
 
+    def test_openai_responses_adapter_strict(self):
+        """Test that a strict schema is sent as strict, with its objects sealed."""
+        function_def = FunctionSchema(
+            name="search",
+            description="Search the index",
+            properties={
+                "query": {"type": "string"},
+                "filter": {
+                    "type": "object",
+                    "properties": {"tag": {"type": "string"}},
+                    "required": ["tag"],
+                },
+                # An optional parameter, spelled as a nullable type.
+                "scope": {
+                    "type": ["object", "null"],
+                    "properties": {"team": {"type": "string"}},
+                    "required": ["team"],
+                },
+                # An object that says for itself what it accepts.
+                "headers": {"type": "object", "additionalProperties": {"type": "string"}},
+                # Objects reached through a keyword other than "properties".
+                "hits": {"type": "array", "items": {"type": "object", "properties": {}}},
+                "target": {"anyOf": [{"type": "string"}, {"type": "object", "properties": {}}]},
+                # A parameter named like a schema keyword.
+                "additionalProperties": {"type": "string"},
+            },
+            required=[
+                "query",
+                "filter",
+                "scope",
+                "headers",
+                "hits",
+                "target",
+                "additionalProperties",
+            ],
+            strict=True,
+        )
+        expected = [
+            {
+                "type": "function",
+                "name": "search",
+                "description": "Search the index",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "filter": {
+                            "type": "object",
+                            "properties": {"tag": {"type": "string"}},
+                            "required": ["tag"],
+                            "additionalProperties": False,
+                        },
+                        "scope": {
+                            "type": ["object", "null"],
+                            "properties": {"team": {"type": "string"}},
+                            "required": ["team"],
+                            "additionalProperties": False,
+                        },
+                        "headers": {
+                            "type": "object",
+                            "additionalProperties": {"type": "string"},
+                        },
+                        "hits": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": False,
+                            },
+                        },
+                        "target": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {
+                                    "type": "object",
+                                    "properties": {},
+                                    "additionalProperties": False,
+                                },
+                            ]
+                        },
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "required": [
+                        "query",
+                        "filter",
+                        "scope",
+                        "headers",
+                        "hits",
+                        "target",
+                        "additionalProperties",
+                    ],
+                    "additionalProperties": False,
+                },
+                "strict": True,
+            }
+        ]
+        tools_def = ToolsSchema(standard_tools=[function_def])
+
+        assert OpenAIResponsesLLMAdapter().to_provider_tools_format(tools_def) == expected
+
+    def test_openai_adapters_strict_unset_and_opted_out(self):
+        """Test that a tool only carries strict once it asks for one."""
+        unset = ToolsSchema(standard_tools=[self.tools_def.standard_tools[0]])
+        opted_out = ToolsSchema(
+            standard_tools=[
+                FunctionSchema(
+                    name="get_weather",
+                    description="Get the weather in a given location",
+                    properties={"location": {"type": "string"}},
+                    required=["location"],
+                    strict=False,
+                )
+            ]
+        )
+
+        assert unset.standard_tools[0].strict is None
+        assert "strict" not in OpenAILLMAdapter().to_provider_tools_format(unset)[0]["function"]
+        assert (
+            OpenAILLMAdapter().to_provider_tools_format(opted_out)[0]["function"]["strict"] is False
+        )
+        # Only strict mode needs the schema sealed.
+        for adapter in (OpenAILLMAdapter(), OpenAIResponsesLLMAdapter()):
+            tools = adapter.to_provider_tools_format(opted_out)
+            parameters = tools[0].get("parameters") or tools[0]["function"]["parameters"]
+            assert "additionalProperties" not in parameters
+
+    def test_openai_adapter_strict(self):
+        """Test that Chat Completions carries strict and seals the schema too."""
+        function_def = FunctionSchema(
+            name="search",
+            description="Search the index",
+            properties={"query": {"type": "string"}},
+            required=["query"],
+            strict=True,
+        )
+        expected = [
+            ChatCompletionToolParam(
+                type="function",
+                function={
+                    "name": "search",
+                    "description": "Search the index",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            )
+        ]
+        tools_def = ToolsSchema(standard_tools=[function_def])
+
+        assert OpenAILLMAdapter().to_provider_tools_format(tools_def) == expected
+
+    def test_openai_responses_adapter_strict_leaves_the_schema_untouched(self):
+        """Test that sealing a strict schema doesn't write back to its author's properties."""
+        properties = {"query": {"type": "string"}}
+        function_def = FunctionSchema(
+            name="search",
+            description="Search the index",
+            properties=properties,
+            required=["query"],
+            strict=True,
+        )
+        tools_def = ToolsSchema(standard_tools=[function_def])
+        adapter = OpenAIResponsesLLMAdapter()
+
+        adapter.to_provider_tools_format(tools_def)
+
+        # Tools are converted on every inference, and the properties dict is shared
+        # with the other adapters.
+        assert properties == {"query": {"type": "string"}}
+        assert adapter.to_provider_tools_format(tools_def)[0]["parameters"] == {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+            "additionalProperties": False,
+        }
+
     def test_openai_realtime_adapter_with_custom_tools(self):
         """Test OpenAI Realtime adapter appends custom tools."""
         tool_search = {"type": "tool_search"}


### PR DESCRIPTION
Fixes #5604

## Problem

`FunctionSchema` has no way to ask for OpenAI's strict function calling. The Responses adapter reads a `strict` key off the dict `to_default_dict()` produces, but nothing ever sets it, so every Responses tool goes out with `strict: null`. The Chat Completions path sends no `strict` at all. The only way to turn strict on today is hand-writing a raw provider tool dict through `custom_tools`, which bypasses `FunctionSchema` and loses its handler auto-registration.

## Changes

`strict` is now a `FunctionSchema` argument with a matching read-only property, read directly by both OpenAI adapters. It defaults to `None`, so tools that don't ask for it go out exactly as before.

OpenAI rejects a strict tool unless every object in `parameters` carries `additionalProperties: false`, and the root object is built by `FunctionSchema` rather than by the tool's author, so the adapters fill it in. An object that declares its own `additionalProperties` keeps what it declared.

`strict` stays out of `to_default_dict()`. The Gemini and bus adapters pass that dict on whole and neither reads a strict key.

Strict mode also expects every property to appear in `required`. That one is left to the caller, since adding it would make optional parameters mandatory.