### PR TITLE
fix(tts): deliver the LLMFullResponseEndFrame of turns that produce no audio

### DIFF
--- a/changelog/5654.fixed.md
+++ b/changelog/5654.fixed.md
@@ -1,0 +1,7 @@
+A `TTSService` with `push_text_frames=False` no longer drops the
+`LLMFullResponseEndFrame` of an LLM turn that produces no audio. The frame is
+held in `process_frame` and re-pushed by `_maybe_reset_word_timestamps` at the
+end of the turn's audio context, so a tool-only or empty response — which never
+reaches `run_tts` and therefore opens no audio context — never had its end frame
+delivered. Processors downstream of the TTS, including `LLMAssistantAggregator`,
+saw the turn start and never saw it end.

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -721,6 +721,13 @@ class TTSService(AIService):
 
     async def on_turn_context_completed(self):
         """Handle the completion of a turn."""
+        # Captured before the reset below, so the silent-turn flush at the end
+        # can still identify the turn whose end frame is held.
+        turn_context_id = self._turn_context_id
+        had_audio_context = bool(turn_context_id) and self.audio_context_available(
+            turn_context_id
+        )
+
         # For HTTP services they emit the frames synchronously, so close the audio context here
         # once all frames (including TTSTextFrame above) have been enqueued.
         if (
@@ -744,6 +751,39 @@ class TTSService(AIService):
 
         # Reset the turn context ID
         self._turn_context_id = None
+
+        await self._maybe_flush_silent_turn_end_frame(turn_context_id, had_audio_context)
+
+    async def _maybe_flush_silent_turn_end_frame(
+        self, turn_context_id: str | None, had_audio_context: bool
+    ):
+        """Emit the held LLMFullResponseEndFrame for a turn that produced no audio.
+
+        When ``push_text_frames`` is False, ``process_frame`` holds the end frame in
+        ``_pending_llm_response_end_frames`` and ``_maybe_reset_word_timestamps``
+        re-pushes it at the end of that turn's audio context. A tool-only or empty
+        LLM response never reaches ``run_tts``, so it has no audio context, that
+        method never runs for it, and the frame is dropped: downstream processors
+        see the turn start and never see it end.
+
+        Args:
+            turn_context_id: The turn context that just completed.
+            had_audio_context: Whether that turn had opened an audio context.
+        """
+        if had_audio_context or not turn_context_id:
+            # Audible turn: _maybe_reset_word_timestamps re-pushes the frame when
+            # this turn's audio ends, with the PTS of the last word frame.
+            return
+
+        # A TTSSpeakFrame also completes a turn context, but under a fresh context
+        # ID that is never a key here, so this no-ops for that path.
+        frame = self._pending_llm_response_end_frames.pop(turn_context_id, None)
+        if frame is None or not self._llm_response_started:
+            return
+
+        self._llm_response_started = False
+        frame.pts = self._word_last_pts
+        await self.push_frame(frame)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         """Process frames for text-to-speech conversion.

--- a/tests/test_tts_silent_turn_end_frame.py
+++ b/tests/test_tts_silent_turn_end_frame.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests that every LLM turn ends downstream, including the ones that say nothing.
+
+With ``push_text_frames=False`` the ``LLMFullResponseEndFrame`` is not forwarded
+when it arrives: ``process_frame`` holds it in
+``_pending_llm_response_end_frames`` so ``_maybe_reset_word_timestamps`` can
+re-push it, with the PTS of the last word frame, at the end of that turn's audio
+context.
+
+A tool-only or empty LLM response never reaches ``run_tts``, so it opens no audio
+context and that method never runs for it. Without the flush in
+``on_turn_context_completed`` the held frame is dropped, and any processor
+downstream of the TTS — including ``LLMAssistantAggregator``, which uses the end
+frame as a turn boundary — sees the turn start and never sees it end.
+"""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from pipecat.frames.frames import (
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    TextFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+)
+from pipecat.services.settings import TTSSettings
+from pipecat.services.tts_service import TTSService
+from pipecat.tests.utils import SleepFrame, run_test
+
+_FAKE_AUDIO = b"\x00\x01" * 320
+_SAMPLE_RATE = 16000
+
+
+class MockTTSService(TTSService):
+    """HTTP-style TTS service that speaks whatever text reaches it."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            push_start_frame=True,
+            push_stop_frames=True,
+            push_text_frames=False,
+            sample_rate=_SAMPLE_RATE,
+            settings=TTSSettings(model=None, voice=None, language=None),
+            **kwargs,
+        )
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame | None, None]:
+        yield TTSAudioRawFrame(_FAKE_AUDIO, _SAMPLE_RATE, 1)
+
+
+async def _run(frames) -> list[Frame]:
+    received_down, _ = await run_test(
+        MockTTSService(), frames_to_send=frames, expected_down_frames=None
+    )
+    return list(received_down)
+
+
+def _end_frames(frames) -> list[LLMFullResponseEndFrame]:
+    return [f for f in frames if isinstance(f, LLMFullResponseEndFrame)]
+
+
+@pytest.mark.asyncio
+async def test_audible_turn_ends_downstream():
+    """The existing path: the end frame rides out with the turn's audio."""
+    received = await _run(
+        [
+            LLMFullResponseStartFrame(),
+            TextFrame("Hello there."),
+            LLMFullResponseEndFrame(),
+            SleepFrame(1.0),
+        ]
+    )
+
+    assert len(_end_frames(received)) == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_only_turn_ends_downstream():
+    """A turn with no text opens no audio context, so nothing else re-pushes it."""
+    received = await _run([LLMFullResponseStartFrame(), LLMFullResponseEndFrame(), SleepFrame(1.0)])
+
+    assert len(_end_frames(received)) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_silent_turn_between_audible_ones_ends_exactly_once():
+    """Each turn is delivered once, and the silent one does not borrow its
+    neighbour's audio context to get out."""
+    received = await _run(
+        [
+            LLMFullResponseStartFrame(),
+            TextFrame("First."),
+            LLMFullResponseEndFrame(),
+            SleepFrame(0.5),
+            LLMFullResponseStartFrame(),
+            LLMFullResponseEndFrame(),
+            SleepFrame(0.5),
+            LLMFullResponseStartFrame(),
+            TextFrame("Third."),
+            LLMFullResponseEndFrame(),
+            SleepFrame(1.0),
+        ]
+    )
+
+    assert len(_end_frames(received)) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_tts_speak_frame_does_not_emit_a_turn_end():
+    """TTSSpeakFrame completes a turn context too, under a fresh context ID that
+    is never a key in the held-frame dict. It must not synthesise a turn end."""
+    received = await _run([TTSSpeakFrame("Standalone."), SleepFrame(1.0)])
+
+    assert _end_frames(received) == []
+
+
+@pytest.mark.asyncio
+async def test_the_original_end_frame_is_delivered_not_a_replacement():
+    """Observers dedup by frame id, which is why the held frame is re-pushed
+    rather than a fresh one being emitted."""
+    end_frame = LLMFullResponseEndFrame()
+
+    received = await _run([LLMFullResponseStartFrame(), end_frame, SleepFrame(1.0)])
+
+    delivered = _end_frames(received)
+    assert len(delivered) == 1
+    assert delivered[0].id == end_frame.id


### PR DESCRIPTION
Fixes #5654.

### The problem

With `push_text_frames=False`, `process_frame` does not forward the `LLMFullResponseEndFrame` when it arrives — it holds it in `_pending_llm_response_end_frames` so `_maybe_reset_word_timestamps` can re-push it, with the PTS of the last word frame, at the end of that turn's audio context.

A tool-only or empty LLM response never reaches `run_tts`, so it opens no audio context, `_handle_audio_context` never runs for it, and the held frame is never delivered — `_handle_interruption` eventually clears it. Everything downstream of the TTS sees the turn start and never sees it end. That includes `LLMAssistantAggregator`, which uses the end frame as a turn boundary.

`CartesiaTTSService` hard-codes `push_text_frames=False`, so every Cartesia pipeline is affected by default.

The issue has a self-contained repro (no provider credentials — a bare `TTSService` subclass is enough). On `main` today it prints:

```
audible turn -> LLMFullResponseEndFrame downstream: 1  (expect 1)
silent  turn -> LLMFullResponseEndFrame downstream: 0  (expect 1)
```

### The fix

`on_turn_context_completed` is where the turn is known to be over, and it already tests `audio_context_available` — so it covers exactly the turns `_maybe_reset_word_timestamps` cannot reach. The flush is a separate method purely to keep the existing body untouched and reviewable.

Details worth checking:

- **The turn context id is captured first.** The existing body clears `_turn_context_id` at its end, so the flush would otherwise have nothing to look up.
- **`TTSSpeakFrame` no-ops.** That path also calls `on_turn_context_completed`, but under a fresh context id that is never a key in `_pending_llm_response_end_frames`, so the `pop` returns `None`. There is a test for this.
- **No double emission.** The `_llm_response_started` check mirrors `_maybe_reset_word_timestamps`; whichever runs first clears the flag.
- **The original frame object is re-pushed**, not a replacement — matching the existing intent that observers dedup by `frame.id`. Also tested.

### Tests

New `tests/test_tts_silent_turn_end_frame.py`, in the shape of `test_tts_zero_audio_contexts.py`. All five fail on `main` in the ways you would expect (the audible control passes either way) and pass with the fix:

- an audible turn still ends downstream (control);
- a tool-only turn ends downstream;
- a silent turn between two audible ones ends exactly once — it does not borrow a neighbour's audio context to get out;
- a standalone `TTSSpeakFrame` does not synthesise a turn end;
- the frame delivered is the original object, by id.

The existing TTS suites (`test_tts_zero_audio_contexts.py`, `test_tts_frame_ordering.py`, `test_tts_interruptible_service.py`, `test_tts_processing_metrics.py`, `test_cartesia_tts.py` — 82 tests) pass unchanged.

Full `pytest tests/` on my machine is `3588 passed, 28 failed`, but the 28 are in `test_websocket_proxy.py` / `test_runner_utils.py` and fail identically with this commit reverted — unrelated to TTS. (28 collection errors are missing optional provider extras, e.g. `aws_sdk_sagemaker_runtime_http2`.)

### One thing I found but deliberately did not fix

`_maybe_reset_word_timestamps` falls back to a **fresh** `LLMFullResponseEndFrame()` when the pop misses:

```python
frame = self._pending_llm_response_end_frames.pop(context_id, None) or (
    LLMFullResponseEndFrame()
)
```

A `TTSSpeakFrame` emitted *inside* an LLM turn creates its own audio context, so that fallback fires with the speak frame's context id and pushes a spurious turn end before the real turn is over. It reproduces on `main` with and without this commit, so it is a separate bug — happy to file it, or fold it in here if you would rather have both at once.

### Impact this had for us

A gate in our pipeline defers an inference until the assistant aggregator has committed the preceding response to the LLM context. One tool-only turn left it closed permanently: a production session went silent for 165 s after the user typed a reply, and the user left. Only an `InterruptionFrame` — the user giving up and speaking — reopened it. Sessions where the user spoke looked healthy the whole time, because function-call result re-runs took a different path; only typed turns died.

We are running this as a subclass override against 1.4.0 in production and it resolves the stall.

---

Reproduced on `1.8.1` and `1.4.0`; the relevant code is unchanged between them and on `main`. Changelog fragment included.
