### PR TITLE
fix(openai): skip unfinished function calls after a terminal WebSocket stream error

### DIFF
--- a/changelog/5619.fixed.md
+++ b/changelog/5619.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `OpenAIResponsesLLMService` running a function call with fabricated empty arguments when a response ended in a terminal error (`response.failed`, `response.incomplete`, or an `error` event) before the call's arguments finished streaming. Calls whose arguments did finish streaming still run, matching `OpenAIResponsesHttpLLMService`.

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -1061,6 +1061,7 @@ class OpenAIResponsesLLMService(
         function_calls: dict[str, dict[str, str]] = {}
         current_arguments: dict[str, str] = {}
         reasoning_summary_open = False
+        stream_errored = False
 
         deadline = time.monotonic() + output_timeout_secs if output_timeout_secs else None
 
@@ -1179,6 +1180,7 @@ class OpenAIResponsesLLMService(
                 error_info = status_details.get("error") or {}
                 error_msg = error_info.get("message", f"Response {event_type.split('.')[-1]}")
                 await self.push_error(error_msg=f"LLM response error: {error_msg}")
+                stream_errored = True
                 break
 
             elif event_type == "error":
@@ -1192,7 +1194,19 @@ class OpenAIResponsesLLMService(
                     raise _ConnectionLimitReachedError(message)
                 else:
                     await self.push_error(error_msg=f"WebSocket API error: {message}")
+                    stream_errored = True
                     break
+
+        # A response that ended in a terminal error may have announced a function
+        # call whose arguments never finished streaming. Those are dropped rather
+        # than run with fabricated empty arguments. `arguments` is only written
+        # by the Done events, so a non-empty string means the call completed
+        # (e.g. parallel tool calls finished before a later item was truncated)
+        # and it still runs.
+        if stream_errored:
+            function_calls = {
+                item_id: call for item_id, call in function_calls.items() if call["arguments"]
+            }
 
         # Process any function calls
         if function_calls:

--- a/tests/test_openai_responses_websocket.py
+++ b/tests/test_openai_responses_websocket.py
@@ -588,6 +588,98 @@ class TestReceiveResponseEventsErrors:
         service.push_error.assert_called_once()
         assert "Internal server error" in service.push_error.call_args.kwargs["error_msg"]
 
+    @pytest.mark.parametrize(
+        "terminal_event",
+        [
+            {"type": "response.failed", "response": {"id": "resp_1"}},
+            {"type": "response.incomplete", "response": {"id": "resp_1"}},
+            {"type": "error", "error": {"code": "server_error", "message": "boom"}},
+        ],
+        ids=["failed", "incomplete", "error"],
+    )
+    @pytest.mark.asyncio
+    async def test_terminal_error_does_not_run_announced_function_call(self, terminal_event):
+        """A function call whose arguments never finished streaming before a
+        terminal error must not be executed with fabricated empty arguments."""
+        service = _make_service()
+        service.stop_ttfb_metrics = AsyncMock()
+        service.push_error = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        ws = _ws_events(
+            {"type": "response.created", "response": {"id": "resp_1"}},
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "item_1",
+                    "name": "get_weather",
+                    "call_id": "call_1",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "item_1",
+                "delta": '{"city": "SF"',
+            },
+            terminal_event,
+        )
+        service._websocket = ws
+
+        context = MagicMock(spec=LLMContext)
+        await service._receive_response_events(context, [])
+
+        service.push_error.assert_called_once()
+        service.run_function_calls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_still_runs_completed_function_calls(self):
+        """Parallel tool calls: a call whose arguments finished streaming before
+        the terminal error (e.g. a later item truncated by max_output_tokens)
+        must still run. Only the unfinished call is dropped."""
+        service = _make_service()
+        service.stop_ttfb_metrics = AsyncMock()
+        service.push_error = AsyncMock()
+        service.run_function_calls = AsyncMock()
+
+        def _tool_call_added(item_id, name, call_id):
+            return {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": item_id,
+                    "name": name,
+                    "call_id": call_id,
+                },
+            }
+
+        ws = _ws_events(
+            {"type": "response.created", "response": {"id": "resp_1"}},
+            _tool_call_added("item_1", "get_weather", "call_1"),
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "item_1",
+                "arguments": '{"city": "SF"}',
+            },
+            _tool_call_added("item_2", "get_time", "call_2"),
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "item_2",
+                "delta": '{"city": "NY',
+            },
+            {"type": "response.incomplete", "response": {"id": "resp_1"}},
+        )
+        service._websocket = ws
+
+        context = MagicMock(spec=LLMContext)
+        await service._receive_response_events(context, [])
+
+        service.push_error.assert_called_once()
+        service.run_function_calls.assert_called_once()
+        fc_list = service.run_function_calls.call_args.args[0]
+        assert [fc.function_name for fc in fc_list] == ["get_weather"]
+        assert fc_list[0].arguments == {"city": "SF"}
+
 
 class TestDrainCancelledResponse:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Over WebSocket, a Responses turn can end in `response.failed`, `response.incomplete` or an `error`
event after a function call has been announced but before its arguments finish streaming.
`arguments` starts empty and is only written when the arguments or the output item complete, so
those branches break straight into function-call dispatch with the empty string still in place.
`_process_function_calls` reads that as `{}` rather than a parse failure, so the handler runs as
though the model had asked for it with no arguments, and nothing flags the arguments as
incomplete.

`OpenAIResponsesHttpLLMService` has been guarded against this since #5270. The WebSocket class
already existed then and was missed.

## Changes

Track whether the stream ended in a terminal error and drop announced calls whose arguments never
arrived. Calls that did finish still run, which covers parallel tool calls where one completes and
a later one is truncated. Tests cover all three terminal events plus the mixed case.

The success path is unchanged, as are the retryable errors that raise before dispatch. The error
text those branches report is also unchanged: #5490 is rewriting it in the same lines, and this
rebases onto it if it lands first.
