### PR TITLE
fix: parse setup files with platform path separator

### DIFF
--- a/changelog/5638.fixed.md
+++ b/changelog/5638.fixed.md
@@ -1,0 +1,1 @@
+Fixed `PIPECAT_SETUP_FILES` parsing on platforms whose path separator is not a colon.

--- a/src/pipecat/utils/startup.py
+++ b/src/pipecat/utils/startup.py
@@ -6,8 +6,9 @@
 
 """Shared loader for ``PIPECAT_SETUP_FILES`` hooks.
 
-Each file listed in the ``PIPECAT_SETUP_FILES`` environment variable (colon
-separated) may define one or both of the following async functions:
+Each file listed in the ``PIPECAT_SETUP_FILES`` environment variable (separated
+by the platform path separator) may define one or both of the following async
+functions:
 
 - ``setup_worker_runner(runner)`` — invoked once per :class:`~pipecat.workers.runner.WorkerRunner`
   before its spawned workers start.
@@ -34,7 +35,9 @@ _module_cache: dict[str, ModuleType] = {}
 
 
 def _setup_file_paths() -> list[Path]:
-    return [Path(f).resolve() for f in os.environ.get("PIPECAT_SETUP_FILES", "").split(":") if f]
+    return [
+        Path(f).resolve() for f in os.environ.get("PIPECAT_SETUP_FILES", "").split(os.pathsep) if f
+    ]
 
 
 def _load_module(path: Path) -> ModuleType | None:

--- a/tests/test_utils_startup.py
+++ b/tests/test_utils_startup.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+from pipecat.utils import startup
+
+
+def test_setup_file_paths_uses_platform_path_separator(monkeypatch, tmp_path):
+    first = tmp_path / "first.py"
+    second = tmp_path / "second.py"
+    monkeypatch.setattr(startup.os, "pathsep", ";")
+    monkeypatch.setenv("PIPECAT_SETUP_FILES", f"{first};{second}")
+
+    assert startup._setup_file_paths() == [first.resolve(), second.resolve()]


### PR DESCRIPTION
## Summary

`PIPECAT_SETUP_FILES` is documented as a list of file paths, but splitting it on a literal colon breaks Windows drive-letter paths.

Use `os.pathsep` so the variable follows the host platform's path-list convention, and update the module documentation accordingly.

## Testing

- Added a regression test that uses a semicolon path separator and two setup files.
- `pytest --noconftest tests/test_utils_startup.py -q`
- Ruff check and formatting check on both changed files.