### PR TITLE
fix(openai): preserve Responses WebSocket failure metadata

### DIFF
--- a/changelog/5575.fixed.md
+++ b/changelog/5575.fixed.md
@@ -1,0 +1,1 @@
+- Fixed OpenAI Responses WebSocket failures dropping the provider response id and error code, and classify known provider failures for error handlers.

--- a/src/pipecat/services/openai/responses/llm.py
+++ b/src/pipecat/services/openai/responses/llm.py
@@ -64,6 +64,7 @@ from pipecat.services.llm_service import (
     WebsocketReconnectedError,
 )
 from pipecat.services.settings import LLMSettings
+from pipecat.utils.errors import classify_openai_response_error_code
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 
@@ -1174,12 +1175,31 @@ class OpenAIResponsesLLMService(
 
                 break  # Response complete
 
-            elif event_type in ("response.failed", "response.incomplete"):
-                response = event.get("response", {})
-                status_details = response.get("status_details") or {}
-                error_info = status_details.get("error") or {}
-                error_msg = error_info.get("message", f"Response {event_type.split('.')[-1]}")
-                await self.push_error(error_msg=f"LLM response error: {error_msg}")
+            elif event_type == "response.failed":
+                response = event.get("response") or {}
+                error_info = response.get("error") or {}
+                message = error_info.get("message") or "Response failed"
+                response_id = response.get("id")
+                code = error_info.get("code")
+                metadata = ", ".join(
+                    detail
+                    for detail in (
+                        f"response_id={response_id}" if response_id else "",
+                        f"code={code}" if code else "",
+                    )
+                    if detail
+                )
+                await self.push_error(
+                    error_msg=f"LLM response error{' [' + metadata + ']' if metadata else ''}: {message}",
+                    category=classify_openai_response_error_code(code),
+                )
+                break
+
+            elif event_type == "response.incomplete":
+                response = event.get("response") or {}
+                details = response.get("incomplete_details") or {}
+                reason = details.get("reason") or "Response incomplete"
+                await self.push_error(error_msg=f"LLM response error: {reason}")
                 break
 
             elif event_type == "error":

--- a/src/pipecat/utils/errors.py
+++ b/src/pipecat/utils/errors.py
@@ -16,6 +16,7 @@ from enum import Enum
 
 __all__ = [
     "ErrorCategory",
+    "classify_openai_response_error_code",
     "classify_http_exception",
     "classify_http_status_code",
     "extract_http_status_code",
@@ -79,6 +80,29 @@ _HTTP_STATUS_CODE_CATEGORIES = {
     429: ErrorCategory.RATE_LIMIT,
 }
 
+_OPENAI_RESPONSE_ERROR_CODE_CATEGORIES = {
+    "server_error": ErrorCategory.SERVER,
+    "vector_store_timeout": ErrorCategory.SERVER,
+    "rate_limit_exceeded": ErrorCategory.RATE_LIMIT,
+    "invalid_prompt": ErrorCategory.INVALID_REQUEST,
+    "data_residency_mismatch": ErrorCategory.INVALID_REQUEST,
+    "bio_policy": ErrorCategory.INVALID_REQUEST,
+    "invalid_image": ErrorCategory.INVALID_REQUEST,
+    "invalid_image_format": ErrorCategory.INVALID_REQUEST,
+    "invalid_base64_image": ErrorCategory.INVALID_REQUEST,
+    "invalid_image_url": ErrorCategory.INVALID_REQUEST,
+    "image_too_large": ErrorCategory.INVALID_REQUEST,
+    "image_too_small": ErrorCategory.INVALID_REQUEST,
+    "image_parse_error": ErrorCategory.INVALID_REQUEST,
+    "image_content_policy_violation": ErrorCategory.INVALID_REQUEST,
+    "invalid_image_mode": ErrorCategory.INVALID_REQUEST,
+    "image_file_too_large": ErrorCategory.INVALID_REQUEST,
+    "unsupported_image_media_type": ErrorCategory.INVALID_REQUEST,
+    "empty_image_file": ErrorCategory.INVALID_REQUEST,
+    "failed_to_download_image": ErrorCategory.INVALID_REQUEST,
+    "image_file_not_found": ErrorCategory.INVALID_REQUEST,
+}
+
 _CONNECTIVITY_EXCEPTIONS = (ConnectionError, TimeoutError, socket.gaierror)
 
 
@@ -98,6 +122,19 @@ def classify_http_status_code(status_code: int) -> ErrorCategory:
     if 500 <= status_code < 600:
         return ErrorCategory.SERVER
     return ErrorCategory.UNKNOWN
+
+
+def classify_openai_response_error_code(code: str | None) -> ErrorCategory:
+    """Classify an OpenAI Responses API error code.
+
+    Args:
+        code: The code carried by a Responses API ``response.failed`` event.
+
+    Returns:
+        The matching category, or `ErrorCategory.UNKNOWN` for a missing or
+        unrecognized provider code.
+    """
+    return _OPENAI_RESPONSE_ERROR_CODE_CATEGORIES.get(code, ErrorCategory.UNKNOWN)
 
 
 def extract_http_status_code(exception: BaseException) -> int | None:

--- a/tests/test_openai_responses_websocket.py
+++ b/tests/test_openai_responses_websocket.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pipecat.frames.frames import (
+    ErrorFrame,
     LLMMessagesAppendFrame,
     LLMThoughtEndFrame,
     LLMThoughtStartFrame,
@@ -24,6 +25,7 @@ from pipecat.services.openai.responses.llm import (
     OpenAIResponsesLLMService,
     _model_supports_reasoning,
 )
+from pipecat.utils.errors import ErrorCategory
 
 
 def _make_service(**kwargs):
@@ -513,16 +515,14 @@ class TestReceiveResponseEventsErrors:
         service = _make_service()
         service.stop_ttfb_metrics = AsyncMock()
         service.start_llm_usage_metrics = AsyncMock()
-        service.push_error = AsyncMock()
+        service.push_error_frame = AsyncMock()
 
         ws = _ws_events(
             {
                 "type": "response.failed",
                 "response": {
                     "id": "resp_1",
-                    "status_details": {
-                        "error": {"message": "Content filter triggered"},
-                    },
+                    "error": {"code": "server_error", "message": "Content filter triggered"},
                 },
             },
         )
@@ -531,8 +531,35 @@ class TestReceiveResponseEventsErrors:
         context = MagicMock(spec=LLMContext)
         await service._receive_response_events(context, [])
 
-        service.push_error.assert_called_once()
-        assert "Content filter triggered" in service.push_error.call_args.kwargs["error_msg"]
+        service.push_error_frame.assert_called_once()
+        error_frame = service.push_error_frame.call_args.kwargs["error"]
+        assert isinstance(error_frame, ErrorFrame)
+        assert "Content filter triggered" in error_frame.error
+        assert "resp_1" in error_frame.error
+        assert "server_error" in error_frame.error
+        assert error_frame.category == ErrorCategory.SERVER
+
+    @pytest.mark.asyncio
+    async def test_response_failed_with_sparse_payload_uses_generic_unknown_error(self):
+        service = _make_service()
+        service.stop_ttfb_metrics = AsyncMock()
+        service.start_llm_usage_metrics = AsyncMock()
+        service.push_error_frame = AsyncMock()
+
+        service._websocket = _ws_events(
+            {
+                "type": "response.failed",
+                "response": {},
+            },
+        )
+
+        context = MagicMock(spec=LLMContext)
+        await service._receive_response_events(context, [])
+
+        service.push_error_frame.assert_called_once()
+        error_frame = service.push_error_frame.call_args.kwargs["error"]
+        assert error_frame.error == "LLM response error: Response failed"
+        assert error_frame.category == ErrorCategory.UNKNOWN
 
     @pytest.mark.asyncio
     async def test_response_incomplete_pushes_error(self):

--- a/tests/test_processor_usable.py
+++ b/tests/test_processor_usable.py
@@ -20,6 +20,7 @@ from pipecat.utils.errors import (
     ErrorCategory,
     classify_http_exception,
     classify_http_status_code,
+    classify_openai_response_error_code,
     extract_http_status_code,
 )
 
@@ -62,6 +63,21 @@ class TestErrorClassification(unittest.TestCase):
     def test_unremarkable_status_codes_are_unknown(self):
         for status_code in (200, 301, 418, 600):
             self.assertEqual(classify_http_status_code(status_code), ErrorCategory.UNKNOWN)
+
+    def test_openai_response_error_codes_map_to_categories(self):
+        cases = {
+            "server_error": ErrorCategory.SERVER,
+            "vector_store_timeout": ErrorCategory.SERVER,
+            "rate_limit_exceeded": ErrorCategory.RATE_LIMIT,
+            "invalid_prompt": ErrorCategory.INVALID_REQUEST,
+            "invalid_image": ErrorCategory.INVALID_REQUEST,
+            "future_openai_code": ErrorCategory.UNKNOWN,
+            None: ErrorCategory.UNKNOWN,
+        }
+
+        for code, category in cases.items():
+            with self.subTest(code=code):
+                self.assertEqual(classify_openai_response_error_code(code), category)
 
     def test_extracts_status_code_from_websocket_rejection(self):
         self.assertEqual(extract_http_status_code(websocket_rejection(401)), 401)


### PR DESCRIPTION
## Description

I preserve the response id and provider code from WebSocket `response.failed` events, then map known OpenAI Responses codes into `ErrorCategory`. Sparse and unrecognized failures keep the generic `UNKNOWN` path.

Fixes #5575

## Why

Error handlers can now distinguish server, rate-limit, and invalid-request failures without changing reconnect or retry behavior.

## Verification

- before, on current `main`: `uv run pytest tests/test_openai_responses_websocket.py::TestReceiveResponseEventsErrors::test_response_failed_pushes_error tests/test_openai_responses_websocket.py::TestReceiveResponseEventsErrors::test_response_failed_with_sparse_payload_uses_generic_unknown_error` failed because the WebSocket error was generic and had no category.
- after: `uv run pytest tests/test_openai_responses_websocket.py tests/test_openai_responses_http.py tests/test_processor_usable.py` passes.
