### PR TITLE
Cartesia: keep one word-timestamp token per reported entry

### DIFF
--- a/changelog/5679.changed.md
+++ b/changelog/5679.changed.md
@@ -1,0 +1,1 @@
+Cartesia word timestamps for Chinese and Japanese now keep one token per reported entry, each with its own start time, instead of joining a whole `word_timestamps` message into a single token.

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -484,42 +484,22 @@ class CartesiaTTSService(WebsocketTTSService):
         """Normalize raw word timestamps from Cartesia before further processing.
 
         Strips Cartesia SSML tags (spell, emotion, break, volume, speed) from each word
-        and drops entries that become empty after stripping.
-
-        For Chinese and Japanese, Cartesia groups related characters in the same timestamp
-        message.
-        For example, in Japanese a single message might be `['こ', 'ん', 'に', 'ち', 'は', '。']`.
-        We combine these into single words so the downstream aggregator can add natural
-        spacing between meaningful units rather than individual characters.
-
-        For other languages, words are already properly separated and are used as-is.
+        and drops entries that become empty after stripping. Each entry keeps its own
+        start time, so one entry in is at most one token out, whatever the language.
 
         Args:
             words: List of words/characters from Cartesia.
             starts: List of start timestamps for each word/character.
 
         Returns:
-            List of (word, start_time) tuples processed for the language.
+            List of (word, start_time) tuples.
         """
-        current_language = assert_given(self._settings.language)
-
-        # Check if this is a Chinese/Japanese language (if language is None, treat as other)
-        if current_language and self._is_chinese_or_japanese_language(current_language):
-            # For Chinese/Japanese, combine all characters in this message into one word
-            # using the first character's start time.
-            if words and starts:
-                combined_word = "".join(self._strip_cartesia_tags(w) for w in words)
-                first_start = starts[0]
-                return [(combined_word, first_start)] if combined_word else []
-            else:
-                return []
-        else:
-            result = []
-            for word, start in zip(words, starts):
-                cleaned = self._strip_cartesia_tags(word)
-                if cleaned:
-                    result.append((cleaned, start))
-            return result
+        result = []
+        for word, start in zip(words, starts):
+            cleaned = self._strip_cartesia_tags(word)
+            if cleaned:
+                result.append((cleaned, start))
+        return result
 
     def _word_timestamps_include_inter_frame_spaces(self) -> bool:
         """Whether timestamp text should be treated as carrying its own spacing."""

--- a/tests/test_cartesia_tts.py
+++ b/tests/test_cartesia_tts.py
@@ -50,20 +50,27 @@ def _concatenate_processed_timestamps(
     return concatenate_aggregated_text(text_parts)
 
 
-def test_cartesia_chinese_word_timestamps_join_without_spaces():
+def test_cartesia_chinese_word_timestamps_keep_one_entry_per_character():
     assert _process_word_timestamps(
         words=["你", "好", "。"],
         starts=[0.0, 0.1, 0.2],
         language="zh",
-    ) == [("你好。", 0.0)]
+    ) == [("你", 0.0), ("好", 0.1), ("。", 0.2)]
 
 
-def test_cartesia_japanese_word_timestamps_join_without_spaces():
+def test_cartesia_japanese_word_timestamps_keep_one_entry_per_character():
     assert _process_word_timestamps(
         words=["こ", "ん", "に", "ち", "は", "。"],
         starts=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
         language="ja",
-    ) == [("こんにちは。", 0.0)]
+    ) == [
+        ("こ", 0.0),
+        ("ん", 0.1),
+        ("に", 0.2),
+        ("ち", 0.3),
+        ("は", 0.4),
+        ("。", 0.5),
+    ]
 
 
 def test_cartesia_korean_word_timestamps_preserve_words_and_timestamps():


### PR DESCRIPTION
## Changes

For Chinese and Japanese, `CartesiaTTSService._normalize_word_timestamps` joined every entry in a `word_timestamps` message into one token, keeping only the first entry's start time. Word boundaries were therefore a function of how the provider packs entries into websocket messages.

That packing is not part of the API contract — it varies by model, and between runs of the same request. The same Chinese turn came back as two different tokenizations in one test session:

```
['您', '好', '，', '感', '谢', '您', '致电', '。', '请', '问有', '什么', '可以', '帮', '您的', '吗？']
['您', '好', '，', '感', '谢', '您', '致电', '。', '请问', '有什', '么可', '以', '帮', '您的', '吗？']
```

`问有`, `有什` and `么可` are packing artifacts rather than units of anything, so it doesn't make sense to track them as one word. We now emits one token per reported entry, each keeping its own start time — the path every other language already takes.

The merge dates from a time when the aggregator inserted spaces between consecutive `TTSTextFrame`s heuristically, so coarser tokens were the only way to avoid `こ ん に ち は 。`. `includes_inter_frame_spaces` now covers that directly, and `_word_timestamps_include_inter_frame_spaces()` already returns True for these languages, so the assembled text is unchanged.

## Testing

`tests/test_cartesia_tts.py` — the two tests that asserted the joined token now assert one entry per character. The reassembly tests, which go through `includes_inter_frame_spaces` and `concatenate_aggregated_text`, are **unchanged and pass**, which is the assertion that spacing is unaffected:

- `test_cartesia_japanese_timestamp_groups_reassemble_without_spaces`
- `test_cartesia_chinese_timestamp_groups_reassemble_without_spaces`
- `test_cartesia_korean_timestamp_groups_reassemble_with_spaces`

Korean was already on the per-entry path and is untouched.

635 tests pass across the word-timestamp and text-tracking files (`test_cartesia_tts`, `test_word_completion_tracker`, `test_text_segment_map`, `test_aggregated_frame_sequencer`, `test_word_timestamp_utils`, `test_utils_string`, the ElevenLabs/Inworld/Soniox TTS files, and the context aggregators).

End to end against the live Cartesia websocket, driving `CartesiaTTSService` with `sonic-3.6`: Chinese and Korean multi-sentence turns reproduce their text exactly, with no injected spaces.

A Japanese turn with a spaced em dash gives the same tokens on both the streamed-LLM and `TTSSpeakFrame` routes, where before the tokenization differed between them from run to run. That case was also duplicating the dash: a message holding `['は', '—']` became the token `'は—'`, whose text spans the space the source has between them, so the cursor consumed only `は` and the force-completed tail re-emitted the mark. With one token per entry no such token exists.

## Reviewing

`uv run pytest tests/test_cartesia_tts.py`. For a live check, drive `CartesiaTTSService` with `language="zh"` or `"ja"` and confirm the assistant context text has no spaces between characters.
