### PR TITLE
fix(xai): stop emitting the cumulative speech_final transcript twice

### DIFF
--- a/changelog/5672.fixed.md
+++ b/changelog/5672.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `XAISTTService` emitting the cumulative `speech_final` transcript as a second `TranscriptionFrame`, which duplicated utterance text for any consumer that accumulates finals.

--- a/src/pipecat/services/xai/stt.py
+++ b/src/pipecat/services/xai/stt.py
@@ -12,6 +12,7 @@ API documented at https://docs.x.ai/developers/rest-api-reference/inference/voic
 
 import asyncio
 import json
+import re
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any
@@ -166,6 +167,11 @@ class XAISTTService(WebsocketSTTService):
 
         self._receive_task: asyncio.Task | None = None
         self._session_ready = asyncio.Event()
+
+        # Per-utterance state for de-duplicating the cumulative speech_final
+        # transcript. See _unrepeated_final.
+        self._emitted_final_norm = ""
+        self._utterance_closed = True
 
     def can_generate_metrics(self) -> bool:
         """Check if the service can generate metrics.
@@ -341,10 +347,71 @@ class XAISTTService(WebsocketSTTService):
         else:
             logger.debug(f"{self} unhandled xAI STT message: {message}")
 
+    @staticmethod
+    def _norm(text: str) -> str:
+        """Alphanumerics only, lowercased: the comparable form of a transcript."""
+        return re.sub(r"[^a-z0-9]", "", (text or "").lower())
+
+    def _begin_utterance(self) -> None:
+        """Drop leftover de-duplication state when a new utterance starts.
+
+        An utterance does not always end with a speech_final: an endpointing
+        timeout or a dropped connection can end it after segment finals only.
+        Clearing here, and not just after a speech_final, keeps one
+        utterance's text from being subtracted from the next one's.
+        """
+        if self._utterance_closed:
+            self._emitted_final_norm = ""
+            self._utterance_closed = False
+
+    def _unrepeated_final(self, cumulative: str) -> str:
+        """The part of a speech_final transcript not already emitted.
+
+        xAI sends a final per segment as speech arrives, then restates the
+        ENTIRE utterance at speech_final::
+
+            is_final=True  speech_final=False  "my order number"
+            is_final=True  speech_final=False  "is four two one."
+            is_final=True  speech_final=True   "my order number is four two one."
+
+        That last message is a summary, not new material. Pushing it as
+        another TranscriptionFrame gives every consumer that accumulates
+        frame text the utterance twice.
+
+        Compared on the normalized form because the restatement is
+        re-punctuated ("is four two one." appears as "is four two one"
+        inside the full utterance), so neither equality nor startswith on
+        the raw strings detects the repeat.
+
+        Returns the unemitted tail in its original formatting, or "" when
+        the message restates only what has already been sent.
+        """
+        already = self._emitted_final_norm
+        if not already:
+            return cumulative
+        if not self._norm(cumulative).startswith(already):
+            # Not a restatement of what was sent: pass it through whole
+            # rather than guess at a split point.
+            return cumulative
+        seen = 0
+        tail = ""
+        for i, ch in enumerate(cumulative):
+            if seen == len(already):
+                tail = cumulative[i:].strip()
+                break
+            if self._norm(ch):
+                seen += 1
+        # A punctuation-only tail is not new content: the restatement ends
+        # "one." where the segment final ended "one.", and emitting the
+        # leftover "." would append a stray token.
+        return tail if self._norm(tail) else ""
+
     async def _handle_transcript(self, message: dict[str, Any]):
         text = message.get("text", "")
         if not text:
             return
+
+        self._begin_utterance()
 
         is_final = bool(message.get("is_final"))
         speech_final = bool(message.get("speech_final"))
@@ -375,7 +442,22 @@ class XAISTTService(WebsocketSTTService):
     ):
         text = text if text is not None else message.get("text", "")
         if not text:
+            if speech_final:
+                # An empty speech_final still ends the utterance; returning
+                # without clearing would carry state into the next one.
+                self._emitted_final_norm = ""
+                self._utterance_closed = True
             return
+
+        if speech_final:
+            text = self._unrepeated_final(text)
+            self._emitted_final_norm = ""
+            self._utterance_closed = True
+            if not text:
+                return
+        else:
+            self._emitted_final_norm += self._norm(text)
+
         language = language if language is not None else self._language_for_frame()
 
         # Report usage before the transcription frame so tracing can attach

--- a/tests/test_xai_stt.py
+++ b/tests/test_xai_stt.py
@@ -9,6 +9,7 @@
 import asyncio
 from urllib.parse import parse_qs, urlparse
 
+from pipecat.frames.frames import TranscriptionFrame
 from pipecat.services.xai.stt import XAISTTService
 from pipecat.utils.asyncio.task_manager import TaskManager
 from tests.frame_processor_helpers import frame_processor_setup
@@ -49,3 +50,134 @@ def test_explicit_sample_rate_overrides_setup(monkeypatch):
 
     assert service.sample_rate == 16000
     assert _query(service)["sample_rate"] == ["16000"]
+
+
+def _collect_finals(service: XAISTTService) -> list[str]:
+    """Record the text of every TranscriptionFrame the service pushes."""
+    pushed: list[str] = []
+
+    async def fake_push_frame(frame, direction=None):
+        if isinstance(frame, TranscriptionFrame):
+            pushed.append(frame.text)
+
+    service.push_frame = fake_push_frame
+
+    async def noop(*args, **kwargs):
+        pass
+
+    service.emit_stt_usage_metrics = noop
+    service._trace_transcription = noop
+    return pushed
+
+
+def _feed(service: XAISTTService, messages: list[dict]) -> None:
+    async def run():
+        for message in messages:
+            await service._handle_message(message)
+
+    asyncio.run(run())
+
+
+def _partial(text: str, *, is_final: bool = False, speech_final: bool = False) -> dict:
+    return {
+        "type": "transcript.partial",
+        "text": text,
+        "is_final": is_final,
+        "speech_final": speech_final,
+    }
+
+
+def test_cumulative_speech_final_is_not_emitted_a_second_time():
+    """xAI restates the whole utterance at speech_final. Emitting that as
+    another TranscriptionFrame hands every consumer that accumulates frame
+    text the utterance twice."""
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [
+        _partial("my order"),
+        _partial("my order number", is_final=True),
+        _partial("is four"),
+        _partial("is four two one.", is_final=True),
+        # The restatement, re-punctuated: "one." above appears as "one"
+        # here, so a raw equality or startswith check does not see it.
+        _partial("my order number is four two one.", is_final=True, speech_final=True),
+    ])
+
+    assert pushed == ["my order number", "is four two one."]
+
+
+def test_a_speech_final_with_new_words_keeps_them():
+    # Only the already-emitted prefix is dropped, never trailing content.
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [
+        _partial("hello", is_final=True),
+        _partial("hello there friend", is_final=True, speech_final=True),
+    ])
+
+    assert pushed == ["hello", "there friend"]
+
+
+def test_a_speech_final_that_is_the_whole_utterance_is_emitted():
+    # No segment finals came first, so nothing has been said yet.
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [_partial("hello there", is_final=True, speech_final=True)])
+
+    assert pushed == ["hello there"]
+
+
+def test_unrelated_speech_final_text_passes_through_whole():
+    # Not a restatement of what was emitted: pass it through rather than
+    # guess at a split point.
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [
+        _partial("first thing", is_final=True),
+        _partial("something else entirely", is_final=True, speech_final=True),
+    ])
+
+    assert pushed == ["first thing", "something else entirely"]
+
+
+def test_state_is_cleared_between_utterances():
+    """A completed utterance must not subtract its text from the next one:
+    "yes" precedes "yes I do", and carrying the prefix across would strip
+    the second utterance down to " I do"."""
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [
+        _partial("yes", is_final=True),
+        _partial("yes", is_final=True, speech_final=True),
+        # Second utterance, starting with the same word.
+        _partial("yes I do", is_final=True),
+        _partial("yes I do.", is_final=True, speech_final=True),
+    ])
+
+    assert pushed == ["yes", "yes I do"]
+
+
+def test_an_unrecognized_restatement_is_never_truncated():
+    """An utterance can end without a speech_final -- an endpointing
+    timeout, a dropped connection -- leaving no boundary to reset on. The
+    de-duplication then cannot recognize the next restatement, and must pass
+    it through whole: duplicated text is visible and recoverable, silently
+    dropped text is neither."""
+    service = XAISTTService(api_key="test-key")
+    pushed = _collect_finals(service)
+
+    _feed(service, [
+        # First utterance ends after a segment final, with no speech_final.
+        _partial("yes", is_final=True),
+        # Second utterance: its restatement no longer matches the prefix.
+        _partial("I do", is_final=True),
+        _partial("I do.", is_final=True, speech_final=True),
+    ])
+
+    assert pushed == ["yes", "I do", "I do."]
+    assert "".join(pushed).count("I do") == 2, "content duplicated, not lost"


### PR DESCRIPTION
Fixes #5671.

## Problem

`XAISTTService` pushes a `TranscriptionFrame` for every final it receives. xAI sends a final per segment as speech arrives, and then restates the **entire** utterance at `speech_final`:

```
transcript.partial  is_final=True   speech_final=False  "my order number"
transcript.partial  is_final=True   speech_final=False  "is four two one."
transcript.partial  is_final=True   speech_final=True   "my order number is four two one."
```

All three become `TranscriptionFrame`s, so a consumer that accumulates frame text gets the utterance twice. Every other STT service in pipecat emits each word once — `SonioxSTTService` buffers tokens and pushes a single frame per utterance, `AssemblyAISTTService` pushes per turn — so accumulating is the reasonable thing for a consumer to do, and xAI is the one service where it breaks.

Measured impact while benchmarking vendors with `stt-benchmark` (which concatenates finals): 353 of 466 non-empty transcripts came back as an exact `X X` doubling, and the service scored 99–104% character error rate in every category regardless of how well it actually heard the audio.

## Change

On `speech_final`, emit only the part of the transcript not already sent.

The comparison is on an alphanumeric-lowercase form, because the restatement is **re-punctuated** — `"is four two one."` appears as `"is four two one"` inside the full utterance — so neither `==` nor `startswith` on the raw strings detects the repeat. A tail consisting only of punctuation counts as nothing new.

Per-segment finals still go out as they arrive, so first-final latency is unchanged.

## De-duplication state

Scoped to one utterance: cleared on `speech_final`, when transcript activity resumes after one, and on reconnect.

Where no boundary is available — an utterance ended by an endpointing timeout rather than a `speech_final` — an unrecognized restatement is passed through whole rather than subtracted from. Duplicated text is visible and recoverable; silently dropped text is neither. `test_an_unrecognized_restatement_is_never_truncated` pins that direction.

## Tests

Six new cases in `tests/test_xai_stt.py`, driving `_handle_message` with the captured message sequence:

- the cumulative `speech_final` is not emitted a second time
- a `speech_final` carrying new words keeps them
- a `speech_final` that is the whole utterance (no prior segment finals) is emitted
- unrelated `speech_final` text passes through whole
- state is cleared between utterances, so `"yes"` followed by `"yes I do"` is not truncated
- an unrecognized restatement duplicates rather than truncates

`python -m pytest tests/test_xai_stt.py` — 8 passed.
