### PR TITLE
Drop the redundant text field from InterimTranscriptionFrame

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -487,7 +487,6 @@ class InterimTranscriptionFrame(TextFrame):
         result: Raw result from the STT service.
     """
 
-    text: str
     user_id: str
     timestamp: str
     language: Language | None = None


### PR DESCRIPTION
Found this while reviewing Filipi's eager end of turn PR.

---

`InterimTranscriptionFrame` subclasses `TextFrame`, which already declares `text: str`. The subclass redeclared the same field; this removes that line.

Nothing about the frame changes. A dataclass field redeclared by a subclass keeps its original position, so the constructor signature and the full field list are identical with the line removed:

```
(text: 'str', user_id: 'str', timestamp: 'str', language: 'Language | None' = None, result: 'Any | None' = None) -> None
```

No changelog fragment: nothing user-visible changes.