### PR TITLE
fix(nvidia): apply STT settings changes to the running stream

### DIFF
--- a/changelog/5632.fixed.md
+++ b/changelog/5632.fixed.md
@@ -1,0 +1,1 @@
+Applied NVIDIA STT settings changes to the running stream. `NvidiaSTTService` rebuilt its recognition config on a settings update but never reconnected, so the open gRPC stream kept transcribing with the previous settings while `self._settings` reported the new ones.

--- a/src/pipecat/services/nvidia/stt.py
+++ b/src/pipecat/services/nvidia/stt.py
@@ -434,7 +434,7 @@ class NvidiaSTTService(STTService):
         return True
 
     async def _update_settings(self, delta: STTSettings) -> dict[str, Any]:
-        """Apply a settings delta and sync internal state.
+        """Apply a settings delta, then reconnect so the stream picks it up.
 
         Args:
             delta: A :class:`STTSettings` (or ``NvidiaSTTService.Settings``) delta.
@@ -444,8 +444,17 @@ class NvidiaSTTService(STTService):
         """
         changed = await super()._update_settings(delta)
 
-        if changed and self._config is not None:
+        if not changed:
+            return changed
+
+        if self._config is not None:
             self._config = self._create_recognition_config()
+
+        # streaming_response_generator() receives streaming_config once, when the
+        # gRPC stream is opened, so rebuilding the config alone leaves the running
+        # stream transcribing with the previous settings. _request_reconnect()
+        # defers until the user stops speaking, so this cannot cut into a turn.
+        await self._request_reconnect()
 
         return changed
 

--- a/tests/test_nvidia_stt.py
+++ b/tests/test_nvidia_stt.py
@@ -5,12 +5,14 @@
 #
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
 pytest.importorskip("riva.client")
 
 from pipecat.services.nvidia.stt import AudioChunkIterator, NvidiaSTTService
+from pipecat.transcriptions.language import Language
 
 
 def _make_service(**kwargs) -> NvidiaSTTService:
@@ -84,3 +86,51 @@ async def test_send_keepalive_noop_without_iterator():
     """Sending keepalive with no active stream does not raise."""
     service = _make_service()
     await service._send_keepalive(b"\x00\x00")
+
+
+@pytest.mark.asyncio
+async def test_update_settings_reconnects_so_the_stream_uses_them(monkeypatch):
+    """A settings change must reach the gRPC stream, not just the local config.
+
+    streaming_response_generator() is handed streaming_config once, when the
+    stream is opened, so rebuilding the config without reconnecting leaves the
+    live stream transcribing with the previous settings and nothing logs.
+    """
+    service = _make_service()
+    service._config = service._create_recognition_config()
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_request_reconnect", reconnect)
+
+    changed = await service._update_settings(NvidiaSTTService.Settings(language=Language.ES))
+
+    assert changed
+    assert service._settings.language == Language.ES
+    reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_settings_rebuilds_the_recognition_config(monkeypatch):
+    """The rebuilt config carries the new language into the next stream."""
+    service = _make_service()
+    service._config = service._create_recognition_config()
+    monkeypatch.setattr(service, "_request_reconnect", AsyncMock())
+
+    assert service._config.config.language_code == Language.EN_US
+
+    await service._update_settings(NvidiaSTTService.Settings(language=Language.ES))
+
+    assert service._config.config.language_code == Language.ES
+
+
+@pytest.mark.asyncio
+async def test_update_settings_without_changes_does_not_reconnect(monkeypatch):
+    """A no-op delta must not tear down a healthy stream."""
+    service = _make_service()
+    service._config = service._create_recognition_config()
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_request_reconnect", reconnect)
+
+    changed = await service._update_settings(NvidiaSTTService.Settings())
+
+    assert not changed
+    reconnect.assert_not_awaited()


### PR DESCRIPTION
## Problem

`NvidiaSTTService._update_settings` rebuilds `self._config` but never reconnects:

```python
changed = await super()._update_settings(delta)

if changed and self._config is not None:
    self._config = self._create_recognition_config()

return changed
```

`streaming_response_generator()` is handed `streaming_config` **once**, when the gRPC stream is opened:

```python
responses = asr_service.streaming_response_generator(
    audio_chunks=iterator,
    streaming_config=self._config,
)
```

So rebuilding the config alone does nothing to the stream that is already running. Change `language` mid-session and `self._settings` reports the new value while the server keeps transcribing in the old one, until something else happens to trigger a reconnect.

Nothing surfaces the gap. `_update_settings` returns the changed-field dict as though the update applied, and unlike other services it never calls `_warn_unhandled_updated_settings`, so the caller gets **neither the change nor a warning**.

## Why this shape

The base class asks for exactly this:

> Concrete services should override this method and handle language changes **(including any reconnect logic)** based on the returned changed-field dict.
> — `STTService._update_settings`

And the three sibling streaming STT services already do it:

| Service | |
|---|---|
| `cartesia/stt.py:389` | `await self._request_reconnect()` |
| `deepgram/stt.py:517` | `await self._request_reconnect()` |
| `soniox/stt.py:466` | `await self._request_reconnect()` |
| `nvidia/stt.py` | — missing |

`_request_reconnect()` is the safe primitive: it defers until `UserStoppedSpeaking` when the user is mid-turn, and `_reconnect()` buffers audio across the swap, so a settings change cannot cut into an active turn. The early `if not changed: return changed` keeps a no-op delta from tearing down a healthy stream.

## Scope

**Only the streaming service is affected.** `NvidiaSegmentedSTTService` passes `self._config` to `offline_recognize()` on every request, so rebuilding it there is already sufficient — that path is untouched.

The deprecated `set_model` is also untouched. It is documented as a no-op for this service ("Model cannot be changed after initialization"), which is a deliberate provider constraint, not this bug.

## Tests

Three added to `tests/test_nvidia_stt.py`, following the shape of `test_cartesia_update_keyterm_reconnects`:

- a settings change reconnects, so the stream picks it up
- the rebuilt recognition config carries the new language
- a no-op delta does **not** reconnect

**Verified by mutation, not assumption.** With the `_request_reconnect()` call removed, `test_update_settings_reconnects_so_the_stream_uses_them` fails; with it, all 10 tests in the file pass. `ruff format --check` and `ruff check` are clean.

Note the tests need the `nvidia` extra installed to run — `pytest.importorskip("riva.client")` at the top of that file silently skips the whole module otherwise. I installed it (`pip install --group dev -e ".[nvidia]"`) and confirmed the tests genuinely execute rather than skip.
