### PR TITLE
fix: track real message count since last summary

### DIFF
--- a/changelog/5642.fixed.md
+++ b/changelog/5642.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `LLMContextSummarizer`'s message-count trigger (`max_unsummarized_messages`), which never reset after a summary was applied and counted the injected summary message as a new conversation turn.

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -129,10 +129,10 @@ class LLMContextSummarizer(BaseObject):
         self._summarization_in_progress = False
         self._pending_summary_request_id: str | None = None
 
-        # Number of leading messages excluded from the message-count trigger:
-        # the preserved system message (if any), and, once a summary has been
-        # applied, the injected summary message on top of that.
-        self._messages_since_summary_baseline = self._leading_system_message_count(context.messages)
+        # The summary message injected by the last applied summary, tracked by
+        # identity so the message-count trigger can exclude it only while it is
+        # still at the head of the context.
+        self._summary_message: LLMContextMessage | None = None
 
         self._register_event_handler("on_request_summarization", sync=True)
         self._register_event_handler("on_summary_applied")
@@ -143,8 +143,8 @@ class LLMContextSummarizer(BaseObject):
 
         Mirrors the messages[0] system-message check used elsewhere when
         selecting messages to summarize and when reconstructing the context
-        after a summary, so the baseline stays consistent with what those
-        steps actually preserve.
+        after a summary, so the message count stays consistent with what
+        those steps actually preserve.
 
         Args:
             messages: The context messages to check.
@@ -159,6 +159,28 @@ class LLMContextSummarizer(BaseObject):
         ):
             return 1
         return 0
+
+    def _messages_since_summary(self) -> int:
+        """Count the conversation messages added since the last applied summary.
+
+        Excludes the leading system message, if present, and the summary
+        message injected by the last summary while it still sits directly
+        after it. Both are computed from the current context so that replacing
+        the messages (for example, resetting the conversation) resets the
+        count as well.
+
+        Returns:
+            The number of messages that count toward ``max_unsummarized_messages``.
+        """
+        messages = self._context.messages
+        excluded = self._leading_system_message_count(messages)
+        if (
+            self._summary_message is not None
+            and len(messages) > excluded
+            and messages[excluded] is self._summary_message
+        ):
+            excluded += 1
+        return len(messages) - excluded
 
     async def setup(self, setup: FrameProcessorSetup):
         """Set up the summarizer.
@@ -261,7 +283,7 @@ class LLMContextSummarizer(BaseObject):
         token_limit_exceeded = token_limit is not None and total_tokens >= token_limit
 
         # Check if we've exceeded max unsummarized messages
-        messages_since_summary = len(self._context.messages) - self._messages_since_summary_baseline
+        messages_since_summary = self._messages_since_summary()
         message_threshold = self._auto_config.max_unsummarized_messages
         message_threshold_exceeded = (
             message_threshold is not None and messages_since_summary >= message_threshold
@@ -461,7 +483,7 @@ class LLMContextSummarizer(BaseObject):
         # Create summary message as a user message (the summary is context
         # provided *to* the assistant, not something the assistant said)
         summary_content = config.summary_message_template.format(summary=summary)
-        summary_message = {"role": "user", "content": summary_content}
+        summary_message: LLMContextMessage = {"role": "user", "content": summary_content}
 
         # Reconstruct context
         new_messages = []
@@ -474,10 +496,7 @@ class LLMContextSummarizer(BaseObject):
         original_message_count = len(messages)
         self._context.set_messages(new_messages)
 
-        # Reset the message-count trigger baseline: the preserved system
-        # message and the newly injected summary message don't count toward
-        # max_unsummarized_messages.
-        self._messages_since_summary_baseline = num_system_preserved + 1
+        self._summary_message = summary_message
 
         # Messages actually summarized = index range minus the preserved system message
         summarized_count = last_summarized_index + 1 - num_system_preserved

--- a/src/pipecat/processors/aggregators/llm_context_summarizer.py
+++ b/src/pipecat/processors/aggregators/llm_context_summarizer.py
@@ -21,7 +21,11 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     LLMSummarizeContextFrame,
 )
-from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
+from pipecat.processors.aggregators.llm_context import (
+    LLMContext,
+    LLMContextMessage,
+    LLMSpecificMessage,
+)
 from pipecat.processors.frame_processor import FrameProcessorSetup
 from pipecat.utils.base_object import BaseObject
 from pipecat.utils.context.llm_context_summarization import (
@@ -125,8 +129,36 @@ class LLMContextSummarizer(BaseObject):
         self._summarization_in_progress = False
         self._pending_summary_request_id: str | None = None
 
+        # Number of leading messages excluded from the message-count trigger:
+        # the preserved system message (if any), and, once a summary has been
+        # applied, the injected summary message on top of that.
+        self._messages_since_summary_baseline = self._leading_system_message_count(context.messages)
+
         self._register_event_handler("on_request_summarization", sync=True)
         self._register_event_handler("on_summary_applied")
+
+    @staticmethod
+    def _leading_system_message_count(messages: list[LLMContextMessage]) -> int:
+        """Return 1 if the first message is a system message, else 0.
+
+        Mirrors the messages[0] system-message check used elsewhere when
+        selecting messages to summarize and when reconstructing the context
+        after a summary, so the baseline stays consistent with what those
+        steps actually preserve.
+
+        Args:
+            messages: The context messages to check.
+
+        Returns:
+            1 if ``messages[0]`` is a system message, otherwise 0.
+        """
+        if (
+            messages
+            and not isinstance(messages[0], LLMSpecificMessage)
+            and messages[0].get("role") == "system"
+        ):
+            return 1
+        return 0
 
     async def setup(self, setup: FrameProcessorSetup):
         """Set up the summarizer.
@@ -229,7 +261,7 @@ class LLMContextSummarizer(BaseObject):
         token_limit_exceeded = token_limit is not None and total_tokens >= token_limit
 
         # Check if we've exceeded max unsummarized messages
-        messages_since_summary = len(self._context.messages) - 1
+        messages_since_summary = len(self._context.messages) - self._messages_since_summary_baseline
         message_threshold = self._auto_config.max_unsummarized_messages
         message_threshold_exceeded = (
             message_threshold is not None and messages_since_summary >= message_threshold
@@ -420,13 +452,8 @@ class LLMContextSummarizer(BaseObject):
         # Only messages[0] is treated as the system preamble — system messages at
         # other positions are mid-conversation injections and are not preserved
         # separately (they will be part of the summary or the recent messages).
-        first_system_msg = None
-        if (
-            messages
-            and not isinstance(messages[0], LLMSpecificMessage)
-            and messages[0].get("role") == "system"
-        ):
-            first_system_msg = messages[0]
+        num_system_preserved = self._leading_system_message_count(messages)
+        first_system_msg = messages[0] if num_system_preserved else None
 
         # Get recent messages to keep
         recent_messages = messages[last_summarized_index + 1 :]
@@ -445,8 +472,12 @@ class LLMContextSummarizer(BaseObject):
 
         # Update context
         original_message_count = len(messages)
-        num_system_preserved = 1 if first_system_msg else 0
         self._context.set_messages(new_messages)
+
+        # Reset the message-count trigger baseline: the preserved system
+        # message and the newly injected summary message don't count toward
+        # max_unsummarized_messages.
+        self._messages_since_summary_baseline = num_system_preserved + 1
 
         # Messages actually summarized = index range minus the preserved system message
         summarized_count = last_summarized_index + 1 - num_system_preserved

--- a/tests/test_llm_context_summarizer.py
+++ b/tests/test_llm_context_summarizer.py
@@ -760,6 +760,136 @@ class TestLLMContextSummarizer(unittest.IsolatedAsyncioTestCase):
 
         await summarizer.cleanup()
 
+    async def _check_trigger(self, summarizer) -> bool:
+        """Run one threshold check and report whether a summary was requested."""
+        requested = False
+
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal requested
+            requested = True
+
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+        return requested
+
+    async def test_message_count_excludes_system_message_only_when_present(self):
+        """The message threshold counts conversation messages, not the system message."""
+        config = LLMAutoContextSummarizationConfig(
+            max_context_tokens=100000,
+            max_unsummarized_messages=5,
+        )
+
+        # With a leading system message, 5 conversation messages trigger.
+        summarizer = LLMContextSummarizer(context=self.context, config=config)
+        await summarizer.setup(frame_processor_setup(self.task_manager))
+        for i in range(4):
+            self.context.add_message({"role": "user", "content": f"Message {i}"})
+        self.assertFalse(await self._check_trigger(summarizer))
+        self.context.add_message({"role": "user", "content": "Message 4"})
+        self.assertTrue(await self._check_trigger(summarizer))
+        await summarizer.cleanup()
+
+        # Without one, 5 conversation messages still trigger.
+        context = LLMContext()
+        summarizer = LLMContextSummarizer(context=context, config=config)
+        await summarizer.setup(frame_processor_setup(self.task_manager))
+        for i in range(4):
+            context.add_message({"role": "user", "content": f"Message {i}"})
+        self.assertFalse(await self._check_trigger(summarizer))
+        context.add_message({"role": "user", "content": "Message 4"})
+        self.assertTrue(await self._check_trigger(summarizer))
+        await summarizer.cleanup()
+
+    async def test_message_count_resets_after_summary(self):
+        """After a summary, only messages added since it count toward the threshold."""
+        config = LLMAutoContextSummarizationConfig(
+            max_context_tokens=100000,
+            max_unsummarized_messages=5,
+            summary_config=LLMContextSummaryConfig(min_messages_after_summary=2),
+        )
+
+        summarizer = LLMContextSummarizer(context=self.context, config=config)
+        await summarizer.setup(frame_processor_setup(self.task_manager))
+
+        request_frame = None
+
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal request_frame
+            request_frame = frame
+
+        for i in range(5):
+            self.context.add_message({"role": "user", "content": f"Message {i}"})
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+        self.assertIsNotNone(request_frame)
+
+        # Summarize messages 1..3, keeping the last two. The context becomes
+        # [system, summary, Message 3, Message 4].
+        await summarizer.process_frame(
+            LLMContextSummaryResultFrame(
+                request_id=request_frame.request_id,
+                summary="Summary.",
+                last_summarized_index=3,
+            )
+        )
+        self.assertEqual(len(self.context.messages), 4)
+
+        # Two kept messages plus two new ones is below the threshold of five.
+        for i in range(2):
+            self.context.add_message({"role": "user", "content": f"New message {i}"})
+        self.assertFalse(await self._check_trigger(summarizer))
+
+        # The fifth conversation message since the summary triggers again.
+        self.context.add_message({"role": "user", "content": "New message 2"})
+        self.assertTrue(await self._check_trigger(summarizer))
+
+        await summarizer.cleanup()
+
+    async def test_message_count_resets_when_context_replaced(self):
+        """Replacing the context after a summary drops the summary from the count."""
+        config = LLMAutoContextSummarizationConfig(
+            max_context_tokens=100000,
+            max_unsummarized_messages=5,
+            summary_config=LLMContextSummaryConfig(min_messages_after_summary=2),
+        )
+
+        summarizer = LLMContextSummarizer(context=self.context, config=config)
+        await summarizer.setup(frame_processor_setup(self.task_manager))
+
+        request_frame = None
+
+        @summarizer.event_handler("on_request_summarization")
+        async def on_request_summarization(summarizer, frame):
+            nonlocal request_frame
+            request_frame = frame
+
+        for i in range(5):
+            self.context.add_message({"role": "user", "content": f"Message {i}"})
+        await summarizer.process_frame(LLMFullResponseStartFrame())
+        await summarizer.process_frame(
+            LLMContextSummaryResultFrame(
+                request_id=request_frame.request_id,
+                summary="Summary.",
+                last_summarized_index=3,
+            )
+        )
+
+        # A fresh conversation with no summary message: every message counts.
+        self.context.set_messages(
+            [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Message 0"},
+                {"role": "user", "content": "Message 1"},
+                {"role": "user", "content": "Message 2"},
+                {"role": "user", "content": "Message 3"},
+            ]
+        )
+        self.assertFalse(await self._check_trigger(summarizer))
+        self.context.add_message({"role": "user", "content": "Message 4"})
+        self.assertTrue(await self._check_trigger(summarizer))
+
+        await summarizer.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #5504

## Summary
`LLMContextSummarizer._should_summarize()` was calculating unsummarized messages using `len(context.messages) - 1`. The issue was that this calculation never reset after running a summary, and it blindly assumed a leading system message was always present.

Because of this, `max_unsummarized_messages` was effectively evaluating total context size rather than new messages. It also caused context summarization to loop continuously, as the newly injected summary message was counted as a fresh turn and immediately triggered another summary.

## Fix
Following the fix suggested in #5504:
- Replaced the hardcoded `- 1` with a `_messages_since_summary_baseline` marker to track state accurately.
- Updated `_apply_summary()` to reset the baseline to `num_system_preserved + 1`, accounting for both the preserved system message and the newly added summary message.
- Updated `_should_summarize()` to compute `messages_since_summary` against this new baseline instead of `len(messages) - 1`.

*Note: This PR only addresses the message-count trigger. The related token-trigger issue (#5505) is intentionally left out and will be handled separately.*

## Test plan
- [x] `uv run pytest tests/test_llm_context_summarizer.py tests/test_context_summarization.py`
- [x] Verified manually that summaries no longer re-trigger immediately after running.