### PR TITLE
evals: a turn waits for the bot to finish, a judge's no waits for the reply to end, and a hang-up leaves the bot its closing turn

### DIFF
--- a/src/pipecat/evals/events.py
+++ b/src/pipecat/evals/events.py
@@ -41,6 +41,8 @@ import time
 
 from pipecat.evals.results import EvalTrace
 from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
     Frame,
     FunctionCallCancelFrame,
     FunctionCallInProgressFrame,
@@ -105,6 +107,32 @@ class EvalEventStream:
         # harness's turn analyzer finalizes it.
         self._input_sent_at: float = 0.0
         self._bot_turn_started_at: float | None = None
+        # Whether the bot is speaking, by its own report: cleared when it
+        # starts, set when it stops or is interrupted. An event, so a driver
+        # that must not talk over the bot can wait for it without polling.
+        self._bot_quiet = asyncio.Event()
+        self._bot_quiet.set()
+
+    @property
+    def bot_speaking(self) -> bool:
+        """Whether the bot reports itself speaking right now."""
+        return not self._bot_quiet.is_set()
+
+    async def wait_bot_quiet(self, timeout: float) -> bool:
+        """Wait for the bot to stop speaking.
+
+        Args:
+            timeout: Seconds to wait at most.
+
+        Returns:
+            Whether the bot is quiet, or False if it was still speaking at the
+            timeout.
+        """
+        try:
+            await asyncio.wait_for(self._bot_quiet.wait(), timeout)
+        except TimeoutError:
+            return False
+        return True
 
     async def append(self, event: dict) -> None:
         """Queue an event for the drivers.
@@ -243,6 +271,12 @@ class EvalEventStream:
             if self._bot_audio:
                 return self._segment_event("tts_response", frame.text)
             return None
+        elif isinstance(frame, BotStartedSpeakingFrame):
+            self._bot_quiet.clear()
+            return {"type": "bot_started_speaking"}
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            self._bot_quiet.set()
+            return {"type": "bot_stopped_speaking"}
         elif isinstance(frame, FunctionCallInProgressFrame):
             return {
                 "type": "function_call",
@@ -288,6 +322,14 @@ class EvalEventStream:
 
     def input_sent(self) -> None:
         """Mark the user's input as sent: the bot's reply is what it says from now on."""
+        self.turn_boundary()
+
+    def turn_boundary(self) -> None:
+        """Start a new turn: only what the bot says from now on belongs to it.
+
+        A spoken turn that began before this point, however late its
+        transcription lands, is the previous turn's and is discarded.
+        """
         self._awaiting_reply = True
         self._input_sent_at = time.monotonic()
 
@@ -295,6 +337,7 @@ class EvalEventStream:
         """The bot reported an interruption: drop its pending output and wait for a fresh reply."""
         self.drop_pending_bot_output("on interruption")
         self._awaiting_reply = True
+        self._bot_quiet.set()
 
     def _message_to_event(self, message) -> dict | None:
         """Map one of the bot's reports about the harness to its event, if any."""

--- a/src/pipecat/evals/matcher.py
+++ b/src/pipecat/evals/matcher.py
@@ -13,12 +13,18 @@ reply across its segments, the any-order matching of a turn's function calls,
 and the inverted ``absent:`` check.
 """
 
+import time
+
 from loguru import logger
 
 from pipecat.evals.events import EvalEventStream
 from pipecat.evals.judge import EvalJudge
 from pipecat.evals.results import EvalAssertionFailure, EvalTrace
 from pipecat.evals.script import FUNCTION_CALL_EVENTS, EvalExpectation
+
+# How long a judge's "no" waits for more of the reply once the bot has stopped
+# speaking: the transcription of its last sentence lands after the stop.
+JUDGE_NO_GRACE_S = 2.0
 
 
 class ExpectationMatcher:
@@ -143,13 +149,17 @@ class ExpectationMatcher:
         aggregate = ""
         last_reason = ""
         seen_any = False
+        pending: dict | None = None
         while True:
-            try:
-                event = await self._stream.next_event(expectation.event, deadline)
-            except TimeoutError:
-                if not seen_any:
-                    raise  # no response at all: the caller reports the missing event
-                return self._unsatisfied(expectation, turn_idx, exp_idx, budget_ms, last_reason)
+            if pending is not None:
+                event, pending = pending, None
+            else:
+                try:
+                    event = await self._stream.next_event(expectation.event, deadline)
+                except TimeoutError:
+                    if not seen_any:
+                        raise  # no response at all: the caller reports the missing event
+                    return self._unsatisfied(expectation, turn_idx, exp_idx, budget_ms, last_reason)
 
             seen_any = True
             delta = self._event_text(event)
@@ -165,12 +175,34 @@ class ExpectationMatcher:
                 self.last_match_text = aggregate
                 return None
             if status == "fail":
-                # Only the judge can affirmatively fail an aggregate.
-                return self._failure(expectation, turn_idx, exp_idx, reason, "judge_no")
+                # Only the judge can affirmatively fail an aggregate, and only
+                # once the reply is complete: a "no" on a reply still being
+                # spoken, or whose last sentence is still being transcribed, is
+                # a "continue" that the next segment may turn into a "yes".
+                pending = await self._rest_of_reply(expectation.event, deadline)
+                if pending is None:
+                    return self._failure(expectation, turn_idx, exp_idx, reason, "judge_no")
+                self._trace.log("eval: no, but the reply goes on: judging the rest")
             # "continue": wait for the next segment, separated by a space so
             # sentences don't run together (e.g. "...that. The weather...").
             aggregate += " "
             last_reason = reason
+
+    async def _rest_of_reply(self, event_type: str, deadline: float) -> dict | None:
+        """The next segment of a reply the judge rejected, or ``None`` when the reply is over.
+
+        While the bot is speaking the next segment is awaited within the turn's
+        budget; once it has stopped, only for the grace its last sentence's
+        transcription needs.
+        """
+        if self._stream.bot_speaking:
+            until = deadline
+        else:
+            until = min(deadline, time.monotonic() + JUDGE_NO_GRACE_S)
+        try:
+            return await self._stream.next_event(event_type, until)
+        except TimeoutError:
+            return None
 
     def _unsatisfied(
         self,

--- a/src/pipecat/evals/scenario_loader.py
+++ b/src/pipecat/evals/scenario_loader.py
@@ -15,7 +15,6 @@ file relative to the including one, so scenarios can share ``user:`` and
 
 import re
 from pathlib import Path
-from typing import Any
 
 import yaml
 

--- a/src/pipecat/evals/script.py
+++ b/src/pipecat/evals/script.py
@@ -23,8 +23,9 @@ simulation, where an LLM plays the user (:mod:`pipecat.evals.simulation`).
 
 Event names are the friendly names the harness maps RTVI server messages onto:
 ``user_started_speaking``, ``user_stopped_speaking``, ``vad_user_started_speaking``,
-``vad_user_stopped_speaking``, ``user_transcription``, ``llm_started``, ``response``,
-``llm_response``, ``tts_response``, ``function_call``, ``function_call_stopped``. The
+``vad_user_stopped_speaking``, ``user_transcription``, ``bot_started_speaking``,
+``bot_stopped_speaking``, ``llm_started``, ``response``, ``llm_response``,
+``tts_response``, ``function_call``, ``function_call_stopped``. The
 ``vad_*`` events are the raw
 VAD signal, useful as a timing anchor when a turn-detection strategy gates or defers the
 turn-level ``user_stopped_speaking`` (e.g. filtering incomplete turns).
@@ -107,7 +108,10 @@ regardless of the scenario's user/judge modality. A bot running a
 ``DTMFAggregator`` accumulates them and flushes — on the ``#`` terminator or its
 idle timeout — into a ``DTMF: ...`` transcription it reacts to.
 
-A turn may also include ``send_after:`` to schedule its ``user``/``dtmf`` send
+A turn is sent once the bot has finished speaking, like a caller who waits for
+the end of the sentence, so a reply the previous turn was satisfied with early
+is never talked over. A turn may also include ``send_after:`` to schedule its
+``user``/``dtmf`` send
 relative to a prior event (used for interruption / barge-in tests), or
 ``image:`` (a path, relative to the scenario file) to register an image for the
 turn — when a function-calling-video bot requests a user image, the eval

--- a/src/pipecat/evals/script_driver.py
+++ b/src/pipecat/evals/script_driver.py
@@ -26,6 +26,11 @@ from pipecat.evals.results import (
 from pipecat.evals.script import EvalScriptScenario, EvalScriptTurn, EvalSendAfter
 
 SEND_AFTER_MAX_WAIT_S = 30.0
+# How long a turn waits for the bot to finish speaking before it is sent. A
+# reply is still spoken after its first sentence satisfied the previous turn;
+# a turn sent over it would have that tail transcribed as its own reply, or
+# discarded together with the answer that followed it in the same breath.
+BOT_QUIET_MAX_WAIT_S = 30.0
 SEND_AFTER_POLL_S = 0.01
 
 
@@ -144,12 +149,40 @@ class EvalScriptDriver(BaseEvalDriver[EvalScriptResult]):
             failure = await self._await_send_after(turn.send_after, turn_idx)
             if failure is not None:
                 return [failure]
+        elif turn.user is not None or turn.dtmf is not None:
+            # A caller waits for the bot to finish; a turn that means to talk
+            # over it says so with ``send_after``.
+            await self._await_bot_quiet()
+        elif turn_idx > 0:
+            await self._await_previous_reply()
 
         await self._send_turn(turn)
         await self._progress(
             EvalScriptTurnProgress(turn_idx, -1, turn.user or turn.dtmf or "", "turn")
         )
         return await self._match_expectations(turn, turn_idx)
+
+    async def _await_bot_quiet(self) -> None:
+        """Hold the send while the bot is speaking, up to ``BOT_QUIET_MAX_WAIT_S``."""
+        if not self._stream.bot_speaking:
+            return
+        self._trace.log("send: waiting for the bot to finish speaking")
+        if not await self._stream.wait_bot_quiet(BOT_QUIET_MAX_WAIT_S):
+            self._trace.log(f"send: bot still speaking after {BOT_QUIET_MAX_WAIT_S:g}s, sending")
+
+    async def _await_previous_reply(self) -> None:
+        """Let a reply the bot is still speaking end before an observing turn starts.
+
+        A turn that sends nothing waits for what the bot says next, so what
+        the bot is still saying belongs to the turn before it, however late its
+        transcription lands. The first turn keeps the bot's greeting.
+        """
+        if not self._stream.bot_speaking:
+            return
+        self._trace.log("observe: waiting for the bot to finish the previous reply")
+        await self._stream.wait_bot_quiet(BOT_QUIET_MAX_WAIT_S)
+        self._stream.drop_pending_bot_output("the previous reply")
+        self._stream.turn_boundary()
 
     async def _await_send_after(
         self, send_after: EvalSendAfter, turn_idx: int

--- a/src/pipecat/evals/simulation_driver.py
+++ b/src/pipecat/evals/simulation_driver.py
@@ -36,6 +36,10 @@ from pipecat.services.llm_service import FunctionCallParams
 
 # The event the driver appends when the persona calls end_call.
 END_CALL_EVENT = "end_call"
+# How long the run waits, after the persona hangs up on its own last line, for
+# the bot's reply to it. A flow makes its final tool calls in that turn, and a
+# caller who hangs up mid-sentence is not what the simulation tests.
+CLOSING_REPLY_WAIT_S = 15.0
 
 
 def _call_matches(spec: EvalFunctionCall, call: EvalFunctionCall) -> bool:
@@ -124,21 +128,38 @@ class EvalSimulationDriver(BaseEvalDriver[EvalSimulationResult]):
             f"persona: listening (up to {simulation.max_turns} turn(s), "
             f"{simulation.max_duration_s:g}s, {simulation.max_silence_s:g}s of silence)"
         )
+        # Set when the persona hangs up on its own last line: the run then
+        # waits for the bot's reply to it, or this long, before ending.
+        closing_ends: float | None = None
         while self._ended_by is None:
             lull_ends = self._stream.last_activity + simulation.max_silence_s
+            waits = [deadline, lull_ends] + ([closing_ends] if closing_ends is not None else [])
             try:
-                event = await self._stream.next_any(min(deadline, lull_ends))
+                event = await self._stream.next_any(min(waits))
             except TimeoutError:
-                if time.monotonic() >= deadline:
+                now = time.monotonic()
+                if closing_ends is not None:
+                    # The persona already hung up; the bot's reply was a courtesy.
+                    self._trace.log("persona: no closing reply from the bot; ending the call")
+                    self._ended_by = "end_call"
+                    break
+                if now >= deadline:
                     self._ended_by = "max_duration"
                     break
-                if self._stream.last_activity + simulation.max_silence_s > time.monotonic():
+                if self._stream.last_activity + simulation.max_silence_s > now:
                     continue
                 self._ended_by = "silence"
                 break
             self._observe_new_events()
             if event["type"] == END_CALL_EVENT:
-                self._ended_by = "end_call"
+                # The persona says nothing more from here. The bot still gets
+                # its turn if the persona hung up on its own last line.
+                await self._client.hang_up()
+                if self._pending or not self._lines or self._lines[-1]["role"] != "user":
+                    self._ended_by = "end_call"
+                else:
+                    self._trace.log("persona: hung up; waiting for the bot's closing turn")
+                    closing_ends = time.monotonic() + CLOSING_REPLY_WAIT_S
             elif event["type"] == BOT_ENDED_EVENT:
                 self._ended_by = "bot"
             elif event["type"] == HARNESS_ERROR_EVENT:
@@ -151,6 +172,8 @@ class EvalSimulationDriver(BaseEvalDriver[EvalSimulationResult]):
                     self._ended_by = "max_turns"
             elif event["type"] == self._bot_said and event.get("text"):
                 await self._report("bot", event["text"])
+                if closing_ends is not None:
+                    self._ended_by = "end_call"
         # The persona has said its last word either way: nothing the bot says
         # from here on gets an answer.
         await self._client.hang_up()

--- a/tests/test_evals_session.py
+++ b/tests/test_evals_session.py
@@ -23,10 +23,12 @@ import base64
 import json
 import socket
 import tempfile
+import time
 import unittest
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import websockets
 
@@ -48,6 +50,7 @@ from pipecat.evals.script_session import EvalScriptSession
 from pipecat.frames.frames import (
     AggregationType,
     BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
     FunctionCallInProgressFrame,
     FunctionCallResultFrame,
     InputTransportMessageFrame,
@@ -300,6 +303,131 @@ class _FakeJudge:
         self.calls.append(criterion)
         v = self._verdicts.pop(0)
         return JudgeVerdict(verdict=v, reason=f"({v})", raw_response="")
+
+
+class TestBotSpeaking(unittest.IsolatedAsyncioTestCase):
+    """The stream follows the bot's own report of whether it is speaking."""
+
+    async def test_the_bots_speaking_frames_become_events_and_a_wait(self):
+        stream = _stream()
+        self.assertFalse(stream.bot_speaking)
+        self.assertTrue(await stream.wait_bot_quiet(0.01))
+
+        self.assertEqual(
+            stream.frame_to_event(BotStartedSpeakingFrame()), {"type": "bot_started_speaking"}
+        )
+        self.assertTrue(stream.bot_speaking)
+        self.assertFalse(await stream.wait_bot_quiet(0.05))
+
+        self.assertEqual(
+            stream.frame_to_event(BotStoppedSpeakingFrame()), {"type": "bot_stopped_speaking"}
+        )
+        self.assertFalse(stream.bot_speaking)
+        self.assertTrue(await stream.wait_bot_quiet(0.01))
+
+    async def test_an_interruption_counts_as_the_bot_going_quiet(self):
+        stream = _stream()
+        stream.frame_to_event(BotStartedSpeakingFrame())
+        stream._interrupted()
+        self.assertFalse(stream.bot_speaking)
+
+
+class TestSendWaitsForTheBot(unittest.IsolatedAsyncioTestCase):
+    """A turn is not sent over a speaking bot."""
+
+    async def test_the_send_waits_until_the_bot_stops_speaking(self):
+        session = _session()
+        driver, stream = session._driver, session._stream
+        stream.frame_to_event(BotStartedSpeakingFrame())
+
+        async def stop_soon():
+            await asyncio.sleep(0.15)
+            stream.frame_to_event(BotStoppedSpeakingFrame())
+
+        task = asyncio.create_task(stop_soon())
+        started = asyncio.get_running_loop().time()
+        await driver._await_bot_quiet()
+        await task
+        self.assertGreaterEqual(asyncio.get_running_loop().time() - started, 0.15)
+
+    async def test_an_observing_turn_lets_the_previous_reply_end_first(self):
+        # The bot is still speaking turn 1's reply when turn 2, which only
+        # listens for the bot's next move, begins: the rest of that reply,
+        # however late its transcription lands, is not turn 2's response.
+        session = _session(bot_audio=True)
+        driver, stream = session._driver, session._stream
+        stream.frame_to_event(BotStartedSpeakingFrame())
+        stream.bot_turn_started()
+        await stream.append({"type": "response", "text": "Spring in Japan is gorgeous."})
+
+        async def finish_reply():
+            await asyncio.sleep(0.1)
+            stream.frame_to_event(BotStoppedSpeakingFrame())
+
+        task = asyncio.create_task(finish_reply())
+        await driver._await_previous_reply()
+        await task
+        # The queued tail is gone, and one transcribed after the wait is stale.
+        with self.assertRaises(TimeoutError):
+            await stream.next_event("response", time.monotonic() + 0.05)
+        await stream.bot_turn_stopped("Do you have cities in mind?")
+        with self.assertRaises(TimeoutError):
+            await stream.next_event("response", time.monotonic() + 0.05)
+
+    async def test_a_quiet_bot_holds_nothing_up(self):
+        session = _session()
+        started = asyncio.get_running_loop().time()
+        await session._driver._await_bot_quiet()
+        self.assertLess(asyncio.get_running_loop().time() - started, 0.05)
+
+
+class TestJudgeNoIsProvisional(unittest.IsolatedAsyncioTestCase):
+    """A judge's "no" fails the reply only once the reply is over."""
+
+    def setUp(self):
+        self.exp = EvalExpectation(event="response", eval="gives the weather")
+
+    async def _match(self, s: ExpectationMatcher, budget_ms: int = 5000):
+        return await s.match(self.exp, time.monotonic(), budget_ms, 0, 0)
+
+    async def test_a_no_while_the_bot_speaks_waits_for_the_rest(self):
+        judge = _FakeJudge(["no", "yes"])
+        s = _matcher(judge, bot_audio=True)
+        s._stream.frame_to_event(BotStartedSpeakingFrame())
+        await s._stream.append({"type": "response", "text": "Sure. Why don't skeletons fight?"})
+
+        async def rest():
+            await asyncio.sleep(0.1)
+            await s._stream.append({"type": "response", "text": "The weather is 75 degrees."})
+
+        task = asyncio.create_task(rest())
+        self.assertIsNone(await self._match(s))
+        await task
+        self.assertEqual(judge.calls, ["gives the weather"] * 2)
+
+    async def test_a_no_after_the_bot_stopped_waits_out_the_transcription(self):
+        judge = _FakeJudge(["no", "yes"])
+        s = _matcher(judge, bot_audio=True)
+        await s._stream.append({"type": "response", "text": "Transferring you now."})
+
+        async def late_sentence():
+            await asyncio.sleep(0.1)
+            await s._stream.append({"type": "response", "text": "The boots cost $299."})
+
+        task = asyncio.create_task(late_sentence())
+        self.assertIsNone(await self._match(s))
+        await task
+
+    async def test_a_no_on_a_finished_reply_fails(self):
+        from pipecat.evals import matcher as matcher_module
+
+        judge = _FakeJudge(["no"])
+        s = _matcher(judge, bot_audio=True)
+        await s._stream.append({"type": "response", "text": "I like turtles."})
+        with patch.object(matcher_module, "JUDGE_NO_GRACE_S", 0.1):
+            failure = await self._match(s)
+        assert failure is not None
+        self.assertEqual(failure.kind, "judge_no")
 
 
 class TestBotTurn(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_evals_simulation.py
+++ b/tests/test_evals_simulation.py
@@ -414,6 +414,8 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
             results = await _end_call(llm, success=True, reason="I got my answer")
             self.assertEqual(results[0][0], {"status": "call ended"})
             self.assertFalse(results[0][1].run_llm)
+            # The bot's reply to the persona's last line closes the conversation.
+            await stream.append({"type": "llm_response", "text": "You're welcome!"})
 
         task = asyncio.create_task(conversation())
         failures = await driver.run()
@@ -430,6 +432,7 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
                 {"role": "user", "content": "What is the capital of Germany?"},
                 {"role": "assistant", "content": "Berlin."},
                 {"role": "user", "content": "Thanks!"},
+                {"role": "assistant", "content": "You're welcome!"},
             ],
         )
         self.assertEqual(
@@ -446,10 +449,10 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.ended_by, "end_call")
         self.assertEqual(result.turns, 2)
         self.assertEqual(result.end_call, {"success": True, "reason": "I got my answer"})
-        self.assertEqual([m.score for m in result.metrics], [1.0, 0.5])
+        self.assertEqual([m.score for m in result.metrics], [1.0, 2 / 3])
         # brevity scored 0.5 but gates nothing, so the run still passes.
         self.assertEqual([m.passed for m in result.metrics], [True, True])
-        self.assertEqual(result.metrics[0].reason, "all 2 turn(s)")
+        self.assertEqual(result.metrics[0].reason, "all 3 turn(s)")
         self.assertEqual(result.metrics[1].reason, "turn 2: because kept it short")
         self.assertEqual([v.turn for v in result.metrics[1].verdicts if not v.passed], [2])
         self.assertIsNone(result.failure)
@@ -466,6 +469,7 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
             await stream.append({"type": "llm_response", "text": "What do you want."})
             await stream.append({"type": PERSONA_TURN_EVENT, "text": "The capital of Germany?"})
             await _end_call(llm, success=True, reason="rude but answered")
+            await stream.append({"type": "llm_response", "text": "Berlin. Anything else."})
 
         task = asyncio.create_task(conversation())
         await driver.run()
@@ -476,7 +480,7 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.succeeded)
         self.assertFalse(result.passed)
         self.assertEqual(
-            result.failure, "politeness 0.00 below 1.00: turn 1: because stayed polite"
+            result.failure, "politeness 0.50 below 1.00: turn 1: because stayed polite"
         )
         self.assertEqual(
             [(r.status, r.text, r.turn) for r in records if r.status != "bot"],
@@ -800,6 +804,65 @@ class TestSimulationDriver(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.passed)
         self.assertEqual(result.ended_by, "error")
         self.assertEqual(result.reason, "refused")
+
+
+class TestClosingTurn(unittest.IsolatedAsyncioTestCase):
+    """A persona that hangs up on its own last line leaves the bot its reply to it."""
+
+    async def test_the_bots_reply_to_the_last_line_closes_the_run(self):
+        driver, stream, llm, client = _driver(_simulation(), _FakeConversationJudge(["yes"]))
+
+        async def conversation():
+            await stream.append({"type": "llm_response", "text": "Is that all correct?"})
+            await stream.append({"type": PERSONA_TURN_EVENT, "text": "Yes, all correct."})
+            await _end_call(llm, success=True, reason="done")
+            await asyncio.sleep(0.1)
+            # The persona is silent by now, and the bot's reply still counts.
+            self.assertTrue(client.hung_up)
+            await stream.append({"type": "llm_response", "text": "Great, you're all set."})
+
+        task = asyncio.create_task(conversation())
+        await driver.run()
+        await task
+        result = driver.result(failures=[], duration_ms=0, events_seen=[], debug_log=[])
+        self.assertEqual(result.ended_by, "end_call")
+        self.assertEqual(
+            result.messages[-1], {"role": "assistant", "content": "Great, you're all set."}
+        )
+
+    async def test_a_hang_up_with_no_reply_coming_still_ends_as_end_call(self):
+        driver, stream, llm, _ = _driver(
+            _simulation(max_duration_s=0.3), _FakeConversationJudge(["yes"])
+        )
+
+        async def conversation():
+            await stream.append({"type": "llm_response", "text": "Is that all correct?"})
+            await stream.append({"type": PERSONA_TURN_EVENT, "text": "Yes, bye."})
+            await _end_call(llm, success=True, reason="done")
+
+        task = asyncio.create_task(conversation())
+        await driver.run()
+        await task
+        result = driver.result(failures=[], duration_ms=0, events_seen=[], debug_log=[])
+        self.assertEqual(result.ended_by, "end_call")
+        self.assertEqual(result.messages[-1], {"role": "user", "content": "Yes, bye."})
+
+    async def test_a_hang_up_on_the_bots_line_ends_at_once(self):
+        driver, stream, llm, _ = _driver(_simulation(), _FakeConversationJudge(["yes"]))
+
+        async def conversation():
+            await stream.append({"type": "llm_response", "text": "Hello?"})
+            await stream.append({"type": PERSONA_TURN_EVENT, "text": "Wrong number."})
+            await stream.append({"type": "llm_response", "text": "No problem, goodbye."})
+            await _end_call(llm, success=False, reason="wrong number")
+
+        started = asyncio.get_running_loop().time()
+        task = asyncio.create_task(conversation())
+        await driver.run()
+        await task
+        self.assertLess(asyncio.get_running_loop().time() - started, 1.0)
+        result = driver.result(failures=[], duration_ms=0, events_seen=[], debug_log=[])
+        self.assertEqual(result.ended_by, "end_call")
 
 
 class TestSimulationEarlyEndings(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

Three ways the eval harness failed a bot that had done nothing wrong, found in the release sweep of 2026-09-10 (13 of its 18 failures), each fixed where the harness makes the decision.

- **A turn is sent once the bot has finished speaking.** A scripted turn passed as soon as its first sentence satisfied the judge, and the next turn was sent over the rest of the reply. The transcriber then merged that tail with the answer into one segment, which the harness discarded as pre-send (Groq timed out on "The capital of Germany is Berlin"), or handed the tail to the judge as the next reply (Inworld, Speechify). The script driver now waits for the bot's own `bot-stopped-speaking` before sending, unless `send_after` schedules the turn over the bot, which is what a barge-in test says. An observing turn, one that sends nothing and waits for the bot's next move, likewise lets a reply still being spoken end and leaves its late sentences to the previous turn; the first turn keeps the greeting.
- **A judge's "no" fails a reply only once the reply is over.** The judge is asked per sentence and answers yes, no, or continue; the small judge said no to a half-reply that the next sentence completed ("Why don't skeletons fight?" before "By the way, the weather in San Francisco is 75 degrees"). While the bot is still speaking, the matcher waits for the next segment within the turn's budget; once it has stopped, for a two-second grace, since the last sentence's transcription lands after the stop.
- **A persona that hangs up on its own last line leaves the bot its closing turn.** The persona confirmed and called `end_call` in the same turn, so a flow never reached the turn that calls `complete_intake`, `end_quote`, or `complete_order`, and the `function_calls` metric failed on exactly that call. The simulation driver now hangs the persona up at once, so it says nothing more, and waits up to fifteen seconds for the bot's reply to that line before ending as `end_call`. A hang-up on the bot's line ends the run immediately.

`bot_started_speaking` and `bot_stopped_speaking` are now scenario events, from the bot's own reports.

## Proof

The nine scenarios that failed for these reasons in the release sweep, rerun against their real bots with this branch:

| scenario | before | after |
|---|---|---|
| `voice-groq` capital_question | timeout, answer discarded | ✓ |
| `voice-inworld-http` capital_question | judge no, greeting tail | ✓ |
| `voice-speechify-http` capital_question | judge no, greeting tail | ✓ |
| `filter_incomplete_turns_user_idle` | judge no, previous reply's tail | ✓ |
| `function-calling-openai-async` async_tool_deferred_delivery_audio | judge no on a half-reply | ✓ |
| `local-handoff-two-agents-tts` acme_handoff_voices | judge no on a half-reply | ✓ |
| `order_pizza` (3 runs, two bots) | `complete_order` never reached | 6/6 |
| `complete_patient_intake` (3 runs) | `complete_intake` never reached | 3/3 |
| `get_insurance_quote` (3 runs) | `end_quote` never reached | 3/3 |

## Testing

```
uv run pytest tests/test_evals_session.py tests/test_evals_simulation.py
```

New tests cover the bot-speaking events and wait, the send holding for a speaking bot and not for a quiet one, an observing turn letting the previous reply end, a judge "no" waiting while the bot speaks and through the transcription grace and failing once the reply is over, and the closing turn in its three cases: the bot replies, no reply comes, and a hang-up on the bot's line. The full eval and CLI suites pass (785 tests).
