### PR TITLE
Log the composed system instruction only when it changes

### DIFF
--- a/changelog/5635.fixed.md
+++ b/changelog/5635.fixed.md
@@ -1,0 +1,1 @@
+- `LLMService` now logs the composed system instruction only when it changes. Previously every tool sync recomposed it, so the full prompt was logged once per turn.

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -371,6 +371,9 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         base_si = self._settings.system_instruction
         self._base_system_instruction: str | None = base_si if isinstance(base_si, str) else None
         self._appended_system_instructions: list[str] = []
+        # The instruction as last composed, so a recomposition that changes
+        # nothing (every tool sync recomposes) is not logged again.
+        self._composed_system_instruction: str | None = None
         # `adapter_class` is typed as `type[BaseLLMAdapter]` so subclasses
         # don't need to spell out the generic parameter just to subclass
         # (backward compatibility for 3rd-party providers outside this repo).
@@ -620,7 +623,8 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         updates) with any appended instructions (e.g. the ``UIWorker`` prompt
         guide), turn completion instructions (when enabled), and async tool
         cancellation instructions (when enabled). Safe to call repeatedly — it
-        always rebuilds from the base, so it never compounds.
+        always rebuilds from the base, so it never compounds, and it logs the
+        result only when it differs from the previous composition.
         """
         base = self._base_system_instruction
         parts = [base] if base else []
@@ -631,9 +635,11 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             parts.append(ASYNC_TOOL_CANCELLATION_INSTRUCTIONS)
         if self._has_async_tools():
             parts.append(ASYNC_TOOL_INSTRUCTIONS)
-        composed = "\n\n".join(p for p in parts if p)
-        self._settings.system_instruction = composed or None
-        logger.debug(f"{self}: System instruction composed: {self._settings.system_instruction}")
+        composed = "\n\n".join(p for p in parts if p) or None
+        self._settings.system_instruction = composed
+        if composed != self._composed_system_instruction:
+            self._composed_system_instruction = composed
+            logger.debug(f"{self}: System instruction composed: {composed}")
 
     async def _update_settings(self, delta: LLMSettings) -> dict[str, Any]:
         """Apply a settings delta, handling turn-completion fields.

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
+from loguru import logger
 
 from pipecat.adapters.base_llm_adapter import BaseLLMAdapter
 from pipecat.adapters.schemas.function_schema import FunctionSchema
@@ -992,6 +993,25 @@ class TestAppendSystemInstruction(unittest.IsolatedAsyncioTestCase):
         service.append_system_instruction("G1")
         service.append_system_instruction("G2")
         self.assertEqual(service._settings.system_instruction, "APP\n\nG1\n\nG2")
+
+    def test_composition_is_logged_only_when_it_changes(self):
+        service = self._service("APP")
+        logged: list[str] = []
+        handler_id = logger.add(
+            lambda message: logged.append(str(message)), level="DEBUG", format="{message}"
+        )
+        try:
+            service.append_system_instruction("GUIDE")
+            # Every tool sync recomposes; an unchanged instruction stays quiet.
+            service._compose_system_instruction()
+            service._compose_system_instruction()
+            service.append_system_instruction("MORE")
+        finally:
+            logger.remove(handler_id)
+        composed = [line for line in logged if "System instruction composed" in line]
+        self.assertEqual(len(composed), 2)
+        self.assertIn("APP\n\nGUIDE\n", composed[0])
+        self.assertIn("MORE", composed[1])
 
     async def test_appended_guide_survives_turn_completion_toggle(self):
         service = self._service("APP")


### PR DESCRIPTION
`LLMService` recomposes the system instruction on every tool sync, which runs on every context frame, so the full prompt was logged once per turn. It now keeps the last composition and logs only when it changes: the first composition and a runtime change of the prompt still print in full.