### PR TITLE
feat(services/qwen): add Qwen3STTService for local speech-to-text

### DIFF
--- a/changelog/5723.added.md
+++ b/changelog/5723.added.md
@@ -1,0 +1,1 @@
+- Added `Qwen3STTService` — local speech-to-text using the Qwen3-ASR model family (0.6B / 1.7B / 8B) via the `qwen-asr` package. Install with `uv add "pipecat-ai[qwen-asr]"`.

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -108,6 +108,9 @@ autodoc_mock_imports = [
     "mlx_whisper",  # Note: might need underscore format too
     # pocket-tts dependencies (torch is mocked above)
     "pocket_tts",
+    # Qwen3-ASR - the qwen-asr extra is excluded from the docs environment
+    # because it pulls in torch, which is mocked above
+    "qwen_asr",
     # Pydantic v2 compatibility issues in third-party SDKs
     "hume",
     "hume.tts",

--- a/docs/api/install-deps.sh
+++ b/docs/api/install-deps.sh
@@ -14,4 +14,5 @@ uv sync --group docs --all-extras \
     --no-extra local-smart-turn \
     --no-extra mlx-whisper \
     --no-extra moondream \
-    --no-extra pocket-tts
+    --no-extra pocket-tts \
+    --no-extra qwen-asr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ pgmq = ["pgmq>=1.0.6,<1.1", "asyncpg>=0.30.0"]
 piper = [ "piper-tts>=1.3.0,<2", "requests>=2.32.5,<3" ]
 pocket-tts = [ "pocket-tts>=2.1.0,<3" ]
 qwen = []
+qwen-asr = [ "qwen-asr>=0.0.6" ]
 redis = ["redis[hiredis]>=5.0.0"]
 resembleai = []
 rime = []
@@ -195,6 +196,18 @@ docs = [
 environments = [
     "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version != '3.13.*' or sys_platform != 'linux'",
+]
+
+# qwen-asr pins accelerate==1.12.0, while the moondream extra constrains the same
+# package to ~=1.10.0. A single universal resolution therefore cannot satisfy both,
+# even though no one needs a local Qwen3-ASR model and Moondream vision in the same
+# environment. Declaring the pair conflicting resolves them in separate forks; uv
+# then errors at install time only if both extras are activated together.
+conflicts = [
+    [
+        { extra = "moondream" },
+        { extra = "qwen-asr" },
+    ],
 ]
 
 [tool.setuptools.packages.find]

--- a/src/pipecat/services/qwen/stt.py
+++ b/src/pipecat/services/qwen/stt.py
@@ -1,0 +1,226 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Qwen3-ASR speech-to-text service with locally-downloaded models.
+
+This module implements speech-to-text using the locally-run Qwen3-ASR model
+family (Qwen/Qwen3-ASR-0.6B, 1.7B, 8B). Qwen3-ASR is a multilingual,
+autoregressive ASR model that runs on CUDA via the ``qwen-asr`` package.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from enum import StrEnum
+
+import numpy as np
+from loguru import logger
+from typing_extensions import override
+
+from pipecat.frames.frames import ErrorFrame, Frame, TranscriptionFrame
+from pipecat.services.settings import STTSettings
+from pipecat.services.stt_service import SegmentedSTTService
+from pipecat.transcriptions.language import Language
+from pipecat.utils.time import time_now_iso8601
+from pipecat.utils.tracing.service_decorators import traced_stt
+
+try:
+    import torch
+    from qwen_asr import Qwen3ASRModel
+except ModuleNotFoundError as e:
+    logger.error(f"Exception: {e}")
+    logger.error('In order to use Qwen3-ASR, you need to `uv add "pipecat-ai[qwen-asr]"`.')
+    raise ImportError(f"Missing module: {e}") from e
+
+# Qwen3-ASR natively operates on 16 kHz mono PCM.
+_SAMPLE_RATE = 16000
+
+_LANGUAGE_MAP = {
+    Language.EN: "English",
+    Language.ZH: "Chinese",
+    Language.ES: "Spanish",
+    Language.FR: "French",
+    Language.DE: "German",
+    Language.JA: "Japanese",
+    Language.KO: "Korean",
+    Language.PT: "Portuguese",
+    Language.RU: "Russian",
+    Language.AR: "Arabic",
+    Language.IT: "Italian",
+    Language.HI: "Hindi",
+}
+
+
+class Model(StrEnum):
+    """Qwen3-ASR model size options.
+
+    Parameters:
+        ASR_0_6B: Smallest model, fastest inference, lower accuracy.
+        ASR_1_7B: Best accuracy/speed balance. Recommended default.
+        ASR_8B: Highest accuracy, slower inference, more VRAM required.
+    """
+
+    ASR_0_6B = "Qwen/Qwen3-ASR-0.6B"
+    ASR_1_7B = "Qwen/Qwen3-ASR-1.7B"
+    ASR_8B = "Qwen/Qwen3-ASR-8B"
+
+
+@dataclass
+class Qwen3STTSettings(STTSettings):
+    """Settings for ``Qwen3STTService``.
+
+    ``model`` and ``language`` are inherited from ``STTSettings``.
+
+    Parameters:
+        max_new_tokens: Maximum tokens the model may generate per utterance.
+            Higher values allow longer transcriptions but increase latency.
+    """
+
+    max_new_tokens: int = 256
+
+
+class Qwen3STTService(SegmentedSTTService):
+    """Speech-to-text using a locally-downloaded Qwen3-ASR model.
+
+    Transcribes VAD-segmented speech with a local Qwen3-ASR model.
+    The model is loaded once at construction and reused for each transcription.
+
+    Audio is expected as 16 kHz, 16-bit signed PCM (the pipecat STT default).
+    Requires a CUDA-capable GPU.
+
+    For deployments with many concurrent sessions, note that each service
+    instance loads its own copy of the model into VRAM. To share one model
+    across sessions, subclass this service and override ``_load()`` to inject
+    a pre-loaded ``Qwen3ASRModel``.
+
+    Example::
+
+        stt = Qwen3STTService(
+            model=Model.ASR_1_7B,
+            device="cuda:0",
+            language=Language.EN,
+        )
+    """
+
+    Settings = Qwen3STTSettings
+    _settings: Settings
+
+    @property
+    def wants_wav_segments(self) -> bool:
+        """Receive segments as raw 16-bit PCM — no WAV wrapping needed."""
+        return False
+
+    def __init__(
+        self,
+        *,
+        model: str | Model = Model.ASR_1_7B,
+        device: str = "cuda:0",
+        language: Language | None = None,
+        settings: Settings | None = None,
+        **kwargs,
+    ):
+        """Initialize the Qwen3-ASR STT service.
+
+        Args:
+            model: The Qwen3-ASR model to use. Can be a :class:`Model` enum
+                value or a HuggingFace model ID string.
+                Defaults to :attr:`Model.ASR_1_7B`.
+            device: The CUDA device to load the model onto. Defaults to
+                ``"cuda:0"``.
+            language: The default transcription language. Defaults to
+                :attr:`Language.EN` when not provided via ``settings``.
+            settings: Runtime-updatable settings (``model``, ``language``,
+                ``max_new_tokens``). Values in ``settings`` take precedence
+                over the ``language`` argument.
+            **kwargs: Additional arguments passed to ``SegmentedSTTService``.
+        """
+        default_settings = self.Settings(
+            model=model if isinstance(model, str) else model.value,
+            language=language or Language.EN,
+        )
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        super().__init__(settings=default_settings, **kwargs)
+        self._device = device
+        self._qwen_model: "Qwen3ASRModel | None" = None
+        self._load()
+
+    def can_generate_metrics(self) -> bool:
+        """Indicate that this service can generate processing metrics."""
+        return True
+
+    def language_to_service_language(self, language: Language) -> str | None:
+        """Map a pipecat ``Language`` to the Qwen3-ASR language string.
+
+        Args:
+            language: The pipecat language to convert.
+
+        Returns:
+            The Qwen3-ASR language string (e.g. ``"English"``), or ``None``
+            if the language is not in the supported set.
+        """
+        return _LANGUAGE_MAP.get(language)
+
+    def _load(self) -> None:
+        """Load the Qwen3-ASR model from HuggingFace (cached after first run)."""
+        logger.debug(f"Loading Qwen3-ASR model: {self._settings.model} ...")
+        self._qwen_model = Qwen3ASRModel.from_pretrained(
+            self._settings.model,
+            dtype=torch.bfloat16,
+            device_map=self._device,
+            max_new_tokens=self._settings.max_new_tokens,
+        )
+        logger.debug("Qwen3-ASR model loaded")
+
+    @traced_stt
+    async def _handle_transcription(
+        self, transcript: str, is_final: bool, language: Language | None = None
+    ):
+        """Handle a transcription result with tracing."""
+        pass
+
+    @override
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+        """Transcribe an audio segment with Qwen3-ASR.
+
+        Args:
+            audio: Raw audio bytes in 16-bit signed PCM format (16 kHz mono).
+
+        Yields:
+            Frame: A ``TranscriptionFrame`` with the recognized text, or an
+                ``ErrorFrame`` if the model is unavailable or inference fails.
+        """
+        if not self._qwen_model:
+            yield ErrorFrame("Qwen3-ASR model not available")
+            return
+
+        await self.start_processing_metrics()
+
+        # 16-bit signed PCM -> float32 in [-1, 1].
+        audio_float = np.frombuffer(audio, dtype=np.int16).astype(np.float32) / 32768.0
+        language = self._settings.language
+        lang_str = self.language_to_service_language(language) if language else "English"
+
+        try:
+            results = await asyncio.to_thread(
+                self._qwen_model.transcribe,
+                (audio_float, _SAMPLE_RATE),
+                language=lang_str,
+            )
+            text = results[0].text.strip() if results else ""
+        except Exception as e:
+            logger.exception("Qwen3-ASR transcription failed")
+            await self.stop_processing_metrics()
+            yield ErrorFrame(error=str(e))
+            return
+
+        await self.stop_processing_metrics()
+
+        if text:
+            await self._handle_transcription(text, True, language)
+            logger.debug(f"Transcription: [{text}]")
+            yield TranscriptionFrame(text, self._user_id, time_now_iso8601(), language)

--- a/tests/test_qwen3_stt.py
+++ b/tests/test_qwen3_stt.py
@@ -1,0 +1,191 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for the Qwen3-ASR STT service."""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+from pipecat.frames.frames import ErrorFrame, TranscriptionFrame
+from pipecat.transcriptions.language import Language
+
+
+@pytest.fixture()
+def qwen_asr_module(monkeypatch):
+    class FakeResult:
+        def __init__(self, text):
+            self.text = text
+
+    class FakeQwen3ASRModel:
+        instances = []
+
+        def __init__(self, model_name, **kwargs):
+            self.model_name = model_name
+            self.kwargs = kwargs
+            self.transcribe_calls = []
+            FakeQwen3ASRModel.instances.append(self)
+
+        @classmethod
+        def from_pretrained(cls, model_name, **kwargs):
+            return cls(model_name, **kwargs)
+
+        def transcribe(self, audio, language=None):
+            self.transcribe_calls.append({"audio": audio, "language": language})
+            return [FakeResult(" hello world ")]
+
+    torch_mod = types.ModuleType("torch")
+    torch_mod.bfloat16 = "bfloat16"
+
+    qwen_asr_mod = types.ModuleType("qwen_asr")
+    qwen_asr_mod.Qwen3ASRModel = FakeQwen3ASRModel
+
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "qwen_asr", qwen_asr_mod)
+    sys.modules.pop("pipecat.services.qwen.stt", None)
+
+    module = importlib.import_module("pipecat.services.qwen.stt")
+    FakeQwen3ASRModel.instances = []
+    yield module, FakeQwen3ASRModel
+
+    sys.modules.pop("pipecat.services.qwen.stt", None)
+
+
+def test_qwen3_stt_defaults(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+
+    service = stt.Qwen3STTService()
+
+    assert service._settings.model == "Qwen/Qwen3-ASR-1.7B"
+    assert service._settings.language == Language.EN
+    assert service._device == "cuda:0"
+    assert service._settings.max_new_tokens == 256
+    assert fake_model.instances[-1].model_name == "Qwen/Qwen3-ASR-1.7B"
+    assert fake_model.instances[-1].kwargs["dtype"] == "bfloat16"
+    assert fake_model.instances[-1].kwargs["device_map"] == "cuda:0"
+
+
+def test_qwen3_stt_settings_override(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+
+    service = stt.Qwen3STTService(
+        model=stt.Model.ASR_0_6B,
+        device="cuda:1",
+        settings=stt.Qwen3STTService.Settings(
+            language=Language.ZH,
+            max_new_tokens=128,
+        ),
+    )
+
+    assert service._settings.model == "Qwen/Qwen3-ASR-0.6B"
+    assert service._settings.language == Language.ZH
+    assert service._device == "cuda:1"
+    assert service._settings.max_new_tokens == 128
+    assert fake_model.instances[-1].kwargs["max_new_tokens"] == 128
+
+
+def test_qwen3_stt_model_string_accepted(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+
+    service = stt.Qwen3STTService(model="Qwen/Qwen3-ASR-8B")
+
+    assert service._settings.model == "Qwen/Qwen3-ASR-8B"
+    assert fake_model.instances[-1].model_name == "Qwen/Qwen3-ASR-8B"
+
+
+def test_language_to_service_language(qwen_asr_module):
+    stt, _ = qwen_asr_module
+    service = stt.Qwen3STTService()
+
+    assert service.language_to_service_language(Language.EN) == "English"
+    assert service.language_to_service_language(Language.ZH) == "Chinese"
+    assert service.language_to_service_language(Language.JA) == "Japanese"
+    assert service.language_to_service_language(Language.DE) == "German"
+
+
+def test_can_generate_metrics(qwen_asr_module):
+    stt, _ = qwen_asr_module
+    service = stt.Qwen3STTService()
+
+    assert service.can_generate_metrics() is True
+
+
+def test_wants_wav_segments_is_false(qwen_asr_module):
+    stt, _ = qwen_asr_module
+    service = stt.Qwen3STTService()
+
+    assert service.wants_wav_segments is False
+
+
+@pytest.mark.asyncio
+async def test_run_stt_yields_transcription_frame(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+    service = stt.Qwen3STTService(settings=stt.Qwen3STTService.Settings(language=Language.EN))
+
+    frames = [frame async for frame in service.run_stt(b"\x00\x00" * 160)]
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], TranscriptionFrame)
+    assert frames[0].text == "hello world"
+    assert frames[0].language == Language.EN
+    call = fake_model.instances[-1].transcribe_calls[-1]
+    assert call["language"] == "English"
+    assert call["audio"][1] == stt._SAMPLE_RATE
+
+
+@pytest.mark.asyncio
+async def test_run_stt_passes_correct_language(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+    service = stt.Qwen3STTService(settings=stt.Qwen3STTService.Settings(language=Language.JA))
+
+    await service.run_stt(b"\x00\x00" * 160).__aiter__().__anext__()
+
+    call = fake_model.instances[-1].transcribe_calls[-1]
+    assert call["language"] == "Japanese"
+
+
+@pytest.mark.asyncio
+async def test_run_stt_returns_error_frame_when_model_missing(qwen_asr_module):
+    stt, _ = qwen_asr_module
+    service = stt.Qwen3STTService()
+    service._qwen_model = None
+
+    frames = [frame async for frame in service.run_stt(b"\x00\x00" * 160)]
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], ErrorFrame)
+    assert frames[0].error == "Qwen3-ASR model not available"
+
+
+@pytest.mark.asyncio
+async def test_run_stt_returns_error_frame_on_inference_failure(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+    service = stt.Qwen3STTService()
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("CUDA out of memory")
+
+    fake_model.instances[-1].transcribe = fail
+
+    frames = [frame async for frame in service.run_stt(b"\x00\x00" * 160)]
+
+    assert len(frames) == 1
+    assert isinstance(frames[0], ErrorFrame)
+    assert "CUDA out of memory" in frames[0].error
+
+
+@pytest.mark.asyncio
+async def test_run_stt_skips_empty_transcript(qwen_asr_module):
+    stt, fake_model = qwen_asr_module
+    service = stt.Qwen3STTService()
+
+    fake_model.instances[-1].transcribe = lambda *a, **kw: []
+
+    frames = [frame async for frame in service.run_stt(b"\x00\x00" * 160)]
+
+    assert frames == []


### PR DESCRIPTION
## Summary

Adds `Qwen3STTService` — a local speech-to-text service backed by the [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) model family via the [`qwen-asr`](https://pypi.org/project/qwen-asr/) package.

- Extends `SegmentedSTTService`, following `FunASRSTTService` / `WhisperSTTService` / `MoonshineSTTService`
- Three model sizes: `Qwen/Qwen3-ASR-0.6B`, `Qwen/Qwen3-ASR-1.7B` (default), `Qwen/Qwen3-ASR-8B`
- Multilingual: English, Chinese, Spanish, French, German, Japanese, Korean, Portuguese, Russian, Arabic, Italian, Hindi
- Runs on CUDA via `torch.bfloat16`; transcription dispatched with `asyncio.to_thread`
- Unit tests with a mocked `qwen-asr`, following the FunASR/Moonshine test patterns

Replaces #5415, which was opened against a three-week-old `main` and had drifted far enough that rebasing in place was messier than starting clean.

## Packaging: conflicting extras

`qwen-asr` depends on `accelerate==1.12.0`, while the `moondream` extra constrains the same package to `~=1.10.0`. uv resolves a single universal lockfile across all extras, so the two pins are unsatisfiable together and `uv lock` fails outright — regardless of which extras a given install actually selects. That is what broke the docs build on #5415.

Since nobody runs a local Qwen3-ASR model and Moondream vision in one environment, the two are declared conflicting:

```toml
conflicts = [
    [
        { extra = "moondream" },
        { extra = "qwen-asr" },
    ],
]
```

uv then resolves them in separate forks, and activating both together becomes an explicit install-time error rather than a resolution failure for everyone.

`qwen-asr` is also excluded in `docs/api/install-deps.sh` alongside the other heavy ML extras (it pulls in torch), and `qwen_asr` is added to `autodoc_mock_imports` so the service's API page still generates.

## Usage

```python
from pipecat.services.qwen.stt import Qwen3STTService, Model
from pipecat.transcriptions.language import Language

stt = Qwen3STTService(
    model=Model.ASR_1_7B,   # or "Qwen/Qwen3-ASR-0.6B", "Qwen/Qwen3-ASR-8B"
    device="cuda:0",
    language=Language.EN,
)
```

Install: `uv add "pipecat-ai[qwen-asr]"`

## Not done here

`uv.lock` is not regenerated — this branch carries `main`'s lockfile, which predates the `qwen-asr` extra. Read the Docs re-resolves during `uv sync`, so the docs build exercises the `conflicts` change, but `uv lock` has not been run against it directly.

## Test plan

- [x] Unit tests: defaults, settings overrides, string model ID, language mapping, `run_stt` transcription, missing-model error, inference-exception error, empty-transcript skip
- [x] Validated in production prior to this PR in a pipecat-based voice server (Qwen3-ASR-1.7B on CUDA)
- [ ] `uv lock` regenerated and committed

## Notes

- No changes to the existing `qwen/llm.py` or `qwen/__init__.py`; the `qwen = []` extra (DashScope LLM) is untouched and `qwen-asr` is separate
- Each service instance loads its own copy of the model into VRAM. The class docstring documents the subclass pattern for sharing one `Qwen3ASRModel` across pipeline sessions.