### PR TITLE
Retire the MoQ audio track on interruption

### DIFF
--- a/changelog/5716.changed.md
+++ b/changelog/5716.changed.md
@@ -1,0 +1,1 @@
+- Changed `MOQOutputTransport` to retire its audio track when an interruption catches audio still to be played, publishing a successor in its place, so that audio is discarded along with the track that carried it rather than relying on the client to flush.

--- a/src/pipecat/transports/moq/transport.py
+++ b/src/pipecat/transports/moq/transport.py
@@ -22,8 +22,11 @@ subscribes to the peer at ``<namespace>/<peer_id>`` (e.g.
 both peers agree on a namespace up front; when the paths are instead
 assigned externally, ``response_path``/``request_path`` set them
 directly and the namespace is unused. Audio rides on a
-single Opus track; RTVI JSON rides on a fixed-name ``transcript.json.z``
-track carried by moq's JSON stream helper (``publish_json_stream`` /
+single Opus track, replaced by a fresh one when an interruption catches
+audio still in flight, so that audio is discarded along with the track
+that carried it (see :meth:`MOQTransportClient.restart_audio_track`);
+RTVI JSON rides on a fixed-name ``transcript.json.z`` track carried by
+moq's JSON stream helper (``publish_json_stream`` /
 ``subscribe_json_stream``). The stream is an ordered, lossless append-log
 of records — every message is delivered in order, unlike the JSON
 *snapshot* helper (``publish_json_snapshot`` / ``subscribe_json_snapshot``)
@@ -223,6 +226,12 @@ DEFAULT_TRANSCRIPT_TRACK = "transcript.json.z"
 # pipeline rate up to this for us.
 OPUS_SAMPLE_RATE = 48000
 
+# Unplayed audio below this doesn't justify retiring the audio track. A
+# lead this small is the client's own jitter buffer, or a mixer writing
+# at real-time pace, rather than the write-ahead frontier of an
+# abandoned utterance. See :meth:`MOQTransportClient.restart_audio_track`.
+AUDIO_IN_FLIGHT_FLOOR_S = 0.3
+
 
 def _downmix_s16_to_mono(pcm: bytes, channels: int) -> bytes:
     """Downmix interleaved S16 PCM to mono by averaging channels.
@@ -291,7 +300,11 @@ class MOQParams(TransportParams):
         request_path: Full broadcast path the bot subscribes to (incoming
             requests), overriding ``<namespace>/<peer_id>``. See
             :attr:`response_path`.
-        audio_out_track: Name of the bot's outgoing audio track.
+        audio_out_track: Name of the bot's outgoing audio track. An
+            interruption that catches audio still to be played retires
+            the track and publishes a successor named
+            ``<audio_out_track>-<n>``; subscribers discover the current
+            one through the catalog rather than by this name.
         transcript_track: Name of the bot's outgoing transcript track. A
             fixed-name JSON stream track carrying RTVI messages as a
             lossless, ordered append-log (moq's ``publish_json_stream`` /
@@ -360,9 +373,7 @@ class MOQParams(TransportParams):
             past this many milliseconds. Keep it a little under the
             player's buffer ceiling (``MoqTransportOptions.audioBufferMaxMs``,
             30s) so the producer self-limits below the player's drop
-            ceiling and the player never has to drop. On interruption the
-            pacing clock is re-anchored (see :meth:`reset_audio_pacing`) so
-            the next utterance isn't delayed by the previous buffer.
+            ceiling and the player never has to drop.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -524,12 +535,24 @@ class MOQTransportClient:
         # Wall-clock target for the next publish_audio write. ``None``
         # means "reset" — the next write anchors to ``time.monotonic()``.
         self._publish_audio_clock: float | None = None
-        # Monotonic presentation timestamp (microseconds) for the next
-        # audio chunk, advanced by each chunk's duration. The browser
-        # player uses these future-dated timestamps to buffer and pace
-        # playback. Not reset on interruption — the player re-anchors on
-        # its own (reset() on user-started-speaking).
-        self._publish_pts_us: int = 0
+        # Origin of the broadcast's presentation timeline. Every track the
+        # bot publishes stamps against this one clock, so they stay
+        # mutually synchronizable — the audio track being replaced on
+        # interruption doesn't restart the timescale, it just re-anchors
+        # into it. Monotonic and publisher-local, matching the browser
+        # side's ``performance.now()`` convention.
+        self._clock_origin: float = time.monotonic()
+        # Presentation timestamp (microseconds) for the next audio chunk,
+        # advanced by each chunk's duration. The browser player uses these
+        # future-dated timestamps to buffer and pace playback. Only the
+        # first stamp of a track reaches the wire as given: the encoder
+        # takes it as that track's epoch and derives every later PTS from
+        # the running sample count. ``None`` means the current track has
+        # no epoch yet — the next write takes one from the timeline.
+        self._publish_pts_us: int | None = None
+        # Counter distinguishing successive audio tracks. Bumped per
+        # interruption; the name of track 0 is `audio_out_track` itself.
+        self._audio_track_generation: int = 0
 
         # Track consumers we created so disconnect() can cancel them.
         # Each entry has a sync .cancel() method that terminates any
@@ -588,8 +611,31 @@ class MOQTransportClient:
             return
 
         self._audio_out_sample_rate = sample_rate
+        self._open_audio_track(sample_rate)
+
+    @property
+    def _audio_track_name(self) -> str:
+        """Name of the audio track for the current generation."""
+        if self._audio_track_generation == 0:
+            return self._params.audio_out_track
+        return f"{self._params.audio_out_track}-{self._audio_track_generation}"
+
+    def _elapsed_us(self) -> int:
+        """Microseconds elapsed on the broadcast's presentation timeline."""
+        return int((time.monotonic() - self._clock_origin) * 1_000_000)
+
+    def _open_audio_track(self, sample_rate: int):
+        """Publish an audio track for the current generation.
+
+        The epoch is left unset for the first write to fill in, so the
+        track anchors at the timeline position it starts playing from
+        rather than where it was opened. The two are seconds apart
+        whenever an utterance waits on the LLM, and the encoder takes
+        that first stamp as the track's epoch.
+        """
+        self._publish_pts_us = None
         self._audio_out = self._publish_broadcast.publish_audio(
-            self._params.audio_out_track,
+            self._audio_track_name,
             moq.AudioEncoderInput(
                 format=moq.AudioFormat.S16,
                 sample_rate=sample_rate,
@@ -607,22 +653,63 @@ class MOQTransportClient:
             f"MOQ: publishing audio as Opus "
             f"(pipeline rate={sample_rate}Hz, opus rate={OPUS_SAMPLE_RATE}Hz, "
             f"frame={self._params.audio_out_frame_ms}ms, "
-            f"track={self._params.audio_out_track!r})"
+            f"track={self._audio_track_name!r})"
         )
 
-    def reset_audio_pacing(self):
-        """Re-anchor the publish_audio pacing clock to wall-clock now.
+    def restart_audio_track(self):
+        """Retire the current audio track and publish a fresh one.
 
-        Called from :class:`MOQOutputTransport.process_frame` on
-        InterruptionFrame so the next utterance plays immediately
-        instead of waiting for the (now-cancelled) previous one to
-        finish in pacing time.
+        The bot writes TTS faster than real-time, so when an interruption
+        arrives the previous utterance is already encoded and in flight —
+        seconds of it. Retiring the track is what discards it: the track
+        name identifies the utterance it carries, so anything still
+        arriving on the old one is recognizably stale rather than
+        indistinguishable from the new utterance's first frame.
 
-        Part of the publish_audio pacing workaround; goes away once
-        moq-rs exposes a flush primitive on ``AudioProducer``. See
-        :meth:`publish_audio`.
+        ``finish()`` drops the producer's catalog rendition, and the new
+        track publishes its own, so the catalog always advertises exactly
+        one audio track and subscribers follow the swap through normal
+        rendition selection.
+
+        The successor anchors at its own first write rather than
+        continuing from where the abandoned utterance had written to, so
+        the next utterance plays immediately instead of waiting out the
+        buffer it replaced. The pacing clock re-anchors with it. PTS stays
+        on the same broadcast timeline: a replacement does not reset the
+        origin to zero, only the new producer's group sequence.
+
+        Interruptions are broadcast on every user turn, not only on
+        barge-in, so a swap is worth its cost — a catalog update and a
+        resubscribe for every subscriber — only when the track actually
+        carries audio nobody has heard yet. ``_publish_audio_clock`` is
+        the presentation deadline of the last chunk written, so its lead
+        over wall-clock is exactly what is still to be played.
         """
+        if self._audio_out is None or not self._audio_out_sample_rate:
+            return
+
+        in_flight_s = (
+            0.0
+            if self._publish_audio_clock is None
+            else self._publish_audio_clock - time.monotonic()
+        )
+        if in_flight_s <= AUDIO_IN_FLIGHT_FLOOR_S:
+            return
+
+        old = self._audio_out
+        # Cleared before finishing so a chunk still paced against the old
+        # track can tell its write is no longer wanted (see publish_audio).
+        self._audio_out = None
+        try:
+            old.finish()
+        except Exception as e:
+            # A peer that already went away fails the flush; the rendition
+            # is gone either way, so the new track is still worth opening.
+            logger.debug(f"MOQ: finishing audio track {self._audio_track_name!r} failed: {e}")
+
+        self._audio_track_generation += 1
         self._publish_audio_clock = None
+        self._open_audio_track(self._audio_out_sample_rate)
 
     async def publish_audio(self, audio: bytes):
         """Push a PCM chunk to the bot's audio track with real PTS, paced to a cap.
@@ -630,21 +717,24 @@ class MOQTransportClient:
         The library does the Opus encode + resample inside the FFI, so we
         just write S16 PCM bytes.
 
-        Each chunk is stamped with a monotonic presentation timestamp so
-        the browser player (``@moq/watch``) can buffer the future-dated
-        frames and play them at the encoded pace. ``AudioProducer.write()``
-        is fire-and-forget, so to bound how far ahead the bot runs we pace
-        the writes against a virtual clock: each call advances the clock by
-        the chunk's audio duration, and we sleep until wall-clock is within
-        ``audio_out_max_buffer_ms`` (25s) of it. That keeps the in-flight
-        buffer a little under the player's drop ceiling
-        (``MoqTransportOptions.audioBufferMaxMs``, 30s), so the producer
-        self-limits below the consumer's cap. Interruptions are flushed on
-        the browser side (``reset()`` on ``user-started-speaking``); the
-        pacing clock is re-anchored here (see :meth:`reset_audio_pacing`)
-        so the next utterance isn't delayed by the previous buffer.
+        Each chunk is stamped with a presentation timestamp so the browser
+        player (``@moq/watch``) can buffer the future-dated frames and play
+        them at the encoded pace. ``AudioProducer.write()`` is
+        fire-and-forget, so to bound how far ahead the bot runs we pace the
+        writes against a virtual clock: each call advances the clock by the
+        chunk's audio duration, and we sleep until wall-clock is within
+        ``audio_out_max_buffer_ms`` of it. Interruptions retire the whole
+        track (see :meth:`restart_audio_track`), so the cap bounds how much
+        encoded audio a retired track can strand rather than how much can
+        still reach the player. It also bounds how long the lead stays
+        above the floor a retirement needs to be worth making.
+
+        The producer is captured before the pacing wait so a rotation that
+        finishes it while this call is asleep cannot land the abandoned
+        chunk on the successor.
         """
-        if self._audio_out is None or not self._audio_out_sample_rate:
+        producer = self._audio_out
+        if producer is None or not self._audio_out_sample_rate:
             return
 
         now = time.monotonic()
@@ -659,12 +749,25 @@ class MOQTransportClient:
         if wait > 0:
             await asyncio.sleep(wait)
 
+        # Pacing can sleep for seconds, long enough for an interruption to
+        # retire the track this chunk was destined for. It belongs to the
+        # utterance that was just discarded, so drop it rather than letting
+        # it anchor the successor track's epoch.
+        if producer is not self._audio_out:
+            return
+
         # Advance the virtual clock and the presentation timestamp by the
         # duration of this chunk. S16 = 2 bytes/sample, mono.
         duration_s = len(audio) / (self._audio_out_sample_rate * 2)
         self._publish_audio_clock += duration_s
 
-        self._audio_out.write(moq.AudioFrame(timestamp_us=self._publish_pts_us, data=audio))
+        # First write on this track: it decides where the track sits on the
+        # broadcast timeline, so take the position now that audio is
+        # actually going out.
+        if self._publish_pts_us is None:
+            self._publish_pts_us = self._elapsed_us()
+
+        producer.write(moq.AudioFrame(timestamp_us=self._publish_pts_us, data=audio))
         self._publish_pts_us += int(duration_s * 1_000_000)
 
     async def wait_for_audio_drain(self, jitter_buffer_margin_s: float = 0.3) -> None:
@@ -1348,20 +1451,20 @@ class MOQOutputTransport(BaseOutputTransport):
         await self._client.cleanup()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Reset the publish_audio pacing clock on interruption.
+        """Retire the audio track when an interruption strands audio on it.
 
-        The pacing in ``write_audio_frame`` keeps moq's in-flight buffer
-        bounded so InterruptionFrame can actually stop playback in the
-        browser — but the pacing clock needs to be re-anchored to ``now``
-        so the next utterance plays immediately instead of catching up.
+        The base class drains the queued audio and stops the writer first,
+        so the track is retired with no writes still racing it. Everything
+        the retired track carried is discarded with it; the next utterance
+        goes out on the new one.
 
         Args:
             frame: The frame to process.
             direction: The direction of frame flow in the pipeline.
         """
-        if isinstance(frame, InterruptionFrame):
-            self._client.reset_audio_pacing()
         await super().process_frame(frame, direction)
+        if isinstance(frame, InterruptionFrame):
+            self._client.restart_audio_track()
 
     async def send_message(
         self, frame: OutputTransportMessageFrame | OutputTransportMessageUrgentFrame

--- a/tests/test_moq_transport.py
+++ b/tests/test_moq_transport.py
@@ -6,7 +6,7 @@
 
 """Tests for the MoQ (Media over QUIC) transport.
 
-Four areas covered:
+Five areas covered:
 
 1. **``_downmix_s16_to_mono``** — the workaround for ``@moq/publish``'s
    browser-side encoder publishing stereo even when the source mic
@@ -31,9 +31,18 @@ Four areas covered:
    future refactor moves either into ``_run()``, the bot will lose its
    first few hundred ms of audio (this was a real bug PR #4557's
    self-review fixed).
+
+5. **Audio track restart on interruption** — the bot writes TTS ahead of
+   real-time, so an interruption has to discard audio that has already
+   left. Retiring the track is what does it, and these tests pin the
+   properties that makes possible: a uniquely named successor, continuous
+   PTS on the broadcast timeline, stale paced writes dropped, catalog
+   replacement, and group zero on every replacement track.
 """
 
 import argparse
+import asyncio
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -754,6 +763,222 @@ class TestIsNormalClose(unittest.TestCase):
 
     def test_non_moq_exception_is_not_normal(self):
         self.assertFalse(_is_normal_close(RuntimeError("moq: remote error: code=24")))
+
+
+# ----------------------------------------------------------------------
+# Audio track restart on interruption
+# ----------------------------------------------------------------------
+
+# 200 ms of S16 mono at 16 kHz: enough for several Opus frames after the
+# 16 kHz → 48 kHz resample, so a live consumer sees at least one group.
+_PCM_200MS = b"\x00" * (16000 * 2 // 5)
+
+
+class TestMOQAudioTrackRestart(unittest.IsolatedAsyncioTestCase):
+    """An interruption must discard audio the bot has already published.
+
+    Pacing lets the bot run seconds ahead of real-time, so by the time a
+    user barges in the rest of the utterance is encoded and gone. The
+    track it went out on is retired and a successor published in its
+    place: the track name is what marks the audio as belonging to the
+    abandoned utterance, so a straggler can't be mistaken for the first
+    frame of the next one.
+    """
+
+    def setUp(self):
+        patcher = patch("pipecat.transports.moq.transport.moq")
+        self.moq = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.broadcast = MagicMock(name="broadcast")
+        self.broadcast.publish_json_stream.return_value = MagicMock(name="transcript_stream")
+        self.broadcast.publish_audio.side_effect = lambda *a, **k: MagicMock(name="audio_producer")
+        origin = MagicMock(name="publish_origin")
+        origin.create_broadcast.return_value = self.broadcast
+        self.moq.OriginProducer.return_value = origin
+
+        params = MOQParams(audio_in_enabled=True, audio_out_enabled=True)
+        self.client = MOQTransport(params=params, host="localhost", port=4080)._client
+
+    def _published_track_names(self):
+        return [call.args[0] for call in self.broadcast.publish_audio.call_args_list]
+
+    def _advance_timeline(self, seconds: float):
+        """Fast-forward the broadcast timeline, as an LLM turn does.
+
+        A track opens the moment the interruption lands but doesn't write
+        until STT, the LLM and TTS have all run, so the gap between the two
+        is what distinguishes the two candidate anchors.
+        """
+        self.client._clock_origin -= seconds
+
+    def _leave_audio_in_flight(self, seconds: float = 5.0):
+        """Park the pacing clock ahead of wall-clock, as a live utterance does.
+
+        Unplayed audio on the track is what a restart exists to discard, so
+        it is also what a restart checks for.
+        """
+        self.client._publish_audio_clock = time.monotonic() + seconds
+
+    def test_interruption_retires_the_track_and_publishes_a_successor(self):
+        """The old producer is finished — which drops its catalog rendition —
+        and a differently-named track takes its place, so the catalog still
+        advertises exactly one audio track for subscribers to follow."""
+        self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
+        retired = self.client._audio_out
+
+        self.client.restart_audio_track()
+
+        retired.finish.assert_called_once()
+        self.assertIsNotNone(self.client._audio_out)
+        self.assertIsNot(self.client._audio_out, retired)
+        self.assertEqual(self._published_track_names(), ["bot-audio", "bot-audio-1"])
+
+    def test_each_interruption_names_a_further_track(self):
+        """Names keep advancing, so no two utterances in a session share one."""
+        self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
+        self.client.restart_audio_track()
+        self._leave_audio_in_flight()
+        self.client.restart_audio_track()
+
+        self.assertEqual(self._published_track_names(), ["bot-audio", "bot-audio-1", "bot-audio-2"])
+
+    async def test_replacement_pts_stays_on_the_broadcast_timeline(self):
+        """PTS is not reset to zero. Every track stamps against one broadcast
+        clock, so a successor re-anchors into that timeline at the position
+        it starts playing from rather than the write-ahead frontier the
+        abandoned utterance had reached, and rather than where the track
+        was opened (a whole LLM turn earlier)."""
+        self.client.open_audio_track(16000)
+        self._leave_audio_in_flight()
+        # Pacing runs ahead of real-time, so the abandoned utterance left the
+        # timestamp far in the future.
+        self.client._publish_pts_us = self.client._elapsed_us() + 25_000_000
+
+        self.client.restart_audio_track()
+        self.assertIsNone(self.client._publish_pts_us, "anchored before any audio")
+        opened_at = self.client._elapsed_us()
+        self._advance_timeline(2.0)
+        await self.client.publish_audio(b"\x00" * 320)
+
+        anchor = self.moq.AudioFrame.call_args.kwargs["timestamp_us"]
+        self.assertGreater(anchor, 0, "replacement PTS reset the broadcast timeline")
+        self.assertLess(
+            anchor, opened_at + 25_000_000, "successor anchored at the write-ahead frontier"
+        )
+        self.assertAlmostEqual(anchor, opened_at + 2_000_000, delta=100_000)
+
+    async def test_first_track_anchors_into_the_same_timeline(self):
+        """The first track is not special-cased: it anchors off the same clock,
+        so a successor's stamps are comparable with its own, and it waits for
+        its first write the same way."""
+        self.client.open_audio_track(16000)
+        opened_at = self.client._elapsed_us()
+        self._advance_timeline(2.0)
+        await self.client.publish_audio(b"\x00" * 320)
+
+        anchor = self.moq.AudioFrame.call_args.kwargs["timestamp_us"]
+        self.assertAlmostEqual(anchor, opened_at + 2_000_000, delta=100_000)
+
+    def test_restart_without_audio_in_flight_is_a_no_op(self):
+        """Interruptions are broadcast on every user turn, so most of them find
+        nothing left to play. There is no stale audio to disambiguate, and
+        swapping anyway would cost every subscriber a resubscribe."""
+        self.client.open_audio_track(16000)
+        kept = self.client._audio_out
+
+        self.client.restart_audio_track()
+
+        kept.finish.assert_not_called()
+        self.assertIs(self.client._audio_out, kept)
+        self.assertEqual(self._published_track_names(), ["bot-audio"])
+
+    def test_restart_before_the_track_opens_is_a_no_op(self):
+        """An interruption can land before StartFrame opens the track (the
+        sample rate isn't known until then). There is nothing to retire, and
+        no track should be conjured at an unknown rate."""
+        self.client.restart_audio_track()
+
+        self.assertIsNone(self.client._audio_out)
+        self.broadcast.publish_audio.assert_not_called()
+
+    async def test_a_chunk_paced_against_a_retired_track_is_dropped(self):
+        """Pacing can park a chunk in a sleep for seconds — long enough for the
+        interruption that abandons its utterance. It must not land on the
+        successor track, which would put the discarded audio back at the head
+        of the new timeline."""
+        self.client.open_audio_track(16000)
+        retired = self.client._audio_out
+
+        # Park the pacing clock past the buffer budget so the write waits.
+        budget = self.client._params.audio_out_max_buffer_ms / 1000.0
+        self.client._publish_audio_clock = time.monotonic() + budget + 0.2
+
+        write = asyncio.create_task(self.client.publish_audio(b"\x00" * 320))
+        await asyncio.sleep(0)  # let it reach the pacing sleep
+        self.client.restart_audio_track()
+        await write
+
+        retired.write.assert_not_called()
+        self.client._audio_out.write.assert_not_called()
+        # The successor is still waiting on its own first write for an epoch,
+        # rather than taking one from the audio that was just discarded.
+        self.assertIsNone(self.client._publish_pts_us)
+
+
+class TestMOQAudioTrackRestartLive(unittest.IsolatedAsyncioTestCase):
+    """Catalog replacement and group-zero against a real AudioProducer.
+
+    The mocked tests can see finish() and the successor's name; they cannot
+    see the catalog drop the retired rendition or that a new producer starts
+    its group sequence at zero. Those are properties of moq-rs, so they
+    need a live producer.
+    """
+
+    def setUp(self):
+        params = MOQParams(audio_in_enabled=True, audio_out_enabled=True)
+        self.client = MOQTransport(params=params, host="localhost", port=4080)._client
+
+    async def _first_group_sequence(self, track_name: str) -> int:
+        consumer = self.client._publish_broadcast.consume()
+        track = await consumer.subscribe_track(track_name)
+        group = await asyncio.wait_for(track.next_group(), timeout=2)
+        self.assertIsNotNone(group)
+        return group.sequence
+
+    async def test_catalog_advertises_the_replacement_track(self):
+        """finish() drops the retired rendition and the successor publishes
+        its own, so the catalog always names exactly one audio track."""
+        self.client.open_audio_track(16000)
+        catalog = await self.client._publish_broadcast.consume().subscribe_catalog()
+        first = await asyncio.wait_for(anext(catalog), timeout=2)
+        self.assertEqual(set(first.audio), {"bot-audio"})
+
+        self.client._publish_audio_clock = time.monotonic() + 5.0
+        self.client.restart_audio_track()
+
+        updated = await asyncio.wait_for(anext(catalog), timeout=2)
+        self.assertEqual(set(updated.audio), {"bot-audio-1"})
+
+    async def test_every_replacement_track_starts_at_group_zero(self):
+        """A new producer resets only its group sequence. The broadcast PTS
+        origin is shared; group 0 is per-track so a subscriber can join the
+        replacement at the live edge."""
+        self.client.open_audio_track(16000)
+        await self.client.publish_audio(_PCM_200MS)
+        self.assertEqual(await self._first_group_sequence("bot-audio"), 0)
+
+        self.client._publish_audio_clock = time.monotonic() + 5.0
+        self.client.restart_audio_track()
+        await self.client.publish_audio(_PCM_200MS)
+        self.assertEqual(await self._first_group_sequence("bot-audio-1"), 0)
+
+        self.client._publish_audio_clock = time.monotonic() + 5.0
+        self.client.restart_audio_track()
+        await self.client.publish_audio(_PCM_200MS)
+        self.assertEqual(await self._first_group_sequence("bot-audio-2"), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`MOQOutputTransport` publishes bot audio on one MoQ track, writing TTS up to `audio_out_max_buffer_ms` ahead of real time. When the user interrupts, seconds of the abandoned utterance have already left the process and nothing on the bot side can retract them. Discarding them relied on the bot sending RTVI `user-started-speaking` on the transcript track and the browser flushing its buffer, but the two tracks have no ordering relative to each other, and the transcript is subscribed at a lower priority than audio, so the flush signal queues behind the data it exists to flush. This PR retires the audio track on interruption and publishes a successor (`bot-audio`, `bot-audio-1`, ...), so the abandoned audio is discarded along with the track that carried it.

- **Catalog.** `AudioProducer.finish()` drops the retired rendition and the successor publishes its own, so the catalog always advertises exactly one audio track and subscribers follow the swap through normal rendition selection.
- **When to swap.** Interruptions fire on every user turn, and a swap costs every subscriber a catalog update and a resubscribe. The track is retired only when the pacing clock leads wall-clock by more than `AUDIO_IN_FLIGHT_FLOOR_S` (0.3s), meaning it actually carries unplayed audio.
- **Timestamps.** Every track stamps against one broadcast-wide monotonic origin, so tracks stay mutually synchronizable. A successor takes its epoch at its first write rather than when it opens (the two are 1–2s apart while STT, the LLM and TTS run), and only that first stamp reaches the wire: `moq-audio` derives later PTS from the running sample count. Each new producer restarts its group sequence at zero.
- **Ordering.** `process_frame` lets the base class drain the audio queue before the track is retired, and `publish_audio` captures its producer before the pacing sleep and drops the chunk if the track was retired meanwhile, so abandoned audio can't anchor the successor's epoch.
- **Subscriber join position.** A subscriber that joins a track after the bot has written ahead starts at the latest group and misses the head of the utterance. The normal path is unaffected: the browser resubscribes at the catalog change, 1–2s before the successor's first write. Joining mid-utterance improves once `moq-rs` and `@moq/watch` ship moq-dev/moq#3158 (currently on `dev`), which starts a subscription as far back as its latency budget allows; raise the `moq-rs` floor when that release exists.

Supersedes #5443.

(written by Opus 5)
