### PR TITLE
fix(string): raise when NLTK punkt_tab cannot be downloaded

### DIFF
--- a/changelog/5720.fixed.md
+++ b/changelog/5720.fixed.md
@@ -1,0 +1,1 @@
+- Fixed sentence tokenization treating a failed NLTK `punkt_tab` download as a working tokenizer. A missing or blocked download now raises a clear error instead of caching `sent_tokenize` and exploding later with `LookupError` on the first bot turn.

--- a/src/pipecat/utils/string.py
+++ b/src/pipecat/utils/string.py
@@ -17,10 +17,12 @@ Dependencies:
     Source: https://www.nltk.org/api/nltk.tokenize.punkt.html
 
     The tokenizer and its ``punkt_tab`` data load on first use, and the data is
-    downloaded if it isn't already present. Deployments that build their own
-    image should bundle it at build time (``python -m nltk.downloader
-    punkt_tab``) or point ``NLTK_DATA`` at a directory that already has it, so
-    that a slow or unavailable network can't delay the first bot turn.
+    downloaded if it isn't already present. A failed download is an error, not a
+    usable tokenizer: callers must not receive ``sent_tokenize`` when the data
+    is still missing. Deployments that build their own image should bundle it at
+    build time (``python -m nltk.downloader punkt_tab``) or point ``NLTK_DATA``
+    at a directory that already has it, so that a slow or unavailable network
+    can't delay the first bot turn.
 """
 
 import re
@@ -32,6 +34,26 @@ from functools import cache
 from loguru import logger
 
 _load_lock = threading.Lock()
+
+_PUNKT_TAB_RESOURCE = "tokenizers/punkt_tab"
+_PUNKT_TAB_UNAVAILABLE = (
+    "Failed to load NLTK 'punkt_tab' tokenizer data. "
+    "Sentence tokenization needs this data. "
+    "Pre-install it with `python -m nltk.downloader punkt_tab`, "
+    "or set NLTK_DATA to a directory that already contains it. "
+    "If a proxy performs egress, NLTK refuses the download unless you opt in "
+    "with NLTK_ALLOW_PROXIED_URLOPEN=1 for a proxy you trust. "
+    "See https://www.nltk.org/data.html"
+)
+
+
+def _raise_punkt_tab_unavailable(cause: BaseException | None = None) -> None:
+    """Raise after punkt_tab cannot be found or downloaded."""
+    if cause is None:
+        logger.error(_PUNKT_TAB_UNAVAILABLE)
+        raise RuntimeError(_PUNKT_TAB_UNAVAILABLE)
+    logger.error(f"{_PUNKT_TAB_UNAVAILABLE} ({cause})")
+    raise RuntimeError(_PUNKT_TAB_UNAVAILABLE) from cause
 
 
 @cache
@@ -47,25 +69,22 @@ def _sent_tokenizer() -> Callable[[str], list[str]]:
     waits on the lock rather than loading alongside it, so the one-time
     ``punkt_tab`` download cannot run twice at once. The cache keeps the lock
     off the path once the tokenizer is loaded.
+
+    Raises:
+        RuntimeError: If ``punkt_tab`` is missing and cannot be downloaded.
     """
     with _load_lock:
         import nltk
         from nltk.tokenize import sent_tokenize
 
         try:
-            nltk.data.find("tokenizers/punkt_tab")
+            nltk.data.find(_PUNKT_TAB_RESOURCE)
         except LookupError:
             try:
                 nltk.download("punkt_tab", quiet=True)
-            except (OSError, PermissionError) as e:
-                logger.error(
-                    f"Failed to download NLTK 'punkt_tab' tokenizer data: {e}. "
-                    "This data is required for sentence tokenization features. "
-                    "The download failed due to filesystem permissions. "
-                    "To resolve: pre-install the data in a location with appropriate read "
-                    "permissions, or set the NLTK_DATA environment variable to point to a "
-                    "writable directory. See https://www.nltk.org/data.html for more information."
-                )
+                nltk.data.find(_PUNKT_TAB_RESOURCE)
+            except Exception as e:
+                _raise_punkt_tab_unavailable(e)
 
         return sent_tokenize
 
@@ -160,6 +179,10 @@ def match_endofsentence(text: str) -> int:
 
     Returns:
         The position of the end of the sentence if found, otherwise 0.
+
+    Raises:
+        RuntimeError: If NLTK's ``punkt_tab`` data is missing and cannot be
+            downloaded.
     """
     text = text.rstrip()
 

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -5,12 +5,54 @@
 #
 
 import unittest
+from unittest.mock import patch
 
 from pipecat.utils.string import (
+    _sent_tokenizer,
     longest_trailing_partial_match,
     match_endofsentence,
     parse_start_end_tags,
 )
+
+
+class TestSentTokenizerLoad(unittest.TestCase):
+    def tearDown(self):
+        _sent_tokenizer.cache_clear()
+
+    def test_raises_when_download_does_not_install_data(self):
+        import nltk
+
+        _sent_tokenizer.cache_clear()
+        with (
+            patch.object(nltk.data, "find", side_effect=LookupError("missing")),
+            patch.object(nltk, "download", return_value=False) as download,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                _sent_tokenizer()
+
+        self.assertIn("punkt_tab", str(ctx.exception))
+        download.assert_called_once_with("punkt_tab", quiet=True)
+
+    def test_does_not_cache_a_tokenizer_after_a_failed_download(self):
+        import nltk
+
+        _sent_tokenizer.cache_clear()
+        with (
+            patch.object(nltk.data, "find", side_effect=LookupError("missing")),
+            patch.object(nltk, "download", return_value=False),
+        ):
+            with self.assertRaises(RuntimeError):
+                _sent_tokenizer()
+
+        with (
+            patch.object(nltk.data, "find", return_value="/tmp/punkt_tab"),
+            patch.object(nltk, "download") as download,
+        ):
+            tokenizer = _sent_tokenizer()
+
+        self.assertTrue(callable(tokenizer))
+        download.assert_not_called()
+
 
 
 class TestUtilsString(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -54,7 +54,6 @@ class TestSentTokenizerLoad(unittest.TestCase):
         download.assert_not_called()
 
 
-
 class TestUtilsString(unittest.IsolatedAsyncioTestCase):
     async def test_endofsentence(self):
         assert match_endofsentence("This is a sentence.") == 19


### PR DESCRIPTION
## Problem

`_sent_tokenizer()` treats a failed NLTK `punkt_tab` download as success. `nltk.download("punkt_tab")` often prints a warning and returns `False` instead of raising `OSError` or `PermissionError` (offline, firewall, or a proxy that NLTK pathsec refuses). The loader still cached `sent_tokenize`.

The first real sentence-boundary call then exploded with NLTK's `LookupError` wall of text on the opening bot turn.

## Approach

After a download attempt, re-check that `tokenizers/punkt_tab` is present. If it is still missing, raise `RuntimeError` with install / `NLTK_DATA` / trusted-proxy guidance and do not cache a broken tokenizer. `functools.cache` does not store the failed call, so a later successful load can proceed.

## User impact

Bots that start without bundled `punkt_tab` now fail immediately with an actionable error instead of crashing later during the first spoken turn. Deployments that already bundle the data, or set `NLTK_DATA`, are unchanged.

## Evidence

- Reproduced on Windows with a proxy: `nltk.download("punkt_tab")` failed with pathsec "Security Violation" and returned `False`; `match_endofsentence("Hello from Pipecat!")` then raised the new `RuntimeError` instead of caching `sent_tokenize`.
- `uv run pytest tests/test_utils_string.py` — 15 passed after installing `punkt_tab` with `NLTK_ALLOW_PROXIED_URLOPEN=1`.
- `TestSentTokenizerLoad` covers a download that returns `False` and confirms the failure is not cached.
