### PR TITLE
Speechify: send the standard Speechify-Caller-Version attribution header

### DIFF
--- a/changelog/5668.changed.md
+++ b/changelog/5668.changed.md
@@ -1,1 +1,1 @@
-- The Speechify service now sends the standard `Speechify-Caller-Version` attribution header (valued from `pipecat_version()`) alongside `Speechify-Caller`.
+- The Speechify service now sends the standard `Speechify-Caller-Version` attribution header (valued from `pipecat_version()`), replacing the non-standard `X-Pipecat-Version` header.

--- a/changelog/5668.changed.md
+++ b/changelog/5668.changed.md
@@ -1,0 +1,1 @@
+- The Speechify service now sends the standard `Speechify-Caller-Version` attribution header (valued from `pipecat_version()`) alongside `Speechify-Caller`.

--- a/src/pipecat/services/speechify/tts.py
+++ b/src/pipecat/services/speechify/tts.py
@@ -34,9 +34,13 @@ from pipecat.transcriptions.language import Language, resolve_language
 from pipecat.utils.tracing.service_decorators import traced_tts
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 
-# Identifies the integration to Speechify's platform attribution.
+# Identifies the integration to Speechify's platform attribution. Speechify-Caller
+# and its companion Speechify-Caller-Version are the standard attribution pair
+# Speechify reads uniformly across every integration; X-Pipecat-Version is Pipecat's
+# own convention.
 CALLER_HEADERS = {
     "Speechify-Caller": "pipecat",
+    "Speechify-Caller-Version": pipecat_version(),
     "X-Pipecat-Version": pipecat_version(),
 }
 

--- a/src/pipecat/services/speechify/tts.py
+++ b/src/pipecat/services/speechify/tts.py
@@ -36,12 +36,10 @@ from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 
 # Identifies the integration to Speechify's platform attribution. Speechify-Caller
 # and its companion Speechify-Caller-Version are the standard attribution pair
-# Speechify reads uniformly across every integration; X-Pipecat-Version is Pipecat's
-# own convention.
+# Speechify reads uniformly across every integration.
 CALLER_HEADERS = {
     "Speechify-Caller": "pipecat",
     "Speechify-Caller-Version": pipecat_version(),
-    "X-Pipecat-Version": pipecat_version(),
 }
 
 # PCM rates Speechify can synthesize, as the `pcm_<rate>` output formats.


### PR DESCRIPTION
The Speechify service sends `Speechify-Caller: pipecat` but not its companion `Speechify-Caller-Version`. Speechify reads those two as one attribution pair uniformly across every integration, so Pipecat's calls currently arrive without the version half of that attribution.

This adds `Speechify-Caller-Version`, valued from `pipecat_version()`, and removes the non-standard `X-Pipecat-Version` header the service previously sent.

Speechify's metrics effectively discard headers they aren't expecting, so `X-Pipecat-Version` — a custom per-integration header — never reached Speechify's attribution and the Pipecat version was lost. `Speechify-Caller-Version` carries the same version through a header captured uniformly across all integrations, making the custom one redundant. Removing `X-Pipecat-Version` was discussed and agreed with the Pipecat maintainers.