### PR TITLE
fix(audio): treat a frame with no samples as silence

### DIFF
--- a/changelog/5724.fixed.md
+++ b/changelog/5724.fixed.md
@@ -1,0 +1,3 @@
+`is_silence()` now reports a frame carrying no samples as silence instead of raising
+`ValueError`, so an empty audio frame reaching the output transport's speaking
+detection no longer interrupts the pipeline.

--- a/src/pipecat/audio/utils.py
+++ b/src/pipecat/audio/utils.py
@@ -305,7 +305,7 @@ def is_silence(pcm_bytes: bytes) -> bool:
 
     Returns:
         bool: True if the audio sample is considered silence (below threshold),
-              False otherwise.
+              False otherwise. A frame carrying no audio counts as silence.
 
     Note:
         Normal speech typically produces amplitude values between ±500 to ±5000,
@@ -315,6 +315,11 @@ def is_silence(pcm_bytes: bytes) -> bool:
     """
     # Convert raw audio bytes to a NumPy array of int16 samples
     audio_data = np.frombuffer(pcm_bytes, dtype=np.int16)
+
+    # No samples carry no speech. max() on an empty array raises, and audio
+    # frames arriving from a transport can be empty.
+    if audio_data.size == 0:
+        return True
 
     # Check the maximum absolute amplitude in the frame
     max_value = np.abs(audio_data).max()

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -68,9 +68,8 @@ class TestIsSilence(unittest.TestCase):
 
     Services build SpeechOutputAudioRawFrame straight from a transport's audio
     callback without checking the payload length, and the output transport calls
-    is_silence() on every one of them. numpy's max() raises on an empty array, so
-    a zero-length frame took down the speaking-detection path rather than being
-    read as what it is: no audio, therefore no speech.
+    is_silence() on every one of them, so a zero-length frame has to answer the
+    question rather than raise.
     """
 
     def test_empty_audio_is_silence(self):

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -8,7 +8,7 @@ import io
 import unittest
 import wave
 
-from pipecat.audio.utils import pcm_to_wav
+from pipecat.audio.utils import is_silence, pcm_to_wav
 
 
 class TestPcmToWav(unittest.TestCase):
@@ -61,3 +61,36 @@ class TestPcmToWav(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestIsSilence(unittest.TestCase):
+    """An audio frame can arrive carrying no samples at all.
+
+    Services build SpeechOutputAudioRawFrame straight from a transport's audio
+    callback without checking the payload length, and the output transport calls
+    is_silence() on every one of them. numpy's max() raises on an empty array, so
+    a zero-length frame took down the speaking-detection path rather than being
+    read as what it is: no audio, therefore no speech.
+    """
+
+    def test_empty_audio_is_silence(self):
+        self.assertTrue(is_silence(b""))
+
+    def test_quiet_audio_is_silence(self):
+        pcm = (10).to_bytes(2, "little", signed=True) * 160
+        self.assertTrue(is_silence(pcm))
+
+    def test_loud_audio_is_not_silence(self):
+        pcm = (3000).to_bytes(2, "little", signed=True) * 160
+        self.assertFalse(is_silence(pcm))
+
+    def test_a_single_loud_sample_is_not_silence(self):
+        """max() is over the whole frame, so one loud sample is enough."""
+        pcm = (10).to_bytes(2, "little", signed=True) * 159 + (3000).to_bytes(
+            2, "little", signed=True
+        )
+        self.assertFalse(is_silence(pcm))
+
+    def test_negative_amplitude_is_measured_by_magnitude(self):
+        pcm = (-3000).to_bytes(2, "little", signed=True) * 160
+        self.assertFalse(is_silence(pcm))


### PR DESCRIPTION
`is_silence()` takes the max over the frame:

```python
audio_data = np.frombuffer(pcm_bytes, dtype=np.int16)
max_value = np.abs(audio_data).max()
```

numpy raises on an empty array, so a zero-length frame does not read as silence, it raises:

```
>>> is_silence(b"")
ValueError: zero-size array to reduction operation maximum which has no identity
```

## Where an empty frame comes from

`BaseOutputTransport` calls it on every `SpeechOutputAudioRawFrame` in the speaking-detection path:

```python
async def _maybe_bot_currently_speaking(self, frame: SpeechOutputAudioRawFrame):
    if not is_silence(frame.audio):
```

and services build those frames directly from a transport's audio callback, with no check on the payload length:

```python
# services/tavus/video.py
async def _on_participant_audio_data(self, participant_id, audio, audio_source):
    frame = SpeechOutputAudioRawFrame(
        audio=audio.audio_frames,
        ...
```

`services/heygen/video.py` does the same. So a zero-length audio frame from the peer reaches `is_silence()` and raises inside the output transport during a live call.

Two places in the tree already treat this as a real condition:

`BaseInputTransport` skips them explicitly, and its comment names a cause:

```python
# Skip frames with no audio data (e.g. filter is buffering).
if not frame.audio:
```

and `detect_speech_onset()`, in this same module, returns early rather than reducing over nothing:

```python
samples = np.frombuffer(pcm_bytes, dtype=np.int16)
if samples.size == 0:
    return None
```

## The change

Return `True` for a frame with no samples. No audio carries no speech, so silence is the answer the caller wants, and it matches what the input transport already does by skipping the frame.

## Tests

Five added to `tests/test_audio_utils.py`. `test_empty_audio_is_silence` fails on `main` with the `ValueError` above. The other four pin the existing behaviour so the guard cannot change it: quiet frames are silence, loud frames are not, a single loud sample in an otherwise quiet frame is not, and negative amplitude is measured by magnitude.

## Not fixed here

`np.frombuffer` also raises on an odd-length buffer (`buffer size must be a multiple of element size`). That is a malformed PCM16 payload rather than a legitimate empty one, and quietly truncating it would hide a real problem upstream, so I left it alone. Happy to add a guard if you would rather it degrade than raise.
