### PR TITLE
Default CrusoeLLMService to openai/gpt-oss-120b

### DIFF
--- a/changelog/5656.changed.md
+++ b/changelog/5656.changed.md
@@ -1,0 +1,1 @@
+- `CrusoeLLMService` now defaults to `openai/gpt-oss-120b`. The previous default was `zai/GLM-5.2`. Pass `settings=CrusoeLLMService.Settings(model=...)` to choose a different model.

--- a/src/pipecat/services/crusoe/llm.py
+++ b/src/pipecat/services/crusoe/llm.py
@@ -56,7 +56,7 @@ class CrusoeLLMService(OpenAILLMService):
         """
         # Initialize default_settings with hardcoded defaults
         default_settings = self.Settings(
-            model="zai/GLM-5.2",
+            model="openai/gpt-oss-120b",
         )
 
         # Apply settings delta (canonical API, always wins)


### PR DESCRIPTION
The previous default, `zai/GLM-5.2`, is deprecated.

## Summary

- `CrusoeLLMService` now defaults to `openai/gpt-oss-120b` instead of `zai/GLM-5.2`
- Pass `settings=CrusoeLLMService.Settings(model=...)` to select a different model