### PR TITLE
eager end of turn: the strategy bounds a speculation, and frames carry no speculation id

### DIFF
--- a/changelog/5625.changed.2.md
+++ b/changelog/5625.changed.2.md
@@ -1,1 +1,1 @@
-- `UserStoppedSpeakingFrame` carries a `speculation_id`, naming the speculative response a turn end confirms, and `LLMContextFrame` carries one marking an inference as speculative.
+- `LLMContextFrame` carries a `speculative` flag marking an inference as run from an eager end of turn, whose response the LLM service holds until the user turn ends.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -511,17 +511,12 @@ class EagerTranscriptionFrame(TextFrame):
     Parameters:
         user_id: Identifier for the user who spoke.
         timestamp: When the eager end of turn occurred.
-        speculation_id: Identifies this prediction, so whatever is generated from
-            it can be matched against the
-            :class:`EagerEndOfTurnCancelFrame` that may withdraw it. Minted by
-            the service, which is the authority on which prediction it withdraws.
         language: Detected or specified language of the speech.
         result: Raw result from the STT service.
     """
 
     user_id: str
     timestamp: str
-    speculation_id: str
     language: Language | None = None
     result: Any | None = None
 
@@ -588,14 +583,14 @@ class LLMContextFrame(Frame):
 
     Parameters:
         context: The LLM context containing messages, tools, and configuration.
-        speculation_id: Identifies a speculative inference, run from a provisional
-            context that is not part of the conversation. Non-None means the
-            response must not reach the user or the context until the speculation
-            is confirmed, and that the service must not execute tool calls for it.
+        speculative: Whether the inference answers an eager end of turn, run
+            from a provisional context that is not part of the conversation.
+            The response must then not reach the user or the context until the
+            turn ends, and the service must not execute tool calls for it.
     """
 
     context: LLMContext
-    speculation_id: str | None = None
+    speculative: bool = False
 
 
 @dataclass
@@ -1203,18 +1198,12 @@ class UserStoppedSpeakingFrame(SystemFrame):
     """Frame indicating that the user turn has ended.
 
     Emitted when the user turn ends. This usually coincides with the start of
-    the bot turn.
-
-    Parameters:
-        speculation_id: Set when the turn ended on an eager end of turn that
-            held, naming the speculative response that answers it. The
-            :class:`~pipecat.turns.speculation_gate.SpeculationGate` releases
-            that response on this frame. None on every other turn end, including
-            one where the eager prediction missed — a response held for a
-            speculation this frame doesn't name is never released by it.
+    the bot turn. A response generated speculatively for the turn, from an
+    eager end of turn, is released on this frame by the
+    :class:`~pipecat.turns.speculation_gate.SpeculationGate`.
     """
 
-    speculation_id: str | None = None
+    pass
 
 
 @dataclass
@@ -1228,14 +1217,11 @@ class EagerEndOfTurnCancelFrame(SystemFrame):
     was holding — which is everything the response produced, so nothing further
     down the pipeline has anything to undo.
 
-    A system frame so it overtakes the speculative output it cancels.
-
-    Parameters:
-        speculation_id: The prediction being withdrawn, from the
-            :class:`EagerTranscriptionFrame` that made it.
+    A system frame so it overtakes the speculative output it cancels. There is
+    one prediction per user turn, so the frame names none.
     """
 
-    speculation_id: str
+    pass
 
 
 @dataclass
@@ -2151,19 +2137,13 @@ class LLMFullResponseStartFrame(ControlFrame):
 
     Parameters:
         skip_tts: Whether the response should be skipped by the TTS service.
-        speculation_id: Set by the LLM service when the response comes from a
-            speculative inference. It bounds the speculation: every frame between
-            this frame and the matching :class:`LLMFullResponseEndFrame` belongs
-            to it.
     """
 
     skip_tts: bool | None = field(init=False)
-    speculation_id: str | None = field(init=False)
 
     def __post_init__(self):
         super().__post_init__()
         self.skip_tts = None
-        self.speculation_id = None
 
 
 @dataclass
@@ -2172,18 +2152,13 @@ class LLMFullResponseEndFrame(ControlFrame):
 
     Parameters:
         skip_tts: Whether the response should be skipped by the TTS service.
-        speculation_id: Set by the LLM service when the response comes from a
-            speculative inference. Closes the window opened by the matching
-            :class:`LLMFullResponseStartFrame`.
     """
 
     skip_tts: bool | None = field(init=False)
-    speculation_id: str | None = field(init=False)
 
     def __post_init__(self):
         super().__post_init__()
         self.skip_tts = None
-        self.speculation_id = None
 
 
 @dataclass

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -30,6 +30,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     CancelFrame,
+    EagerEndOfTurnCancelFrame,
     EagerTranscriptionFrame,
     EndFrame,
     Frame,
@@ -742,6 +743,10 @@ class LLMUserAggregator(LLMContextAggregator):
             "on_reset_aggregation", self._on_reset_aggregation
         )
 
+        # Whether a speculative inference is in flight for the current turn,
+        # started on an eager end of turn and not yet withdrawn or confirmed.
+        self._speculation_pending = False
+
         self._user_idle_controller = UserIdleController(
             user_idle_timeout=self._params.user_idle_timeout
         )
@@ -832,6 +837,10 @@ class LLMUserAggregator(LLMContextAggregator):
             # final TranscriptionFrame. The turn strategies still see them: the
             # controller is fed every frame below.
             pass
+        elif isinstance(frame, EagerEndOfTurnCancelFrame):
+            # The service, or the stop strategy, withdrew the speculation.
+            self._speculation_pending = False
+            await self.push_frame(frame, direction)
         elif isinstance(frame, LLMRunFrame):
             await self._handle_llm_run(frame)
         elif isinstance(frame, LLMMessagesAppendFrame):
@@ -1386,7 +1395,8 @@ class LLMUserAggregator(LLMContextAggregator):
             tools=self._context.tools,
             tool_choice=self._context.tool_choice,
         )
-        await self.push_frame(LLMContextFrame(context=provisional, speculation_id=speculation.id))
+        self._speculation_pending = True
+        await self.push_frame(LLMContextFrame(context=provisional, speculative=True))
 
     async def _on_user_turn_stopped(
         self,
@@ -1396,10 +1406,18 @@ class LLMUserAggregator(LLMContextAggregator):
     ):
         logger.debug(f"{self}: User stopped speaking (strategy: {strategy})")
 
+        if self._speculation_pending and not params.speculated:
+            # The turn ended without confirming the speculation: the committed
+            # transcript differed, or nothing was committed at all. Withdraw it
+            # ahead of the turn end, which would otherwise release the held
+            # response, and ahead of the fresh inference below, which the
+            # withdrawal's interruption at the LLM would otherwise flush.
+            logger.debug(f"{self}: turn ended without confirming the speculation, withdrawing it")
+            await self.broadcast_frame(EagerEndOfTurnCancelFrame)
+        self._speculation_pending = False
+
         if params.enable_user_speaking_frames:
-            await self.broadcast_frame(
-                UserStoppedSpeakingFrame, speculation_id=params.speculation_id
-            )
+            await self.broadcast_frame(UserStoppedSpeakingFrame)
 
         await self._user_idle_controller.process_frame(UserStoppedSpeakingFrame())
 
@@ -1415,10 +1433,10 @@ class LLMUserAggregator(LLMContextAggregator):
             await self._call_event_handler("on_user_turn_stopped", strategy, message)
             return
 
-        # A turn end that confirms a speculation has its response already: the
-        # context write is all that's left, and running inference again would
-        # answer the same turn twice.
-        await self._maybe_emit_user_turn_stopped(strategy, run_llm=params.speculation_id is None)
+        # A turn already answered speculatively has its response: the context
+        # write is all that's left, and running inference again would answer
+        # the same turn twice.
+        await self._maybe_emit_user_turn_stopped(strategy, run_llm=not params.speculated)
 
     async def _on_reset_aggregation(
         self, controller: UserTurnController, strategy: BaseUserTurnStartStrategy

--- a/src/pipecat/services/llm_service.py
+++ b/src/pipecat/services/llm_service.py
@@ -65,7 +65,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSet
 from pipecat.services.ai_service import AIService
 from pipecat.services.settings import LLMSettings
 from pipecat.services.websocket_service import WebsocketService
-from pipecat.turns.speculation_gate import GatedFrame, SpeculationGate
+from pipecat.turns.speculation_gate import SpeculationGate
 from pipecat.turns.user_turn_completion_mixin import UserTurnCompletionLLMServiceMixin
 from pipecat.utils.async_tool_cancellation import (
     ASYNC_TOOL_CANCELLATION_INSTRUCTIONS,
@@ -301,10 +301,6 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
     FUNCTION_CALL_ERROR_MESSAGE_TEMPLATE = (
         "The function `{function_name}` failed and returned no result."
     )
-    # How long a speculative response may be held before the gate gives up on
-    # it. Without this bound, a service that stops sending turn signals mid-
-    # speculation would leave the bot silent for the rest of the session.
-    SPECULATION_HOLD_TIMEOUT = 5.0
 
     def __init__(
         self,
@@ -367,11 +363,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         self._filter_incomplete_user_turns: bool = False
         # Holds a speculative response until its turn is confirmed. Frames are
         # routed through it on the way out, in `push_frame`.
-        self._speculation_gate = SpeculationGate(
-            name=f"{self}::SpeculationGate",
-            withdraw_expired=self._withdraw_expired_speculation,
-            max_hold_duration=self.SPECULATION_HOLD_TIMEOUT,
-        )
+        self._speculation_gate = SpeculationGate(name=f"{self}::SpeculationGate")
         self._warn_turn_completion_settings_are_strategy_owned()
         # The per-tool cancel tools currently advertised, by name.
         self._cancel_tool_names: set[str] = set()
@@ -557,17 +549,6 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             await self._cancel_sequential_runner_task()
         await self._cancel_summary_task()
 
-    async def setup(self, setup: FrameProcessorSetup):
-        """Set up the LLM service.
-
-        Args:
-            setup: Configuration object containing setup parameters.
-        """
-        await super().setup(setup)
-        # The gate runs the bound on how long it may hold a response, so it
-        # needs somewhere to run that task.
-        await self._speculation_gate.setup(setup.task_manager)
-
     async def cleanup(self):
         """Release LLM service resources at teardown.
 
@@ -579,7 +560,6 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
             await self._cancel_sequential_runner_task()
         await self._cancel_summary_task()
         await self._cancel_all_function_call_tasks()
-        await self._speculation_gate.cleanup()
         await self._run_tool_cleanups()
 
     def _warn_turn_completion_settings_are_strategy_owned(self):
@@ -739,7 +719,7 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         if isinstance(frame, LLMContextFrame):
             # Runs before the subclass starts the completion, so the gate knows
             # what this inference answers before any of its frames arrive.
-            self._speculation_gate.begin_speculation(frame.speculation_id)
+            self._speculation_gate.begin_speculation(frame.speculative)
 
             # Sync the registered handlers with the tools advertised in the
             # context: register any newly advertised handler, drop the ones we
@@ -763,13 +743,6 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         if isinstance(frame, (LLMTextFrame, LLMFullResponseStartFrame, LLMFullResponseEndFrame)):
             if self._skip_tts is not None:
                 frame.skip_tts = self._skip_tts
-
-        if isinstance(frame, (LLMFullResponseStartFrame, LLMFullResponseEndFrame)):
-            # Marks the response while it is unconfirmed, for whatever holds it
-            # back. The gate three lines down clears the mark on everything it
-            # releases, so the mark reaches the pipeline only if nothing gated
-            # the response at all.
-            frame.speculation_id = self._speculation_gate.speculation_id
 
         # The gate decides synchronously, so its verdict can't be torn by
         # another task pushing at the same time. Everything it hands back is
@@ -811,33 +784,13 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         never spoke, and the user is still mid-turn.
         """
         # Runs before the frame reaches the gate, which is what clears the
-        # speculation, so this still sees the one being withdrawn.
-        if frame.speculation_id != self._speculation_gate.speculation_id:
+        # speculation, so this still sees whether one is being withdrawn.
+        if not self._speculation_gate.speculating:
             return
 
         logger.debug(f"{self}: eager end of turn withdrawn, stopping the speculative inference")
         await self._start_interruption()
         await self.stop_all_metrics()
-
-    async def _withdraw_expired_speculation(self, speculation_id: str, frames: list[GatedFrame]):
-        """Deliver what an expired hold left behind, then withdraw the speculation.
-
-        The frames go past the gate, since it has already resolved them; routing
-        them back through :meth:`push_frame` would re-gate them.
-
-        The withdrawal goes both ways, because the strategy that started the
-        speculation is upstream and nothing else tells it the response is gone.
-        A turn that then confirmed this speculation would be answered by
-        nothing: the gate has no response left to release, and the aggregator
-        skips inference for a turn it believes is already answered.
-        """
-        for frame, direction in frames:
-            await super().push_frame(frame, direction)
-
-        # Inert within this service — the gate cleared the speculation before
-        # calling us, so `_handle_eager_end_of_turn_cancel` matches nothing.
-        # There is no inference left to stop; this is for upstream.
-        await self.broadcast_frame(EagerEndOfTurnCancelFrame, speculation_id=speculation_id)
 
     async def _handle_summary_request(self, frame: LLMContextSummaryRequestFrame):
         """Handle context summarization request from aggregator.
@@ -1525,15 +1478,14 @@ class LLMService(UserTurnCompletionLLMServiceMixin, AIService, Generic[TAdapter]
         if len(function_calls) == 0:
             return
 
-        speculation_id = self._speculation_gate.speculation_id
-        if speculation_id:
+        if self._speculation_gate.speculating:
             # Tools run inside the service, so no downstream gate can undo their
             # side effects if the speculation is discarded. Withdraw it instead;
             # the inference that follows the committed transcript runs the call.
-            # A turn confirmed before the call was reached leaves nothing
+            # A turn that ended before the call was reached leaves nothing
             # pending, and the call runs as an ordinary one.
             logger.debug(f"{self}: speculative inference wants a tool call, cancelling it")
-            await self.broadcast_frame(EagerEndOfTurnCancelFrame, speculation_id=speculation_id)
+            await self.broadcast_frame(EagerEndOfTurnCancelFrame)
             return
 
         # Exclude the built-in cancel tool — it's an internal mechanism and

--- a/src/pipecat/turns/eager_end_of_turn_mixin.py
+++ b/src/pipecat/turns/eager_end_of_turn_mixin.py
@@ -6,7 +6,6 @@
 
 """Mixin for STT services that predict the end of a turn before committing to it."""
 
-import uuid
 from typing import Any
 
 from loguru import logger
@@ -31,8 +30,7 @@ class EagerEndOfTurnSTTServiceMixin(FrameProcessor):
 
     Some services report that a turn has probably ended before committing to it,
     and withdraw the prediction if the user turns out to be mid-sentence. A
-    response can be generated during that gap, so the prediction carries an id
-    identifying it across the pipeline — see
+    response can be generated during that gap; see
     :class:`~pipecat.turns.user_stop.EagerUserTurnStopStrategy`, which acts on
     the frames pushed here.
 
@@ -76,7 +74,7 @@ class EagerEndOfTurnSTTServiceMixin(FrameProcessor):
         super().__init__(*args, **kwargs)
         self._enable_eager_end_of_turn = enable_eager_end_of_turn
         self._eager_match_policy = eager_match_policy
-        self._eager_speculation_id: str | None = None
+        self._eager_end_of_turn_pending = False
 
     @property
     def eager_end_of_turn_enabled(self) -> bool:
@@ -84,9 +82,9 @@ class EagerEndOfTurnSTTServiceMixin(FrameProcessor):
         return self._enable_eager_end_of_turn
 
     @property
-    def eager_speculation_id(self) -> str | None:
-        """The prediction awaiting a committed end of turn, if any."""
-        return self._eager_speculation_id
+    def eager_end_of_turn_pending(self) -> bool:
+        """Whether a prediction awaits a committed end of turn."""
+        return self._eager_end_of_turn_pending
 
     def recommended_user_turn_strategies(self, *, enable_interruptions: bool) -> UserTurnStrategies:
         """Build the turn strategies this service recommends.
@@ -129,27 +127,22 @@ class EagerEndOfTurnSTTServiceMixin(FrameProcessor):
         if not self._enable_eager_end_of_turn:
             return
 
-        self._eager_speculation_id = str(uuid.uuid4())
+        self._eager_end_of_turn_pending = True
         logger.trace(f"{self}: eager end of turn: [{transcript}]")
         await self.push_frame(
             EagerTranscriptionFrame(
-                transcript,
-                user_id,
-                time_now_iso8601(),
-                self._eager_speculation_id,
-                language,
-                result=result,
+                transcript, user_id, time_now_iso8601(), language, result=result
             )
         )
 
     async def _cancel_eager_end_of_turn(self):
-        """Withdraw the prediction, naming it so consumers can match it."""
-        if not self._eager_speculation_id:
+        """Withdraw the prediction."""
+        if not self._eager_end_of_turn_pending:
             return
 
         logger.trace(f"{self}: eager end of turn withdrawn")
-        speculation_id, self._eager_speculation_id = self._eager_speculation_id, None
-        await self.push_frame(EagerEndOfTurnCancelFrame(speculation_id))
+        self._eager_end_of_turn_pending = False
+        await self.push_frame(EagerEndOfTurnCancelFrame())
 
     def _clear_eager_end_of_turn(self):
         """Resolve the prediction without withdrawing it.
@@ -157,4 +150,4 @@ class EagerEndOfTurnSTTServiceMixin(FrameProcessor):
         Called when the turn is committed: whatever was generated from the
         prediction is settled by the committed transcript, not by this.
         """
-        self._eager_speculation_id = None
+        self._eager_end_of_turn_pending = False

--- a/src/pipecat/turns/speculation_gate.py
+++ b/src/pipecat/turns/speculation_gate.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-"""Decision engine holding a speculative bot response until its turn is confirmed."""
+"""Decision engine holding a speculative bot response until its turn ends."""
 
-import asyncio
-from collections.abc import Awaitable, Callable
 from enum import Enum
 
 from loguru import logger
@@ -21,6 +19,7 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     SystemFrame,
     UninterruptibleFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
@@ -35,7 +34,7 @@ class SpeculationState(Enum):
     """What the gate is doing with the frames passing through it.
 
     - ``OPEN``: emitting everything.
-    - ``HOLDING``: holding a speculative response until it is confirmed.
+    - ``HOLDING``: holding a speculative response until its turn ends.
     - ``DROPPING``: discarding the rest of a withdrawn speculative response.
     """
 
@@ -47,34 +46,32 @@ class SpeculationState(Enum):
 class SpeculationGate(BaseObject):
     """Decides which frames of a speculative bot response may be emitted, and when.
 
-    A speculative response is generated from an eager end of turn — a
-    provisional guess that the user has finished talking — so it may answer a
+    A speculative response is generated from an eager end of turn, a
+    provisional guess that the user has finished talking, so it may answer a
     transcript the user never actually completed. This holds everything such a
-    response produces until the turn is confirmed, then releases it, or discards
-    it if the guess is withdrawn.
+    response produces while the user turn is still open, then releases it when
+    the turn ends, or discards it if the guess is withdrawn.
 
-    A host calls :meth:`begin_speculation` when it starts an inference for a
-    turn that may not have ended, and the response that follows is held from its
-    :class:`~pipecat.frames.frames.LLMFullResponseStartFrame` onward. A
-    :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame` naming that
-    speculation releases the response (the turn ended, and this response answers
-    it) and an :class:`~pipecat.frames.frames.EagerEndOfTurnCancelFrame`
-    discards it.
+    A host calls :meth:`begin_speculation` when it starts an inference, saying
+    whether the turn it answers may not have ended. A speculative response is
+    held from its :class:`~pipecat.frames.frames.LLMFullResponseStartFrame`
+    onward. A :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame` ends the
+    turn and releases the response, and an
+    :class:`~pipecat.frames.frames.EagerEndOfTurnCancelFrame` withdraws the
+    speculation and discards it.
 
-    Whether an inference is still answering an unconfirmed turn is therefore the
-    gate's to answer, through :attr:`speculation_id`, rather than something a
-    host tracks alongside it. A host that kept its own copy would
-    have to clear it on every path that settles a speculation, and the two would
-    disagree on the paths it missed.
-
-    Only one speculation is ever in flight, since producing one takes a whole
-    user turn, so the gate tracks a single response. Both signals still carry an
-    id: a turn that ends without naming a speculation must not release one, and
-    a confirmation can arrive before the response it confirms, since Pipecat
-    dispatches system frames ahead of the queued frames they pass.
+    There is one speculation per user turn and one component that settles it,
+    the stop strategy that started it, so the gate needs no identity for it:
+    the turn's end releases whatever is held, and a withdrawal discards it.
+    The two are system frames, which keep their order, so a withdrawal always
+    precedes the turn end that follows it. What the gate does track is whether
+    the turn is open, from the user speaking frames: the turn end is a system
+    frame and can overtake the queued context frame that starts the inference
+    it confirms, and a speculative inference that begins after its turn has
+    ended answers a turn that is over, so it is not held at all.
 
     While holding, everything is held in arrival order except system frames,
-    which are out-of-band throughout Pipecat — and which carry the verdicts the
+    which are out-of-band throughout Pipecat, and which carry the verdicts the
     gate is waiting for, so holding them would deadlock it. That includes
     :class:`~pipecat.frames.frames.UninterruptibleFrame` ones, which are ordered
     like any other frame; discarding a speculation keeps them and emits them on,
@@ -82,79 +79,35 @@ class SpeculationGate(BaseObject):
 
     This decides rather than processes frames: :meth:`process` is synchronous
     and returns the frames its caller should push, in order. A host can
-    therefore push from several tasks at once — every state transition
+    therefore push from several tasks at once, since every state transition
     completes without an await for another task to interleave with.
     :class:`~pipecat.services.llm_service.LLMService` hosts one, gating every
     response it produces.
 
-    A hold bounds itself. A service that stops sending turn signals
-    mid-speculation would otherwise leave the bot silent for the rest of the
-    session, so a hold that outlasts ``max_hold_duration`` is discarded. That
-    is the one point where frames leave with no caller to hand them to, so they
-    go to ``withdraw_expired`` instead of being returned — along with the
-    speculation to withdraw, since giving up on a response is only half the
-    job.
-
     Example::
 
-        gate = SpeculationGate(withdraw_expired=self._withdraw_expired_speculation)
-        await gate.setup(task_manager)
-
+        gate = SpeculationGate()
         for frame, direction in gate.process(frame, direction):
             await self.push_frame(frame, direction)
     """
 
-    def __init__(
-        self,
-        *,
-        withdraw_expired: Callable[[str, list[GatedFrame]], Awaitable[None]],
-        max_hold_duration: float = 5.0,
-        **kwargs,
-    ):
+    def __init__(self, **kwargs):
         """Initialize the speculation gate.
 
         Args:
-            withdraw_expired: Called with the speculation a hold was for and
-                the frames it leaves behind when it outlasts
-                ``max_hold_duration``. The frames are whatever the discarded
-                response was holding back that has to be delivered anyway,
-                handed over rather than returned because the hold runs out on
-                the gate's own task with no :meth:`process` caller waiting to
-                push them. The speculation comes with them because the gate can
-                only settle its own state: whoever started the speculation is
-                elsewhere and has to be told it is over, or a turn confirming it
-                would be answered by nothing.
-            max_hold_duration: Seconds a response may be held before the gate
-                gives up on it.
             **kwargs: Additional arguments passed to the parent class.
         """
         super().__init__(**kwargs)
-        self._withdraw_expired = withdraw_expired
-        self._max_hold_duration = max_hold_duration
-        # A hold is bounded by a task waiting for it to end. Waiting rather than
-        # being cancelled at the end: holds start and end inside `process`,
-        # which is synchronous, and cancelling a task has to be awaited.
-        self._hold_ended = asyncio.Event()
-        self._hold_timeout_task: asyncio.Task | None = None
         self._state = SpeculationState.OPEN
-        # The inference in flight for a turn that has not been confirmed. Set
+        # Whether the inference in flight answers a turn that has not ended. Set
         # when the inference starts, cleared when the turn settles it either
-        # way — so it outlives any one response frame.
-        self._speculation_id: str | None = None
+        # way, so it outlives any one response frame.
+        self._speculating = False
+        # Whether the user turn has ended and no new one has begun. A
+        # speculative inference that begins in that state answers a turn that
+        # is already over, so its response needs no holding.
+        self._turn_ended = False
         self._buffer: FrameQueue = FrameQueue(frame_getter=lambda item: item[0])
-        # A speculation confirmed before its response arrived. The confirmation
-        # travels as a system frame, so it can pass the queued frames it
-        # confirms, and nothing follows it to correct a response held by
-        # mistake — the turn is over, so no further response is coming.
-        # One slot is enough: only one speculation is ever in flight.
-        self._confirmed_id: str | None = None
-
-    async def cleanup(self):
-        """Stop bounding a hold that outlived the pipeline."""
-        await super().cleanup()
-        if self._hold_timeout_task:
-            task, self._hold_timeout_task = self._hold_timeout_task, None
-            await self.cancel_task(task)
 
     @property
     def state(self) -> SpeculationState:
@@ -162,35 +115,31 @@ class SpeculationGate(BaseObject):
         return self._state
 
     @property
-    def speculation_id(self) -> str | None:
-        """The inference answering a turn that has not been confirmed, if any.
+    def speculating(self) -> bool:
+        """Whether the inference in flight answers a turn that has not ended.
 
         Set from :meth:`begin_speculation` until the turn settles it, so it
         covers the whole inference rather than only the stretch with frames in
-        flight. None means whatever is generating now answers a turn that has
+        flight. False means whatever is generating now answers a turn that has
         ended, and its side effects can be let through. Use :attr:`state` to ask
         the narrower question of whether frames are being held right now.
         """
-        return self._speculation_id
+        return self._speculating
 
-    def begin_speculation(self, speculation_id: str | None):
-        """Take note of an inference whose turn may not have ended.
+    def begin_speculation(self, speculative: bool):
+        """Take note of an inference starting, and whether its turn may not have ended.
 
         Called when the inference starts rather than when its first response
-        frame arrives, so a turn confirmed in between is already accounted for
+        frame arrives, so a turn that ended in between is already accounted for
         by the time the response shows up.
 
         Args:
-            speculation_id: The speculation the inference answers, or None for
-                an ordinary inference against a turn that has ended.
+            speculative: Whether the inference answers an eager end of turn.
+                False for an ordinary inference against a turn that has ended.
         """
-        if speculation_id and speculation_id == self._confirmed_id:
-            # The turn ended before the inference reached us, so the response
-            # answers a turn that is already over and needs no holding.
-            self._confirmed_id = None
-            speculation_id = None
-
-        self._speculation_id = speculation_id
+        # A speculative inference that begins after its turn ended answers a
+        # turn that is over: the turn end overtook its context frame.
+        self._speculating = speculative and not self._turn_ended
 
     def process(self, frame: Frame, direction: FrameDirection) -> list[GatedFrame]:
         """Decide what a frame passing through the gate releases.
@@ -211,19 +160,20 @@ class SpeculationGate(BaseObject):
             # Emitted before the verdict is applied, so a released response
             # still follows the frame that ended the turn it answers.
             emitted = [(frame, direction)]
-            if isinstance(frame, EagerEndOfTurnCancelFrame):
-                emitted += self._discard(frame.speculation_id)
+            if isinstance(frame, UserStartedSpeakingFrame):
+                self._turn_ended = False
             elif isinstance(frame, UserStoppedSpeakingFrame):
-                emitted += self._release(frame.speculation_id)
-            elif isinstance(frame, InterruptionFrame):
-                emitted += self._discard(None)
+                self._turn_ended = True
+                emitted += self._release()
+            elif isinstance(frame, (EagerEndOfTurnCancelFrame, InterruptionFrame)):
+                emitted += self._discard()
             return emitted
 
         if isinstance(frame, EndFrame):
             # Uninterruptible, and the runner awaits it: holding it hangs
             # shutdown. Discarding first delivers whatever is held that has to
             # outlive the speculation, ahead of it.
-            return self._discard(None) + [(frame, direction)]
+            return self._discard() + [(frame, direction)]
 
         emitted: list[GatedFrame] = []
         if isinstance(frame, LLMFullResponseStartFrame):
@@ -242,69 +192,12 @@ class SpeculationGate(BaseObject):
             elif isinstance(frame, LLMFullResponseEndFrame):
                 self._state = SpeculationState.OPEN
         else:
-            emitted.append(self._resolved(frame, direction))
-
+            emitted.append((frame, direction))
         return emitted
-
-    def _bound_hold(self):
-        """Start the clock on the hold just taken.
-
-        Starting a task needs no await, so this runs inside the state
-        transition that took the hold. A hold that supersedes another leaves
-        that one's task to notice the end and exit.
-        """
-        self._hold_ended.clear()
-        self._hold_timeout_task = self.create_task(self._hold_timeout_handler(), "_hold_timeout")
-
-    def _end_hold(self, state: SpeculationState):
-        """Leave the hold, releasing the bound on it.
-
-        The single exit from ``HOLDING``, which is what lets the bound end
-        exactly once however the hold ended. Whether the speculation itself is
-        over is a separate question — a response superseded by a new one ends
-        its hold while the inference that replaced it is still pending.
-
-        Args:
-            state: What the gate does with the frames that follow.
-        """
-        self._state = state
-        self._hold_ended.set()
-
-    async def _hold_timeout_handler(self):
-        """Discard a hold that outlasted its bound, and withdraw what it held."""
-        try:
-            await asyncio.wait_for(self._hold_ended.wait(), self._max_hold_duration)
-            return
-        except TimeoutError:
-            pass
-
-        speculation_id = self._speculation_id
-        if not speculation_id:
-            # Settled between the bound running out and this line.
-            return
-
-        logger.warning(
-            f"{self}: speculative response unresolved after {self._max_hold_duration}s, "
-            "discarding it"
-        )
-        await self._withdraw_expired(speculation_id, self._discard(None))
-
-    def _resolved(self, frame: Frame, direction: FrameDirection) -> GatedFrame:
-        """Prepare a frame the gate has resolved.
-
-        A response that gets past the gate has been confirmed, or never belonged
-        to a speculation, so it carries no speculation id onward. That keeps the
-        id meaning exactly one thing downstream: this response answers a turn
-        that may not have ended.
-        """
-        if isinstance(frame, (LLMFullResponseStartFrame, LLMFullResponseEndFrame)):
-            frame.speculation_id = None
-        return (frame, direction)
 
     def _begin(self) -> list[GatedFrame]:
         """Decide what to do with the response opening here."""
         emitted: list[GatedFrame] = []
-
         if self._state != SpeculationState.OPEN:
             # A new response supersedes the one we were holding or dropping. A
             # withdrawn response may never send its end frame, since its
@@ -312,69 +205,41 @@ class SpeculationGate(BaseObject):
             # void once something else starts answering. Nothing of it can still
             # be queued behind this frame, so there is no tail left to drop.
             emitted += self._drop_held("superseded by a new response", keep_dropping=False)
-
         # Whether this response is speculative was settled when its inference
-        # started, so a turn confirmed since then already cleared it.
-        if not self._speculation_id:
-            return emitted
-
-        self._state = SpeculationState.HOLDING
-        self._bound_hold()
+        # started, so a turn that ended since then already cleared it.
+        if self._speculating:
+            self._state = SpeculationState.HOLDING
         return emitted
 
-    def _release(self, speculation_id: str | None) -> list[GatedFrame]:
-        """Release the response the turn end confirms.
-
-        Args:
-            speculation_id: The speculation the turn confirms. A turn that ends
-                without naming one confirms nothing, and releases nothing.
+    def _release(self) -> list[GatedFrame]:
+        """Release the held response: the turn it answers has ended.
 
         Returns:
-            The frames the confirmation releases, in arrival order.
+            The frames the turn end releases, in arrival order.
         """
-        if not speculation_id:
-            return []
-
-        if speculation_id != self._speculation_id:
-            # Confirmed before its inference reached us. Remember it, or the
-            # response would be held on arrival and never released: the turn is
-            # over, so nothing follows to supersede it.
-            self._confirmed_id = speculation_id
-            return []
-
         # The turn ended, so nothing this inference still produces is
-        # speculative — including a tool call it has yet to reach.
-        self._speculation_id = None
-
+        # speculative, including a tool call it has yet to reach.
+        self._speculating = False
         if self._state != SpeculationState.HOLDING:
             return []
-
         logger.debug(f"{self}: releasing speculative response ({self._buffer.qsize()} frames)")
-        self._end_hold(SpeculationState.OPEN)
+        self._state = SpeculationState.OPEN
         return self._flush()
 
-    def _discard(self, speculation_id: str | None) -> list[GatedFrame]:
-        """Discard the response a withdrawal or an interruption voids.
+    def _discard(self) -> list[GatedFrame]:
+        """Discard the held response: the speculation was withdrawn, or an interruption voided it.
 
         A withdrawal that arrives before the response it voids needs no memory:
         the response is held on arrival, and whatever answers the turn instead
-        supersedes it — or the bound on the hold runs out if nothing does.
-
-        Args:
-            speculation_id: The speculation being withdrawn, or None to discard
-                whatever is held, which is what an interruption and shutdown do.
+        supersedes it.
 
         Returns:
             Whatever the discarded response was holding back that has to be
             delivered anyway.
         """
-        if speculation_id and speculation_id != self._speculation_id:
-            return []
-
         # The speculation is void, so nothing the inference still produces
         # answers a turn worth holding for.
-        self._speculation_id = None
-
+        self._speculating = False
         return self._drop_held("withdrawn", keep_dropping=True)
 
     def _drop_held(self, reason: str, *, keep_dropping: bool) -> list[GatedFrame]:
@@ -392,7 +257,6 @@ class SpeculationGate(BaseObject):
         if self._state != SpeculationState.HOLDING:
             self._state = SpeculationState.OPEN
             return []
-
         logger.debug(
             f"{self}: discarding speculative response ({self._buffer.qsize()} frames, {reason})"
         )
@@ -401,7 +265,7 @@ class SpeculationGate(BaseObject):
         # Drops the speculative response and keeps anything that must always be
         # delivered, which is then emitted rather than discarded with it.
         self._buffer.reset()
-        self._end_hold(
+        self._state = (
             SpeculationState.DROPPING if keep_dropping and not complete else SpeculationState.OPEN
         )
         return self._flush()
@@ -412,5 +276,5 @@ class SpeculationGate(BaseObject):
         while not self._buffer.empty():
             frame, direction = self._buffer.get_nowait()
             self._buffer.task_done()
-            emitted.append(self._resolved(frame, direction))
+            emitted.append((frame, direction))
         return emitted

--- a/src/pipecat/turns/types.py
+++ b/src/pipecat/turns/types.py
@@ -34,11 +34,7 @@ class UserTurnSpeculation:
     until the turn is confirmed.
 
     Parameters:
-        id: Identifies this speculation across the pipeline. The LLM service
-            stamps it onto the response frames so the gate holding the response
-            can tell which frames it owns.
         text: The user turn text the inference was run against.
     """
 
-    id: str
     text: str

--- a/src/pipecat/turns/user_stop/base_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/base_user_turn_stop_strategy.py
@@ -29,14 +29,15 @@ class UserTurnStoppedParams:
             turn. False when the turn end was already announced elsewhere — by a
             shared :class:`~pipecat.turns.user_turn_processor.UserTurnProcessor`,
             or by a service that emits turn frames rather than proposing them.
-        speculation_id: The speculative response this turn end confirms, if any.
-            Travels to the :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame`
-            the aggregator emits, which is what releases that response.
-
+        speculated: Whether the turn's inference already ran, speculatively,
+            on an eager end of turn that held. The aggregator then writes the
+            turn to the context without running inference again; the
+            :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame` it emits
+            releases the response.
     """
 
     enable_user_speaking_frames: bool
-    speculation_id: str | None = None
+    speculated: bool = False
 
 
 class BaseUserTurnStopStrategy(BaseObject):
@@ -245,7 +246,7 @@ class BaseUserTurnStopStrategy(BaseObject):
         self,
         *,
         enable_user_speaking_frames: bool | None = None,
-        speculation_id: str | None = None,
+        speculated: bool = False,
     ):
         """Trigger only the `on_user_turn_stopped` event.
 
@@ -254,9 +255,9 @@ class BaseUserTurnStopStrategy(BaseObject):
                 :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame` for this
                 turn. Pass False when something else in the pipeline has already
                 emitted it.
-            speculation_id: The speculative response this turn end confirms, if
-                any. Pass it to release a response generated ahead of the turn
-                ending.
+            speculated: Whether the turn's inference already ran speculatively,
+                so the turn end only writes the context and releases the
+                response generated ahead of it.
         """
         await self._call_event_handler(
             "on_user_turn_stopped",
@@ -266,6 +267,6 @@ class BaseUserTurnStopStrategy(BaseObject):
                     if enable_user_speaking_frames is None
                     else enable_user_speaking_frames
                 ),
-                speculation_id=speculation_id,
+                speculated=speculated,
             ),
         )

--- a/src/pipecat/turns/user_stop/eager_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/eager_user_turn_stop_strategy.py
@@ -6,6 +6,8 @@
 
 """User turn stop strategy that answers an eager end of turn speculatively."""
 
+import asyncio
+
 from loguru import logger
 
 from pipecat.frames.frames import (
@@ -26,24 +28,35 @@ class EagerUserTurnStopStrategy(ExternalUserTurnStopStrategy):
     strategy starts generating a response on that prediction, so the gap between
     it and the committed end of turn is spent generating rather than waiting.
 
-    The prediction can be wrong in two ways, and both discard the response:
+    The prediction can be wrong in three ways, and all three discard the
+    response with an
+    :class:`~pipecat.frames.frames.EagerEndOfTurnCancelFrame`:
 
     - the user resumes speaking, and the service withdraws the eager end of turn
-    - the committed transcript differs from the eager one, per ``match_policy``
+    - the committed transcript differs from the eager one, per ``match_policy``;
+      the turn then ends without confirming the speculation, and the aggregator
+      withdraws it ahead of the turn end
+    - the service never commits or withdraws within ``speculation_timeout``
 
     Nothing the speculation produces reaches the user or the context. The
     inference runs against a provisional context, and its response is held by
     the LLM service's
-    :class:`~pipecat.turns.speculation_gate.SpeculationGate` until the turn is
-    confirmed. The turn ends normally: the user message written to the context
-    is always the committed transcript, never the eager one.
+    :class:`~pipecat.turns.speculation_gate.SpeculationGate` until the turn
+    ends. The turn ends normally: the user message written to the context is
+    always the committed transcript, never the eager one.
 
     Install it with :class:`~pipecat.turns.user_turn_strategies.EagerUserTurnStrategies`
     rather than directly — the service owns turn detection here, so it replaces
     the detector chain instead of running alongside it.
     """
 
-    def __init__(self, *, match_policy: EagerMatchPolicy | None = None, **kwargs):
+    def __init__(
+        self,
+        *,
+        match_policy: EagerMatchPolicy | None = None,
+        speculation_timeout: float = 5.0,
+        **kwargs,
+    ):
         """Initialize the eager user turn stop strategy.
 
         Args:
@@ -54,16 +67,28 @@ class EagerUserTurnStopStrategy(ExternalUserTurnStopStrategy):
                 commonly add when they commit a transcript. Pass
                 :class:`~pipecat.turns.user_stop.ExactMatch` to require the two
                 to be identical.
+            speculation_timeout: Seconds a speculation may wait for the service
+                to commit or withdraw the eager end of turn before the strategy
+                withdraws it. Without this bound, a service that stops sending
+                turn signals mid-speculation would leave the response held, and
+                the bot silent, for the rest of the session.
             **kwargs: Additional keyword arguments forwarded to the base class.
         """
         super().__init__(**kwargs)
         self._match_policy = match_policy or NormalizedMatch()
+        self._speculation_timeout = speculation_timeout
         self._speculation: UserTurnSpeculation | None = None
+        self._timeout_task: asyncio.Task | None = None
 
     @property
     def match_policy(self) -> EagerMatchPolicy:
         """The policy deciding whether a speculative response still applies."""
         return self._match_policy
+
+    async def cleanup(self):
+        """Stop bounding a speculation that outlived the pipeline."""
+        await self._settle()
+        await super().cleanup()
 
     async def process_frame(self, frame: Frame) -> ProcessFrameResult:
         """Start a speculation on an eager end of turn, or withdraw one.
@@ -79,7 +104,7 @@ class EagerUserTurnStopStrategy(ExternalUserTurnStopStrategy):
         elif isinstance(frame, EagerEndOfTurnCancelFrame):
             # The service withdrew its prediction, and its frame reaches every
             # consumer on its own. Only our own state is left to clear.
-            self._forget(frame.speculation_id)
+            await self._settle()
 
         return await super().process_frame(frame)
 
@@ -91,23 +116,19 @@ class EagerUserTurnStopStrategy(ExternalUserTurnStopStrategy):
                 :class:`~pipecat.frames.frames.UserStoppedSpeakingFrame` for this
                 turn.
         """
-        speculation = self._speculation
+        speculation = await self._settle()
         if not speculation:
             await super().trigger_user_turn_stopped(
                 enable_user_speaking_frames=enable_user_speaking_frames
             )
             return
 
-        self._speculation = None
-
         if self._match_policy.matches(speculation.text, self._text):
             logger.debug(f"{self}: eager end of turn held, keeping the speculative response")
-            # Inference already ran, on the eager transcript. Only finalize,
-            # naming the speculation: the UserStoppedSpeakingFrame that carries
-            # its id is what releases the response.
+            # Inference already ran, on the eager transcript. Only finalize: the
+            # UserStoppedSpeakingFrame that ends the turn releases the response.
             await self.trigger_user_turn_finalized(
-                enable_user_speaking_frames=enable_user_speaking_frames,
-                speculation_id=speculation.id,
+                enable_user_speaking_frames=enable_user_speaking_frames, speculated=True
             )
             return
 
@@ -115,36 +136,61 @@ class EagerUserTurnStopStrategy(ExternalUserTurnStopStrategy):
             f"{self}: eager end of turn missed, discarding the speculative response "
             f"(eager: [{speculation.text}], committed: [{self._text}])"
         )
-        await self.push_frame(EagerEndOfTurnCancelFrame(speculation.id))
-        # Inference has to run again, on the committed transcript, so fire both
-        # events rather than just finalizing.
-        await super().trigger_user_turn_stopped(
+        # Only finalize, without confirming the speculation: the aggregator
+        # withdraws it ahead of the turn end and runs inference again, on the
+        # committed transcript, behind it. Withdrawing from here would queue
+        # the cancel behind frames the aggregator is processing, and the turn
+        # end would overtake it and release the response.
+        await self.trigger_user_turn_finalized(
             enable_user_speaking_frames=enable_user_speaking_frames
         )
 
+    async def handle_user_turn_started(self):
+        """Start a turn, withdrawing a speculation the previous turn left in flight."""
+        if await self._settle():
+            # The previous turn never ended, so nothing withdrew its
+            # speculation, and the response would be held for good. A turn that
+            # ends without confirming its speculation is withdrawn by the
+            # aggregator, ahead of the turn end.
+            logger.debug(f"{self}: new turn over a live speculation, discarding its response")
+            await self.push_frame(EagerEndOfTurnCancelFrame())
+        await super().handle_user_turn_started()
+
     async def _reset(self):
         """Clear per-turn state. Runs at both turn boundaries."""
-        speculation = self._speculation
+        await self._settle()
         await super()._reset()
-        self._speculation = None
-        if speculation:
-            # The turn ended without resolving the speculation — the stop
-            # watchdog, an interruption, session end. Nothing else will withdraw
-            # it, so the response would be held until the gate times out.
-            logger.debug(f"{self}: turn ended unresolved, discarding the speculative response")
-            await self.push_frame(EagerEndOfTurnCancelFrame(speculation.id))
 
     async def _speculate(self, frame: EagerTranscriptionFrame):
         """Answer an eager end of turn, leaving the turn open."""
+        # A prediction the service replaces without withdrawing: the response
+        # to the old one answers nothing, so it is withdrawn here.
+        if await self._settle():
+            await self.push_frame(EagerEndOfTurnCancelFrame())
         # Segments committed earlier in this turn are part of what the LLM will
         # see, so they're part of what the committed transcript is compared to.
-        self._speculation = UserTurnSpeculation(
-            id=frame.speculation_id, text=self._text + frame.text
+        self._speculation = UserTurnSpeculation(text=self._text + frame.text)
+        self._timeout_task = self.create_task(
+            self._speculation_timeout_handler(), f"{self}::_speculation_timeout"
         )
         logger.debug(f"{self}: speculating on eager end of turn: [{self._speculation.text}]")
         await self.trigger_user_turn_inference_triggered(speculation=self._speculation)
 
-    def _forget(self, speculation_id: str):
-        """Drop a speculation the service withdrew."""
-        if self._speculation and self._speculation.id == speculation_id:
-            self._speculation = None
+    async def _settle(self) -> UserTurnSpeculation | None:
+        """Take the speculation in flight, if any, and stop bounding it."""
+        speculation, self._speculation = self._speculation, None
+        task, self._timeout_task = self._timeout_task, None
+        if task and task is not asyncio.current_task():
+            await self.cancel_task(task)
+        return speculation
+
+    async def _speculation_timeout_handler(self):
+        """Withdraw a speculation the service neither committed nor withdrew in time."""
+        await asyncio.sleep(self._speculation_timeout)
+        if not await self._settle():
+            return
+        logger.warning(
+            f"{self}: eager end of turn unresolved after {self._speculation_timeout}s, "
+            "discarding the speculative response"
+        )
+        await self.push_frame(EagerEndOfTurnCancelFrame())

--- a/src/pipecat/turns/user_turn_processor.py
+++ b/src/pipecat/turns/user_turn_processor.py
@@ -231,9 +231,7 @@ class UserTurnProcessor(FrameProcessor):
         logger.debug(f"{self}: User stopped speaking (strategy: {strategy})")
 
         if params.enable_user_speaking_frames:
-            await self.broadcast_frame(
-                UserStoppedSpeakingFrame, speculation_id=params.speculation_id
-            )
+            await self.broadcast_frame(UserStoppedSpeakingFrame)
 
         await self._user_idle_controller.process_frame(UserStoppedSpeakingFrame())
 

--- a/src/pipecat/turns/user_turn_strategies.py
+++ b/src/pipecat/turns/user_turn_strategies.py
@@ -193,6 +193,8 @@ class EagerUserTurnStrategies(ExternalUserTurnStrategies):
         enable_interruptions: Whether to broadcast an interruption when a
             proposal starts a turn. Services route their ``should_interrupt``
             setting here.
+        speculation_timeout: Seconds a speculation may wait for the service to
+            commit or withdraw the eager end of turn before it is withdrawn.
 
     Example::
 
@@ -203,7 +205,12 @@ class EagerUserTurnStrategies(ExternalUserTurnStrategies):
     """
 
     match_policy: EagerMatchPolicy | None = None
+    speculation_timeout: float = 5.0
 
     def __post_init__(self):
         super().__post_init__()
-        self.stop = [EagerUserTurnStopStrategy(match_policy=self.match_policy)]
+        self.stop = [
+            EagerUserTurnStopStrategy(
+                match_policy=self.match_policy, speculation_timeout=self.speculation_timeout
+            )
+        ]

--- a/tests/test_eager_end_of_turn_mixin.py
+++ b/tests/test_eager_end_of_turn_mixin.py
@@ -32,10 +32,11 @@ class Predictor(EagerEndOfTurnSTTServiceMixin, FrameProcessor):
 
 
 class TestEagerEndOfTurnMixin(unittest.IsolatedAsyncioTestCase):
-    async def test_a_withdrawal_names_the_prediction_it_withdraws(self):
+    async def test_a_prediction_is_pushed_and_a_resume_withdraws_it(self):
         service = Predictor()
 
         await service._push_eager_end_of_turn("book a flight", user_id="user")
+        assert service.eager_end_of_turn_pending
         await service._cancel_eager_end_of_turn()
 
         prediction, withdrawal = service.pushed
@@ -43,18 +44,7 @@ class TestEagerEndOfTurnMixin(unittest.IsolatedAsyncioTestCase):
         assert prediction.text == "book a flight"
         assert prediction.user_id == "user"
         assert isinstance(withdrawal, EagerEndOfTurnCancelFrame)
-        assert withdrawal.speculation_id == prediction.speculation_id
-        assert service.eager_speculation_id is None
-
-    async def test_each_prediction_gets_its_own_id(self):
-        service = Predictor()
-
-        await service._push_eager_end_of_turn("i think", user_id="user")
-        await service._push_eager_end_of_turn("i think i'll book it", user_id="user")
-
-        first, second = service.pushed
-        assert first.speculation_id and second.speculation_id
-        assert first.speculation_id != second.speculation_id
+        assert not service.eager_end_of_turn_pending
 
     async def test_a_committed_turn_resolves_the_prediction_without_withdrawing_it(self):
         service = Predictor()
@@ -66,7 +56,7 @@ class TestEagerEndOfTurnMixin(unittest.IsolatedAsyncioTestCase):
         await service._cancel_eager_end_of_turn()
 
         assert not any(isinstance(f, EagerEndOfTurnCancelFrame) for f in service.pushed)
-        assert service.eager_speculation_id is None
+        assert not service.eager_end_of_turn_pending
 
     async def test_withdrawing_without_a_prediction_does_nothing(self):
         service = Predictor()
@@ -75,7 +65,7 @@ class TestEagerEndOfTurnMixin(unittest.IsolatedAsyncioTestCase):
         service._clear_eager_end_of_turn()
 
         assert service.pushed == []
-        assert service.eager_speculation_id is None
+        assert not service.eager_end_of_turn_pending
 
 
 class TestEagerEndOfTurnIsOptIn(unittest.IsolatedAsyncioTestCase):
@@ -89,7 +79,7 @@ class TestEagerEndOfTurnIsOptIn(unittest.IsolatedAsyncioTestCase):
         service._clear_eager_end_of_turn()
 
         assert service.pushed == []
-        assert service.eager_speculation_id is None
+        assert not service.eager_end_of_turn_pending
         assert not service.eager_end_of_turn_enabled
 
     def test_it_recommends_eager_strategies_only_when_enabled(self):

--- a/tests/test_eager_user_turn_strategies.py
+++ b/tests/test_eager_user_turn_strategies.py
@@ -11,7 +11,6 @@ from pipecat.frames.frames import (
     EagerEndOfTurnCancelFrame,
     EagerTranscriptionFrame,
     FunctionCallFromLLM,
-    InterruptionFrame,
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
@@ -19,7 +18,6 @@ from pipecat.frames.frames import (
     ProposedUserStartedSpeakingFrame,
     ProposedUserStoppedSpeakingFrame,
     TranscriptionFrame,
-    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -33,6 +31,9 @@ from pipecat.services.settings import LLMSettings
 from pipecat.tests.utils import SleepFrame, run_test
 from pipecat.turns.user_stop import EagerUserTurnStopStrategy, ExactMatch, deferred
 from pipecat.turns.user_turn_strategies import EagerUserTurnStrategies
+from pipecat.utils.asyncio.task_manager import TaskManager
+
+from .frame_processor_helpers import frame_processor_setup
 
 
 def aggregator(
@@ -47,8 +48,15 @@ def aggregator(
     )
 
 
-def eager(text: str, speculation_id: str = "abc") -> EagerTranscriptionFrame:
-    return EagerTranscriptionFrame(text, "user", "2026-09-03T00:00:00Z", speculation_id)
+def eager(text: str) -> EagerTranscriptionFrame:
+    return EagerTranscriptionFrame(text, "user", "2026-09-03T00:00:00Z")
+
+
+async def strategy_alone(**kwargs) -> EagerUserTurnStopStrategy:
+    """A strategy set up outside a pipeline, since it runs a task of its own."""
+    strategy = EagerUserTurnStopStrategy(**kwargs)
+    await strategy.setup(frame_processor_setup(TaskManager()))
+    return strategy
 
 
 def final(text: str) -> TranscriptionFrame:
@@ -72,7 +80,7 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
 
         # Inference ran against a provisional copy carrying the eager transcript.
         provisional = next(f for f in down if isinstance(f, LLMContextFrame))
-        assert provisional.speculation_id is not None
+        assert provisional.speculative
         assert provisional.context is not context
         assert provisional.context.messages[-1] == {"role": "user", "content": "book a flight"}
 
@@ -103,9 +111,9 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
         # One inference, the speculative one: the confirmed turn is written to
         # the context without answering it a second time.
         assert len(contexts) == 1
-        assert contexts[0].speculation_id is not None
-        # The turn end names the speculation, which is what releases its response.
-        assert [f.speculation_id for f in stops] == [contexts[0].speculation_id]
+        assert contexts[0].speculative
+        # The turn end is what releases its response.
+        assert len(stops) == 1
         assert context.messages == [{"role": "user", "content": "book a flight"}]
 
     async def test_differing_transcript_withdraws_the_speculation(self):
@@ -129,16 +137,15 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
         cancel = next(f for f in down if isinstance(f, EagerEndOfTurnCancelFrame))
 
         # The speculative inference, then a second one on the committed transcript.
-        assert [c.speculation_id is not None for c in contexts] == [True, False]
-        assert cancel.speculation_id == contexts[0].speculation_id
+        assert [c.speculative for c in contexts] == [True, False]
+        # The withdrawal precedes the turn end, so the gate has nothing to release.
+        assert down.index(cancel) < next(
+            i for i, f in enumerate(down) if isinstance(f, UserStoppedSpeakingFrame)
+        )
         assert contexts[1].context.messages[-1] == {
             "role": "user",
             "content": "i want to cancel, actually reschedule it",
         }
-        # The turn end confirms nothing, so it releases nothing.
-        assert all(
-            f.speculation_id is None for f in down if isinstance(f, UserStoppedSpeakingFrame)
-        )
 
         # Only the committed transcript reaches the context.
         assert context.messages == [
@@ -156,7 +163,7 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
                 eager("i think"),
                 SleepFrame(),
                 # The service withdraws the prediction it made.
-                EagerEndOfTurnCancelFrame("abc"),
+                EagerEndOfTurnCancelFrame(),
                 SleepFrame(),
                 final("i think i'll book it tomorrow"),
                 SleepFrame(),
@@ -168,11 +175,10 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
         contexts = [f for f in down if isinstance(f, LLMContextFrame)]
         cancels = [f for f in down if isinstance(f, EagerEndOfTurnCancelFrame)]
 
-        # The service's withdrawal travels on its own, naming the prediction the
-        # speculative inference was run from. The strategy adds none of its own.
-        assert [c.speculation_id for c in cancels] == ["abc"]
-        assert contexts[0].speculation_id == "abc"
-        assert contexts[1].speculation_id is None
+        # The service's withdrawal travels on its own. The strategy adds none of
+        # its own.
+        assert len(cancels) == 1
+        assert [c.speculative for c in contexts] == [True, False]
         assert context.messages == [{"role": "user", "content": "i think i'll book it tomorrow"}]
 
     async def test_formatting_differences_are_tolerated_by_default(self):
@@ -225,10 +231,7 @@ class TestEagerUserTurnStrategies(unittest.IsolatedAsyncioTestCase):
 
         assert not any(isinstance(f, EagerEndOfTurnCancelFrame) for f in down)
         assert len(contexts) == 1
-        assert contexts[0].speculation_id is None
-        assert all(
-            f.speculation_id is None for f in down if isinstance(f, UserStoppedSpeakingFrame)
-        )
+        assert not contexts[0].speculative
         assert context.messages == [{"role": "user", "content": "hello there"}]
 
     async def test_eager_transcript_is_not_pushed_downstream(self):
@@ -282,13 +285,14 @@ class TestSpeculativeToolCalls(unittest.IsolatedAsyncioTestCase):
         llm.register_function("book_flight", lambda params: calls.append(params))
 
         context = LLMContext(messages=[{"role": "user", "content": "book a flight"}])
-        speculative = LLMContextFrame(context=context, speculation_id="abc")
+        speculative = LLMContextFrame(context=context, speculative=True)
 
         down, up = await run_test(llm, frames_to_send=[speculative, SleepFrame()])
 
         assert calls == []
+        # Broadcast both ways: downstream to the gate, upstream to the strategy.
         withdrawals = [f for f in [*down, *up] if isinstance(f, EagerEndOfTurnCancelFrame)]
-        assert [f.speculation_id for f in withdrawals] == ["abc", "abc"]
+        assert len(withdrawals) == 2
 
     async def test_committed_inference_executes_tools(self):
         calls = []
@@ -309,12 +313,12 @@ class TestSpeculativeToolCalls(unittest.IsolatedAsyncioTestCase):
 
 class TestUnresolvedSpeculation(unittest.IsolatedAsyncioTestCase):
     async def test_new_turn_withdraws_a_speculation_left_in_flight(self):
-        # A turn boundary the service didn't resolve — a fresh turn starting
-        # over a live prediction — still has to withdraw it, or the gate would
-        # hold the response until its buffer times out.
+        # A fresh turn starting over a live prediction has to withdraw it, or
+        # the gate would hold the response for good: no turn end withdraws it,
+        # since the previous turn never ended.
         pushed = []
 
-        strategy = EagerUserTurnStopStrategy()
+        strategy = await strategy_alone()
         strategy.add_event_handler(
             "on_push_frame", lambda s, frame, direction: pushed.append(frame)
         )
@@ -322,9 +326,7 @@ class TestUnresolvedSpeculation(unittest.IsolatedAsyncioTestCase):
         await strategy.process_frame(eager("book a flight"))
         await strategy.handle_user_turn_started()
 
-        assert [f.speculation_id for f in pushed if isinstance(f, EagerEndOfTurnCancelFrame)] == [
-            "abc"
-        ]
+        assert len([f for f in pushed if isinstance(f, EagerEndOfTurnCancelFrame)]) == 1
 
         # The withdrawal happens once: a second boundary has nothing left to
         # withdraw.
@@ -358,13 +360,8 @@ class TestTurnCommittedWithoutATranscript(unittest.IsolatedAsyncioTestCase):
         cancels = [f for f in down if isinstance(f, EagerEndOfTurnCancelFrame)]
 
         # Only the speculative inference ran, and it was withdrawn.
-        assert [c.speculation_id for c in contexts] == ["abc"]
-        assert [c.speculation_id for c in cancels] == ["abc"]
-        # The turn end confirms nothing, so the gate would release nothing even
-        # if it saw the turn end before the withdrawal.
-        assert all(
-            f.speculation_id is None for f in down if isinstance(f, UserStoppedSpeakingFrame)
-        )
+        assert [c.speculative for c in contexts] == [True]
+        assert len(cancels) == 1
         # The eager transcript is never written: only a committed one is.
         assert context.messages == []
 
@@ -377,6 +374,7 @@ class TestDeferredEagerStrategy(unittest.IsolatedAsyncioTestCase):
 
         inner = EagerUserTurnStopStrategy()
         wrapper = deferred(inner)
+        await wrapper.setup(frame_processor_setup(TaskManager()))
         wrapper.add_event_handler(
             "on_user_turn_inference_triggered",
             lambda strategy, speculation: triggered.append(speculation),
@@ -385,7 +383,6 @@ class TestDeferredEagerStrategy(unittest.IsolatedAsyncioTestCase):
         await wrapper.process_frame(eager("book a flight"))
 
         assert [s.text for s in triggered] == ["book a flight"]
-        assert triggered[0].id == "abc"
 
 
 class TestExactMatchPolicy(unittest.IsolatedAsyncioTestCase):
@@ -410,8 +407,83 @@ class TestExactMatchPolicy(unittest.IsolatedAsyncioTestCase):
         )
 
         cancels = [f for f in down if isinstance(f, EagerEndOfTurnCancelFrame)]
-        assert [c.speculation_id for c in cancels] == ["abc"]
+        assert len(cancels) == 1
         assert context.messages == [{"role": "user", "content": "Book a flight to Tokyo."}]
+
+
+class EchoingStreamLLM(LLMService):
+    """LLM service that answers every context frame slowly, naming the user message it answers."""
+
+    def __init__(self, *, stream_for: float = 0.3, **kwargs):
+        super().__init__(settings=LLMSettings(model="test-model"), **kwargs)
+        self._stream_for = stream_for
+
+    async def process_frame(self, frame, direction):
+        await super().process_frame(frame, direction)
+        if not isinstance(frame, LLMContextFrame):
+            await self.push_frame(frame, direction)
+            return
+
+        user = frame.context.messages[-1]["content"]
+        await self.push_frame(LLMFullResponseStartFrame())
+        await self.push_frame(LLMTextFrame(f"Answer to: {user}"))
+        await asyncio.sleep(self._stream_for)
+        await self.push_frame(LLMFullResponseEndFrame())
+
+
+class TestMismatchEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """A prediction that misses is withdrawn ahead of the turn end, and the turn is still answered."""
+
+    async def test_only_the_answer_to_the_committed_transcript_is_spoken(self):
+        context = LLMContext()
+
+        down, _ = await run_test(
+            Pipeline([aggregator(context), EchoingStreamLLM()]),
+            frames_to_send=[
+                ProposedUserStartedSpeakingFrame(),
+                SleepFrame(),
+                eager("i want to cancel"),
+                # The speculative response is still streaming when the commit lands.
+                SleepFrame(sleep=0.1),
+                final("i want to cancel, actually reschedule it"),
+                SleepFrame(),
+                ProposedUserStoppedSpeakingFrame(),
+                SleepFrame(sleep=1.5),
+            ],
+        )
+
+        # The withdrawal reaches the LLM before the turn end, so the held
+        # speculative response is discarded rather than released.
+        cancel_at = next(i for i, f in enumerate(down) if isinstance(f, EagerEndOfTurnCancelFrame))
+        stop_at = next(i for i, f in enumerate(down) if isinstance(f, UserStoppedSpeakingFrame))
+        assert cancel_at < stop_at
+        assert [f.text for f in down if isinstance(f, LLMTextFrame)] == [
+            "Answer to: i want to cancel, actually reschedule it"
+        ]
+        assert context.messages == [
+            {"role": "user", "content": "i want to cancel, actually reschedule it"}
+        ]
+
+    async def test_a_prediction_that_holds_is_spoken_once(self):
+        context = LLMContext()
+
+        down, _ = await run_test(
+            Pipeline([aggregator(context), EchoingStreamLLM()]),
+            frames_to_send=[
+                ProposedUserStartedSpeakingFrame(),
+                SleepFrame(),
+                eager("book a flight"),
+                SleepFrame(sleep=0.1),
+                final("Book a flight."),
+                SleepFrame(),
+                ProposedUserStoppedSpeakingFrame(),
+                SleepFrame(sleep=1.5),
+            ],
+        )
+
+        assert [f.text for f in down if isinstance(f, LLMTextFrame)] == ["Answer to: book a flight"]
+        assert not any(isinstance(f, EagerEndOfTurnCancelFrame) for f in down)
+        assert context.messages == [{"role": "user", "content": "Book a flight."}]
 
 
 class SpeculativeLLM(LLMService):
@@ -444,17 +516,17 @@ class TestLLMServiceHoldsTheSpeculation(unittest.IsolatedAsyncioTestCase):
         ]
 
     @staticmethod
-    def context_frame(speculation_id=None):
+    def context_frame(speculative=False):
         context = LLMContext(messages=[{"role": "user", "content": "book a flight"}])
-        return LLMContextFrame(context=context, speculation_id=speculation_id)
+        return LLMContextFrame(context=context, speculative=speculative)
 
-    async def test_a_speculative_response_leaves_the_service_only_once_confirmed(self):
+    async def test_a_speculative_response_leaves_the_service_only_once_the_turn_ends(self):
         down, _ = await run_test(
             SpeculativeLLM(),
             frames_to_send=[
-                self.context_frame("abc"),
+                self.context_frame(True),
                 SleepFrame(),
-                UserStoppedSpeakingFrame(speculation_id="abc"),
+                UserStoppedSpeakingFrame(),
                 SleepFrame(),
             ],
         )
@@ -472,20 +544,14 @@ class TestLLMServiceHoldsTheSpeculation(unittest.IsolatedAsyncioTestCase):
             i for i, f in enumerate(down) if isinstance(f, LLMFullResponseStartFrame)
         )
         assert response_at > confirmed_at
-        # Confirmed on the way out, so nothing downstream sees it as speculative.
-        assert all(
-            f.speculation_id is None
-            for f in down
-            if isinstance(f, (LLMFullResponseStartFrame, LLMFullResponseEndFrame))
-        )
 
     async def test_a_withdrawn_speculative_response_never_leaves_the_service(self):
         down, _ = await run_test(
             SpeculativeLLM(),
             frames_to_send=[
-                self.context_frame("abc"),
+                self.context_frame(True),
                 SleepFrame(),
-                EagerEndOfTurnCancelFrame(speculation_id="abc"),
+                EagerEndOfTurnCancelFrame(),
                 SleepFrame(),
             ],
         )
@@ -504,43 +570,54 @@ class TestLLMServiceHoldsTheSpeculation(unittest.IsolatedAsyncioTestCase):
             LLMFullResponseEndFrame,
         ]
 
-    async def test_a_speculation_nothing_resolves_is_dropped_after_the_hold_timeout(self):
-        class ImpatientLLM(SpeculativeLLM):
-            SPECULATION_HOLD_TIMEOUT = 0.2
 
-        down, up = await run_test(
-            ImpatientLLM(),
-            frames_to_send=[
-                self.context_frame("abc"),
-                SleepFrame(sleep=0.8),
-                # Confirmation arriving after the service gave up on it.
-                UserStoppedSpeakingFrame(speculation_id="abc"),
-                SleepFrame(),
-            ],
+class TestSpeculationTimeout(unittest.IsolatedAsyncioTestCase):
+    """The strategy withdraws a speculation the service neither commits nor withdraws."""
+
+    async def test_an_unresolved_speculation_is_withdrawn_after_the_timeout(self):
+        pushed = []
+
+        strategy = await strategy_alone(speculation_timeout=0.1)
+        strategy.add_event_handler(
+            "on_push_frame", lambda s, frame, direction: pushed.append(frame)
         )
 
-        assert self.response_frames(down) == []
-        # Withdrawn, so the strategy that started it stops expecting it. Without
-        # this the committed turn confirms a response that no longer exists.
-        withdrawals = [f for f in [*down, *up] if isinstance(f, EagerEndOfTurnCancelFrame)]
-        assert [f.speculation_id for f in withdrawals] == ["abc", "abc"]
+        await strategy.process_frame(eager("book a flight"))
+        await asyncio.sleep(0.4)
+
+        assert [type(f) for f in pushed] == [EagerEndOfTurnCancelFrame]
+
+    async def test_a_speculation_resolved_in_time_is_not_withdrawn(self):
+        pushed = []
+
+        strategy = await strategy_alone(speculation_timeout=0.1)
+        strategy.add_event_handler(
+            "on_push_frame", lambda s, frame, direction: pushed.append(frame)
+        )
+
+        await strategy.process_frame(eager("book a flight"))
+        # The service withdrew it itself, so the timer has nothing left to do.
+        await strategy.process_frame(EagerEndOfTurnCancelFrame())
+        await asyncio.sleep(0.4)
+
+        assert pushed == []
 
 
 class TestATurnOutlastingTheHoldIsStillAnswered(unittest.IsolatedAsyncioTestCase):
-    """A hold that runs out must not cost the turn its reply.
+    """A speculation that times out must not cost the turn its reply.
 
-    The bound exists so the bot is never left silent; giving up on the held
-    response has to put the turn back on the ordinary path rather than leave the
-    strategy waiting for a response the gate has already dropped.
+    The bound exists so the bot is never left silent; withdrawing the held
+    response has to put the turn back on the ordinary path.
     """
 
     @staticmethod
-    def aggregator_and_llm(hold_timeout: float):
-        class ImpatientLLM(SpeculativeLLM):
-            SPECULATION_HOLD_TIMEOUT = hold_timeout
-
+    def aggregator_and_llm(speculation_timeout: float):
         context = LLMContext()
-        return context, aggregator(context), ImpatientLLM()
+        return (
+            context,
+            aggregator(context, speculation_timeout=speculation_timeout),
+            SpeculativeLLM(),
+        )
 
     async def test_a_matching_commit_after_the_hold_expires_runs_a_fresh_inference(self):
         context, user_aggregator, llm = self.aggregator_and_llm(0.2)
@@ -551,7 +628,7 @@ class TestATurnOutlastingTheHoldIsStillAnswered(unittest.IsolatedAsyncioTestCase
                 ProposedUserStartedSpeakingFrame(),
                 SleepFrame(),
                 eager("book a flight"),
-                # Longer than the hold, so the gate gives up before the commit.
+                # Longer than the timeout, so the strategy withdraws it before the commit.
                 SleepFrame(sleep=0.8),
                 final("Book a flight."),
                 SleepFrame(),
@@ -626,9 +703,9 @@ class TestToolCallsAcrossTheConfirmation(unittest.IsolatedAsyncioTestCase):
     """A tool call is speculative only until the turn it answers is confirmed."""
 
     @staticmethod
-    def context_frame(speculation_id=None):
+    def context_frame(speculative=False):
         context = LLMContext(messages=[{"role": "user", "content": "book a flight"}])
-        return LLMContextFrame(context=context, speculation_id=speculation_id)
+        return LLMContextFrame(context=context, speculative=speculative)
 
     @staticmethod
     def withdrawals(down, up):
@@ -643,9 +720,9 @@ class TestToolCallsAcrossTheConfirmation(unittest.IsolatedAsyncioTestCase):
         down, up = await run_test(
             llm,
             frames_to_send=[
-                self.context_frame("abc"),
+                self.context_frame(True),
                 SleepFrame(sleep=0.15),
-                UserStoppedSpeakingFrame(speculation_id="abc"),
+                UserStoppedSpeakingFrame(),
                 SleepFrame(sleep=1.0),
             ],
         )
@@ -656,17 +733,17 @@ class TestToolCallsAcrossTheConfirmation(unittest.IsolatedAsyncioTestCase):
         assert [f.text for f in down if isinstance(f, LLMTextFrame)] == ["Let me check that."]
         assert self.withdrawals(down, up) == []
 
-    async def test_a_confirmation_that_overtakes_the_inference_lets_the_call_run(self):
-        # The confirmation is a system frame, so it can pass the context frame
-        # that starts the inference it confirms.
+    async def test_a_turn_end_that_overtakes_the_inference_lets_the_call_run(self):
+        # The turn end is a system frame, so it can pass the context frame that
+        # starts the inference it confirms.
         llm = StreamingToolCallLLM(stream_for=0.1)
 
         down, up = await run_test(
             llm,
             frames_to_send=[
-                UserStoppedSpeakingFrame(speculation_id="abc"),
+                UserStoppedSpeakingFrame(),
                 SleepFrame(),
-                self.context_frame("abc"),
+                self.context_frame(True),
                 SleepFrame(sleep=0.5),
             ],
         )
@@ -675,17 +752,17 @@ class TestToolCallsAcrossTheConfirmation(unittest.IsolatedAsyncioTestCase):
         assert self.withdrawals(down, up) == []
 
     async def test_a_call_reached_before_the_turn_ends_is_withdrawn(self):
-        # Still speculative: the tool must not run, and the withdrawal names the
-        # speculation so the strategy re-runs on the committed transcript.
+        # Still speculative: the tool must not run, and the withdrawal reaches
+        # the strategy so it re-runs on the committed transcript.
         llm = StreamingToolCallLLM(stream_for=0.05)
 
         down, up = await run_test(
             llm,
-            frames_to_send=[self.context_frame("abc"), SleepFrame(sleep=0.8)],
+            frames_to_send=[self.context_frame(True), SleepFrame(sleep=0.8)],
         )
 
         assert llm.calls == []
-        assert [f.speculation_id for f in self.withdrawals(down, up)] == ["abc", "abc"]
+        assert len(self.withdrawals(down, up)) == 2
 
     async def test_an_ordinary_inference_calls_its_tool(self):
         llm = StreamingToolCallLLM(stream_for=0.05)

--- a/tests/test_speculation_gate.py
+++ b/tests/test_speculation_gate.py
@@ -4,11 +4,8 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
-import asyncio
 import unittest
-from unittest.mock import AsyncMock, patch
-
-from loguru import logger
+from unittest.mock import AsyncMock
 
 from pipecat.frames.frames import (
     EagerEndOfTurnCancelFrame,
@@ -25,6 +22,7 @@ from pipecat.frames.frames import (
     ProposedUserStoppedSpeakingFrame,
     TranscriptionFrame,
     TTSAudioRawFrame,
+    UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -39,22 +37,17 @@ from pipecat.services.settings import LLMSettings
 from pipecat.tests.utils import SleepFrame, run_test
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.transports.base_transport import TransportParams
-from pipecat.turns.speculation_gate import GatedFrame, SpeculationGate, SpeculationState
+from pipecat.turns.speculation_gate import SpeculationGate, SpeculationState
 from pipecat.turns.user_turn_strategies import EagerUserTurnStrategies
-from pipecat.utils.asyncio.task_manager import TaskManager
 
 DOWN = FrameDirection.DOWNSTREAM
 
 
-def response(speculation_id: str | None, *texts: str, end: bool = True) -> list[Frame]:
-    """Build the frames of one LLM response, stamped as the service would."""
-    start = LLMFullResponseStartFrame()
-    start.speculation_id = speculation_id
-    frames: list[Frame] = [start, *(LLMTextFrame(t) for t in texts)]
+def response(*texts: str, end: bool = True) -> list[Frame]:
+    """Build the frames of one LLM response."""
+    frames: list[Frame] = [LLMFullResponseStartFrame(), *(LLMTextFrame(t) for t in texts)]
     if end:
-        stop = LLMFullResponseEndFrame()
-        stop.speculation_id = speculation_id
-        frames.append(stop)
+        frames.append(LLMFullResponseEndFrame())
     return frames
 
 
@@ -67,33 +60,16 @@ def tool_result(value: str = "booked") -> FunctionCallResultFrame:
     )
 
 
-async def make_gate(**kwargs) -> SpeculationGate:
-    """Build a gate wired up the way a host wires one."""
-    gate = SpeculationGate(
-        withdraw_expired=kwargs.pop("withdraw_expired", None) or _ignore, **kwargs
-    )
-    await gate.setup(TaskManager())
-    return gate
-
-
-async def _ignore(speculation_id: str, frames: list[GatedFrame]):
-    pass
-
-
-async def _collect(into: list, speculation_id: str, frames: list[GatedFrame]):
-    into.append((speculation_id, [frame for frame, _ in frames]))
-
-
 def speculate(
-    gate: SpeculationGate, speculation_id: str | None, *texts: str, end: bool = True, then=()
+    gate: SpeculationGate, speculative: bool, *texts: str, end: bool = True, then=()
 ) -> list[Frame]:
     """Run an inference through the gate the way a host does.
 
-    The gate is told what the inference answers before its frames arrive, which
-    is what decides whether the response is held.
+    The gate is told whether the inference is speculative before its frames
+    arrive, which is what decides whether the response is held.
     """
-    gate.begin_speculation(speculation_id)
-    return emit(gate, *response(speculation_id, *texts, end=end), *then)
+    gate.begin_speculation(speculative)
+    return emit(gate, *response(*texts, end=end), *then)
 
 
 def emit(gate: SpeculationGate, *frames: Frame) -> list[Frame]:
@@ -110,22 +86,22 @@ def types(frames: list[Frame]) -> list[type]:
 
 class TestSpeculationGate(unittest.IsolatedAsyncioTestCase):
     async def test_non_speculative_response_passes_through(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        assert types(speculate(gate, None, "Hello.")) == [
+        assert types(speculate(gate, False, "Hello.")) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
         ]
 
     async def test_speculative_response_is_held_until_the_turn_ends(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        assert speculate(gate, "abc", "Booking ", "your flight.") == []
+        assert speculate(gate, True, "Booking ", "your flight.") == []
         assert gate.state == SpeculationState.HOLDING
 
-        # Confirmed: the whole response follows, in the order it was generated.
-        released = emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
+        # The turn ended: the whole response follows, in the order it was generated.
+        released = emit(gate, UserStoppedSpeakingFrame())
         assert types(released) == [
             UserStoppedSpeakingFrame,
             LLMFullResponseStartFrame,
@@ -140,17 +116,15 @@ class TestSpeculationGate(unittest.IsolatedAsyncioTestCase):
         assert gate.state == SpeculationState.OPEN
 
     async def test_withdrawn_speculation_is_discarded(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        assert speculate(gate, "abc", "Cancelling ", "your booking.", end=False) == []
-        assert types(emit(gate, EagerEndOfTurnCancelFrame(speculation_id="abc"))) == [
-            EagerEndOfTurnCancelFrame
-        ]
+        assert speculate(gate, True, "Cancelling ", "your booking.", end=False) == []
+        assert types(emit(gate, EagerEndOfTurnCancelFrame())) == [EagerEndOfTurnCancelFrame]
 
         # Straggling frames of the withdrawn response, still queued behind the
         # cancellation, which overtook them.
         assert emit(gate, LLMTextFrame(" Done.")) == []
-        assert types(speculate(gate, None, "Rescheduling instead.")) == [
+        assert types(speculate(gate, False, "Rescheduling instead.")) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
@@ -159,27 +133,11 @@ class TestSpeculationGate(unittest.IsolatedAsyncioTestCase):
     async def test_withdrawal_arriving_before_the_response_it_cancels(self):
         # A cancellation is a system frame, so it can overtake the response
         # frames it withdraws.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        assert types(emit(gate, EagerEndOfTurnCancelFrame(speculation_id="abc"))) == [
-            EagerEndOfTurnCancelFrame
-        ]
-        assert speculate(gate, "abc", "Cancelling.") == []
-        assert types(speculate(gate, None, "Rescheduling instead.")) == [
-            LLMFullResponseStartFrame,
-            LLMTextFrame,
-            LLMFullResponseEndFrame,
-        ]
-
-    async def test_withdrawal_leaves_a_different_speculation_alone(self):
-        gate = await make_gate()
-
-        speculate(gate, "abc", "Booking.")
-        assert types(emit(gate, EagerEndOfTurnCancelFrame(speculation_id="other"))) == [
-            EagerEndOfTurnCancelFrame
-        ]
-        assert types(emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))) == [
-            UserStoppedSpeakingFrame,
+        assert types(emit(gate, EagerEndOfTurnCancelFrame())) == [EagerEndOfTurnCancelFrame]
+        assert speculate(gate, True, "Cancelling.") == []
+        assert types(speculate(gate, False, "Rescheduling instead.")) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
@@ -187,24 +145,22 @@ class TestSpeculationGate(unittest.IsolatedAsyncioTestCase):
 
     async def test_synthesized_audio_is_held_with_the_response(self):
         # A host that gates after synthesis holds the audio too.
-        gate = await make_gate()
+        gate = SpeculationGate()
         audio = TTSAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
 
-        assert speculate(gate, "abc", "Hi.", end=False, then=(audio,)) == []
-        assert types(emit(gate, EagerEndOfTurnCancelFrame(speculation_id="abc"))) == [
-            EagerEndOfTurnCancelFrame
-        ]
+        assert speculate(gate, True, "Hi.", end=False, then=(audio,)) == []
+        assert types(emit(gate, EagerEndOfTurnCancelFrame())) == [EagerEndOfTurnCancelFrame]
 
     async def test_interruption_discards_the_speculation(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
+        speculate(gate, True, "Booking.", end=False)
         assert types(emit(gate, InterruptionFrame())) == [InterruptionFrame]
 
     async def test_upstream_frames_are_never_held(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
+        speculate(gate, True, "Booking.", end=False)
         upstream = LLMTextFrame("upstream")
         assert gate.process(upstream, FrameDirection.UPSTREAM) == [
             (upstream, FrameDirection.UPSTREAM)
@@ -213,130 +169,96 @@ class TestSpeculationGate(unittest.IsolatedAsyncioTestCase):
     async def test_shutdown_delivers_what_has_to_outlive_the_speculation(self):
         # EndFrame is uninterruptible and awaited by the runner, so holding it
         # would hang shutdown.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False, then=(tool_result(),))
+        speculate(gate, True, "Booking.", end=False, then=(tool_result(),))
         assert types(emit(gate, EndFrame())) == [FunctionCallResultFrame, EndFrame]
 
-    async def test_a_hold_that_outlasts_its_bound_is_discarded(self):
-        expired = []
-        gate = await make_gate(
-            max_hold_duration=0.05, withdraw_expired=lambda i, f: _collect(expired, i, f)
-        )
 
-        speculate(gate, "abc", "Booking.")
-        await asyncio.sleep(0.2)
-
-        assert gate.state == SpeculationState.OPEN
-        # The speculation comes with the frames: the gate can settle its own
-        # state, but whoever started it has to be told it is over.
-        assert expired == [("abc", [])]
-        # Confirmation arriving after the gate gave up releases nothing.
-        assert types(emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))) == [
-            UserStoppedSpeakingFrame
-        ]
-
-    async def test_a_hold_resolved_in_time_never_expires(self):
-        expired = []
-        gate = await make_gate(
-            max_hold_duration=0.05, withdraw_expired=lambda i, f: _collect(expired, i, f)
-        )
-
-        speculate(gate, "abc", "Booking.")
-        emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
-        await asyncio.sleep(0.2)
-
-        assert expired == []
-
-    async def test_an_expired_hold_still_delivers_what_must_outlive_it(self):
-        expired = []
-        gate = await make_gate(
-            max_hold_duration=0.05, withdraw_expired=lambda i, f: _collect(expired, i, f)
-        )
-
-        speculate(gate, "abc", "Booking.", end=False, then=(tool_result(),))
-        await asyncio.sleep(0.2)
-
-        assert [(spec, types(frames)) for spec, frames in expired] == [
-            ("abc", [FunctionCallResultFrame])
-        ]
-
-
-class TestPendingSpeculation(unittest.IsolatedAsyncioTestCase):
+class TestSpeculating(unittest.IsolatedAsyncioTestCase):
     """What the gate reports about the inference in flight.
 
     A host asks this rather than tracking it alongside, so it has to hold up
     however the turn and the inference are ordered.
     """
 
-    async def test_an_ordinary_inference_is_never_pending(self):
-        gate = await make_gate()
-        gate.begin_speculation(None)
+    async def test_an_ordinary_inference_is_never_speculating(self):
+        gate = SpeculationGate()
+        gate.begin_speculation(False)
 
-        assert gate.speculation_id is None
+        assert not gate.speculating
 
-    async def test_it_names_the_inference_until_the_turn_is_confirmed(self):
-        gate = await make_gate()
-        assert gate.speculation_id is None
+    async def test_it_lasts_until_the_turn_ends(self):
+        gate = SpeculationGate()
+        assert not gate.speculating
 
-        speculate(gate, "abc", "Booking.", end=False)
-        assert gate.speculation_id == "abc"
+        speculate(gate, True, "Booking.", end=False)
+        assert gate.speculating
 
-        emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
-        assert gate.speculation_id is None
+        emit(gate, UserStoppedSpeakingFrame())
+        assert not gate.speculating
 
-    async def test_a_turn_confirmed_mid_inference_clears_it_before_the_response_ends(self):
-        # The window the feature exists to exploit: the turn is confirmed while
-        # the inference is still generating, so what it does next is committed.
-        gate = await make_gate()
+    async def test_a_turn_ending_mid_inference_clears_it_before_the_response_ends(self):
+        # The window the feature exists to exploit: the turn ends while the
+        # inference is still generating, so what it does next is committed.
+        gate = SpeculationGate()
 
-        gate.begin_speculation("abc")
-        emit(gate, response("abc", "Let me check.", end=False)[0])
-        emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
+        gate.begin_speculation(True)
+        emit(gate, response("Let me check.", end=False)[0])
+        emit(gate, UserStoppedSpeakingFrame())
 
-        assert gate.speculation_id is None
+        assert not gate.speculating
 
-    async def test_a_turn_confirmed_before_the_inference_is_never_pending(self):
-        # The confirmation is a system frame and can pass the context frame that
+    async def test_a_turn_that_ended_before_the_inference_is_never_speculating(self):
+        # The turn end is a system frame and can pass the context frame that
         # starts the inference it confirms.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
-        gate.begin_speculation("abc")
+        emit(gate, UserStoppedSpeakingFrame())
+        gate.begin_speculation(True)
 
-        assert gate.speculation_id is None
+        assert not gate.speculating
         # And nothing is held back, since the turn it answers is already over.
-        assert types(emit(gate, *response("abc", "Booking."))) == [
+        assert types(emit(gate, *response("Booking."))) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
         ]
 
+    async def test_a_new_turn_makes_a_speculative_inference_speculative_again(self):
+        gate = SpeculationGate()
+
+        emit(gate, UserStoppedSpeakingFrame())
+        emit(gate, UserStartedSpeakingFrame())
+        assert speculate(gate, True, "Booking.") == []
+        assert gate.speculating
+        assert gate.state == SpeculationState.HOLDING
+
     async def test_a_withdrawal_clears_it(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
-        emit(gate, EagerEndOfTurnCancelFrame("abc"))
+        speculate(gate, True, "Booking.", end=False)
+        emit(gate, EagerEndOfTurnCancelFrame())
 
-        assert gate.speculation_id is None
+        assert not gate.speculating
 
     async def test_an_interruption_clears_it(self):
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
+        speculate(gate, True, "Booking.", end=False)
         emit(gate, InterruptionFrame())
 
-        assert gate.speculation_id is None
+        assert not gate.speculating
 
     async def test_a_superseding_inference_keeps_its_own(self):
         # Dropping the held response ends that hold, but the inference that
-        # replaced it is pending and must stay so.
-        gate = await make_gate()
+        # replaced it is speculative and must stay so.
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
-        speculate(gate, "def", "Rescheduling.", end=False)
+        speculate(gate, True, "Booking.", end=False)
+        speculate(gate, True, "Rescheduling.", end=False)
 
-        assert gate.speculation_id == "def"
+        assert gate.speculating
 
 
 class TestEagerMatchPolicies(unittest.IsolatedAsyncioTestCase):
@@ -360,24 +282,20 @@ class TestEagerMatchPolicies(unittest.IsolatedAsyncioTestCase):
 
 
 class TestSpeculationGateOrdering(unittest.IsolatedAsyncioTestCase):
-    async def test_turn_ending_without_confirming_the_speculation_releases_nothing(self):
-        # The mismatch path ends the turn and withdraws the speculation, and the
-        # two signals can arrive in either order.
-        gate = await make_gate()
+    async def test_a_withdrawal_then_the_turn_end_releases_nothing(self):
+        # The mismatch path withdraws the speculation and then ends the turn.
+        # Both are system frames, so they arrive in that order.
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Cancelling.", end=False)
+        speculate(gate, True, "Cancelling.", end=False)
+        assert types(emit(gate, EagerEndOfTurnCancelFrame())) == [EagerEndOfTurnCancelFrame]
         assert types(emit(gate, UserStoppedSpeakingFrame())) == [UserStoppedSpeakingFrame]
-        assert types(emit(gate, EagerEndOfTurnCancelFrame(speculation_id="abc"))) == [
-            EagerEndOfTurnCancelFrame
-        ]
 
-    async def test_confirmation_arriving_before_the_response(self):
-        gate = await make_gate()
+    async def test_the_turn_end_arriving_before_the_response(self):
+        gate = SpeculationGate()
 
-        assert types(emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))) == [
-            UserStoppedSpeakingFrame
-        ]
-        assert types(speculate(gate, "abc", "Booking.")) == [
+        assert types(emit(gate, UserStoppedSpeakingFrame())) == [UserStoppedSpeakingFrame]
+        assert types(speculate(gate, True, "Booking.")) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
@@ -389,11 +307,11 @@ class TestSupersededSpeculation(unittest.IsolatedAsyncioTestCase):
         # A withdrawal that arrives before the response it voids needs no
         # memory: the response is held on arrival, and whatever answers the
         # turn instead supersedes it.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        emit(gate, EagerEndOfTurnCancelFrame("abc"))
-        assert speculate(gate, "abc", "Cancelling.", end=False) == []
-        assert types(speculate(gate, None, "Rescheduling instead.")) == [
+        emit(gate, EagerEndOfTurnCancelFrame())
+        assert speculate(gate, True, "Cancelling.", end=False) == []
+        assert types(speculate(gate, False, "Rescheduling instead.")) == [
             LLMFullResponseStartFrame,
             LLMTextFrame,
             LLMFullResponseEndFrame,
@@ -404,12 +322,11 @@ class TestSupersededSpeculation(unittest.IsolatedAsyncioTestCase):
         # The held response never ends: its generation was cancelled mid-flight,
         # so no end frame is coming and only a new response resolves it. Its
         # frames are dropped, but the response that supersedes it has to pass
-        # through whole — nothing of the held one can still be queued behind a
-        # frame that arrived after it.
-        gate = await make_gate()
+        # through whole.
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
-        emitted = speculate(gate, None, "Something else entirely.")
+        speculate(gate, True, "Booking.", end=False)
+        emitted = speculate(gate, False, "Something else entirely.")
 
         assert types(emitted) == [
             LLMFullResponseStartFrame,
@@ -426,10 +343,10 @@ class TestUninterruptibleFrames(unittest.IsolatedAsyncioTestCase):
         # An async tool started in an earlier turn can return while a
         # speculation is held. Its result belongs to that earlier work and is
         # guaranteed delivery, so discarding the speculation around it keeps it.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False, then=(tool_result(),))
-        emitted = emit(gate, EagerEndOfTurnCancelFrame("abc"))
+        speculate(gate, True, "Booking.", end=False, then=(tool_result(),))
+        emitted = emit(gate, EagerEndOfTurnCancelFrame())
 
         assert types(emitted) == [EagerEndOfTurnCancelFrame, FunctionCallResultFrame]
         assert [f.result for f in emitted if isinstance(f, FunctionCallResultFrame)] == ["booked"]
@@ -437,10 +354,10 @@ class TestUninterruptibleFrames(unittest.IsolatedAsyncioTestCase):
     async def test_a_tool_result_is_held_in_order_with_the_response(self):
         # Uninterruptible frames are ordered like any other, so one that arrives
         # mid-response is released in the position it arrived in.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False, then=(tool_result(),))
-        assert types(emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))) == [
+        speculate(gate, True, "Booking.", end=False, then=(tool_result(),))
+        assert types(emit(gate, UserStoppedSpeakingFrame())) == [
             UserStoppedSpeakingFrame,
             LLMFullResponseStartFrame,
             LLMTextFrame,
@@ -450,40 +367,12 @@ class TestUninterruptibleFrames(unittest.IsolatedAsyncioTestCase):
     async def test_a_tool_result_is_not_dropped_with_a_response_being_dropped(self):
         # Nothing is held back while dropping a withdrawn response's tail, so an
         # uninterruptible frame passes on in order rather than being dropped.
-        gate = await make_gate()
+        gate = SpeculationGate()
 
-        speculate(gate, "abc", "Booking.", end=False)
-        assert types(emit(gate, EagerEndOfTurnCancelFrame("abc"))) == [EagerEndOfTurnCancelFrame]
+        speculate(gate, True, "Booking.", end=False)
+        assert types(emit(gate, EagerEndOfTurnCancelFrame())) == [EagerEndOfTurnCancelFrame]
         # Still queued behind the withdrawal, which overtook it.
         assert types(emit(gate, LLMTextFrame(" Done."), tool_result())) == [FunctionCallResultFrame]
-
-
-class TestResolvedResponsesCarryNoSpeculationId(unittest.IsolatedAsyncioTestCase):
-    async def test_a_released_response_is_no_longer_marked_speculative(self):
-        # Past the gate the response is confirmed, so the id is cleared: an id
-        # downstream means nothing held the response back.
-        gate = await make_gate()
-
-        speculate(gate, "abc", "Booking.")
-        emitted = emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
-
-        assert [
-            f.speculation_id
-            for f in emitted
-            if isinstance(f, (LLMFullResponseStartFrame, LLMFullResponseEndFrame))
-        ] == [None, None]
-
-    async def test_a_response_confirmed_before_it_arrives_is_unmarked_too(self):
-        gate = await make_gate()
-
-        emit(gate, UserStoppedSpeakingFrame(speculation_id="abc"))
-        emitted = speculate(gate, "abc", "Booking.")
-
-        assert [
-            f.speculation_id
-            for f in emitted
-            if isinstance(f, (LLMFullResponseStartFrame, LLMFullResponseEndFrame))
-        ] == [None, None]
 
 
 class GatedLLM(LLMService):
@@ -504,7 +393,7 @@ class GatedLLM(LLMService):
 
 
 class TestGatedPipeline(unittest.IsolatedAsyncioTestCase):
-    async def test_the_transport_sees_a_response_only_once_it_is_confirmed(self):
+    async def test_the_transport_sees_a_response_only_once_the_turn_ends(self):
         # The whole path: aggregator, gating LLM, output transport. Nothing the
         # speculation produced reaches the transport before the turn ends, and
         # the context records the committed transcript rather than the eager one.
@@ -521,7 +410,7 @@ class TestGatedPipeline(unittest.IsolatedAsyncioTestCase):
             frames_to_send=[
                 ProposedUserStartedSpeakingFrame(),
                 SleepFrame(),
-                EagerTranscriptionFrame("book a flight", "user", "t", "abc"),
+                EagerTranscriptionFrame("book a flight", "user", "t"),
                 SleepFrame(),
                 TranscriptionFrame("Book a flight.", "user", "t"),
                 SleepFrame(),


### PR DESCRIPTION
Draft against #5625, for the two suggestions from the review there. Same behavior, less bookkeeping: one commit, and the diff is a net removal.

## Summary

- **The strategy bounds a speculation.** `EagerUserTurnStopStrategy` takes `speculation_timeout` (5 s, also on `EagerUserTurnStrategies`) and withdraws a speculation the service neither commits nor withdraws in time, by pushing the same `EagerEndOfTurnCancelFrame` it pushes on a mismatch. The strategy is the one component that starts a speculation and the one that settles it. The gate loses its timer, `setup(task_manager)`, `cleanup()`, and `withdraw_expired`; `SpeculationGate.process()` is the whole interface again.
- **No `speculation_id` anywhere.** One speculation per user turn, settled by one component, needs no identity. `LLMContextFrame` carries `speculative: bool`; `EagerTranscriptionFrame`, `EagerEndOfTurnCancelFrame`, `UserStoppedSpeakingFrame`, and the response start and end frames carry nothing. The mixin keeps a boolean for "prediction outstanding" instead of minting ids. `UserTurnStoppedParams.speculation_id` is `speculated: bool`, telling the aggregator the turn's inference already ran.
- **The gate keys on the turn, not on an id.** It tracks whether the user turn is open from `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame`. A speculative inference that begins after its turn ended, the turn end having overtaken its queued context frame, is not held at all. That replaces `_confirmed_id`, and the PR's overtaking tests still pass.

## One thing the id was quietly covering

A cancel the strategy pushes goes through `_on_push_frame`, which *queues* it on the aggregator's input, while the turn end is broadcast directly. So on a mismatch the turn end overtook the strategy's cancel, and with ids that was harmless: the turn end named no speculation, so it released nothing. Without ids the turn end must not overtake the withdrawal, so the withdrawal moved to the aggregator: `LLMUserAggregator` remembers it ran a speculative inference and, when a turn ends without confirming it (mismatch, or the stop watchdog with nothing committed), broadcasts the cancel right before `UserStoppedSpeakingFrame` and before the fresh context frame. The order matters twice: the turn end would release the held response, and the cancel's interruption at the LLM flushes the LLM's queued frames, which would drop the fresh inference. The strategy's mismatch path now only finalizes; its own fallback withdrawal stays for a new turn starting over a live speculation, where no turn end is coming.

`TestMismatchEndToEnd` proves both ends of that with a streaming LLM in the pipeline: only the answer to the committed transcript is spoken, and a prediction that holds is spoken once.

## Testing

```
uv run pytest tests/test_speculation_gate.py tests/test_eager_user_turn_strategies.py tests/test_eager_end_of_turn_mixin.py
```

58 pass. The gate tests are rewritten for the new contract (timeout tests gone, id tests gone, turn-open tests added); the strategy tests gain the timeout, the end-to-end mismatch, and the "spoken once" cases. The wider turn, aggregator, Flux, Cartesia Turns, LLM service, and frame processor suites pass too (666 tests), and pyright is clean on the changed files.
