### PR TITLE
piper: voice models download to ~/.cache/pipecat/piper by default

### DIFF
--- a/changelog/5687.changed.md
+++ b/changelog/5687.changed.md
@@ -1,0 +1,1 @@
+- `PiperTTSService` downloads voice models to `~/.cache/pipecat/piper` by default, the same cache location `KokoroTTSService` uses, instead of the current working directory. Pass `download_dir` to keep models elsewhere; a model already downloaded into a working directory is fetched again into the cache on first use.

--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -7,6 +7,7 @@
 """Piper TTS service implementation."""
 
 import asyncio
+import os
 from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +33,8 @@ except ModuleNotFoundError as e:
     logger.error(f"Exception: {e}")
     logger.error('In order to use Piper, you need to `uv add "pipecat-ai[piper]"`.')
     raise ImportError(f"Missing module: {e}") from e
+
+PIPER_CACHE_DIR = Path(os.path.expanduser("~/.cache/pipecat/piper"))
 
 
 @dataclass
@@ -80,7 +83,7 @@ class PiperTTSService(TTSService):
                     Will be removed in 2.0.0.
 
             download_dir: Directory for storing voice model files. Defaults to
-                the current working directory.
+                Pipecat's cache directory.
             force_redownload: Re-download the voice model even if it already exists.
             use_cuda: Use CUDA for GPU-accelerated inference.
             settings: Runtime-updatable settings. When provided alongside deprecated
@@ -108,11 +111,13 @@ class PiperTTSService(TTSService):
             **kwargs,
         )
 
-        download_dir = download_dir or Path.cwd()
+        download_dir = download_dir or PIPER_CACHE_DIR
+        if not download_dir.exists():
+            download_dir.mkdir(parents=True, exist_ok=True)
 
         _voice = require_given(self._settings.voice, "Piper TTS voice")
         model_file = f"{_voice}.onnx"
-        model_path_resolved = Path(download_dir) / model_file
+        model_path_resolved = download_dir / model_file
 
         if not model_path_resolved.exists():
             logger.debug(f"Downloading Piper '{_voice}' model")


### PR DESCRIPTION
## Summary

- `PiperTTSService` downloads voice models to `~/.cache/pipecat/piper` by default, creating the directory if needed, instead of the current working directory. This matches `KokoroTTSService`, whose models live in `~/.cache/pipecat/kokoro-onnx`, so a voice is fetched once per machine rather than once per directory a bot is started from.
- `download_dir` still overrides the location.

## Breaking Changes

- A voice model that an earlier version downloaded into a bot's working directory is not found there anymore, so the first run after upgrading downloads it again into the cache. Pass `download_dir=Path.cwd()` to keep the old location.

## Testing

```
uv run pytest tests/test_piper_tts.py
```
