### PR TITLE
Satisfy DeepSeek's reasoning_content rule and default thinking off

### DIFF
--- a/changelog/5710.changed.md
+++ b/changelog/5710.changed.md
@@ -1,0 +1,1 @@
+- `DeepSeekLLMService` now defaults `thinking` to disabled. DeepSeek's V4 models otherwise reason before every answer, which delays the first spoken token. Pass `thinking=DeepSeekLLMService.ThinkingConfig(type="enabled")` to turn it on, or `thinking=None` to use DeepSeek's own default.

--- a/changelog/5710.fixed.md
+++ b/changelog/5710.fixed.md
@@ -1,0 +1,1 @@
+- Fixed `DeepSeekLLMService` failing every request after a tool call in thinking mode with a 400 (`The reasoning_content in the thinking mode must be passed back to the API`). DeepSeek requires `reasoning_content` on each assistant message of the current turn once a tool call is involved; the new `DeepSeekLLMAdapter` supplies an empty one on assistant messages that have none.

--- a/src/pipecat/adapters/services/deepseek_adapter.py
+++ b/src/pipecat/adapters/services/deepseek_adapter.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""DeepSeek LLM adapter for Pipecat.
+
+DeepSeek's API is OpenAI-compatible, but in thinking mode it requires every
+assistant message of the current turn to carry a ``reasoning_content`` field
+once a tool call is involved, and rejects the request with a 400 otherwise.
+Pipecat does not keep a model's reasoning in the context, so this adapter
+supplies an empty ``reasoning_content`` on assistant messages that lack one.
+DeepSeek accepts the empty field on any assistant message and ignores it when
+thinking is disabled, so it is applied uniformly rather than per turn.
+"""
+
+from typing import Any, cast
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from pipecat.adapters.services.open_ai_adapter import OpenAILLMAdapter, OpenAILLMInvocationParams
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+
+class DeepSeekLLMAdapter(OpenAILLMAdapter):
+    """Adapter that shapes messages to satisfy DeepSeek's thinking-mode rules.
+
+    Extends ``OpenAILLMAdapter`` and adds an empty ``reasoning_content`` to
+    every assistant message that has none, so requests are accepted in
+    thinking mode after a tool call.
+    """
+
+    def get_llm_invocation_params(
+        self,
+        context: LLMContext,
+        *,
+        system_instruction: str | None = None,
+        convert_developer_to_user: bool,
+    ) -> OpenAILLMInvocationParams:
+        """Get OpenAI-compatible invocation parameters with DeepSeek message fixes applied.
+
+        Args:
+            context: The LLM context containing messages, tools, etc.
+            system_instruction: Optional system instruction from service settings
+                or ``run_inference``. Forwarded to the parent adapter.
+            convert_developer_to_user: If True, convert "developer"-role messages
+                to "user"-role messages. Forwarded to the parent adapter.
+
+        Returns:
+            Dictionary of parameters for DeepSeek's ChatCompletion API, with
+            ``reasoning_content`` present on every assistant message.
+        """
+        params = super().get_llm_invocation_params(
+            context,
+            system_instruction=system_instruction,
+            convert_developer_to_user=convert_developer_to_user,
+        )
+        params["messages"] = self._add_reasoning_content(list(params["messages"]))
+        return params
+
+    def _add_reasoning_content(
+        self, messages: list[ChatCompletionMessageParam]
+    ) -> list[ChatCompletionMessageParam]:
+        """Return the messages with ``reasoning_content`` on every assistant message.
+
+        Assistant messages that already carry the field are left as they are.
+        Message dicts are shared with the source ``LLMContext``, so a stamped
+        message is a copy rather than a mutation.
+
+        Args:
+            messages: List of OpenAI-shaped message dicts.
+
+        Returns:
+            The message list, with copies of the assistant messages that needed
+            the field.
+        """
+        result: list[dict[str, Any]] = []
+        for message in messages:
+            msg = cast(dict[str, Any], message)
+            if msg.get("role") == "assistant" and "reasoning_content" not in msg:
+                msg = {**msg, "reasoning_content": ""}
+            result.append(msg)
+        return cast(list[ChatCompletionMessageParam], result)

--- a/src/pipecat/services/deepseek/llm.py
+++ b/src/pipecat/services/deepseek/llm.py
@@ -12,6 +12,7 @@ from typing import Literal
 from loguru import logger
 from pydantic import BaseModel
 
+from pipecat.adapters.services.deepseek_adapter import DeepSeekLLMAdapter
 from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.services.openai.llm import OpenAILLMService
@@ -36,8 +37,11 @@ class DeepSeekLLMSettings(BaseOpenAILLMService.Settings):
     """Settings for DeepSeekLLMService.
 
     Parameters:
-        thinking: Thinking mode configuration. When unset, DeepSeek's own
-            default applies: thinking enabled at "high" reasoning effort.
+        thinking: Thinking mode configuration. The service defaults this to
+            disabled: DeepSeek's V4 models otherwise run a reasoning pass before
+            every answer, which delays the first spoken token. Set
+            ``DeepSeekThinkingConfig(type="enabled")`` to turn it on, or
+            ``None`` to leave the choice to DeepSeek's own default.
     """
 
     thinking: DeepSeekThinkingConfig | None | NotGiven = field(default_factory=lambda: NOT_GIVEN)
@@ -58,6 +62,10 @@ class DeepSeekLLMService(OpenAILLMService):
     # DeepSeek doesn't support the "developer" message role.
     # This value is used by BaseOpenAILLMService when calling the adapter.
     supports_developer_role = False
+
+    # Supplies the `reasoning_content` DeepSeek requires on assistant messages
+    # in thinking mode.
+    adapter_class = DeepSeekLLMAdapter
 
     Settings = DeepSeekLLMSettings
     ThinkingConfig = DeepSeekThinkingConfig
@@ -88,7 +96,9 @@ class DeepSeekLLMService(OpenAILLMService):
             **kwargs: Additional keyword arguments passed to OpenAILLMService.
         """
         # 1. Initialize default_settings with hardcoded defaults
-        default_settings = self.Settings(model="deepseek-v4-flash", thinking=None)
+        default_settings = self.Settings(
+            model="deepseek-v4-flash", thinking=DeepSeekThinkingConfig(type="disabled")
+        )
 
         # 2. Apply direct init arg overrides (deprecated)
         if model is not None:

--- a/tests/test_get_llm_invocation_params.py
+++ b/tests/test_get_llm_invocation_params.py
@@ -85,6 +85,7 @@ from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.services.anthropic_adapter import AnthropicLLMAdapter
 from pipecat.adapters.services.aws_nova_sonic_adapter import AWSNovaSonicLLMAdapter
 from pipecat.adapters.services.bedrock_adapter import AWSBedrockLLMAdapter
+from pipecat.adapters.services.deepseek_adapter import DeepSeekLLMAdapter
 from pipecat.adapters.services.gemini_adapter import GeminiLLMAdapter
 from pipecat.adapters.services.gemini_live_adapter import GeminiLiveLLMAdapter
 from pipecat.adapters.services.grok_realtime_adapter import GrokRealtimeLLMAdapter
@@ -2288,6 +2289,103 @@ class TestPerplexityGetLLMInvocationParams(unittest.TestCase):
         params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
 
         self.assertEqual(params["messages"], [])
+
+
+class TestDeepSeekGetLLMInvocationParams(unittest.TestCase):
+    # DeepSeek doesn't support the "developer" role, so DeepSeekLLMService
+    # sets supports_developer_role = False. Tests below pass
+    # convert_developer_to_user=True to match production behavior.
+
+    def setUp(self) -> None:
+        """Sets up a common adapter instance for all tests."""
+        self.adapter = DeepSeekLLMAdapter()
+
+    def _tool_call(self) -> dict:
+        return {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"location": "LA"}'},
+        }
+
+    def test_tool_call_message_gets_empty_reasoning_content(self):
+        """An assistant tool-call message without reasoning_content gets an empty one."""
+        messages: list[LLMStandardMessage] = [
+            {"role": "user", "content": "Weather in LA?"},
+            {"role": "assistant", "tool_calls": [self._tool_call()]},
+            {"role": "tool", "content": '{"temperature": "75"}', "tool_call_id": "call_1"},
+        ]
+
+        context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
+
+        assistant = params["messages"][1]
+        self.assertEqual(assistant["role"], "assistant")
+        self.assertEqual(assistant["reasoning_content"], "")
+        self.assertEqual(assistant["tool_calls"], [self._tool_call()])
+
+    def test_spoken_text_before_tool_call_also_stamped(self):
+        """Assistant text recorded before a tool call (e.g. spoken via TTS) is stamped too."""
+        messages: list[LLMStandardMessage] = [
+            {"role": "user", "content": "Weather in LA?"},
+            {"role": "assistant", "content": "Let me check on that."},
+            {"role": "assistant", "tool_calls": [self._tool_call()]},
+            {"role": "tool", "content": '{"temperature": "75"}', "tool_call_id": "call_1"},
+        ]
+
+        context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
+
+        self.assertEqual(params["messages"][1]["content"], "Let me check on that.")
+        self.assertEqual(params["messages"][1]["reasoning_content"], "")
+        self.assertEqual(params["messages"][2]["reasoning_content"], "")
+
+    def test_existing_reasoning_content_preserved(self):
+        """An assistant message that already carries reasoning_content is left alone."""
+        messages: list[LLMStandardMessage] = [
+            {"role": "user", "content": "Weather in LA?"},
+            {
+                "role": "assistant",
+                "tool_calls": [self._tool_call()],
+                "reasoning_content": "Need the weather tool.",
+            },
+        ]
+
+        context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
+
+        self.assertEqual(params["messages"][1]["reasoning_content"], "Need the weather tool.")
+
+    def test_non_assistant_messages_untouched(self):
+        """System, user, and tool messages never get the field."""
+        messages: list[LLMStandardMessage] = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Weather in LA?"},
+            {"role": "assistant", "tool_calls": [self._tool_call()]},
+            {"role": "tool", "content": '{"temperature": "75"}', "tool_call_id": "call_1"},
+            {"role": "user", "content": "Thanks."},
+        ]
+
+        context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
+
+        for i in (0, 1, 3, 4):
+            self.assertNotIn("reasoning_content", params["messages"][i])
+        self.assertEqual(params["messages"][2]["reasoning_content"], "")
+
+    def test_context_messages_not_mutated(self):
+        """Stamping produces copies; the context's own message dicts are unchanged."""
+        assistant: LLMStandardMessage = {"role": "assistant", "content": "Hi!"}
+        messages: list[LLMStandardMessage] = [
+            {"role": "user", "content": "Hello"},
+            assistant,
+        ]
+
+        context = LLMContext(messages=messages)
+        params = self.adapter.get_llm_invocation_params(context, convert_developer_to_user=True)
+
+        self.assertEqual(params["messages"][1]["reasoning_content"], "")
+        self.assertNotIn("reasoning_content", assistant)
+        self.assertNotIn("reasoning_content", context.get_messages()[1])
 
 
 class TestOpenAIResponsesGetLLMInvocationParams(unittest.TestCase):


### PR DESCRIPTION
## Summary

DeepSeek's API now rejects a thinking-mode request with a 400 (`The reasoning_content in the thinking mode must be passed back to the API`) whenever an assistant message of the current turn lacks `reasoning_content` and a tool call is involved. Since `deepseek-v4-flash` (the default model) thinks by default, every follow-up request after a tool result failed and the service became unusable. The same request shape that passed on Aug 25 is rejected today, so this is server-side enforcement tightening rather than a Pipecat regression.

- New `DeepSeekLLMAdapter` adds `reasoning_content: ""` to every assistant message that has none. Pipecat does not keep the model's reasoning in the context, and DeepSeek accepts the empty field (verified against the live API, including on the spoken pre-tool-call text a `TTSSpeakFrame` records). It is harmless when thinking is disabled.
- `DeepSeekLLMService` defaults `thinking` to disabled. The V4 models otherwise reason before every answer, which delays the first spoken token in a voice pipeline. `None` restores DeepSeek's own default; `DeepSeekLLMService.ThinkingConfig(type="enabled")` turns it on.

## Verification

- `tests/test_get_llm_invocation_params.py::TestDeepSeekGetLLMInvocationParams` covers the tool-call-only shape, spoken text plus tool call, an existing `reasoning_content` left untouched, non-assistant roles untouched, and no mutation of the context's dicts.
- Release eval `weather_function_call` against `function-calling-deepseek.py`: 2/2 with the new default, and 2/2 from a copy with thinking enabled (tool-call turns show ~0.6s thinking, and the post-tool follow-up succeeds).
