### PR TITLE
fix(soniox): send end-of-audio before closing the websocket

### DIFF
--- a/changelog/5682.fixed.md
+++ b/changelog/5682.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SonioxSTTService` dropping Soniox's end-of-audio frame on a graceful end. The websocket closed before it was sent, so sessions ended by dropping the connection rather than closing cleanly, and the service's `on_disconnected` event fired twice.

--- a/src/pipecat/services/soniox/stt.py
+++ b/src/pipecat/services/soniox/stt.py
@@ -479,22 +479,20 @@ class SonioxSTTService(WebsocketSTTService):
     async def stop(self, frame: EndFrame):
         """Stop the Soniox STT websocket connection.
 
-        Stopping waits for the server to close the connection as we might receive
-        additional final tokens after sending the stop recording message.
-
         Args:
             frame: The end frame.
         """
-        await super().stop(frame)
+        # The end-of-audio frame has to reach the socket before teardown closes
+        # it. Trailing final tokens are not waited for: that would hold shutdown
+        # open for a transcript that generates no further turn.
         await self._send_stop_recording()
-        await self._disconnect()
+        await super().stop(frame)
 
     async def cancel(self, frame: CancelFrame):
         """Cancel the Soniox STT websocket connection.
 
-        Compared to stop, this method closes the connection immediately without waiting
-        for the server to close it. This is useful when we want to stop the connection
-        immediately without waiting for the server to send any final tokens.
+        Compared to stop, this closes the connection without sending the
+        end-of-audio frame.
 
         Args:
             frame: The cancel frame.
@@ -549,10 +547,12 @@ class SonioxSTTService(WebsocketSTTService):
                 logger.debug(f"Triggered finalize event on: {frame.name=}, {direction=}")
 
     async def _send_stop_recording(self):
-        """Send stop recording message to Soniox."""
+        """Send the end-of-audio frame, an empty message that ends the session."""
         if self._websocket and self._websocket.state is State.OPEN:
-            # Send stop recording message
-            await self._websocket.send("")
+            try:
+                await self._websocket.send("")
+            except Exception as e:
+                logger.warning(f"{self}: end-of-audio send failed: {e}")
 
     async def _connect(self):
         """Connect to the Soniox service.

--- a/tests/test_soniox_stt.py
+++ b/tests/test_soniox_stt.py
@@ -11,6 +11,8 @@ import pytest
 from websockets.protocol import State
 
 from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
     InterimTranscriptionFrame,
     ProposedUserStartedSpeakingFrame,
     ProposedUserStoppedSpeakingFrame,
@@ -30,7 +32,12 @@ class _FakeWebsocket:
     def __init__(self, messages, *, state=State.OPEN, send_side_effect=None):
         self._messages = messages
         self.state = state
+        self.closed = False
         self.send = AsyncMock(side_effect=send_side_effect)
+
+    async def close(self):
+        self.closed = True
+        self.state = State.CLOSED
 
     def __aiter__(self):
         return self._iter_messages()
@@ -527,3 +534,60 @@ async def test_receive_messages_allows_final_transcription_without_language(monk
     assert final_frames[0].language is None
     assert final_frames[0].finalized is True
     assert traced_transcriptions == [("Tell me a joke.", True, None)]
+
+
+def _connected_service():
+    """Build a service holding an open fake socket, without touching the network."""
+    service = SonioxSTTService(api_key="test-key")
+    service._setup = frame_processor_setup(TaskManager())
+    websocket = _FakeWebsocket([])
+    service._websocket = websocket
+    return service, websocket
+
+
+def _sent_payloads(websocket):
+    return [call.args[0] for call in websocket.send.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_stop_sends_end_of_audio_while_the_socket_is_open():
+    service, websocket = _connected_service()
+
+    await service.stop(EndFrame())
+
+    assert _sent_payloads(websocket) == [""]
+    assert websocket.closed
+
+
+@pytest.mark.asyncio
+async def test_stop_disconnects_once():
+    service, _ = _connected_service()
+    service._disconnect_websocket = AsyncMock(wraps=service._disconnect_websocket)
+
+    await service.stop(EndFrame())
+
+    service._disconnect_websocket.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_does_not_send_end_of_audio():
+    service, websocket = _connected_service()
+
+    await service.cancel(CancelFrame())
+
+    assert _sent_payloads(websocket) == []
+    assert websocket.closed
+
+
+@pytest.mark.asyncio
+async def test_stop_completes_teardown_when_the_end_of_audio_send_fails():
+    service, websocket = _connected_service()
+    websocket.send = AsyncMock(side_effect=ConnectionResetError("transient send failure"))
+    service._flush_stt_usage_metrics = AsyncMock(wraps=service._flush_stt_usage_metrics)
+
+    await service.stop(EndFrame())
+
+    # The send is best-effort: everything after it still has to run.
+    service._flush_stt_usage_metrics.assert_awaited_once()
+    assert service._disconnecting is True
+    assert websocket.closed


### PR DESCRIPTION
Fixes #5401

## Problem

`SonioxSTTService.stop()` called `super().stop(frame)` first. That runs `WebsocketSTTService.stop()`, which disconnects and clears `self._websocket`, so the `_send_stop_recording()` on the next line hit its open-socket guard and returned without sending anything. Soniox never received the empty end-of-audio frame that ends a session, so sessions ended by the connection dropping instead of closing cleanly. The `_disconnect()` after it was a second teardown, so `on_disconnected` fired twice on a graceful end.

## Changes

`stop()` now sends the end-of-audio frame before calling `super().stop(frame)`, so it reaches the socket while it is still open, and the redundant `_disconnect()` is gone since the base class already disconnects. The send is wrapped in try/except so a failed write cannot skip the teardown behind it. The `stop()` docstring no longer claims to wait for the server, and `cancel()` now describes the difference that actually exists, which is that it sends nothing. Trailing final tokens are not waited for, so shutdown stays prompt.