### PR TITLE
whisper: allow language=None to mean auto-detect

### DIFF
--- a/changelog/5645.fixed.md
+++ b/changelog/5645.fixed.md
@@ -1,3 +1,0 @@
-- Fixed `WhisperSTTService` raising `ValueError` at construction when `language=None` is set on a multilingual model. `None` asks Whisper to detect the language itself, which every model supports.
-
-- Fixed the `Model.DISTIL_LARGE_V2` and `MLXModel.DISTIL_LARGE_V3` Whisper models being documented as multilingual. Every Distil-Whisper release is English-only.

--- a/changelog/5645.fixed.md
+++ b/changelog/5645.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `WhisperSTTService` raising `ValueError` at construction when `language=None` is set on a multilingual model. `None` asks Whisper to detect the language itself, which every model supports.

--- a/changelog/5645.fixed.md
+++ b/changelog/5645.fixed.md
@@ -1,1 +1,3 @@
 - Fixed `WhisperSTTService` raising `ValueError` at construction when `language=None` is set on a multilingual model. `None` asks Whisper to detect the language itself, which every model supports.
+
+- Fixed the `Model.DISTIL_LARGE_V2` and `MLXModel.DISTIL_LARGE_V3` Whisper models being documented as multilingual. Every Distil-Whisper release is English-only.

--- a/changelog/5669.fixed.2.md
+++ b/changelog/5669.fixed.2.md
@@ -1,0 +1,1 @@
+- Fixed the `Model.DISTIL_LARGE_V2` and `MLXModel.DISTIL_LARGE_V3` Whisper models being documented as multilingual. Every Distil-Whisper release is English-only.

--- a/changelog/5669.fixed.md
+++ b/changelog/5669.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `WhisperSTTService` raising `ValueError` at construction when `Settings(language=None)` is paired with a multilingual model. `None` asks Whisper to detect the language itself, which every model supports; the language check previously looked `None` up in the model's supported-language list.

--- a/src/pipecat/services/whisper/stt.py
+++ b/src/pipecat/services/whisper/stt.py
@@ -62,7 +62,7 @@ class Model(StrEnum):
         MEDIUM: Medium-sized multilingual model, better quality.
         LARGE: Best quality multilingual model, slower inference.
         LARGE_V3_TURBO: Fast multilingual model, slightly lower quality than LARGE.
-        DISTIL_LARGE_V2: Fast multilingual distilled model.
+        DISTIL_LARGE_V2: Fast English-only distilled model.
         DISTIL_MEDIUM_EN: Fast English-only distilled model.
     """
 
@@ -73,9 +73,11 @@ class Model(StrEnum):
     MEDIUM = "medium"
     LARGE = "large-v3"
     LARGE_V3_TURBO = "deepdml/faster-whisper-large-v3-turbo-ct2"
-    DISTIL_LARGE_V2 = "Systran/faster-distil-whisper-large-v2"
 
-    # English-only models
+    # English-only models. The distilled models keep the multilingual tokenizer
+    # of their teacher, so the loaded model reports itself as multilingual and
+    # the language check can't reject a non-English language for them.
+    DISTIL_LARGE_V2 = "Systran/faster-distil-whisper-large-v2"
     DISTIL_MEDIUM_EN = "Systran/faster-distil-whisper-medium.en"
 
 
@@ -90,8 +92,8 @@ class MLXModel(StrEnum):
         MEDIUM: Medium-sized multilingual model for MLX.
         LARGE_V3: Best quality multilingual model for MLX.
         LARGE_V3_TURBO: Finetuned, pruned Whisper large-v3, much faster with slightly lower quality.
-        DISTIL_LARGE_V3: Fast multilingual distilled model for MLX.
         LARGE_V3_TURBO_Q4: LARGE_V3_TURBO quantized to Q4 for reduced memory usage.
+        DISTIL_LARGE_V3: Fast English-only distilled model for MLX.
     """
 
     # Multilingual models
@@ -99,8 +101,10 @@ class MLXModel(StrEnum):
     MEDIUM = "mlx-community/whisper-medium-mlx"
     LARGE_V3 = "mlx-community/whisper-large-v3-mlx"
     LARGE_V3_TURBO = "mlx-community/whisper-large-v3-turbo"
-    DISTIL_LARGE_V3 = "mlx-community/distil-whisper-large-v3"
     LARGE_V3_TURBO_Q4 = "mlx-community/whisper-large-v3-turbo-q4"
+
+    # English-only models
+    DISTIL_LARGE_V3 = "mlx-community/distil-whisper-large-v3"
 
 
 def language_to_whisper_language(language: Language) -> str:

--- a/src/pipecat/services/whisper/stt.py
+++ b/src/pipecat/services/whisper/stt.py
@@ -351,14 +351,17 @@ class WhisperSTTService(SegmentedSTTService):
         The English-only models (every ``.en`` one, including the default) accept
         any language and transcribe as English regardless, so a mismatch would
         otherwise surface as fluent-looking output in the wrong language rather
-        than as an error.
+        than as an error. A language of ``None`` asks Whisper to detect the
+        language itself, which every model supports.
 
         Returns:
             An explanatory message, or ``None`` when the pairing is usable.
         """
         supported = getattr(self._model, "supported_languages", None)
         language = self._settings.language
-        if not supported or not is_given(language) or language in supported:
+        if not supported or not is_given(language) or language is None:
+            return None
+        if language in supported:
             return None
         return (
             f"Whisper model '{assert_given(self._settings.model)}' cannot transcribe "

--- a/tests/test_whisper_stt_language.py
+++ b/tests/test_whisper_stt_language.py
@@ -49,6 +49,17 @@ def test_english_only_model_without_a_language_is_fine():
     assert service._settings.language == "en"
 
 
+def test_no_language_means_auto_detect_on_a_multilingual_model():
+    """``language=None`` hands language detection to Whisper rather than naming one."""
+    service = _build(["en", "es", "zh"], model="small", language=None)
+    assert service._settings.language is None
+
+
+def test_no_language_means_auto_detect_on_an_english_only_model():
+    service = _build(["en"], model="distil-medium.en", language=None)
+    assert service._settings.language is None
+
+
 def test_model_that_does_not_publish_languages_is_not_second_guessed():
     service = _build(None, model="custom", language=Language.ES)
     assert service._settings.language == "es"


### PR DESCRIPTION
## Summary

- Fixed `WhisperSTTService` raising `ValueError` at construction when `Settings(language=None)` is paired with a multilingual model. `None` asks Whisper to detect the language itself, which every model supports. The language guard now accepts it, both at construction and on a runtime settings update.
- Fixed `Model.DISTIL_LARGE_V2` and `MLXModel.DISTIL_LARGE_V3` being grouped and documented as multilingual. Every Distil-Whisper release is English-only. The distilled models keep their teacher's multilingual tokenizer, so the runtime language guard cannot reject a non-English language for them; the docstrings are where a user learns the limitation.

## Testing

- `uv run pytest tests/test_whisper_stt_language.py` covers `language=None` on both a multilingual and an English-only model
- `WhisperSTTService(settings=WhisperSTTService.Settings(model=Model.SMALL, language=None))` constructs without error