### PR TITLE
fix(workers): remove readiness watches when the wait ends

### DIFF
--- a/changelog/5650.fixed.md
+++ b/changelog/5650.fixed.md
@@ -1,0 +1,3 @@
+- Fixed a watch-handler leak in the worker registry. `job()`, `job_group()`, `request_job()` and `request_job_group()` each installed a readiness watch that was never removed, on the success path as much as on timeout, so a long-running worker accumulated one handler and one `asyncio.Event` per request and every later watch and registration for that worker name paid a longer scan:
+  - `WorkerRegistry` gains `unwatch(worker_name, handler)`, and the readiness wait now removes its handlers on every exit: ready, timed out, or cancelled.
+  - `WorkerRegistry` notifies watchers over a snapshot of its handler list, so a handler that unwatches while a notification is running no longer causes the handler after it to be skipped.

--- a/src/pipecat/registry/registry.py
+++ b/src/pipecat/registry/registry.py
@@ -101,6 +101,30 @@ class WorkerRegistry:
         if existing:
             await handler(existing)
 
+    def unwatch(self, worker_name: str, handler: WatchHandler) -> None:
+        """Stop watching for a worker's registration.
+
+        Tolerant: unwatching a handler that is not registered, or a worker
+        name that was never watched, is a no-op.
+
+        Because :meth:`watch` deduplicates by handler identity, a name and
+        handler pair has a single registration: unwatching it removes the
+        watch for every caller that installed it.
+
+        Args:
+            worker_name: The worker name the handler was watching.
+            handler: The handler passed to :meth:`watch`.
+        """
+        handlers = self._watches.get(worker_name)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            return
+        if not handlers:
+            del self._watches[worker_name]
+
     async def register(self, worker_data: WorkerReadyData) -> bool:
         """Register a worker. Returns True if the worker was new.
 
@@ -134,6 +158,10 @@ class WorkerRegistry:
         return True
 
     async def _notify(self, worker_data: WorkerReadyData) -> None:
-        """Notify watchers of a new registration."""
-        for handler in self._watches.get(worker_data.worker_name, []):
+        """Notify watchers of a new registration.
+
+        Iterates a snapshot: a handler may unwatch while this runs, and
+        mutating the list mid-iteration would skip the handler after it.
+        """
+        for handler in list(self._watches.get(worker_data.worker_name, ())):
             await handler(worker_data)

--- a/src/pipecat/workers/base_worker.py
+++ b/src/pipecat/workers/base_worker.py
@@ -1092,9 +1092,8 @@ class BaseWorker(BaseObject, BusSubscriber):
             timeout=timeout,
             cancel_on_error=cancel_on_error,
         )
-        all_ready = await self._wait_workers_ready(worker_names)
         try:
-            await asyncio.wait_for(all_ready, timeout=group_params.timeout)
+            await self._wait_workers_ready(worker_names, timeout=group_params.timeout)
         except TimeoutError:
             raise JobGroupError("workers not ready within timeout")
 
@@ -1538,29 +1537,46 @@ class BaseWorker(BaseObject, BusSubscriber):
 
         return group
 
-    async def _wait_workers_ready(self, worker_names: list[str]) -> asyncio.Future:
-        """Return a future that resolves when all named workers are ready.
+    async def _wait_workers_ready(
+        self, worker_names: list[str], *, timeout: float | None = None
+    ) -> None:
+        """Wait until all the named workers are registered as ready.
 
-        Callers can race the returned future against a timeout or group
-        done signal.
+        The readiness watches are removed before returning on every path
+        (ready, timed out, or cancelled), so repeated job requests do not
+        accumulate watches on the registry.
+
+        Args:
+            worker_names: Names of the workers to wait for.
+            timeout: Seconds to wait for, or None to wait indefinitely.
 
         Raises:
             RuntimeError: If the registry is not available.
+            TimeoutError: If the workers are not all ready within ``timeout``.
         """
         if not self._registry:
             raise RuntimeError(f"Worker '{self}': registry not available")
 
         ready_events: dict[str, asyncio.Event] = {}
-        for name in worker_names:
-            event = asyncio.Event()
-            ready_events[name] = event
+        watches = []
+        try:
+            for name in worker_names:
+                event = asyncio.Event()
+                ready_events[name] = event
 
-            async def _on_ready(data, ev=event):
-                ev.set()
+                async def _on_ready(data, ev=event):
+                    ev.set()
 
-            await self._registry.watch(name, _on_ready)
+                # Recorded before watching so a mid-loop failure still unwatches.
+                watches.append((name, _on_ready))
+                await self._registry.watch(name, _on_ready)
 
-        return asyncio.ensure_future(asyncio.gather(*(ev.wait() for ev in ready_events.values())))
+            await asyncio.wait_for(
+                asyncio.gather(*(ev.wait() for ev in ready_events.values())), timeout=timeout
+            )
+        finally:
+            for name, handler in watches:
+                self._registry.unwatch(name, handler)
 
     async def _send_job_request(
         self,

--- a/tests/test_base_worker.py
+++ b/tests/test_base_worker.py
@@ -29,7 +29,12 @@ from pipecat.bus import (
 )
 from pipecat.bus.subscriber import BusSubscriber
 from pipecat.frames.frames import EndFrame, Frame, TextFrame, TTSSpeakFrame
-from pipecat.pipeline.job_context import JobGroupParams, JobParams, JobStatus
+from pipecat.pipeline.job_context import (
+    JobGroupError,
+    JobGroupParams,
+    JobParams,
+    JobStatus,
+)
 from pipecat.pipeline.job_decorator import job
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineWorker
@@ -1318,6 +1323,51 @@ class TestJobLifecycle(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request_msgs[0].job_id, job_id)
         self.assertEqual(request_msgs[0].target, "worker")
         self.assertEqual(request_msgs[0].payload, {"key": "val"})
+
+    async def test_repeated_requests_do_not_accumulate_watches(self):
+        """A ready worker's watch list stays empty across repeated requests."""
+        parent = await self._attach(BaseWorker("parent"))
+        await self.registry.register(WorkerReadyData(worker_name="worker", runner="test-runner"))
+
+        for _ in range(5):
+            await parent.request_job("worker", params=JobParams(payload={"k": "v"}))
+
+        self.assertNotIn("worker", self.registry._watches)
+
+    async def test_timed_out_requests_do_not_accumulate_watches(self):
+        """A request that times out waiting for a worker removes its watch."""
+        parent = await self._attach(BaseWorker("parent"))
+
+        for _ in range(5):
+            with self.assertRaises(JobGroupError):
+                await parent.request_job("ghost", params=JobParams(timeout=0.01))
+
+        self.assertNotIn("ghost", self.registry._watches)
+
+    async def test_cancelled_request_does_not_leave_a_watch(self):
+        """Cancelling a request while it waits for a worker removes its watch."""
+        parent = await self._attach(BaseWorker("parent"))
+
+        pending = asyncio.ensure_future(parent.request_job("ghost", params=JobParams()))
+        await asyncio.sleep(0)
+        # Cancelling before the watch exists would make this test vacuous.
+        self.assertEqual(len(self.registry._watches["ghost"]), 1)
+
+        pending.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await pending
+
+        self.assertNotIn("ghost", self.registry._watches)
+
+    async def test_job_group_removes_every_watch_it_installed(self):
+        """A group waiting on several workers cleans up all of their watches."""
+        parent = await self._attach(BaseWorker("parent"))
+        await register_tasks(self.registry, "w1", "w2")
+
+        await parent.request_job_group("w1", "w2", params=JobGroupParams(payload={"a": 1}))
+
+        self.assertNotIn("w1", self.registry._watches)
+        self.assertNotIn("w2", self.registry._watches)
 
     async def test_request_job_group_multiple_tasks(self):
         """request_job_group() with multiple tasks sends messages for each."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -164,6 +164,52 @@ class TestTaskRegistry(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(received), 1)
         self.assertIs(received[0], data)
 
+    async def test_unwatch_removes_the_handler(self):
+        """An unwatched handler no longer fires when the worker registers."""
+        received = []
+
+        async def handler(worker_data):
+            received.append(worker_data)
+
+        await self.registry.watch("greeter", handler)
+        self.registry.unwatch("greeter", handler)
+        await self.registry.register(WorkerReadyData(worker_name="greeter", runner="runner_a"))
+
+        self.assertEqual(received, [])
+        self.assertNotIn("greeter", self.registry._watches)
+
+    async def test_unwatch_unknown_handler_or_worker_is_a_no_op(self):
+        """Unwatching something that was never watched does nothing."""
+        received = []
+
+        async def handler(worker_data):
+            received.append(worker_data)
+
+        self.registry.unwatch("never-watched", handler)
+        await self.registry.watch("greeter", handler)
+        self.registry.unwatch("greeter", handler)
+        self.registry.unwatch("greeter", handler)  # already removed
+        await self.registry.register(WorkerReadyData(worker_name="greeter", runner="runner_a"))
+
+        self.assertEqual(received, [])
+        self.assertNotIn("never-watched", self.registry._watches)
+
+    async def test_handler_removed_while_notifying_does_not_skip_the_next(self):
+        """Unwatching during a notification still lets later handlers fire."""
+        seen = []
+
+        async def removes_itself(worker_data):
+            self.registry.unwatch("greeter", removes_itself)
+
+        async def after(worker_data):
+            seen.append(worker_data)
+
+        await self.registry.watch("greeter", removes_itself)
+        await self.registry.watch("greeter", after)
+        await self.registry.register(WorkerReadyData(worker_name="greeter", runner="runner_a"))
+
+        self.assertEqual(len(seen), 1)
+
     async def test_runner_name_property(self):
         """runner_name returns the name passed at construction."""
         self.assertEqual(self.registry.runner_name, "runner_a")

--- a/tests/test_ui_job_lifecycle.py
+++ b/tests/test_ui_job_lifecycle.py
@@ -324,10 +324,8 @@ def _stub_job_group(worker, job_id="t1", worker_names=("w1",)):
     ``group_completed`` emission) is the production code too.
     """
 
-    async def _ready(names):
-        fut = asyncio.get_running_loop().create_future()
-        fut.set_result(True)
-        return fut
+    async def _ready(names, *, timeout=None):
+        return None
 
     async def _send(worker_name, jid, job_name=None, payload=None):
         pass


### PR DESCRIPTION
## Problem

The job request APIs wait for the target worker to register before sending. That wait installs a watch handler on the registry for each name, and nothing takes it off again on any path, so `job()`, `job_group()`, `request_job()` and `request_job_group()` each leave a handler and an `asyncio.Event` behind. This happens on the success path just as much as on timeout, and the registry has no removal call at all, so nothing reclaims them. A worker that delegates on every turn grows the watch list for the life of the runner, and each later watch or registration for that name walks a longer list.

## Changes

`WorkerRegistry` gets `unwatch(worker_name, handler)`, shaped like the bus `unsubscribe` next to it: tolerant of a handler that is not registered, and it drops the entry once the last handler goes. `_wait_workers_ready` now owns the whole wait rather than handing back a future, so it can remove its handlers in a `finally` that covers ready, timed out and cancelled. `_notify` walks a snapshot of the handler list, since a handler can now unwatch while a notification is running and mutating the list mid iteration would skip the handler after it.