### PR TITLE
Flush TOKEN-mode TTS usage metrics on interruption

### DIFF
--- a/changelog/5613.fixed.md
+++ b/changelog/5613.fixed.md
@@ -1,0 +1,1 @@
+- TOKEN-mode TTS now reports usage metrics for text that was already sent to the provider when an interruption arrives, including canned `TTSSpeakFrame` lines. Those characters were spoken but previously only counted if an `LLMFullResponseEndFrame` or `EndFrame` arrived first.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -446,6 +446,18 @@ class TTSService(AIService):
             return
         await super().start_tts_usage_metrics(text)
 
+    async def _flush_streamed_tts_usage(self):
+        """Emit aggregated TOKEN-mode usage metrics for text already sent to TTS.
+
+        Token streaming skips per-call ``start_tts_usage_metrics`` and instead
+        accumulates into ``_streamed_text``. This reports that accumulator
+        (LLM tokens and ``TTSSpeakFrame`` text alike) and clears it.
+        """
+        if self._streamed_text:
+            logger.debug(f"{self}: Generating TTS [{self._streamed_text}]")
+            await super().start_tts_usage_metrics(self._streamed_text)
+            self._streamed_text = ""
+
     async def start_text_aggregation_metrics(self):
         """Start text aggregation metrics if not already started.
 
@@ -814,11 +826,7 @@ class TTSService(AIService):
             # pause to avoid audio overlapping.
             await self._maybe_pause_frame_processing()
 
-            # Log accumulated streamed text and emit aggregated usage metric.
-            if self._streamed_text:
-                logger.debug(f"{self}: Generating TTS [{self._streamed_text}]")
-                await super().start_tts_usage_metrics(self._streamed_text)
-                self._streamed_text = ""
+            await self._flush_streamed_tts_usage()
 
             # Reset aggregator state
             self._processing_text = False
@@ -1037,7 +1045,7 @@ class TTSService(AIService):
             await filter.handle_interruption()
 
         self._llm_response_started = False
-        self._streamed_text = ""
+        await self._flush_streamed_tts_usage()
         self._text_aggregation_metrics_started = False
         self._aggregated_frame_sequencer.clear()  # discard all pending slots on interruption
         self._pending_llm_response_end_frames.clear()

--- a/tests/test_tts_token_usage_metrics.py
+++ b/tests/test_tts_token_usage_metrics.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""TOKEN-mode TTS usage metrics flush on interruption as well as on LLM/end frames."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from pipecat.frames.frames import (
+    Frame,
+    InterruptionFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    MetricsFrame,
+    TextFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+)
+from pipecat.metrics.metrics import TTSUsageMetricsData
+from pipecat.pipeline.worker import PipelineParams
+from pipecat.services.tts_service import TextAggregationMode, TTSService
+from pipecat.tests.utils import run_test
+
+_SAMPLE_RATE = 16000
+_FAKE_AUDIO = b"\x00\x01" * 320
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class _TokenTTSService(TTSService):
+    def __init__(self, **kwargs):
+        super().__init__(
+            text_aggregation_mode=TextAggregationMode.TOKEN,
+            push_start_frame=True,
+            push_stop_frames=True,
+            push_text_frames=False,
+            sample_rate=_SAMPLE_RATE,
+            **kwargs,
+        )
+
+    def can_generate_metrics(self) -> bool:
+        return True
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        yield TTSAudioRawFrame(
+            audio=_FAKE_AUDIO,
+            sample_rate=_SAMPLE_RATE,
+            num_channels=1,
+            context_id=context_id,
+        )
+
+
+def _tts_usage_values(frames: list[Frame]) -> list[int]:
+    values: list[int] = []
+    for frame in frames:
+        if isinstance(frame, MetricsFrame):
+            for data in frame.data:
+                if isinstance(data, TTSUsageMetricsData):
+                    values.append(data.value)
+    return values
+
+
+async def test_ttsspeak_usage_flushed_on_interruption():
+    text = "Thanks for calling, I'm an AI assistant."
+    tts = _TokenTTSService()
+    down, _up = await run_test(
+        tts,
+        frames_to_send=[TTSSpeakFrame(text=text, append_to_context=False), InterruptionFrame()],
+        pipeline_params=PipelineParams(enable_usage_metrics=True),
+        start_timeout=5.0,
+    )
+    assert _tts_usage_values(down) == [len(text)]
+
+
+async def test_llm_token_usage_flushed_on_response_end():
+    text = "Hello there"
+    tts = _TokenTTSService()
+    down, _up = await run_test(
+        tts,
+        frames_to_send=[
+            LLMFullResponseStartFrame(),
+            TextFrame(text=text),
+            LLMFullResponseEndFrame(),
+        ],
+        pipeline_params=PipelineParams(enable_usage_metrics=True),
+        start_timeout=5.0,
+    )
+    assert _tts_usage_values(down) == [len(text)]
+
+
+async def test_interruption_without_streamed_text_emits_no_tts_usage():
+    tts = _TokenTTSService()
+    down, _up = await run_test(
+        tts,
+        frames_to_send=[InterruptionFrame()],
+        pipeline_params=PipelineParams(enable_usage_metrics=True),
+        start_timeout=5.0,
+    )
+    assert _tts_usage_values(down) == []


### PR DESCRIPTION
## Summary

Closes #5611.

In `TextAggregationMode.TOKEN`, TTS usage is accumulated in `_streamed_text` and only flushed on `LLMFullResponseEndFrame` or `EndFrame`. A following `InterruptionFrame` cleared that accumulator without reporting, so canned `TTSSpeakFrame` text (greetings, transfer lines) was spoken but never appeared in `TTSUsageMetricsData`.

`_handle_interruption` now flushes the same aggregated usage metric before clearing the accumulator.

## Test plan

- [x] `uv run pytest tests/test_tts_token_usage_metrics.py`
