### PR TITLE
SegmentedSTTService: transcribe segments off the audio path

### DIFF
--- a/changelog/5630.fixed.md
+++ b/changelog/5630.fixed.md
@@ -1,0 +1,1 @@
+- `SegmentedSTTService` (Whisper, Moonshine, and the other segmented STT services) now transcribes each speech segment in a background task. Previously the transcription blocked the service's input audio frames, so a VAD downstream could not analyze them until it finished. Transcripts are still pushed in segment order.

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -25,6 +25,7 @@ from pipecat.frames.frames import (
     InputAudioRawFrame,
     InterruptionFrame,
     LLMContextAssistantTurnFrame,
+    StartFrame,
     STTMetadataFrame,
     STTMuteFrame,
     STTUpdateSettingsFrame,
@@ -814,6 +815,13 @@ class SegmentedSTTService(STTService):
     A segment ends right where the VAD stopped, and models tend to drop or
     garble the final word when the audio ends that abruptly, so each segment
     is padded with ``trailing_silence_secs`` of silence before transcription.
+
+    Transcription runs off the audio path. When the VAD stops, the segment is
+    queued and one background task transcribes queued segments in order,
+    pushing each transcript as it completes; meanwhile audio and other frames
+    keep flowing through the service, as they do through a streaming STT whose
+    transcripts arrive asynchronously. A graceful stop transcribes what is
+    queued before the service stops; a cancel drops it.
     """
 
     def __init__(
@@ -840,6 +848,10 @@ class SegmentedSTTService(STTService):
         self._audio_buffer = bytearray()
         self._audio_buffer_size_1s = 0
         self._user_speaking = False
+        # Segments awaiting transcription, drained in order by _segment_task;
+        # None tells the task to finish.
+        self._segment_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._segment_task: asyncio.Task | None = None
 
     async def setup(self, setup: FrameProcessorSetup):
         """Set up the service.
@@ -849,6 +861,36 @@ class SegmentedSTTService(STTService):
         """
         await super().setup(setup)
         self._audio_buffer_size_1s = self.sample_rate * 2
+
+    async def start(self, frame: StartFrame):
+        """Start the service and its transcription task.
+
+        Args:
+            frame: The start frame.
+        """
+        await super().start(frame)
+        self._segment_task = self.create_task(self._segment_task_handler())
+
+    async def stop(self, frame: EndFrame):
+        """Transcribe the queued segments, then stop the service.
+
+        Args:
+            frame: The end frame.
+        """
+        if self._segment_task is not None:
+            await self._segment_queue.put(None)
+            await self._segment_task
+            self._segment_task = None
+        await super().stop(frame)
+
+    async def cancel(self, frame: CancelFrame):
+        """Stop the service at once, dropping any queued segments.
+
+        Args:
+            frame: The cancel frame.
+        """
+        await self._cancel_segment_task()
+        await super().cancel(frame)
 
     @property
     def wants_wav_segments(self) -> bool:
@@ -911,7 +953,24 @@ class SegmentedSTTService(STTService):
             # WAV container would make them misread the 44-byte header as audio.
             audio = pcm
 
-        await self.process_generator(self.run_stt(audio))
+        await self._segment_queue.put(audio)
+
+    async def _segment_task_handler(self):
+        """Transcribe queued segments one at a time, in order, until told to finish."""
+        running = True
+        while running:
+            audio = await self._segment_queue.get()
+            running = audio is not None
+            if audio:
+                try:
+                    await self.process_generator(self.run_stt(audio))
+                except Exception as e:
+                    await self.push_error(f"{self}: transcription failed: {e}", exception=e)
+
+    async def _cancel_segment_task(self):
+        if self._segment_task is not None:
+            await self.cancel_task(self._segment_task)
+            self._segment_task = None
 
     def _trailing_silence(self) -> bytes:
         """Silence appended to a segment, as 16-bit mono PCM at the service sample rate."""

--- a/tests/test_assemblyai_sync_stt.py
+++ b/tests/test_assemblyai_sync_stt.py
@@ -480,6 +480,9 @@ async def test_cleanup_cancels_a_pending_warm():
 async def test_a_new_run_starts_on_an_empty_conversation_context():
     service = AssemblyAISyncSTTService(api_key="k", aiohttp_session=object())
     service._append_context_turn("Booking a flight to Lisbon.")
+    # start() also creates the segment transcription task; this bare service has
+    # no task manager, so stand in for it.
+    service.create_task = lambda coro, *args, **kwargs: coro.close()
 
     await service.start(StartFrame())
 

--- a/tests/test_segmented_stt.py
+++ b/tests/test_segmented_stt.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 import io
 import wave
 from collections.abc import AsyncGenerator
@@ -14,6 +15,7 @@ from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
     MetricsFrame,
+    TranscriptionFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
@@ -29,7 +31,9 @@ PCM = bytes(range(0, 240)) * 4  # 960 bytes, even length
 DEFAULT_SILENCE = bytes(int(SAMPLE_RATE * 0.5) * 2)
 
 
-def _make_capturing_service(wants_wav: bool | None = None, **kwargs) -> SegmentedSTTService:
+def _make_capturing_service(
+    wants_wav: bool | None = None, transcribe_secs: float = 0.0, **kwargs
+) -> SegmentedSTTService:
     """Build a SegmentedSTTService that captures the bytes handed to run_stt().
 
     Defined as a factory (not a module-level class) so this concrete subclass
@@ -39,6 +43,8 @@ def _make_capturing_service(wants_wav: bool | None = None, **kwargs) -> Segmente
     Args:
         wants_wav: If None, inherit the base default; otherwise force the
             ``wants_wav_segments`` contract to this value.
+        transcribe_secs: When set, ``run_stt`` takes this long and then yields
+            a ``TranscriptionFrame`` naming the segment ("segment 1", ...).
         **kwargs: Passed to the service constructor.
     """
 
@@ -52,8 +58,11 @@ def _make_capturing_service(wants_wav: bool | None = None, **kwargs) -> Segmente
 
         async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
             self.captured.append(audio)
-            return
-            yield  # make this an async generator
+            if transcribe_secs:
+                await asyncio.sleep(transcribe_secs)
+                yield TranscriptionFrame(
+                    text=f"segment {len(self.captured)}", user_id="", timestamp=""
+                )
 
     if wants_wav is not None:
         _CapturingSegmentedSTTService.wants_wav_segments = property(lambda self: wants_wav)
@@ -97,6 +106,37 @@ def _wav_frames(audio: bytes) -> bytes:
         assert wav.getsampwidth() == 2
         assert wav.getnchannels() == 1
         return wav.readframes(wav.getnframes())
+
+
+@pytest.mark.asyncio
+async def test_audio_keeps_flowing_while_a_segment_is_transcribed():
+    # A streaming STT never holds the audio path while a transcript is pending;
+    # neither does a segmented one: audio sent after the VAD stop reaches
+    # downstream before the segment's transcript does.
+    service = _make_capturing_service(transcribe_secs=0.2, trailing_silence_secs=0)
+    after_stop = [
+        InputAudioRawFrame(audio=PCM, sample_rate=SAMPLE_RATE, num_channels=1) for _ in range(3)
+    ]
+
+    received_down, _ = await run_test(service, frames_to_send=_segment_frames() + after_stop)
+
+    kinds = [type(f) for f in received_down]
+    transcript_at = kinds.index(TranscriptionFrame)
+    audio_at = [i for i, k in enumerate(kinds) if k is InputAudioRawFrame]
+    assert len(audio_at) == 4
+    assert all(i < transcript_at for i in audio_at)
+
+
+@pytest.mark.asyncio
+async def test_segments_are_transcribed_in_order_and_flushed_on_stop():
+    service = _make_capturing_service(transcribe_secs=0.05, trailing_silence_secs=0)
+
+    received_down, _ = await run_test(
+        service, frames_to_send=_segment_frames() + _segment_frames() + _segment_frames()
+    )
+
+    transcripts = [f.text for f in received_down if isinstance(f, TranscriptionFrame)]
+    assert transcripts == ["segment 1", "segment 2", "segment 3"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`SegmentedSTTService` (Whisper, Moonshine, and the other segmented STT services) transcribes each VAD segment in a background task instead of awaiting the transcription inline. Audio and other frames keep flowing through the service while a segment is transcribed, as with the streaming STTs whose transcripts arrive asynchronously. Transcripts are still pushed in segment order. A graceful stop transcribes what is queued first; a cancel drops it.

## Why

`InputAudioRawFrame` is a system frame, and so is the `VADUserStoppedSpeakingFrame` that triggers a segment's transcription. System frames are handled inline by the processor's input task, so while that task awaits the transcription the audio frames behind it wait too: nothing downstream of the STT, the user aggregator's VAD included, gets to analyze them until the transcription returns. A bot's user is silent right then, so a bot rarely notices, but a pipeline transcribing a party that keeps talking (the eval harness listening to a bot) sees its VAD and turn analysis fall a transcription behind.

## Tests

Two new tests in `tests/test_segmented_stt.py`: audio sent after the VAD stop reaches downstream before the segment's transcript, and transcripts of back-to-back segments arrive in order and are flushed on stop.
