### PR TITLE
LiveKit: make the outgoing audio source queue size configurable

### DIFF
--- a/changelog/5699.added.md
+++ b/changelog/5699.added.md
@@ -1,0 +1,1 @@
+- Added `LiveKitParams.audio_out_queue_size_ms` to configure the outgoing `rtc.AudioSource` buffer size. Defaults to LiveKit's 1000 ms, so existing behaviour is unchanged.

--- a/src/pipecat/transports/livekit/transport.py
+++ b/src/pipecat/transports/livekit/transport.py
@@ -110,10 +110,12 @@ class LiveKitOutputTransportMessageUrgentFrame(OutputTransportMessageUrgentFrame
 class LiveKitParams(TransportParams):
     """Configuration parameters for LiveKit transport.
 
-    Inherits all parameters from TransportParams without additional configuration.
+    Parameters:
+        audio_out_queue_size_ms: Buffer size of the outgoing audio source, in milliseconds
+            (LiveKit's default is 1000).
     """
 
-    pass
+    audio_out_queue_size_ms: int = 1000
 
 
 class LiveKitCallbacks(BaseModel):
@@ -275,7 +277,9 @@ class LiveKitTransportClient:
 
                 # Set up audio source and track
                 self._audio_source = rtc.AudioSource(
-                    self._out_sample_rate, self._params.audio_out_channels
+                    self._out_sample_rate,
+                    self._params.audio_out_channels,
+                    queue_size_ms=self._params.audio_out_queue_size_ms,
                 )
                 self._audio_track = rtc.LocalAudioTrack.create_audio_track(
                     "pipecat-audio", self._audio_source

--- a/tests/test_livekit_transport.py
+++ b/tests/test_livekit_transport.py
@@ -658,3 +658,61 @@ class TestLiveKitAudioTrackSubscribedHandler(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@unittest.skipUnless(LIVEKIT_AVAILABLE, "livekit package not installed")
+class TestLiveKitAudioOutQueueSize(unittest.IsolatedAsyncioTestCase):
+    """``audio_out_queue_size_ms`` sizes the outgoing ``rtc.AudioSource`` buffer."""
+
+    def _create_client(self, params: LiveKitParams) -> LiveKitTransportClient:
+        callbacks = LiveKitCallbacks(
+            on_connected=AsyncMock(),
+            on_disconnected=AsyncMock(),
+            on_before_disconnect=AsyncMock(),
+            on_participant_connected=AsyncMock(),
+            on_participant_disconnected=AsyncMock(),
+            on_audio_track_subscribed=AsyncMock(),
+            on_audio_track_unsubscribed=AsyncMock(),
+            on_video_track_subscribed=AsyncMock(),
+            on_video_track_unsubscribed=AsyncMock(),
+            on_data_received=AsyncMock(),
+            on_first_participant_joined=AsyncMock(),
+            on_dtmf_event=AsyncMock(),
+        )
+        client = LiveKitTransportClient(
+            url="wss://test.livekit.cloud",
+            token="test-token",
+            room_name="test-room",
+            params=params,
+            callbacks=callbacks,
+            transport_name="test-transport",
+        )
+        client._task_manager = MagicMock()
+        client._out_sample_rate = 16000
+        room = MagicMock()
+        room.connect = AsyncMock()
+        room.local_participant.identity = "bot"
+        room.local_participant.publish_track = AsyncMock()
+        room.remote_participants = {}
+        client._room = room
+        return client
+
+    async def _connect_and_get_audio_source_call(self, params: LiveKitParams):
+        client = self._create_client(params)
+        with (
+            patch.object(rtc, "AudioSource") as audio_source,
+            patch.object(rtc.LocalAudioTrack, "create_audio_track"),
+        ):
+            await client.connect()
+        return audio_source.call_args
+
+    async def test_default_matches_livekit_default(self):
+        call = await self._connect_and_get_audio_source_call(LiveKitParams())
+        self.assertEqual(call.kwargs["queue_size_ms"], 1000)
+
+    async def test_queue_size_is_passed_to_the_audio_source(self):
+        call = await self._connect_and_get_audio_source_call(
+            LiveKitParams(audio_out_queue_size_ms=200)
+        )
+        self.assertEqual(call.args, (16000, 1))
+        self.assertEqual(call.kwargs["queue_size_ms"], 200)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

`LiveKitTransportClient` creates its outgoing `rtc.AudioSource` with the SDK's default 1 s buffer and `LiveKitParams` has no way to change it. This adds `audio_out_queue_size_ms` and passes it through as `queue_size_ms`. The default is LiveKit's own 1000, so existing behaviour is unchanged.

Why it matters: the output transport writes ahead of playout until that buffer is full, so `BotStoppedSpeakingFrame` and any downstream observer of bot audio can lead what the listener hears by up to the buffer size. Applications that need those to track playout more closely can now set a smaller buffer.

Tests in `tests/test_livekit_transport.py` cover the default and an explicit value reaching the `AudioSource` constructor. Changelog fragment included.
