### PR TITLE
Only defer an async tool result when the conversation has moved on

### DIFF
--- a/changelog/5703.fixed.md
+++ b/changelog/5703.fixed.md
@@ -1,0 +1,1 @@
+- Async function calls (`cancel_on_interruption=False`) whose result arrives before the conversation moves on are now recorded as ordinary tool results, without the deferred-result message that asks the LLM to convey them. The deferred delivery still applies when the LLM has responded, a new message has landed, or the call sent an intermediate update in the meantime.

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -2255,9 +2255,11 @@ class FunctionCallInProgressFrame(ControlFrame, UninterruptibleFrame):
         tool_call_id: Unique identifier for this function call.
         arguments: Arguments passed to the function.
         cancel_on_interruption: Whether to cancel this call if interrupted.
-            When ``False`` the call is treated as asynchronous: the LLM
-            continues the conversation immediately without waiting for the
-            result, and the result is injected later via a developer message.
+            When ``False`` the call is treated as asynchronous: the
+            conversation is not held while it runs, and a result that arrives
+            after the conversation has moved on is injected via a developer
+            message. A result that arrives before then settles in place like
+            a synchronous call's.
         group_id: Identifier shared by all function calls originating from the
             same LLM response batch. Used to determine when the last call in a
             group completes so the LLM can be triggered exactly once.

--- a/src/pipecat/processors/aggregators/async_tool_messages.py
+++ b/src/pipecat/processors/aggregators/async_tool_messages.py
@@ -20,6 +20,14 @@ progresses:
   finishes. A task that is cancelled instead of finishing settles the same
   way, carrying a cancellation notice in place of a result.
 
+The ``final`` message exists so a result that arrives after the LLM has
+moved on still reaches it. When the result arrives first, before any model
+response or any new user or assistant message, there is nothing to catch up
+on: the ``started`` message is overwritten with the result, as for a
+synchronous call, and no ``final`` message is written. A cancellation always
+gets a ``final`` message, because it has to tell the LLM the task did not
+complete.
+
 This module is the single source of truth for the on-the-wire payload shape:
 
 - The aggregator uses the ``build_*_message`` functions when injecting messages.

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1558,6 +1558,11 @@ class LLMAssistantAggregator(LLMContextAggregator):
 
         self._function_calls_in_progress: dict[str, FunctionCallInProgressFrame | None] = {}
         self._function_calls_image_results: dict[str, UserImageRawFrame] = {}
+        # The response count when each async call's "started" message was
+        # written, keyed by tool_call_id, so _is_deferred can tell whether the
+        # model has run since.
+        self._async_calls_started: dict[str, int] = {}
+        self._response_count = 0
         # Markers seen on LLMMarkerFrames, so a service configured with markers
         # other than the defaults still gets them stripped from transcripts.
         self._seen_turn_markers: set[str] = set()
@@ -1834,6 +1839,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
         for task in list(self._context_updated_tasks):
             await self.cancel_task(task)
         self._context_updated_tasks.clear()
+        self._async_calls_started.clear()
         if self._summarizer:
             await self._summarizer.cleanup()
 
@@ -1868,6 +1874,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
         is_async = not frame.cancel_on_interruption
         if is_async:
             self._context.add_message(async_tool_messages.build_started_message(frame.tool_call_id))
+            self._async_calls_started[frame.tool_call_id] = self._response_count
         else:
             self._context.add_message(
                 {
@@ -1999,6 +2006,9 @@ class LLMAssistantAggregator(LLMContextAggregator):
             logger.warning(f"{self} result_callback called with is_final=False but no result!")
             return
 
+        # An update is a deferred delivery in itself, so the call can no longer
+        # settle in place.
+        self._async_calls_started.pop(frame.tool_call_id, None)
         result = json.dumps(frame.result, ensure_ascii=False)
         self._context.add_message(
             async_tool_messages.build_intermediate_result_message(frame.tool_call_id, result)
@@ -2012,15 +2022,15 @@ class LLMAssistantAggregator(LLMContextAggregator):
         Removes the call from the in-progress map, updates the context, and
         triggers LLM inference when appropriate.
         """
-        is_async = not in_progress_frame.cancel_on_interruption
+        deferred = self._is_deferred(in_progress_frame)
         del self._function_calls_in_progress[frame.tool_call_id]
 
         result = json.dumps(frame.result, ensure_ascii=False) if frame.result else "COMPLETED"
 
-        if is_async:
-            # For async function calls inject a developer message so the LLM is
-            # notified of the completed result instead of updating the IN_PROGRESS
-            # tool message.
+        if deferred:
+            # The conversation moved on while the call ran, so the LLM is told
+            # about the result in a developer message rather than in the tool
+            # message it has already seen.
             self._context.add_message(
                 async_tool_messages.build_final_result_message(frame.tool_call_id, result)
             )
@@ -2035,9 +2045,11 @@ class LLMAssistantAggregator(LLMContextAggregator):
         if not function_call:
             return
 
-        # Update context with the function call cancellation. Async calls are
-        # settled with a developer message, the same channel their results
-        # arrive on.
+        # Update context with the function call cancellation. An async call is
+        # settled with a developer message, the same channel its results use,
+        # whether or not the conversation moved on, since the notice says the
+        # call did not complete and asks for the user to be told.
+        self._async_calls_started.pop(frame.tool_call_id, None)
         if function_call.cancel_on_interruption:
             self._update_function_call_result(frame.function_name, frame.tool_call_id, "CANCELLED")
         else:
@@ -2103,6 +2115,7 @@ class LLMAssistantAggregator(LLMContextAggregator):
             )
 
     async def _handle_llm_start(self, _: LLMFullResponseStartFrame):
+        self._response_count += 1
         # Realtime mode treats LLMFullResponseStartFrame as the user
         # turn's end signal for context-writing purposes — see
         # _realtime_handle_llm_start.
@@ -2262,6 +2275,53 @@ class LLMAssistantAggregator(LLMContextAggregator):
         )
 
         return True
+
+    def _is_deferred(self, in_progress_frame: FunctionCallInProgressFrame) -> bool:
+        """Whether a call's final result must be delivered as a deferred message.
+
+        An async call (``cancel_on_interruption=False``) whose result arrives
+        before the conversation moved on is indistinguishable from a synchronous
+        one, and settles in place: its "started" placeholder becomes the tool
+        result, and the LLM sees an ordinary call. The result is deferred when a
+        model response has started since the placeholder was written, a user or
+        assistant message has landed after it, the call sent an intermediate
+        update, or the placeholder is no longer in the context because the
+        context was rebuilt while the call ran. Messages the protocol writes for
+        other calls in flight do not count as the conversation moving on.
+
+        Args:
+            in_progress_frame: The call's in-progress frame.
+
+        Returns:
+            True when the result goes into a developer message.
+        """
+        if in_progress_frame.cancel_on_interruption:
+            return False
+        # No bookmark: the call sent an intermediate update, which already put
+        # it on the deferred channel. A changed count: the model has responded
+        # since the placeholder was written, so it may have seen "still running".
+        response_count = self._async_calls_started.pop(in_progress_frame.tool_call_id, None)
+        if response_count is None or response_count != self._response_count:
+            return True
+        # Otherwise look at what landed after the placeholder. A user turn or
+        # assistant text means the conversation moved on; other calls'
+        # placeholders and results are the protocol's own bookkeeping.
+        after_placeholder = False
+        for message in self._context.messages:
+            if isinstance(message, LLMSpecificMessage):
+                continue
+            if not after_placeholder:
+                after_placeholder = (
+                    message.get("role") == "tool"
+                    and message.get("tool_call_id") == in_progress_frame.tool_call_id
+                )
+                continue
+            role = message.get("role")
+            if role == "user" or (role == "assistant" and message.get("content")):
+                return True
+        # No placeholder at all: the context was rebuilt while the call ran, so
+        # there is nothing to settle into.
+        return not after_placeholder
 
     def _update_function_call_result(self, function_name: str, tool_call_id: str, result: Any):
         for message in self._context.get_messages():

--- a/tests/test_context_aggregators_universal.py
+++ b/tests/test_context_aggregators_universal.py
@@ -1443,6 +1443,147 @@ class TestLLMAssistantAggregator(unittest.IsolatedAsyncioTestCase):
         assert context.messages[-1]["content"] == "CANCELLED"
         assert not aggregator.has_function_calls_in_progress
 
+    async def test_fast_async_function_call_settles_in_place(self):
+        """An async call whose result lands before anything else settles like a sync one."""
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        frames_to_send = [
+            FunctionCallInProgressFrame(
+                function_name="book_table",
+                tool_call_id="1",
+                arguments={"size": 2},
+                cancel_on_interruption=False,
+            ),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="book_table",
+                tool_call_id="1",
+                arguments={"size": 2},
+                result={"status": "booked"},
+                run_llm=False,
+            ),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send, expected_down_frames=[])
+        tool_messages = [m for m in context.messages if m.get("role") == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["tool_call_id"] == "1"
+        assert tool_messages[0]["content"] == '{"status": "booked"}'
+        assert all(async_tool_messages.parse_message(m) is None for m in context.messages)
+        assert not aggregator.has_function_calls_in_progress
+
+    async def test_async_function_call_after_user_message_is_deferred(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        frames_to_send = [
+            FunctionCallInProgressFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                cancel_on_interruption=False,
+            ),
+            SleepFrame(),
+            LLMMessagesAppendFrame(messages=[{"role": "user", "content": "Any news?"}]),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                result={"answer": 42},
+                run_llm=False,
+            ),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send, expected_down_frames=[])
+        payload = async_tool_messages.parse_message(context.messages[-1])
+        assert payload is not None and payload.kind == "final"
+        assert payload.tool_call_id == "1"
+
+    async def test_async_function_call_after_model_response_is_deferred(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        frames_to_send = [
+            FunctionCallInProgressFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                cancel_on_interruption=False,
+            ),
+            SleepFrame(),
+            LLMFullResponseStartFrame(),
+            LLMFullResponseEndFrame(),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                result={"answer": 42},
+                run_llm=False,
+            ),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send)
+        payload = async_tool_messages.parse_message(context.messages[-1])
+        assert payload is not None and payload.kind == "final"
+
+    async def test_async_function_call_after_context_rebuild_is_deferred(self):
+        """A placeholder the context no longer holds cannot take the result in place."""
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        frames_to_send = [
+            FunctionCallInProgressFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                cancel_on_interruption=False,
+            ),
+            SleepFrame(),
+            LLMMessagesUpdateFrame(messages=[{"role": "developer", "content": "Fresh start."}]),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                result={"answer": 42},
+                run_llm=False,
+            ),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send, expected_down_frames=[])
+        payload = async_tool_messages.parse_message(context.messages[-1])
+        assert payload is not None and payload.kind == "final"
+        assert payload.tool_call_id == "1"
+
+    async def test_intermediate_update_keeps_the_call_deferred(self):
+        context = LLMContext()
+        aggregator = LLMAssistantAggregator(context)
+        frames_to_send = [
+            FunctionCallInProgressFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                cancel_on_interruption=False,
+            ),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                result={"progress": "halfway"},
+                run_llm=False,
+                properties=FunctionCallResultProperties(is_final=False),
+            ),
+            SleepFrame(),
+            FunctionCallResultFrame(
+                function_name="lookup",
+                tool_call_id="1",
+                arguments={},
+                result={"answer": 42},
+                run_llm=False,
+            ),
+        ]
+        await run_test(aggregator, frames_to_send=frames_to_send, expected_down_frames=[])
+        kinds = [
+            p.kind for p in (async_tool_messages.parse_message(m) for m in context.messages) if p
+        ]
+        assert kinds == ["started", "intermediate", "final"]
+
     async def test_async_function_call_cancel(self):
         """A cancelled async call settles on the same channel its results use."""
         context = LLMContext()


### PR DESCRIPTION
## Summary

- Async tools (`cancel_on_interruption=False`) get a "still running" placeholder in the context, and their result is delivered later as a developer message that tells the LLM to convey it. That's right for a slow tool.
- Flows registers every function that way so an interruption can't cancel a transition. Its functions finish in milliseconds, so every result arrived with the "convey this" instruction, and the bot obeyed: "By the way, your party size has been noted."
- Now the aggregator decides when the result arrives. If nothing has happened since the placeholder was written, the placeholder becomes the tool result and the LLM sees an ordinary call.
- The result is still deferred if the model has responded since, a user or assistant message has landed, the call sent an intermediate update, or the context was rebuilt while the call ran. Placeholders and results for other calls in the same batch don't count.
- Cancellations are always deferred. The notice says the call didn't complete; a bare `CANCELLED` doesn't, and one model read it as "still working."
- No new options. `cancel_on_interruption` means what it always did. Slow tools behave exactly as before.

Design note: https://claude.ai/code/artifact/dc224bef-e435-49df-8ca5-69bdd0579e3b

## Testing

- `uv run pytest tests/test_context_aggregators_universal.py`: in place when nothing intervened; deferred after a user message, a model response, an intermediate update, or a context rebuild; cancellation always deferred.
- Release evals: the four function-calling async bots pass their delivery, cancellation, and timeout scenarios; the reservation simulation shows plain tool results and no asides.

Fixes https://github.com/pipecat-ai/pipecat/issues/5700