### PR TITLE
fix: SarvamSTTService language detection and code mapping

### DIFF
--- a/changelog/5692.fixed.md
+++ b/changelog/5692.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `SarvamSTTService` mislabeling every transcript as Hindi when no language was detected, the default behavior in `transcribe` mode. Unresolved languages now stay `None`, and `ur-IN`, `mai-IN`, `sd-IN`, and `kok-IN` are now correctly mapped.

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -749,6 +749,10 @@ class SarvamSTTService(STTService):
             "en-US": Language.EN_US,
             "en-IN": Language.EN_IN,
             "as-IN": Language.AS_IN,
+            "ur-IN": Language.UR_IN,
+            "mai-IN": Language.MAI_IN,
+            "sd-IN": Language.SD_IN,
+            "kok-IN": Language.KOK_IN,
         }
         # "unknown" is Sarvam's own placeholder for "not detected/configured yet"
         # (see MODEL_CONFIGS.default_language), not a data gap worth warning about.

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -345,6 +345,9 @@ class SarvamSTTService(STTService):
         self._websocket_context = None
         self._socket_client = None
         self._receive_task = None
+        # Warn only once per unrecognized language code, so a session stuck
+        # detecting one unmapped language doesn't spam a warning per turn.
+        self._unmapped_language_codes_warned: set[str] = set()
 
         if default_settings.vad_signals:
             self._register_event_handler("on_speech_started")
@@ -684,14 +687,12 @@ class SarvamSTTService(STTService):
                 transcript = message.data.transcript
                 language_code = message.data.language_code
                 # Prefer language from message (auto-detected for translate models). Fallback to configured.
-                if language_code:
-                    language = self._map_language_code_to_enum(language_code)
-                else:
-                    language_string = self._get_language_string()
-                    if language_string:
-                        language = self._map_language_code_to_enum(language_string)
-                    else:
-                        language = Language.HI_IN
+                # Either can resolve to None -- an unrecognized code, or Sarvam's own
+                # "unknown"/auto-detect placeholder -- in which case the frame is left
+                # without a language rather than guessing one.
+                language = self._map_language_code_to_enum(
+                    language_code or self._get_language_string()
+                )
 
                 # Emit utterance end event
                 await self._call_event_handler("on_utterance_end")
@@ -725,8 +726,15 @@ class SarvamSTTService(STTService):
         """
         pass
 
-    def _map_language_code_to_enum(self, language_code: str) -> Language:
-        """Map Sarvam language code to pipecat Language enum."""
+    def _map_language_code_to_enum(self, language_code: str | None) -> Language | None:
+        """Map a Sarvam language code to a pipecat Language, or None if unresolved.
+
+        Returns None for Sarvam's own "unknown"/auto-detect placeholder and for
+        any code -- present or future -- this table doesn't have an entry for,
+        rather than guessing a specific language. A code that IS recognized but
+        maps to a language this table doesn't carry only logs a warning once,
+        so a long-running session doesn't spam it every turn.
+        """
         mapping = {
             "bn-IN": Language.BN_IN,
             "gu-IN": Language.GU_IN,
@@ -742,7 +750,19 @@ class SarvamSTTService(STTService):
             "en-IN": Language.EN_IN,
             "as-IN": Language.AS_IN,
         }
-        return mapping.get(language_code, Language.HI_IN)
+        # "unknown" is Sarvam's own placeholder for "not detected/configured yet"
+        # (see MODEL_CONFIGS.default_language), not a data gap worth warning about.
+        if not language_code or language_code == "unknown":
+            return None
+        language = mapping.get(language_code)
+        if language is None and language_code not in self._unmapped_language_codes_warned:
+            self._unmapped_language_codes_warned.add(language_code)
+            logger.warning(
+                f"{self} received Sarvam language code {language_code!r}, which has no "
+                "Language mapping; leaving TranscriptionFrame.language unset for it "
+                "rather than guessing."
+            )
+        return language
 
     def _is_keepalive_ready(self) -> bool:
         """Check if the Sarvam SDK websocket client is connected."""

--- a/tests/test_sarvam_stt.py
+++ b/tests/test_sarvam_stt.py
@@ -133,6 +133,95 @@ def test_sarvam_without_vad_signals_recommends_no_strategies():
     assert service.service_metadata_frame().user_turn_strategies is None
 
 
+class _FakeSarvamData:
+    """Stands in for the SDK's `message.data` on a "data" (transcript) event."""
+
+    def __init__(self, transcript: str, language_code: str | None = None):
+        self.transcript = transcript
+        self.language_code = language_code
+
+
+class _FakeSarvamMessage:
+    """Stands in for the SDK's parsed response object passed to `_handle_message`."""
+
+    type = "data"
+
+    def __init__(self, transcript: str, language_code: str | None = None):
+        self.data = _FakeSarvamData(transcript, language_code)
+
+    def dict(self):
+        return {"type": self.type, "data": {"transcript": self.data.transcript}}
+
+
+@pytest.mark.asyncio
+async def test_default_configuration_leaves_language_unset(monkeypatch):
+    """No configured language and no language_code on the message -- Sarvam's own
+    "unknown" auto-detect placeholder -- leaves the frame's language unset rather
+    than guessing one."""
+    service = SarvamSTTService(api_key="test-key")
+    pushed = []
+    monkeypatch.setattr(service, "push_frame", _capture(pushed))
+
+    await service._handle_message(_FakeSarvamMessage("Hello there"))
+
+    assert len(pushed) == 1
+    assert pushed[0].language is None
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_language_code_leaves_language_unset(monkeypatch):
+    """A real Sarvam code with no `Language` equivalent at all (Sanskrit has no
+    "sa-IN" member, only the base "sa") is left unset, not silently relabeled as
+    a different language, and is warned about exactly once."""
+    service = SarvamSTTService(api_key="test-key")
+    pushed = []
+    monkeypatch.setattr(service, "push_frame", _capture(pushed))
+
+    await service._handle_message(_FakeSarvamMessage("first", language_code="sa-IN"))
+    await service._handle_message(_FakeSarvamMessage("second", language_code="sa-IN"))
+
+    assert pushed[0].language is None
+    assert pushed[1].language is None
+    assert service._unmapped_language_codes_warned == {"sa-IN"}
+
+
+@pytest.mark.asyncio
+async def test_recognized_language_code_is_mapped(monkeypatch):
+    """A language_code the table does have an entry for still resolves normally."""
+    service = SarvamSTTService(api_key="test-key")
+    pushed = []
+    monkeypatch.setattr(service, "push_frame", _capture(pushed))
+
+    await service._handle_message(_FakeSarvamMessage("नमस्ते", language_code="hi-IN"))
+
+    assert pushed[0].language == Language.HI_IN
+
+
+@pytest.mark.parametrize(
+    ("language_code", "language"),
+    [
+        ("ur-IN", Language.UR_IN),
+        ("mai-IN", Language.MAI_IN),
+        ("sd-IN", Language.SD_IN),
+        ("kok-IN", Language.KOK_IN),
+    ],
+)
+def test_previously_missing_codes_now_map(language_code, language):
+    """Urdu, Maithili, Sindhi, and Konkani have exact `Language` matches and are
+    real entries in SarvamRealtimeSTTService's SUPPORTED_LANGUAGES -- they were
+    simply missing from this table."""
+    service = SarvamSTTService(api_key="test-key")
+    assert service._map_language_code_to_enum(language_code) == language
+
+
+def test_configured_language_is_used_when_message_has_none():
+    """An explicitly configured language is honored when the message carries none."""
+    service = SarvamSTTService(
+        api_key="test-key", settings=SarvamSTTService.Settings(language=Language.EN_IN)
+    )
+    assert service._map_language_code_to_enum(service._get_language_string()) == Language.EN_IN
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
### Summary

`SarvamSTTService` was silently mislabeling transcripts as Hindi (`Language.HI_IN`) whenever it couldn't determine the actual spoken language, which with default settings is essentially always. The default `mode` (`"transcribe"`) never gets a `language_code` back from Sarvam, and `_map_language_code_to_enum` fell back to a hardcoded Hindi guess for that case and for any other language code its table didn't recognize (e.g. `"ur-IN"` for Urdu, even though that's a real, Sarvam-supported code).

This PR:

1. `_map_language_code_to_enum` returns `None` instead of guessing. Sarvam's `"unknown"` placeholder and any unmapped code now resolve to `None`, not a wrong language. A genuinely unmapped code logs one warning instead of failing silently. Matches the convention already used by `SarvamRealtimeSTTService._language_for_frame` in this file, and by Deepgram, Whisper, and Soniox elsewhere in pipecat.

2. Adds 4 missing codes with exact `Language` matches: `ur-IN` (Urdu), `mai-IN` (Maithili), `sd-IN` (Sindhi), `kok-IN` (Konkani). All are real entries in `SarvamRealtimeSTTService.SUPPORTED_LANGUAGES`.

3. Adds test coverage. None existed for this path. `tests/test_sarvam_stt.py` only tested model selection and turn strategy; every `_handle_message` test targeted the other, unaffected class.

Not in scope: `sa-IN`, `ne-IN`, `doi-IN`, `ks-IN`, `sat-IN`, `mni-IN`, `brx-IN` still resolve to `None`. Pipecat's `Language` enum has no member for these at all, or only the base code, not the `-IN` variant. That's correct now, not a gap in this fix. Adding them needs a change to `pipecat.transcriptions.language.Language`.

### Test plan

- [x] `uv run pytest tests/test_sarvam_stt.py`, 79 passed (5 new tests
      added for this change)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run pyright src/pipecat/services/sarvam/stt.py`

### Fixes

Fixes #5691